### PR TITLE
Mutations basics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/*
 packages/*/node_modules/*
 packages/*/dist
+packages/*/yarn-error.log
 lerna-debug.log
 coverage/*

--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ Because most mutations will require arguments, we'll in fact use __mutation crea
 const mutationCreator = label => link => link.collection('io.cozy.todos').create({ label })
 ```
 
-Using `withMutate` higher-order component with mutation creators makes it easy to bind actions to your components. `withMutate` provides only a simple function to the wrapper component, in a prop called `mutate`:
+Using `withMutation` higher-order component with mutation creators makes it easy to bind actions to your components. `withMutation` provides only a simple function to the wrapper component, in a prop called `mutate`:
 
 ```jsx
-import { withMutate } from 'cozy-client'
+import { withMutation } from 'cozy-client'
 
 const AddTodo = ({ mutate }) => {
   let input
@@ -171,9 +171,24 @@ const AddTodo = ({ mutate }) => {
   )
 }
 
-export default withMutate(
+export default withMutation(
   label => link => link.collection('io.cozy.todos').create({ label })
 )(AddTodo)
+```
+
+### Multiple mutations
+
+If you need more than once mutation on a component, you can do something like this:
+
+```jsx
+import { default as compose } from 'lodash/flow'
+import { withMutation, create, update, destroy } from 'cozy-client'
+
+export default compose(
+  withMutation(create, { name: 'createTodo' }),
+  withMutation(update, { name: 'updateTodo' }),
+  withMutation(destroy, { name: 'destroyTodo' })
+)(TodoList)
 ```
 
 ### Updating queries
@@ -191,16 +206,16 @@ const TodoList = ...
 export default connect(query, { as: 'allTodos' })(TodoList)
 ```
 
-Now we can define how the query's data must be updated using the `updateQueries` option of `withMutate`:
+Now we can define how the query's data must be updated using the `updateQueries` option of `withMutation`:
 
 ```jsx
-import { withMutate } from 'cozy-client'
+import { withMutation } from 'cozy-client'
 
 const AddTodo = ({ mutate }) => {
   ...
 }
 
-export default withMutate(
+export default withMutation(
   label => link => link.collection('io.cozy.todos').create({ label }),
   {
     updateQueries: {

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To get started using `cozy-client` with (p)React, you need to create a `CozyClie
 * `CozyStackLink` is the HTTP interface to the stack instance ;
 * `CozyProvider` injects the client into components' context.
 
-#### Creating a client
+### Creating a client
 
 ```js
 import CozyClient from 'cozy-client'
@@ -39,7 +39,7 @@ const client = new CozyClient({
 ```
 If you need guidance to get the URI of your instance and/or the token, see (https://cozy.github.io/cozy-docs-v3/en/dev/app/#behind-the-magic).
 
-#### Creating a provider
+### Creating a provider
 
 All components that we want to connect to data need access to the client. We could pass it as a prop from component to component, but it'll quickly get tedious.
 We recommend that you use a `CozyProvider` somewhere high in your app. It will make the client available to all your components using the context:
@@ -61,7 +61,7 @@ ReactDOM.render(
 ```
 
 
-#### Integrating with an existing redux store
+### Integrating with an existing redux store
 
 `cozy-client` uses redux internally to centralize the statuses of the various fetches and replications triggered by the library, and to store locally the data in a normalized way. If you already have a redux store in your app, you can configure `cozy-client` to use this existing store:
 
@@ -88,7 +88,7 @@ ReactDOM.render(
 )
 ```
 
-### Requesting data
+## Requesting data
 
 To make it easy to fetch data and make it available to your component, we provide a higher-order component called `connect`. Basic example of usage:
 
@@ -117,7 +117,7 @@ TodoList.propTypes = {
 }
 ```
 
-#### The injected props
+### The injected props
 
 As seen above, `connect` will pass the result of the query fetch to the wrapped component as a set of props. For list fetches, the injected props are the following:
  - `data`: an array of documents
@@ -125,7 +125,7 @@ As seen above, `connect` will pass the result of the query fetch to the wrapped 
  - `lastFetch`: when the last fetch occured
  - `hasMore`: the fetches being paginated, this property indicates if there are more documents to load
 
-#### Making queries
+### Making queries
 
 `cozy-client` provides you with a very easy to use DSL to define document queries:
 
@@ -134,3 +134,86 @@ import { find } from 'cozy-client'
 
 const query = find('io.cozy.todos').where({ checked: false })
 ```
+
+## Mutating data
+
+In addition to fetching data using queries, `cozy-client` also helps you mutate (update) data.
+
+In its simplest form, what we call a __mutation__ is a function that calls a mutating method on a link:
+
+```js
+const mutation = link => link.collection('io.cozy.todos').create({ label: 'Jettison boosters' })
+```
+
+Because most mutations will require arguments, we'll in fact use __mutation creators__ ; they are higher-order functions that return a mutation:
+
+```js
+const mutationCreator = label => link => link.collection('io.cozy.todos').create({ label })
+```
+
+Using `withMutate` higher-order component with mutation creators makes it easy to bind actions to your components. `withMutate` provides only a simple function to the wrapper component, in a prop called `mutate`:
+
+```jsx
+import { withMutate } from 'cozy-client'
+
+const AddTodo = ({ mutate }) => {
+  let input
+
+  return (
+    <form onSubmit={e => {
+      e.preventDefault()
+      mutate(input.value)
+      input.value = ''
+    }}>
+      <input ref={node => { input = node }} />
+      <button type="submit">Add Todo</button>
+    </form>
+  )
+}
+
+export default withMutate(
+  label => link => link.collection('io.cozy.todos').create({ label })
+)(AddTodo)
+```
+
+### Updating queries
+
+Because we cache data locally in a [normalized way](https://redux.js.org/docs/recipes/reducers/NormalizingStateShape.html) (that is, queries data are stored as arrays of documents IDs), a mutation that updates a document already stored in the cache will see its result automatically integrated into the cache, which in turn will update the UI automatically. But if we create a new document (a todo for instance) and we want to see it appear in the UI (a todo list displayed using a query), we'll need to manually update the query's data. In order to do that, we need to give a name to the query using the `as` option:
+
+```jsx
+import React from 'react'
+import { connect, find } from 'cozy-client'
+
+const query = find('io.cozy.todos').where({ checked: false })
+
+const TodoList = ...
+
+export default connect(query, { as: 'allTodos' })(TodoList)
+```
+
+Now we can define how the query's data must be updated using the `updateQueries` option of `withMutate`:
+
+```jsx
+import { withMutate } from 'cozy-client'
+
+const AddTodo = ({ mutate }) => {
+  ...
+}
+
+export default withMutate(
+  label => link => link.collection('io.cozy.todos').create({ label }),
+  {
+    updateQueries: {
+      allTodos: (previousData, result) => [
+        result.data[0],
+        ...previousData
+      ]
+    }
+  }
+)(AddTodo)
+```
+
+`options.updateQueries` takes an object where query names are the keys and reducer functions are the values. If you are familiar with Redux, defining your `updateQueries` reducers is very similar to defining Redux reducers. The first argument to the reducer function will be the last data fetched (that is displayed in the UI), and the second argument is the result of the mutation: if data has been created or updated, it will have a `data` property containing the mutated data.
+
+
+

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.0",
+  "version": "1.0.0-beta.1",
   "useWorkspaces": true,
   "npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.0",
   "useWorkspaces": true,
   "npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "useWorkspaces": true,
   "npmClient": "yarn"
 }

--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-client",
-  "version": "1.0.0",
+  "version": "1.0.0-beta.1",
   "license": "MIT",
   "main": "dist/cozy-client.js",
   "dependencies": {

--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-client",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "license": "MIT",
   "main": "dist/cozy-client.js",
   "dependencies": {

--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0-beta.1",
   "license": "MIT",
   "main": "dist/cozy-client.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cozy/cozy-client.git"
+  },
   "dependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.2.0",

--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-client",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.0",
   "license": "MIT",
   "main": "dist/cozy-client.js",
   "dependencies": {

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -21,23 +21,25 @@ export default class CozyClient {
     this.dispatch(initQuery(queryId, queryDefinition))
     try {
       const response = await this.executeQuery(queryDefinition)
-      return this.dispatch(receiveQueryResult(queryId, response))
+      this.dispatch(receiveQueryResult(queryId, response))
+      return response
     } catch (error) {
       return this.dispatch(receiveQueryError(queryId, error))
     }
   }
 
-  async mutate(mutationFn, { updateQueries, ...options }) {
+  async mutate(mutationFn, { updateQueries, ...options } = {}) {
     this.getOrCreateStore()
     const mutationId = options.as || this.generateId()
     this.dispatch(initMutation(mutationId))
     try {
       const response = await this.executeMutation(mutationFn)
-      return this.dispatch(
+      this.dispatch(
         receiveMutationResult(mutationId, response, {
           updateQueries
         })
       )
+      return response
     } catch (error) {
       return this.dispatch(receiveMutationError(mutationId, error))
     }

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -55,7 +55,7 @@ export default class CozyClient {
       : collection.find(selector, options)
   }
 
-  async executeMutation(mutationFn) {
+  executeMutation(mutationFn) {
     return mutationFn(this.link)
   }
 

--- a/packages/cozy-client/src/Mutation.js
+++ b/packages/cozy-client/src/Mutation.js
@@ -1,0 +1,3 @@
+export const create = doc => link => link.collection(doc._type).create(doc)
+export const update = doc => link => link.collection(doc._type).update(doc)
+export const destroy = doc => link => link.collection(doc._type).destroy(doc)

--- a/packages/cozy-client/src/__mocks__/cozy-stack-link.js
+++ b/packages/cozy-client/src/__mocks__/cozy-stack-link.js
@@ -1,6 +1,9 @@
 const collectionMock = {
   all: jest.fn(() => Promise.resolve()),
-  find: jest.fn(() => Promise.resolve())
+  find: jest.fn(() => Promise.resolve()),
+  create: jest.fn(() => Promise.resolve()),
+  update: jest.fn(() => Promise.resolve()),
+  destroy: jest.fn(() => Promise.resolve())
 }
 const linkMock = jest.fn().mockImplementation(() => {
   return { collection: jest.fn(() => collectionMock) }

--- a/packages/cozy-client/src/__tests__/connect.spec.jsx
+++ b/packages/cozy-client/src/__tests__/connect.spec.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { createStore, combineReducers } from 'redux'
 import { default as configureMockStore } from 'redux-mock-store'
 import { shallow } from 'enzyme'

--- a/packages/cozy-client/src/__tests__/withMutate.spec.jsx
+++ b/packages/cozy-client/src/__tests__/withMutate.spec.jsx
@@ -16,6 +16,10 @@ describe('withMutate', () => {
       done: false
     }
 
+    link
+      .collection()
+      .create.mockReturnValue(Promise.resolve({ data: [NEW_TODO] }))
+
     const mutationCreator = newTodo => link =>
       link.collection('io.cozy.todos').create(newTodo)
 

--- a/packages/cozy-client/src/__tests__/withMutate.spec.jsx
+++ b/packages/cozy-client/src/__tests__/withMutate.spec.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import CozyStackLink from 'cozy-stack-link'
+
+import CozyClient from '../CozyClient'
+import withMutate from '../withMutate'
+
+describe('withMutate', () => {
+  const link = new CozyStackLink()
+  const client = new CozyClient({ link })
+
+  it('should inject a `mutate` prop into the wrapped component', async () => {
+    const NEW_TODO = {
+      label: 'Jettison fairings',
+      done: false
+    }
+
+    const mutationCreator = newTodo => link =>
+      link.collection('io.cozy.todos').create(newTodo)
+
+    const AddButton = ({ mutate }) => (
+      <button onClick={() => mutate(NEW_TODO)}>Add</button>
+    )
+    const ConnectedAddButton = withMutate(mutationCreator)(AddButton)
+
+    const wrapper = shallow(<ConnectedAddButton />, {
+      context: { client }
+    })
+    wrapper
+      .dive()
+      .find('button')
+      .simulate('click')
+
+    expect(link.collection().create).toHaveBeenCalledWith(NEW_TODO)
+  })
+})

--- a/packages/cozy-client/src/__tests__/withMutate.spec.jsx
+++ b/packages/cozy-client/src/__tests__/withMutate.spec.jsx
@@ -10,23 +10,42 @@ describe('withMutate', () => {
   const link = new CozyStackLink()
   const client = new CozyClient({ link })
 
+  const NEW_TODO = {
+    label: 'Jettison fairings',
+    done: false
+  }
+
+  link
+    .collection()
+    .create.mockReturnValue(Promise.resolve({ data: [NEW_TODO] }))
+
+  const mutationCreator = newTodo => link =>
+    link.collection('io.cozy.todos').create(newTodo)
+
   it('should inject a `mutate` prop into the wrapped component', async () => {
-    const NEW_TODO = {
-      label: 'Jettison fairings',
-      done: false
-    }
-
-    link
-      .collection()
-      .create.mockReturnValue(Promise.resolve({ data: [NEW_TODO] }))
-
-    const mutationCreator = newTodo => link =>
-      link.collection('io.cozy.todos').create(newTodo)
-
     const AddButton = ({ mutate }) => (
       <button onClick={() => mutate(NEW_TODO)}>Add</button>
     )
     const ConnectedAddButton = withMutate(mutationCreator)(AddButton)
+
+    const wrapper = shallow(<ConnectedAddButton />, {
+      context: { client }
+    })
+    wrapper
+      .dive()
+      .find('button')
+      .simulate('click')
+
+    expect(link.collection().create).toHaveBeenCalledWith(NEW_TODO)
+  })
+
+  it('should inject a prop whose name match the `name` option', async () => {
+    const AddButton = ({ addTodo }) => (
+      <button onClick={() => addTodo(NEW_TODO)}>Add</button>
+    )
+    const ConnectedAddButton = withMutate(mutationCreator, { name: 'addTodo' })(
+      AddButton
+    )
 
     const wrapper = shallow(<ConnectedAddButton />, {
       context: { client }

--- a/packages/cozy-client/src/__tests__/withMutation.spec.jsx
+++ b/packages/cozy-client/src/__tests__/withMutation.spec.jsx
@@ -4,9 +4,9 @@ import { shallow } from 'enzyme'
 import CozyStackLink from 'cozy-stack-link'
 
 import CozyClient from '../CozyClient'
-import withMutate from '../withMutate'
+import withMutation from '../withMutation'
 
-describe('withMutate', () => {
+describe('withMutation', () => {
   const link = new CozyStackLink()
   const client = new CozyClient({ link })
 
@@ -26,7 +26,7 @@ describe('withMutate', () => {
     const AddButton = ({ mutate }) => (
       <button onClick={() => mutate(NEW_TODO)}>Add</button>
     )
-    const ConnectedAddButton = withMutate(mutationCreator)(AddButton)
+    const ConnectedAddButton = withMutation(mutationCreator)(AddButton)
 
     const wrapper = shallow(<ConnectedAddButton />, {
       context: { client }
@@ -43,9 +43,9 @@ describe('withMutate', () => {
     const AddButton = ({ addTodo }) => (
       <button onClick={() => addTodo(NEW_TODO)}>Add</button>
     )
-    const ConnectedAddButton = withMutate(mutationCreator, { name: 'addTodo' })(
-      AddButton
-    )
+    const ConnectedAddButton = withMutation(mutationCreator, {
+      name: 'addTodo'
+    })(AddButton)
 
     const wrapper = shallow(<ConnectedAddButton />, {
       context: { client }

--- a/packages/cozy-client/src/connect.jsx
+++ b/packages/cozy-client/src/connect.jsx
@@ -12,7 +12,7 @@ const connect = (query, options = {}) => WrappedComponent => {
     WrappedComponent
   )
 
-  return class Wrapper extends Component {
+  class Wrapper extends Component {
     componentWillMount() {
       const { client } = this.context
       this.queryId = options.as || client.generateId()
@@ -25,6 +25,11 @@ const connect = (query, options = {}) => WrappedComponent => {
       )
     }
   }
+
+  Wrapper.displayName = `CozyConnect(${WrappedComponent.displayName ||
+    WrappedComponent.name ||
+    'Component'})`
+  return Wrapper
 }
 
 export default connect

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -1,6 +1,6 @@
 export { default } from './CozyClient'
 export { default as CozyProvider } from './Provider'
 export { default as connect } from './connect'
-export { default as withMutate } from './withMutate'
+export { default as withMutation } from './withMutation'
 export { all, find } from './Query'
 export { create, update, destroy } from './Mutation'

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -1,4 +1,5 @@
-export { default as Provider } from './Provider'
-export { default as CozyClient } from './CozyClient'
+export { default } from './CozyClient'
+export { default as CozyProvider } from './Provider'
 export { default as connect } from './connect'
 export { all, find } from './Query'
+export { create, update, destroy } from './Mutation'

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -1,5 +1,6 @@
 export { default } from './CozyClient'
 export { default as CozyProvider } from './Provider'
 export { default as connect } from './connect'
+export { default as withMutate } from './withMutate'
 export { all, find } from './Query'
 export { create, update, destroy } from './Mutation'

--- a/packages/cozy-client/src/store/documents.js
+++ b/packages/cozy-client/src/store/documents.js
@@ -1,10 +1,14 @@
 import { isReceivingData } from './queries'
+import { isReceivingMutationResult } from './mutations'
 
+// reducer
 const documents = (state = {}, action) => {
-  if (!isReceivingData(action)) return state
+  if (!isReceivingData(action) && !isReceivingMutationResult(action)) {
+    return state
+  }
 
   const { data } = action.response
-  if (data.length === 0) return state
+  if (!data || data.length === 0) return state
   const doctype = data[0]._type
 
   return {
@@ -18,7 +22,6 @@ const documents = (state = {}, action) => {
 
 export default documents
 
-export const getDocumentFromStore = (state, doctype, id) =>
-  state.cozy.documents[doctype]
-    ? state.cozy.documents[doctype][id] || null
-    : null
+// selector
+export const getDocumentFromSlice = (state = {}, doctype, id) =>
+  state[doctype] ? state[doctype][id] || null : null

--- a/packages/cozy-client/src/store/index.js
+++ b/packages/cozy-client/src/store/index.js
@@ -1,17 +1,33 @@
-import { combineReducers } from 'redux'
+import { createStore as createReduxStore } from 'redux'
 
-import documents from './documents'
-import queries from './queries'
+import documents, { getDocumentFromSlice } from './documents'
+import queries, { getQueryFromSlice, isQueryAction } from './queries'
+import { isMutationAction } from './mutations'
 
-export default combineReducers({
-  documents,
-  queries
-})
+const combinedReducer = (state = { documents: {}, queries: {} }, action) => {
+  if (!isQueryAction(action) && !isMutationAction(action)) {
+    return state
+  }
+  return {
+    documents: documents(state.documents, action),
+    queries: queries(state.queries, action, state.documents)
+  }
+}
+export default combinedReducer
 
-export { getDocumentFromStore } from './documents'
+export const createStore = () =>
+  createReduxStore(combineReducers({ cozy: combinedReducer }))
+
+export const getDocumentFromStore = (state, doctype, id) =>
+  getDocumentFromSlice(state.cozy.documents, doctype, id)
+
+export const getQueryFromStore = (state, queryId) =>
+  getQueryFromSlice(state.cozy.queries, queryId, state.cozy.documents)
+
+export { initQuery, receiveQueryResult, receiveQueryError } from './queries'
+
 export {
-  getQueryFromStore,
-  initQuery,
-  receiveQueryResult,
-  receiveQueryError
-} from './queries'
+  initMutation,
+  receiveMutationResult,
+  receiveMutationError
+} from './mutations'

--- a/packages/cozy-client/src/store/index.js
+++ b/packages/cozy-client/src/store/index.js
@@ -1,4 +1,4 @@
-import { createStore as createReduxStore } from 'redux'
+import { createStore as createReduxStore, combineReducers } from 'redux'
 
 import documents, { getDocumentFromSlice } from './documents'
 import queries, { getQueryFromSlice, isQueryAction } from './queries'

--- a/packages/cozy-client/src/store/mutations.js
+++ b/packages/cozy-client/src/store/mutations.js
@@ -1,0 +1,30 @@
+const INIT_MUTATION = 'INIT_MUTATION'
+const RECEIVE_MUTATION_RESULT = 'RECEIVE_MUTATION_RESULT'
+const RECEIVE_MUTATION_ERROR = 'RECEIVE_MUTATION_ERROR'
+
+export const isMutationAction = action =>
+  [INIT_MUTATION, RECEIVE_MUTATION_RESULT, RECEIVE_MUTATION_ERROR].indexOf(
+    action.type
+  ) !== -1
+
+export const isReceivingMutationResult = action =>
+  action.type === RECEIVE_MUTATION_RESULT
+
+// actions
+export const initMutation = mutationId => ({
+  type: INIT_MUTATION,
+  mutationId
+})
+
+export const receiveMutationResult = (mutationId, response, options = {}) => ({
+  type: RECEIVE_MUTATION_RESULT,
+  mutationId,
+  response,
+  ...options
+})
+
+export const receiveMutationError = (mutationId, error) => ({
+  type: RECEIVE_MUTATION_ERROR,
+  mutationId,
+  error
+})

--- a/packages/cozy-client/src/withMutate.jsx
+++ b/packages/cozy-client/src/withMutate.jsx
@@ -7,7 +7,10 @@ const withMutate = (mutation, options = {}) => WrappedComponent => {
     }
 
     render() {
-      return <WrappedComponent mutate={this.mutate} {...this.props} />
+      const mutationProps = {
+        [options.name || 'mutate']: this.mutate
+      }
+      return <WrappedComponent {...mutationProps} {...this.props} />
     }
   }
 }

--- a/packages/cozy-client/src/withMutate.jsx
+++ b/packages/cozy-client/src/withMutate.jsx
@@ -1,0 +1,15 @@
+import React, { Component } from 'react'
+
+const withMutate = (mutation, options = {}) => WrappedComponent => {
+  return class Wrapper extends Component {
+    mutate = (...args) => {
+      return this.context.client.mutate(mutation.apply(null, args), options)
+    }
+
+    render() {
+      return <WrappedComponent mutate={this.mutate} {...this.props} />
+    }
+  }
+}
+
+export default withMutate

--- a/packages/cozy-client/src/withMutation.jsx
+++ b/packages/cozy-client/src/withMutation.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 
-const withMutate = (mutation, options = {}) => WrappedComponent => {
+const withMutation = (mutation, options = {}) => WrappedComponent => {
   return class Wrapper extends Component {
     mutate = (...args) => {
       return this.context.client.mutate(mutation.apply(null, args), options)
@@ -15,4 +15,4 @@ const withMutate = (mutation, options = {}) => WrappedComponent => {
   }
 }
 
-export default withMutate
+export default withMutation

--- a/packages/cozy-client/src/withMutation.jsx
+++ b/packages/cozy-client/src/withMutation.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 
 const withMutation = (mutation, options = {}) => WrappedComponent => {
-  return class Wrapper extends Component {
+  class Wrapper extends Component {
     mutate = (...args) => {
       return this.context.client.mutate(mutation.apply(null, args), options)
     }
@@ -13,6 +13,11 @@ const withMutation = (mutation, options = {}) => WrappedComponent => {
       return <WrappedComponent {...mutationProps} {...this.props} />
     }
   }
+
+  Wrapper.displayName = `WithMutation(${WrappedComponent.displayName ||
+    WrappedComponent.name ||
+    'Component'})`
+  return Wrapper
 }
 
 export default withMutation

--- a/packages/cozy-stack-link/package.json
+++ b/packages/cozy-stack-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-stack-link",
-  "version": "1.0.0",
+  "version": "1.0.0-beta.1",
   "license": "MIT",
   "main": "dist/cozy-stack-link.js"
 }

--- a/packages/cozy-stack-link/package.json
+++ b/packages/cozy-stack-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-stack-link",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.0",
   "license": "MIT",
   "main": "dist/cozy-stack-link.js"
 }

--- a/packages/cozy-stack-link/package.json
+++ b/packages/cozy-stack-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-stack-link",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "license": "MIT",
   "main": "dist/cozy-stack-link.js"
 }

--- a/packages/cozy-stack-link/package.json
+++ b/packages/cozy-stack-link/package.json
@@ -2,5 +2,9 @@
   "name": "cozy-stack-link",
   "version": "1.0.0-beta.1",
   "license": "MIT",
-  "main": "dist/cozy-stack-link.js"
+  "main": "dist/cozy-stack-link.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cozy/cozy-client.git"
+  }
 }

--- a/packages/cozy-stack-link/src/CozyStackLink.js
+++ b/packages/cozy-stack-link/src/CozyStackLink.js
@@ -24,6 +24,9 @@ export default class CozyStackLink {
    * @return {DocumentCollection}
    */
   collection(doctype) {
+    if (!doctype) {
+      throw new Error('CozyStackLink.collection() called without a doctype')
+    }
     return new DocumentCollection(doctype, this)
   }
 

--- a/packages/cozy-stack-link/src/CozyStackLink.js
+++ b/packages/cozy-stack-link/src/CozyStackLink.js
@@ -83,7 +83,7 @@ export default class CozyStackLink {
   }
 }
 
-class FetchError extends Error {
+export class FetchError extends Error {
   constructor(response, reason) {
     super()
     if (Error.captureStackTrace) {

--- a/packages/cozy-stack-link/src/DocumentCollection.js
+++ b/packages/cozy-stack-link/src/DocumentCollection.js
@@ -124,11 +124,18 @@ export default class DocumentCollection {
   }
 
   async destroy({ _id, _rev, ...document }) {
-    await this.link.fetch(
+    const resp = await this.link.fetch(
       'DELETE',
       uri`/data/${this.doctype}/${_id}?rev=${_rev}`
     )
-    return
+    return {
+      data: [
+        normalizeDoc(
+          { ...document, _id, _rev: resp.rev, _deleted: true },
+          this.doctype
+        )
+      ]
+    }
   }
 
   async getIndexId(fields) {

--- a/packages/cozy-stack-link/src/DocumentCollection.js
+++ b/packages/cozy-stack-link/src/DocumentCollection.js
@@ -66,13 +66,12 @@ export default class DocumentCollection {
    * @throws {FetchError}
    */
   async find(selector, options = {}) {
-    const indexId =
-      options.indexId ||
-      (await this.getIndexId(this.getIndexFields({ ...options, selector })))
+    const indexFields = this.getIndexFields({ ...options, selector })
+    const indexId = options.indexId || (await this.getIndexId(indexFields))
     const { fields, skip = 0, limit = FETCH_LIMIT } = options
     // Mango wants an array of single-property-objects...
     const sort = options.sort
-      ? index.fields.map(f => ({ [f]: options.sort[f] || 'desc' }))
+      ? indexFields.map(f => ({ [f]: options.sort[f] || 'desc' }))
       : undefined
 
     const mangoOptions = {

--- a/packages/cozy-stack-link/src/DocumentCollection.js
+++ b/packages/cozy-stack-link/src/DocumentCollection.js
@@ -102,6 +102,36 @@ export default class DocumentCollection {
     }
   }
 
+  async create({ _id, _type, ...document }) {
+    const resp = await this.link.fetch(
+      'POST',
+      uri`/data/${this.doctype}/`,
+      document
+    )
+    return {
+      data: [normalizeDoc(resp.data, this.doctype)]
+    }
+  }
+
+  async update(document) {
+    const resp = await this.link.fetch(
+      'PUT',
+      uri`/data/${this.doctype}/${document._id}`,
+      document
+    )
+    return {
+      data: [normalizeDoc(resp.data, this.doctype)]
+    }
+  }
+
+  async destroy({ _id, _rev, ...document }) {
+    await this.link.fetch(
+      'DELETE',
+      uri`/data/${this.doctype}/${_id}?rev=${_rev}`
+    )
+    return
+  }
+
   async getIndexId(fields) {
     const indexName = this.getIndexNameFromFields(fields)
     if (!this.indexes[indexName]) {

--- a/packages/cozy-stack-link/src/__tests__/CozyStackLink.spec.js
+++ b/packages/cozy-stack-link/src/__tests__/CozyStackLink.spec.js
@@ -13,6 +13,14 @@ const FAKE_INIT_OPTIONS = {
 }
 
 describe('CozyStackLink', () => {
+  it('should normalize the provided uri', () => {
+    const link = new CozyStackLink({
+      uri: 'http://cozy.tools:8080//',
+      token: ''
+    })
+    expect(link.fullpath('/foo')).toBe('http://cozy.tools:8080/foo')
+  })
+
   describe('collection', () => {
     const link = new CozyStackLink(FAKE_INIT_OPTIONS)
 
@@ -20,6 +28,10 @@ describe('CozyStackLink', () => {
       expect(link.collection('io.cozy.todos')).toBeInstanceOf(
         DocumentCollection
       )
+    })
+
+    it('should throw if the doctype is undefined', () => {
+      expect(() => link.collection()).toThrow()
     })
   })
 
@@ -48,6 +60,49 @@ describe('CozyStackLink', () => {
       )
     })
 
+    it('should stringify a JSON payload', async () => {
+      const resp = await link.fetch('POST', '/data/io.cozy.todos', {
+        label: 'Buy bread'
+      })
+      expect(fetch).toHaveBeenCalledWith(
+        'http://cozy.tools:8080/data/io.cozy.todos',
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            Accept: 'application/json',
+            Authorization: 'Bearer aAbBcCdDeEfFgGhH',
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            label: 'Buy bread'
+          })
+        }
+      )
+    })
+
+    it('should not transform the payload if a Content-Type header has been set', async () => {
+      const body = 'foo=bar'
+      const resp = await link.fetch('POST', '/data/io.cozy.todos/foo', body, {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        }
+      })
+      expect(fetch).toHaveBeenCalledWith(
+        'http://cozy.tools:8080/data/io.cozy.todos/foo',
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            Accept: 'application/json',
+            Authorization: 'Bearer aAbBcCdDeEfFgGhH',
+            'Content-Type': 'application/x-www-form-urlencoded'
+          },
+          body
+        }
+      )
+    })
+
     it('should return JSON', async () => {
       const resp = await link.fetch('GET', '/data/io.cozy.todos')
       expect(resp).toEqual(FAKE_RESPONSE)
@@ -64,5 +119,22 @@ describe('CozyStackLink', () => {
         expect(e.message).toMatch(/Not/)
       }
     })
+  })
+})
+
+describe('FetchError', () => {
+  it('should have HTTP info about the error', () => {
+    const error = new FetchError(
+      {
+        url: 'http://cozy.tools:8080/data/io.cozy.todos',
+        status: 400
+      },
+      'Bad request'
+    )
+    expect(error).toHaveProperty('status', 400)
+    expect(error).toHaveProperty(
+      'url',
+      'http://cozy.tools:8080/data/io.cozy.todos'
+    )
   })
 })

--- a/packages/cozy-stack-link/src/__tests__/DocumentCollection.spec.js
+++ b/packages/cozy-stack-link/src/__tests__/DocumentCollection.spec.js
@@ -328,9 +328,9 @@ describe('DocumentCollection', () => {
       )
     })
 
-    it('should return nothing', async () => {
+    it('should return a normalized document', async () => {
       const resp = await collection.destroy(TODO_TO_DESTROY)
-      expect(resp).toBeUndefined()
+      expect(resp.data[0]).toHaveDocumentIdentity()
     })
   })
 })

--- a/packages/cozy-stack-link/src/__tests__/DocumentCollection.spec.js
+++ b/packages/cozy-stack-link/src/__tests__/DocumentCollection.spec.js
@@ -27,6 +27,54 @@ const FIND_RESPONSE_FIXTURE = {
   next: false
 }
 
+const NEW_TODO = {
+  label: 'Jettison boosters',
+  done: false
+}
+const CREATE_RESPONSE_FIXTURE = {
+  id: '12345',
+  ok: true,
+  type: 'io.cozy.todos',
+  rev: '1-67890',
+  data: {
+    _id: '12345',
+    _type: 'io.cozy.todos',
+    _rev: '1-67890',
+    ...NEW_TODO
+  }
+}
+
+const TODO_TO_UPDATE = {
+  _id: '12345',
+  _type: 'io.cozy.todos',
+  _rev: '1-67890',
+  label: 'Jettison boosters',
+  done: false
+}
+const UPDATE_RESPONSE_FIXTURE = {
+  id: '12345',
+  ok: true,
+  type: 'io.cozy.todos',
+  rev: '2-67890',
+  data: {
+    _rev: '2-67890',
+    ...TODO_TO_UPDATE
+  }
+}
+
+const TODO_TO_DESTROY = {
+  _id: '12345',
+  _type: 'io.cozy.todos',
+  _rev: '1-67890'
+}
+const DESTROY_RESPONSE_FIXTURE = {
+  id: '12345',
+  type: 'io.cozy.todos',
+  ok: true,
+  rev: '2-12345',
+  _deleted: true
+}
+
 const fail = msg => ({ message: () => msg, pass: false })
 
 expect.extend({
@@ -182,6 +230,65 @@ describe('DocumentCollection', () => {
     it('should return normalized documents', async () => {
       const resp = await collection.find({ done: false })
       expect(resp.data[0]).toHaveDocumentIdentity()
+    })
+  })
+
+  describe('create', () => {
+    beforeAll(() => {
+      link.fetch.mockReturnValue(Promise.resolve(CREATE_RESPONSE_FIXTURE))
+    })
+
+    it('should call the right route with the right payload', async () => {
+      const resp = await collection.create(NEW_TODO)
+      expect(link.fetch).toHaveBeenLastCalledWith(
+        'POST',
+        '/data/io.cozy.todos/',
+        NEW_TODO
+      )
+    })
+
+    it('should return normalized documents', async () => {
+      const resp = await collection.create(NEW_TODO)
+      expect(resp.data[0]).toHaveDocumentIdentity()
+    })
+  })
+
+  describe('update', () => {
+    beforeAll(() => {
+      link.fetch.mockReturnValue(Promise.resolve(UPDATE_RESPONSE_FIXTURE))
+    })
+
+    it('should call the right route with the right payload', async () => {
+      const resp = await collection.update(TODO_TO_UPDATE)
+      expect(link.fetch).toHaveBeenLastCalledWith(
+        'PUT',
+        `/data/io.cozy.todos/${TODO_TO_UPDATE._id}`,
+        TODO_TO_UPDATE
+      )
+    })
+
+    it('should return normalized documents', async () => {
+      const resp = await collection.update(TODO_TO_UPDATE)
+      expect(resp.data[0]).toHaveDocumentIdentity()
+    })
+  })
+
+  describe('destroy', () => {
+    beforeAll(() => {
+      link.fetch.mockReturnValue(Promise.resolve(DESTROY_RESPONSE_FIXTURE))
+    })
+
+    it('should call the right route with the right payload', async () => {
+      const resp = await collection.destroy(TODO_TO_DESTROY)
+      expect(link.fetch).toHaveBeenLastCalledWith(
+        'DELETE',
+        `/data/io.cozy.todos/${TODO_TO_DESTROY._id}?rev=${TODO_TO_DESTROY._rev}`
+      )
+    })
+
+    it('should return nothing', async () => {
+      const resp = await collection.destroy(TODO_TO_DESTROY)
+      expect(resp).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
Dans cette PR, j'introduis les mutations, c.a.d la MAJ de données. Je pense que le mieux est de commencer par lire la doc : https://github.com/goldoraf/cozy-client/blob/6ecce13921175d76b8913e30b5ed50935e7132e3/README.md#mutating-data

Ce système peut paraitre un peu compliqué d'un premier abord (surtout la partie `updateQueries`), mais il présente l'avantage d'être extrêmement flexible, ce qui est important, car toutes les mutations ne sont pas forcément du CRUD basique et, par conséquent, offrir la flexibilité de mettre à jour les queries manuellement est nécessaire. Cependant, pour les cas simples (comme ajouter un todo à une todolist), cela paraitrait vraiment trop compliqué. Aussi mon idée pour la suite (mais ce sera pour une autre PR bien entendu) serait d'enrichir les props injectées par `connect` en y ajoutant des mutations prédéfinies (`create`, `update`, `destroy`), incluant le `updateQueries` qui va bien pour ces cas génériques. Qu'en pensez-vous ?

