### PR TITLE
OAuth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ const client = new CozyClient({
 
 Before you can start making requests to the server, you will need to get a token. `cozy-client` will provide a URL to a page where the user is shown what data you want to access, and asking for his or her permission. After the user accepts these permissions, he or she is redirected to the `oauth.redirectURI` that you declared earlier. You will then have to give this redirected URL back to `cozy-client` as it contains a code, that will be exchanged for the token.
 
-Sounds, tricky, but most of it is taken care of for you. To get started, you call `client.oauthFlow` like this:
+Sounds, tricky, but most of it is taken care of for you. To get started, you call `client.startOAuthFlow` like this:
 
 ```js
 import CozyClient from 'cozy-client'
@@ -390,14 +390,14 @@ const client = new CozyClient({
   }
 })
 
-client.oauthFlow(openURL)
+client.startOAuthFlow(openURL)
 ```
 
 The `openURL` parameter is a callback. It will receive the URL to the page as a parameter, and it must return a Promise that resolves with the redirected URL. How exactly you do this depends on your environment — for a mobile app you may use a WebView, in a browser maybe a new tab… Here is an example that uses the browser's console and an experienced user:
 
 ```js
 const openURL = url => {
-  console.log('Please visit the following URL, accep the permissions and copy the URL you are redirected to, then come back here. you have 10 seconds.', url)
+  console.log('Please visit the following URL, accept the permissions and copy the URL you are redirected to, then come back here. you have 10 seconds.', url)
   return new Promise(resolve => {
     setTimeout(async () => {
       const returnUrl = prompt('Paste the new URL here.')
@@ -426,7 +426,7 @@ const client = new CozyClient({
   }
 })
 
-const {token, infos} = client.oauthFlow(openURL)
+const {token, infos} = client.startOAuthFlow(openURL)
 localStorage.setItem('token', token)
 localStorage.setItem('infos', JSON.stringify(infos))
 ```
@@ -449,7 +449,7 @@ const client = new CozyClient({
 });
 
 if (!storedToken) {
-  const {token, infos} = await client.oauthFlow(openURL)
+  const {token, infos} = await client.startOAuthFlow(openURL)
   localStorage.setItem('token', token)
   localStorage.setItem('infos', JSON.stringify(infos))
 }

--- a/README.md
+++ b/README.md
@@ -351,3 +351,106 @@ ReactDOM.render(
 )
 ```
 
+## Using the OAuth client
+
+`CozyClient` can also be used as an OAuth client. To get started, configure the OAuth informations when creating the client:
+
+```js
+import CozyClient from 'cozy-client'
+
+const client = new CozyClient({
+  uri: 'http://cozy.tools:8080',
+  scope: ['io.cozy.mydoctype'],
+  oauth: {
+    clientName: 'MyClient',
+    softwareID: 'MyAppId',
+    redirectURI: 'http://localhost'
+  }
+})
+```
+
+`scope` is an array of [permissions](https://github.com/cozy/cozy-stack/blob/master/docs/permissions.md) you require for your client, and `oauth` is a list of fields that identify your client for the user and the server. The complete list of field can be found [here](https://github.com/cozy/cozy-stack/blob/master/docs/permissions.md), although they should be camel-cased instead of snake-cased.
+
+### Obtaining a token
+
+Before you can start making requests to the server, you will need to get a token. `cozy-client` will provide a URL to a page where the user is shown what data you want to access, and asking for his or her permission. After the user accepts these permissions, he or she is redirected to the `oauth.redirectURI` that you declared earlier. You will then have to give this redirected URL back to `cozy-client` as it contains a code, that will be exchanged for the token.
+
+Sounds, tricky, but most of it is taken care of for you. To get started, you call `client.oauthFlow` like this:
+
+```js
+import CozyClient from 'cozy-client'
+
+const client = new CozyClient({
+  uri: 'http://cozy.tools:8080',
+  scope: ['io.cozy.mydoctype'],
+  oauth: {
+    clientName: 'MyClient',
+    softwareID: 'MyAppId',
+    redirectURI: 'http://localhost'
+  }
+})
+
+client.oauthFlow(openURL)
+```
+
+The `openURL` parameter is a callback. It will receive the URL to the page as a parameter, and it must return a Promise that resolves with the redirected URL. How exactly you do this depends on your environment — for a mobile app you may use a WebView, in a browser maybe a new tab… Here is an example that uses the browser's console and an experienced user:
+
+```js
+const openURL = url => {
+  console.log('Please visit the following URL, accep the permissions and copy the URL you are redirected to, then come back here. you have 10 seconds.', url)
+  return new Promise(resolve => {
+    setTimeout(async () => {
+      const returnUrl = prompt('Paste the new URL here.')
+      resolve(returnUrl)
+    }, 10000)
+  })
+}
+```
+
+And that's it! After the promise is resolved, `cozy-client` finishes the OAuth flow and you can start using it.
+
+### Restoring a client
+
+Of course you don't want to go through this whole process every time your app starts. In order to restore the client from a previous version, you need to give it a token and some extra information about itself. Both of these are returned by the `openURL` function, so you can store them wherever you see fit — in this example we'll use the `localStorag` API.
+
+```js
+import CozyClient from 'cozy-client'
+
+const client = new CozyClient({
+  uri: 'http://cozy.tools:8080',
+  scope: ['io.cozy.mydoctype'],
+  oauth: {
+    clientName: 'MyClient',
+    softwareID: 'MyAppId',
+    redirectURI: 'http://localhost'
+  }
+})
+
+const {token, infos} = client.oauthFlow(openURL)
+localStorage.setItem('token', token)
+localStorage.setItem('infos', JSON.stringify(infos))
+```
+
+Next time your app starts, you can pass these informations to the constructor. Here is a complete example of the OAuth client initilisation:
+
+```js
+const storedToken = localStorage.getItem('token') || null
+const storedInfos = JSON.parse(localStorage.getItem('infos')) || {
+  clientName: 'MyClient',
+  softwareID: 'MyAppId',
+  redirectURI: 'http://localhost'
+}
+
+const client = new CozyClient({
+  uri: 'http://cozy.tools:8080',
+  oauth: storedInfos,
+  token: storedToken,
+  scope: ['io.cozy.mydoctype']
+});
+
+if (!storedToken) {
+  const {token, infos} = await client.oauthFlow(openURL)
+  localStorage.setItem('token', token)
+  localStorage.setItem('infos', JSON.stringify(infos))
+}
+```

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -392,7 +392,7 @@ export default class CozyClient {
   /**
    * Performs a complete OAuth flow, including upating the internal token at the end.
    * @param   {function} openURLCallback Receives the URL to present to the user as a parameter, and should return a promise that resolves with the URL the user was redirected to after accepting the permissions.
-   * @returns {object}   Contains the fetched token and the client informations. These should be stored and used to restore the client.
+   * @returns {object}   Contains the fetched token and the client information. These should be stored and used to restore the client.
    */
   async startOAuthFlow(openURLCallback) {
     const client = this.getOrCreateStackClient()

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -394,7 +394,7 @@ export default class CozyClient {
    * @param   {function} openURLCallback Receives the URL to present to the user as a parameter, and should return a promise that resolves with the URL the user was redirected to after accepting the permissions.
    * @returns {object}   Contains the fetched token and the client informations. These should be stored and used to restore the client.
    */
-  async oauthFlow(openURLCallback) {
+  async startOAuthFlow(openURLCallback) {
     const client = this.getOrCreateStackClient()
     
     await client.register();

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -397,12 +397,12 @@ export default class CozyClient {
   async startOAuthFlow(openURLCallback) {
     const client = this.getOrCreateStackClient()
     
-    await client.register();
-    const state = client.generateStateCode()
-    const url = client.getAuthCodeURL(state, client.scope)
-    
+    await client.register()
+    const stateCode = client.generateStateCode()
+    const url = client.getAuthCodeURL(stateCode)
+
     const redirectedURL = await openURLCallback(url)
-    const code = client.getAccessCodeFromURL(redirectedURL, state)
+    const code = client.getAccessCodeFromURL(redirectedURL, stateCode)
     const token = await client.fetchAccessToken(code)
     
     client.setCredentials(token)

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -1,7 +1,7 @@
 import StackLink from './StackLink'
 import Association from './associations'
 import { QueryDefinition, Mutations } from './dsl'
-import CozyStackClient from 'cozy-stack-client'
+import CozyStackClient, { OAuthClient } from 'cozy-stack-client'
 import {
   default as reducer,
   createStore,
@@ -375,7 +375,7 @@ export default class CozyClient {
       associations
     }
   }
-
+  
   doctypeModelExists(doctype) {
     if (!this.schema) return false
     return (
@@ -387,6 +387,27 @@ export default class CozyClient {
 
   getDocumentFromStore(type, id) {
     return getDocumentFromStore(this.store.getState(), type, id)
+  }
+  
+  /**
+   * Performs a complete OAuth flow, including upating the internal token at the end.
+   * @param   {function} openURLCallback Receives the URL to present to the user as a parameter, and should return a promise that resolves with the URL the user was redirected to after accepting the permissions.
+   * @returns {object}   Contains the fetched token and the client informations. These should be stored and used to restore the client.
+   */
+  async oauthFlow(openURLCallback) {
+    const client = this.getOrCreateStackClient()
+    
+    await client.register();
+    const state = client.generateStateCode()
+    const url = client.getAuthCodeURL(state, client.scope)
+    
+    const redirectedURL = await openURLCallback(url)
+    const code = client.getAccessCodeFromURL(redirectedURL, state)
+    const token = await client.fetchAccessToken(code)
+    
+    client.setCredentials(token)
+    
+    return {token, infos: client.oauthOptions}
   }
 
   setStore(store) {
@@ -402,7 +423,7 @@ export default class CozyClient {
 
   getOrCreateStackClient() {
     if (!this.client) {
-      this.client = new CozyStackClient(this.options)
+      this.client = this.options.oauth ? new OAuthClient(this.options) : new CozyStackClient(this.options)
     }
     return this.client
   }

--- a/packages/cozy-client/src/CozyLink.js
+++ b/packages/cozy-client/src/CozyLink.js
@@ -20,6 +20,6 @@ const concat = (firstLink, nextLink) => {
     const nextForward = (op, res) => {
       return nextLink.request(op, res, forward)
     }
-    return firstLink.request(operation, result, nextForward) 
+    return firstLink.request(operation, result, nextForward)
   })
 }

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -1,18 +1,11 @@
-import {
-  MutationTypes,
-  CozyLink,
-  getDoctypeFromOperation
-} from 'cozy-client'
+import { MutationTypes, CozyLink, getDoctypeFromOperation } from 'cozy-client'
 import PouchDB from 'pouchdb'
 import PouchDBFind from 'pouchdb-find'
 import mapValues from 'lodash/mapValues'
 import fromPairs from 'lodash/fromPairs'
 import omit from 'lodash/omit'
 import toPairs from 'lodash/toPairs'
-import {
-  getIndexNameFromFields,
-  getIndexFields
-} from './mango'
+import { getIndexNameFromFields, getIndexFields } from './mango'
 
 PouchDB.plugin(PouchDBFind)
 
@@ -50,23 +43,26 @@ const pouchResToJSONAPI = (res, isArray, doctype) => {
     }
   } else {
     return {
-      data: ensureHasBothIds(res),
+      data: ensureHasBothIds(res)
     }
   }
 }
 
 const createPouches = doctypes => {
-  return fromPairs(doctypes.map(
-    doctype => [doctype, {
-      db: new PouchDB(doctype)
-    }]
-  ))
+  return fromPairs(
+    doctypes.map(doctype => [
+      doctype,
+      {
+        db: new PouchDB(doctype)
+      }
+    ])
+  )
 }
 
 const sanitized = doc => omit(doc, '_type')
 
 const parseMutationResult = (original, res) => {
-  return {...original, ...omit(res, 'ok')}
+  return { ...original, ...omit(res, 'ok') }
 }
 
 const doNothing = () => {}
@@ -99,15 +95,15 @@ export default class PouchLink extends CozyLink {
     }
   }
 
-  getAllDBs () {
+  getAllDBs() {
     return Object.values(this.pouches).map(x => x.db)
   }
 
-  resetAllDBs () {
+  resetAllDBs() {
     return Promise.all(this.getAllDBs().map(db => db.destroy()))
   }
 
-  getDBInfo (doctype) {
+  getDBInfo(doctype) {
     const dbInfo = this.pouches[doctype]
     if (!dbInfo) {
       throw new Error(`${doctype} not supported by cozy-pouch-link instance`)
@@ -115,11 +111,11 @@ export default class PouchLink extends CozyLink {
     return dbInfo
   }
 
-  getDB (doctype) {
+  getDB(doctype) {
     return this.getDBInfo(doctype).db
   }
 
-  syncOne (doctype) {
+  syncOne(doctype) {
     return new Promise(resolve => {
       const info = this.getDBInfo(doctype)
       if (info.syncing) {
@@ -155,12 +151,12 @@ export default class PouchLink extends CozyLink {
     return (client.uri + '/data/' + doctype).replace('//', `//${basicAuth}`)
   }
 
-  supportsOperation (operation) {
+  supportsOperation(operation) {
     const impactedDoctype = getDoctypeFromOperation(operation)
     return !!this.pouches[impactedDoctype]
   }
 
-  request(operation, result=null, forward=doNothing) {
+  request(operation, result = null, forward = doNothing) {
     if (!this.synced) {
       return forward(operation)
     }
@@ -177,7 +173,7 @@ export default class PouchLink extends CozyLink {
     }
   }
 
-  hasIndex (name) {
+  hasIndex(name) {
     return Boolean(this.indexes[name])
   }
 
@@ -233,16 +229,16 @@ export default class PouchLink extends CozyLink {
     switch (mutation.mutationType) {
       case MutationTypes.CREATE_DOCUMENT:
         pouchRes = await this.createDocument(mutation)
-      break
+        break
       case MutationTypes.UPDATE_DOCUMENT:
         pouchRes = await this.updateDocument(mutation)
-      break
+        break
       case MutationTypes.DELETE_DOCUMENT:
         pouchRes = await this.deleteDocument(mutation)
-      break
+        break
       case MutationTypes.ADD_REFERENCES_TO:
         pouchRes = await this.addReferencesTo(mutation)
-      break
+        break
       case MutationTypes.UPLOAD_FILE:
         return forward(mutation, result)
       default:
@@ -251,7 +247,7 @@ export default class PouchLink extends CozyLink {
     return pouchResToJSONAPI(pouchRes, false, getDoctypeFromOperation(mutation))
   }
 
-  createDocument (mutation) {
+  createDocument(mutation) {
     return this.dbMethod('post', mutation)
   }
 
@@ -263,7 +259,7 @@ export default class PouchLink extends CozyLink {
     return this.dbMethod('remove', mutation)
   }
 
-  async dbMethod (method, mutation) {
+  async dbMethod(method, mutation) {
     const doctype = getDoctypeFromOperation(mutation)
     const { document } = mutation
     const db = this.getDB(doctype)

--- a/packages/cozy-pouch-link/src/mango.js
+++ b/packages/cozy-pouch-link/src/mango.js
@@ -22,7 +22,7 @@ const getSortKeys = sort => {
  * @param  {Object} options - Mango query options
  * @return {Array} - Fields to index
  */
-const defaultSelector = { _id: {$gt: null}}
+const defaultSelector = { _id: { $gt: null } }
 export const getIndexFields = ({ selector = defaultSelector, sort = {} }) => {
   return Array.from(new Set([...Object.keys(selector), ...getSortKeys(sort)]))
 }

--- a/packages/cozy-stack-client/src/AccessToken.js
+++ b/packages/cozy-stack-client/src/AccessToken.js
@@ -1,30 +1,30 @@
 export default class AccessToken {
-  constructor (data) {
+  constructor(data) {
     if (typeof data === 'string') data = JSON.parse(data)
-    
+
     this.tokenType = data.token_type || data.tokenType
     this.accessToken = data.access_token || data.accessToken
     this.refreshToken = data.refresh_token || data.refreshToken
     this.scope = data.scope
   }
 
-  toAuthHeader () {
+  toAuthHeader() {
     return 'Bearer ' + this.accessToken
   }
 
-  toBasicAuth () {
+  toBasicAuth() {
     return `user:${this.accessToken}@`
   }
-  
-  toJSON () {
+
+  toJSON() {
     return {
       tokenType: this.tokenType,
       accessToken: this.accessToken,
       refreshToken: this.refreshToken,
-      scope: this.scope,
+      scope: this.scope
     }
   }
-  
+
   toString() {
     return JSON.stringify(this.toJSON())
   }

--- a/packages/cozy-stack-client/src/AccessToken.js
+++ b/packages/cozy-stack-client/src/AccessToken.js
@@ -1,0 +1,16 @@
+export default class AccessToken {
+  constructor ({ token_type, access_token, refresh_token, scope }) {
+    this.tokenType = token_type
+    this.accessToken = access_token
+    this.refreshToken = refresh_token
+    this.scope = scope
+  }
+
+  toAuthHeader () {
+    return 'Bearer ' + this.accessToken
+  }
+
+  toBasicAuth () {
+    return `user:${this.accessToken}@`
+  }
+}

--- a/packages/cozy-stack-client/src/AccessToken.js
+++ b/packages/cozy-stack-client/src/AccessToken.js
@@ -1,9 +1,11 @@
 export default class AccessToken {
-  constructor ({ token_type, access_token, refresh_token, scope }) {
-    this.tokenType = token_type
-    this.accessToken = access_token
-    this.refreshToken = refresh_token
-    this.scope = scope
+  constructor (data) {
+    if (typeof data === 'string') data = JSON.parse(data)
+    
+    this.tokenType = data.token_type || data.tokenType
+    this.accessToken = data.access_token || data.accessToken
+    this.refreshToken = data.refresh_token || data.refreshToken
+    this.scope = data.scope
   }
 
   toAuthHeader () {
@@ -12,5 +14,18 @@ export default class AccessToken {
 
   toBasicAuth () {
     return `user:${this.accessToken}@`
+  }
+  
+  toJSON () {
+    return {
+      tokenType: this.tokenType,
+      accessToken: this.accessToken,
+      refreshToken: this.refreshToken,
+      scope: this.scope,
+    }
+  }
+  
+  toString() {
+    return JSON.stringify(this.toJSON())
   }
 }

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -15,7 +15,7 @@ const normalizeUri = uri => {
 export default class CozyStackClient {
   constructor({ token, uri = '' }) {
     this.uri = normalizeUri(uri)
-    this.token = new AppToken(token)
+    this.setCredentials(token)
   }
 
   /**
@@ -85,6 +85,10 @@ export default class CozyStackClient {
 
   getCredentials() {
     return this.token
+  }
+  
+  setCredentials(token) {
+    this.token = token ? new AppToken(token) : null
   }
 }
 

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -61,9 +61,9 @@ export default class CozyStackClient {
       }
     }
 
-    const credentials = this.getCredentials()
+    const credentials = options.credentials || this.getCredentials()
     if (credentials) {
-      headers['Authorization'] = credentials.toAuthHeader()
+      headers['Authorization'] = credentials
       // the option credentials:include tells fetch to include the cookies in the
       // request even for cross-origin requests
       options.credentials = 'include'
@@ -84,7 +84,7 @@ export default class CozyStackClient {
   }
 
   getCredentials() {
-    return this.token
+    return this.token ? this.token.toAuthHeader() : null
   }
   
   setCredentials(token) {

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -85,7 +85,7 @@ export default class CozyStackClient {
 
   getCredentials() {
     if (!this.token) return null
-    return { client: null, token: this.token }
+    return this.token
   }
 }
 

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -63,7 +63,7 @@ export default class CozyStackClient {
 
     const credentials = this.getCredentials()
     if (credentials) {
-      headers['Authorization'] = credentials.token.toAuthHeader()
+      headers['Authorization'] = credentials.toAuthHeader()
       // the option credentials:include tells fetch to include the cookies in the
       // request even for cross-origin requests
       options.credentials = 'include'
@@ -84,7 +84,6 @@ export default class CozyStackClient {
   }
 
   getCredentials() {
-    if (!this.token) return null
     return this.token
   }
 }

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -86,7 +86,7 @@ export default class CozyStackClient {
   getCredentials() {
     return this.token ? this.token.toAuthHeader() : null
   }
-  
+
   setCredentials(token) {
     this.token = token ? new AppToken(token) : null
   }

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -1,0 +1,135 @@
+import CozyStackClient from './CozyStackClient'
+import AccessToken from './AccessToken'
+
+const defaultOAuthOptions = {
+  clientID: '',
+  clientName: 'a',
+  clientKind: '',
+  clientSecret: '',
+  clientURI: '',
+  registrationAccessToken: '',
+  redirectURI: 'http://localhost',
+  softwareID: 'a',
+  softwareVersion: '',
+  logoURI: '',
+  policyURI: '',
+  notificationPlatform: '',
+  notificationDeviceToken: '',
+}
+
+export default class OAuthClient extends CozyStackClient{
+  constructor({ oauthOptions, uri = '' }) {
+    super({token: null, uri})
+    this.oauthOptions = {...defaultOAuthOptions, ...oauthOptions}  
+  }
+  
+  isRegistered () {
+    return this.oauthOptions.clientID !== ''
+  }
+  
+  getRegisterOptions () {
+    return {
+      redirect_uris: [this.oauthOptions.redirectURI],
+      software_id: this.oauthOptions.softwareID,
+      software_version: this.oauthOptions.softwareVersion,
+      client_name: this.oauthOptions.clientName,
+      client_kind: this.oauthOptions.clientKind,
+      client_uri: this.oauthOptions.clientURI,
+      logo_uri: this.oauthOptions.logoURI,
+      policy_uri: this.oauthOptions.policyURI,
+      notification_platform: this.oauthOptions.notificationPlatform,
+      notification_device_token: this.oauthOptions.notificationDeviceToken
+    }
+  }
+  
+  async register() {
+    if (this.isRegistered()) throw new Error('Already registered')
+    
+    const data = await this.fetch('POST', '/auth/register', this.getRegisterOptions())
+    const { 
+      client_id: clientID, 
+      client_name: clientName, 
+      client_secret: clientSecret, 
+      registration_access_token: registrationAccessToken, 
+      software_id: softwareID } = data
+    
+    this.oauthOptions.clientID = clientID
+    this.oauthOptions.clientName = clientName
+    this.oauthOptions.clientSecret = clientSecret
+    this.oauthOptions.registrationAccessToken = registrationAccessToken
+    this.oauthOptions.softwareID = softwareID
+    
+    return this;
+  }
+  
+  generateStateCode() {
+    const STATE_SIZE = 16
+    const hasCrypto = typeof window !== 'undefined' &&
+                      typeof window.crypto !== 'undefined' &&
+                      typeof window.crypto.getRandomValues === 'function'
+    
+    let buffer
+    if (hasCrypto) {
+      buffer = new Uint8Array(STATE_SIZE)
+      window.crypto.getRandomValues(buffer)
+    }
+    else {
+      buffer = new Array(STATE_SIZE)
+      for (let i = 0; i < buffer.length; i++) {
+        buffer[i] = Math.floor((Math.random() * 255))
+      }
+    }
+    
+    return btoa(String.fromCharCode.apply(null, buffer))
+      .replace(/=+$/, '')
+      .replace(/\//g, '_')
+      .replace(/\+/g, '-')
+  }
+  
+  getAuthCodeURL(stateCode, scopes = []) {
+    if (!this.isRegistered()) throw new Error('Not registered')
+    
+    const query = new URLSearchParams({
+      client_id: this.oauthOptions.clientID,
+      redirect_uri: this.oauthOptions.redirectURI,
+      state: stateCode,
+      response_type: 'code',
+      scope: scopes.join(' ')
+    })
+    
+    return `${this.uri}/auth/authorize?${query.toString()}`
+  }
+  
+  getAccessCodeFromURL(pageURL, stateCode) {
+    if (!stateCode) throw new Error('Missing state code')
+    
+    const params = new URL(pageURL).searchParams
+    const urlStateCode = params.get('state')
+    const urlAccessCode = params.get('access_code')
+    
+    if (stateCode !== urlStateCode) throw new Error('Given state does not match url query state')
+    
+    return urlAccessCode
+  }
+  
+  async getAccessToken(accessCode) {
+    if (!this.isRegistered()) throw new Error('Not registered')
+    
+    const data = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: accessCode,
+      client_id: this.oauthOptions.clientID,
+      client_secret: this.oauthOptions.clientSecret,
+    })
+    
+    const result = await this.fetch('POST', '/auth/access_token', data, {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+    })
+    
+    return new AccessToken(result)
+  }
+  
+  setAccessToken(token) {
+    this.token = token
+  }
+}

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -1,7 +1,7 @@
 import CozyStackClient from './CozyStackClient'
 import AccessToken from './AccessToken'
 
-const defaultoAuthOptions = {
+const defaultOAuthOptions = {
   clientID: '',
   clientName: '',
   clientKind: '',
@@ -18,9 +18,9 @@ const defaultoAuthOptions = {
 }
 
 export default class OAuthClient extends CozyStackClient{
-  constructor({ oauth, uri = '' }) {
-    super({token: null, uri})
-    this.oAuthOptions = {...defaultoAuthOptions, ...oauth}  
+  constructor({ oauth, ...options }) {
+    super(options)
+    this.oAuthOptions = {...defaultOAuthOptions, ...oauth}  
   }
   
   isRegistered () {
@@ -53,7 +53,15 @@ export default class OAuthClient extends CozyStackClient{
     this.oAuthOptions.registrationAccessToken = data.registration_access_token
     this.oAuthOptions.softwareID = data.software_id
     
-    return this;
+    return this.oAuthOptions;
+  }
+  
+  unregister() {
+    if (!this.isRegistered()) throw new Error('Client not registered')
+    
+    return this.fetch('DELETE', `/auth/register/${this.oAuthOptions.clientID}`, null, {
+      credentials: 'Bearer ' + this.oAuthOptions.registrationAccessToken
+    })
   }
   
   generateStateCode() {

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -101,7 +101,18 @@ export default class OAuthClient extends CozyStackClient{
   async register() {
     if (this.isRegistered()) throw new Error('Client already registered')
     
-    const data = await this.fetch('POST', '/auth/register', this.snakeCaseOAuthData(this.oauthOptions))
+    const data = await this.fetch('POST', '/auth/register', this.snakeCaseOAuthData({
+      redirectURI: this.oauthOptions.redirectURI,
+      clientName: this.oauthOptions.clientName,
+      softwareID: this.oauthOptions.softwareID,
+      clientKind: this.oauthOptions.clientKind,
+      clientURI: this.oauthOptions.clientURI,
+      logoURI: this.oauthOptions.logoURI,
+      policyURI: this.oauthOptions.policyURI,
+      softwareVersion: this.oauthOptions.softwareVersion,
+      notificationPlatform: this.oauthOptions.notificationPlatform,
+      notificationDeviceToken: this.oauthOptions.notificationDeviceToken,
+    }))
     
     this.oauthOptions = this.camelCaseOAuthData(data)
     
@@ -113,7 +124,7 @@ export default class OAuthClient extends CozyStackClient{
    * @throws {NotRegisteredException} When the client doesn't have it's registration information
    * @returns {promise}
    */
-  unregister() {
+  async unregister() {
     if (!this.isRegistered()) throw new NotRegisteredException()
     
     return this.fetch('DELETE', `/auth/register/${this.oauthOptions.clientID}`, null, {
@@ -126,7 +137,7 @@ export default class OAuthClient extends CozyStackClient{
    * @throws {NotRegisteredException} When the client doesn't have it's registration information
    * @returns {promise} 
    */
-  fetchInformations(){
+  async fetchInformations(){
     if (!this.isRegistered()) throw new NotRegisteredException()
     
     return this.fetch('GET', `/auth/register/${this.oauthOptions.clientID}`, null, {
@@ -237,7 +248,7 @@ export default class OAuthClient extends CozyStackClient{
    * @param   {string} accessCode The access code contained in the redirection URL — sett `client.getAccessCodeFromURL()`
    * @returns {Promise} A promise that resolves with an AccessToken object.
    */
-  aysnc fetchAccessToken(accessCode) {
+  async fetchAccessToken(accessCode) {
     if (!this.isRegistered()) throw new NotRegisteredException()
     
     const data = new URLSearchParams({

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -102,7 +102,7 @@ export default class OAuthClient extends CozyStackClient{
     })
   }
   
-  async updateInformations(informations) {
+  async updateInformations(informations, resetSecret = false) {
     const mandatoryFields = {
       clientID: this.oAuthOptions.clientID,
       clientName: this.oAuthOptions.clientName,
@@ -110,6 +110,8 @@ export default class OAuthClient extends CozyStackClient{
       softwareID: this.oAuthOptions.softwareID,
     }
     const data = this.oauthDataToJSON({...mandatoryFields, ...informations})
+    
+    if (resetSecret) data['cleint_secret'] = this.oAuthOptions.clientSecret
     
     const result = await this.fetch('PUT', `/auth/register/${this.oAuthOptions.clientID}`, data, {
       credentials: 'Bearer ' + this.oAuthOptions.registrationAccessToken

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -347,25 +347,6 @@ export default class OAuthClient extends CozyStackClient {
   registrationAccessTokenToAuthHeader() {
     return 'Bearer ' + this.oauthOptions.registrationAccessToken
   }
-  
-  /**
-   * Performs a complete OAuth flow, including upating the internal token at the end.
-   * @param   {function} openURLCallback Receives the URL to present to the user as a parameter, and should return a promise that resolves with the URL the user was redirected to after accepting the permissions.
-   * @returns {object} Contains the fetched token and the client informations. These should be stored and used to restore the client.
-   */
-  async oauthFlow(openURLCallback) {
-    await this.register();
-    const state = this.generateStateCode()
-    const url = this.getAuthCodeURL(state, this.scope)
-    
-    const redirectedURL = await openURLCallback(url)
-    const code = this.getAccessCodeFromURL(redirectedURL, state)
-    const token = await this.fetchAccessToken(code)
-    
-    this.setCredentials(token)
-    
-    return {token, infos: this.oauthOptions}
-  }
 }
 
 class NotRegisteredException extends Error {

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -189,6 +189,24 @@ export default class OAuthClient extends CozyStackClient{
     return new AccessToken(result)
   }
   
+  async refreshToken() {
+    if (!this.isRegistered()) throw new Error('Not registered')
+    if (!this.token) throw new Error('No token')
+    
+    const data = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: this.token.refreshToken,
+      client_id: this.oAuthOptions.clientID,
+      client_secret: this.oAuthOptions.clientSecret,
+    })
+    
+    const result = await this.fetch('POST', '/auth/access_token', data, {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+    })
+    
+    return new AccessToken({refresh_token: this.token.refreshToken, ...result})
+  }
+  
   setCredentials(token = null) {
     if (token) {
       this.token = (token instanceof AccessToken) ? token : new AccessToken(token)

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -17,28 +17,28 @@ const defaultoauthOptions = {
   notificationDeviceToken: ''
 }
 
-export default class OAuthClient extends CozyStackClient{
+export default class OAuthClient extends CozyStackClient {
   constructor({ oauth, ...options }) {
     super(options)
-    this.oauthOptions = {...defaultoauthOptions, ...oauth}
+    this.oauthOptions = { ...defaultoauthOptions, ...oauth }
   }
-  
+
   /**
    * Checks if the client has his registration informations from the server
-   * @returns {boolean} 
+   * @returns {boolean}
    * @private
    */
-  isRegistered () {
+  isRegistered() {
     return this.oauthOptions.clientID !== ''
   }
-  
+
   /**
-   * Converts a camel-cased data set to snake case, suitable for sending to the OAuth server 
+   * Converts a camel-cased data set to snake case, suitable for sending to the OAuth server
    * @param   {object} data Initial data
    * @returns {object} Formatted data
    * @private
    */
-  snakeCaseOAuthData (data) {
+  snakeCaseOAuthData(data) {
     const mappedFields = {
       softwareID: 'software_id',
       softwareVersion: 'software_version',
@@ -52,21 +52,25 @@ export default class OAuthClient extends CozyStackClient{
       notificationDeviceToken: 'notification_device_token',
       redirectURI: 'redirect_uris'
     }
-    
+
     const result = {}
-    
+
     Object.keys(data).forEach(fieldName => {
       const key = mappedFields[fieldName] || fieldName
       const value = data[fieldName]
       result[key] = value
     })
-    
+
     // special case: turn redirect_uris into an array
-    if (result['redirect_uris'] && result['redirect_uris'] instanceof Array === false) result['redirect_uris'] = [result['redirect_uris']]
-    
+    if (
+      result['redirect_uris'] &&
+      result['redirect_uris'] instanceof Array === false
+    )
+      result['redirect_uris'] = [result['redirect_uris']]
+
     return result
   }
-  
+
   /**
    * Converts a snake-cased data set to camel case, suitable for internal use
    * @param   {object} data Initial data
@@ -79,20 +83,20 @@ export default class OAuthClient extends CozyStackClient{
       client_name: 'clientName',
       client_secret: 'clientSecret',
       registration_access_token: 'registrationAccessToken',
-      software_id: 'softwareID',
+      software_id: 'softwareID'
     }
-    
+
     const result = {}
-    
+
     Object.keys(data).forEach(fieldName => {
       const key = mappedFields[fieldName] || fieldName
       const value = data[fieldName]
       result[key] = value
     })
-    
+
     return result
   }
-  
+
   /**
    * Registers the currenly configured client with the OAuth server. THis function is async and returns a promise.
    * @throws {Error} When the client is already registered
@@ -100,25 +104,29 @@ export default class OAuthClient extends CozyStackClient{
    */
   async register() {
     if (this.isRegistered()) throw new Error('Client already registered')
-    
-    const data = await this.fetch('POST', '/auth/register', this.snakeCaseOAuthData({
-      redirectURI: this.oauthOptions.redirectURI,
-      clientName: this.oauthOptions.clientName,
-      softwareID: this.oauthOptions.softwareID,
-      clientKind: this.oauthOptions.clientKind,
-      clientURI: this.oauthOptions.clientURI,
-      logoURI: this.oauthOptions.logoURI,
-      policyURI: this.oauthOptions.policyURI,
-      softwareVersion: this.oauthOptions.softwareVersion,
-      notificationPlatform: this.oauthOptions.notificationPlatform,
-      notificationDeviceToken: this.oauthOptions.notificationDeviceToken,
-    }))
-    
+
+    const data = await this.fetch(
+      'POST',
+      '/auth/register',
+      this.snakeCaseOAuthData({
+        redirectURI: this.oauthOptions.redirectURI,
+        clientName: this.oauthOptions.clientName,
+        softwareID: this.oauthOptions.softwareID,
+        clientKind: this.oauthOptions.clientKind,
+        clientURI: this.oauthOptions.clientURI,
+        logoURI: this.oauthOptions.logoURI,
+        policyURI: this.oauthOptions.policyURI,
+        softwareVersion: this.oauthOptions.softwareVersion,
+        notificationPlatform: this.oauthOptions.notificationPlatform,
+        notificationDeviceToken: this.oauthOptions.notificationDeviceToken
+      })
+    )
+
     this.oauthOptions = this.camelCaseOAuthData(data)
-    
+
     return this.oauthOptions
   }
-  
+
   /**
    * Unregisters the currenly configured client with the OAuth server. THis function is async and returns a promise.
    * @throws {NotRegisteredException} When the client doesn't have it's registration information
@@ -126,82 +134,100 @@ export default class OAuthClient extends CozyStackClient{
    */
   async unregister() {
     if (!this.isRegistered()) throw new NotRegisteredException()
-    
-    return this.fetch('DELETE', `/auth/register/${this.oauthOptions.clientID}`, null, {
-      credentials: this.registrationAccessTokenToAuthHeader()
-    })
+
+    return this.fetch(
+      'DELETE',
+      `/auth/register/${this.oauthOptions.clientID}`,
+      null,
+      {
+        credentials: this.registrationAccessTokenToAuthHeader()
+      }
+    )
   }
-  
+
   /**
    * Fetches the complete set of client informations from the server after it has been registered.
    * @throws {NotRegisteredException} When the client doesn't have it's registration information
-   * @returns {promise} 
+   * @returns {promise}
    */
-  async fetchInformations(){
+  async fetchInformations() {
     if (!this.isRegistered()) throw new NotRegisteredException()
-    
-    return this.fetch('GET', `/auth/register/${this.oauthOptions.clientID}`, null, {
-      credentials: this.registrationAccessTokenToAuthHeader()
-    })
+
+    return this.fetch(
+      'GET',
+      `/auth/register/${this.oauthOptions.clientID}`,
+      null,
+      {
+        credentials: this.registrationAccessTokenToAuthHeader()
+      }
+    )
   }
-  
+
   /**
    * Updates the client own information. This method will update both the local information and the remote information on the OAuth server.
    * @throws {NotRegisteredException} When the client doesn't have it's registration information
-   * @param   {object} informations Set of informations to update. Note that some fields such as `clientID` can't be updated.       
+   * @param   {object} informations Set of informations to update. Note that some fields such as `clientID` can't be updated.
    * @param   {boolean} resetSecret = false Optionnal, whether to reset the client secret or not
    * @returns {object} A complete, updated list of client informations
    */
   async updateInformations(informations, resetSecret = false) {
     if (!this.isRegistered()) throw new NotRegisteredException()
-    
+
     const mandatoryFields = {
       clientID: this.oauthOptions.clientID,
       clientName: this.oauthOptions.clientName,
       redirectURI: this.oauthOptions.redirectURI,
-      softwareID: this.oauthOptions.softwareID,
+      softwareID: this.oauthOptions.softwareID
     }
-    const data = this.snakeCaseOAuthData({...mandatoryFields, ...informations})
-    
-    if (resetSecret) data['client_secret'] = this.oauthOptions.clientSecret
-    
-    const result = await this.fetch('PUT', `/auth/register/${this.oauthOptions.clientID}`, data, {
-      credentials: this.registrationAccessTokenToAuthHeader()
+    const data = this.snakeCaseOAuthData({
+      ...mandatoryFields,
+      ...informations
     })
-    
+
+    if (resetSecret) data['client_secret'] = this.oauthOptions.clientSecret
+
+    const result = await this.fetch(
+      'PUT',
+      `/auth/register/${this.oauthOptions.clientID}`,
+      data,
+      {
+        credentials: this.registrationAccessTokenToAuthHeader()
+      }
+    )
+
     this.oauthOptions = this.camelCaseOAuthData(result)
-    
+
     return this.oauthOptions
   }
-  
+
   /**
    * Generates a random state code to be used during the OAuth process
    * @returns {string}
    */
   generateStateCode() {
     const STATE_SIZE = 16
-    const hasCrypto = typeof window !== 'undefined' &&
-                      typeof window.crypto !== 'undefined' &&
-                      typeof window.crypto.getRandomValues === 'function'
-    
+    const hasCrypto =
+      typeof window !== 'undefined' &&
+      typeof window.crypto !== 'undefined' &&
+      typeof window.crypto.getRandomValues === 'function'
+
     let buffer
     if (hasCrypto) {
       buffer = new Uint8Array(STATE_SIZE)
       window.crypto.getRandomValues(buffer)
-    }
-    else {
+    } else {
       buffer = new Array(STATE_SIZE)
       for (let i = 0; i < buffer.length; i++) {
-        buffer[i] = Math.floor((Math.random() * 255))
+        buffer[i] = Math.floor(Math.random() * 255)
       }
     }
-    
+
     return btoa(String.fromCharCode.apply(null, buffer))
       .replace(/=+$/, '')
       .replace(/\//g, '_')
       .replace(/\+/g, '-')
   }
-  
+
   /**
    * Generates the URL that the user should be sent to in order to accept the app's permissions.
    * @throws {NotRegisteredException} When the client doesn't have it's registration information
@@ -211,7 +237,7 @@ export default class OAuthClient extends CozyStackClient{
    */
   getAuthCodeURL(stateCode, scopes = []) {
     if (!this.isRegistered()) throw new NotRegisteredException()
-    
+
     const query = new URLSearchParams({
       client_id: this.oauthOptions.clientID,
       redirect_uri: this.oauthOptions.redirectURI,
@@ -219,29 +245,30 @@ export default class OAuthClient extends CozyStackClient{
       response_type: 'code',
       scope: scopes.join(' ')
     })
-    
+
     return `${this.uri}/auth/authorize?${query.toString()}`
   }
-  
+
   /**
    * Retrieves the access code contained in the URL to which the user is redirected after accepting the app's permissions (the `redirectURI`).
    * @throws {Error} The URL should contain the same state code as the one generated with `client.getAuthCodeURL()`. If not, it will throw an error
    * @param   {string} pageURL The redirected page URL, containing the state code and the access code
-   * @param   {string} stateCode The state code that was contained in the original URL the user was sent to (see `client.getAuthCodeURL()`) 
+   * @param   {string} stateCode The state code that was contained in the original URL the user was sent to (see `client.getAuthCodeURL()`)
    * @returns {string} The access code
    */
   getAccessCodeFromURL(pageURL, stateCode) {
     if (!stateCode) throw new Error('Missing state code')
-    
+
     const params = new URL(pageURL).searchParams
     const urlStateCode = params.get('state')
     const urlAccessCode = params.get('access_code')
-    
-    if (stateCode !== urlStateCode) throw new Error('Given state does not match url query state')
-    
+
+    if (stateCode !== urlStateCode)
+      throw new Error('Given state does not match url query state')
+
     return urlAccessCode
   }
-  
+
   /**
    * Exchanges an access code for an access token. This function does **not** update the client's token.
    * @throws {NotRegisteredException} When the client doesn't have it's registration information
@@ -250,21 +277,21 @@ export default class OAuthClient extends CozyStackClient{
    */
   async fetchAccessToken(accessCode) {
     if (!this.isRegistered()) throw new NotRegisteredException()
-    
+
     const data = new URLSearchParams({
       grant_type: 'authorization_code',
       code: accessCode,
       client_id: this.oauthOptions.clientID,
-      client_secret: this.oauthOptions.clientSecret,
+      client_secret: this.oauthOptions.clientSecret
     })
-    
+
     const result = await this.fetch('POST', '/auth/access_token', data, {
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
     })
-    
+
     return new AccessToken(result)
   }
-  
+
   /**
    * Retrieves a new access token by refreshing the currently used token.
    * @throws {NotRegisteredException} When the client doesn't have it's registration information
@@ -274,37 +301,39 @@ export default class OAuthClient extends CozyStackClient{
   async refreshToken() {
     if (!this.isRegistered()) throw new NotRegisteredException()
     if (!this.token) throw new Error('No token to refresh')
-    
+
     const data = new URLSearchParams({
       grant_type: 'refresh_token',
       refresh_token: this.token.refreshToken,
       client_id: this.oauthOptions.clientID,
-      client_secret: this.oauthOptions.clientSecret,
+      client_secret: this.oauthOptions.clientSecret
     })
-    
+
     const result = await this.fetch('POST', '/auth/access_token', data, {
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
     })
-    
-    return new AccessToken({refresh_token: this.token.refreshToken, ...result})
+
+    return new AccessToken({
+      refresh_token: this.token.refreshToken,
+      ...result
+    })
   }
-  
+
   /**
    * Updates the client's stored token
    * @param {string} token = null The new token to use — can be a string, a json object or an AccessToken instance.
    */
   setCredentials(token = null) {
     if (token) {
-      this.token = (token instanceof AccessToken) ? token : new AccessToken(token)
-    }
-    else {
+      this.token = token instanceof AccessToken ? token : new AccessToken(token)
+    } else {
       this.token = null
     }
   }
-  
+
   /**
    * Turns the client's registration access token into a header suitable for HTTP requests. Used in some queries to manipulate the client on the server side.
-   * @returns {string} 
+   * @returns {string}
    * @private
    */
   registrationAccessTokenToAuthHeader() {
@@ -312,10 +341,10 @@ export default class OAuthClient extends CozyStackClient{
   }
 }
 
-class NotRegisteredException extends Error{
-	constructor(message = 'Client not registered or missing OAuth informations') {
-		super(message);
-		this.message = message;
-		this.name = 'NotRegisteredException';
-	}
+class NotRegisteredException extends Error {
+  constructor(message = 'Client not registered or missing OAuth informations') {
+    super(message)
+    this.message = message
+    this.name = 'NotRegisteredException'
+  }
 }

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -25,7 +25,7 @@ export default class OAuthClient extends CozyStackClient {
   }
 
   /**
-   * Checks if the client has his registration informations from the server
+   * Checks if the client has his registration information from the server
    * @returns {boolean}
    * @private
    */
@@ -154,11 +154,11 @@ export default class OAuthClient extends CozyStackClient {
   }
 
   /**
-   * Fetches the complete set of client informations from the server after it has been registered.
+   * Fetches the complete set of client information from the server after it has been registered.
    * @throws {NotRegisteredException} When the client doesn't have it's registration information
    * @returns {promise}
    */
-  async fetchInformations() {
+  async fetchInformation() {
     if (!this.isRegistered()) throw new NotRegisteredException()
 
     return this.fetch(
@@ -174,11 +174,11 @@ export default class OAuthClient extends CozyStackClient {
   /**
    * Updates the client own information. This method will update both the local information and the remote information on the OAuth server.
    * @throws {NotRegisteredException} When the client doesn't have it's registration information
-   * @param   {object} informations Set of informations to update. Note that some fields such as `clientID` can't be updated.
+   * @param   {object} information Set of information to update. Note that some fields such as `clientID` can't be updated.
    * @param   {boolean} resetSecret = false Optionnal, whether to reset the client secret or not
-   * @returns {promise} A promise that resolves to a complete, updated list of client informations
+   * @returns {promise} A promise that resolves to a complete, updated list of client information
    */
-  async updateInformations(informations, resetSecret = false) {
+  async updateInformation(information, resetSecret = false) {
     if (!this.isRegistered()) throw new NotRegisteredException()
 
     const mandatoryFields = {
@@ -189,7 +189,7 @@ export default class OAuthClient extends CozyStackClient {
     }
     const data = this.snakeCaseOAuthData({
       ...mandatoryFields,
-      ...informations
+      ...information
     })
 
     if (resetSecret) data['client_secret'] = this.oauthOptions.clientSecret
@@ -350,7 +350,7 @@ export default class OAuthClient extends CozyStackClient {
 }
 
 class NotRegisteredException extends Error {
-  constructor(message = 'Client not registered or missing OAuth informations') {
+  constructor(message = 'Client not registered or missing OAuth information') {
     super(message)
     this.message = message
     this.name = 'NotRegisteredException'

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -98,7 +98,7 @@ export default class OAuthClient extends CozyStackClient {
   }
 
   /**
-   * Registers the currenly configured client with the OAuth server. THis function is async and returns a promise.
+   * Registers the currenly configured client with the OAuth server. 
    * @throws {Error} When the client is already registered
    * @returns {promise} A promise that resolves with a complete list of client information, including client ID and client secret.
    */
@@ -128,7 +128,7 @@ export default class OAuthClient extends CozyStackClient {
   }
 
   /**
-   * Unregisters the currenly configured client with the OAuth server. THis function is async and returns a promise.
+   * Unregisters the currenly configured client with the OAuth server. 
    * @throws {NotRegisteredException} When the client doesn't have it's registration information
    * @returns {promise}
    */
@@ -168,7 +168,7 @@ export default class OAuthClient extends CozyStackClient {
    * @throws {NotRegisteredException} When the client doesn't have it's registration information
    * @param   {object} informations Set of informations to update. Note that some fields such as `clientID` can't be updated.
    * @param   {boolean} resetSecret = false Optionnal, whether to reset the client secret or not
-   * @returns {object} A complete, updated list of client informations
+   * @returns {promise} A promise that resolves to a complete, updated list of client informations
    */
   async updateInformations(informations, resetSecret = false) {
     if (!this.isRegistered()) throw new NotRegisteredException()

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -331,7 +331,7 @@ export default class OAuthClient extends CozyStackClient {
    * Updates the client's stored token
    * @param {string} token = null The new token to use — can be a string, a json object or an AccessToken instance.
    */
-  setCredentials(token = null) {
+  setCredentials(token) {
     if (token) {
       this.token = token instanceof AccessToken ? token : new AccessToken(token)
     } else {

--- a/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
@@ -1,0 +1,171 @@
+import OAuthClient from '../OAuthClient'
+import AccessToken from '../AccessToken'
+
+const CLIENT_INIT_OPTIONS = {
+  uri: 'http://cozy.tools:8080',
+  oauth: {
+    clientName: 'TestClientName',
+    softwareID: 'TestSofwareID',
+    redirectURI: 'http://localhost'
+  }
+}
+
+const REGISTERED_CLIENT_INIT_OPTIONS = {
+  uri: CLIENT_INIT_OPTIONS.uri,
+  oauth: {
+    ...CLIENT_INIT_OPTIONS.oauth,
+    clientID: '1',
+    clientsecret: '1',
+    registrationAccessToken: '1234',
+  }
+}
+
+describe('OAuthClient', () => {  
+  beforeAll(() => {
+    global.fetch = require('jest-fetch-mock')
+  })
+  
+  beforeEach(() => {
+    fetch.resetMocks()
+  })
+  
+  let client
+  
+  describe('without registration', () => {
+    beforeEach(() => {
+      client = new OAuthClient(CLIENT_INIT_OPTIONS)
+    })
+    
+    it('should register a client', () => {
+      client.register()
+      expect(fetch.mock.calls[0]).toMatchSnapshot()
+    })
+    
+    it('should throw on other server interactions', () => {
+      expect(client.unregister()).rejects.toThrowErrorMatchingSnapshot()
+      expect(client.fetchInformations()).rejects.toThrowErrorMatchingSnapshot()
+      expect(client.updateInformations()).rejects.toThrowErrorMatchingSnapshot()
+      expect(client.fetchAccessToken()).rejects.toThrowErrorMatchingSnapshot()
+      expect(client.refreshToken()).rejects.toThrowErrorMatchingSnapshot()
+    })
+    
+    it('should not generate a auth code URL', () => {
+      expect(() => {
+        client.getAuthCodeURL('statecode')
+      }).toThrowErrorMatchingSnapshot()
+    })
+  })
+  
+  describe('with registration', () => {
+    beforeEach(() => {
+      client = new OAuthClient(REGISTERED_CLIENT_INIT_OPTIONS)
+      client.setCredentials({ 
+        tokenType: 'type', 
+        accessToken: 'abcd',
+        refreshToken: 'refresh-789',
+        scope: 'io.cozy.todos'
+      })
+    })
+    
+    it('should throw when trying to register again', () => {
+      expect(client.register()).rejects.toThrowErrorMatchingSnapshot()
+    })
+    
+    it('should unregister a client', () => {
+      client.unregister()
+      expect(fetch.mock.calls[0]).toMatchSnapshot()
+    })
+
+    it('should fetch client informations', () => {
+      client.fetchInformations()
+      expect(fetch.mock.calls[0]).toMatchSnapshot()
+    })
+
+    it('should update client informations', () => {
+      client.updateInformations({
+        policy_url: 'http://example.com'
+      })
+      expect(fetch.mock.calls[0]).toMatchSnapshot()
+    })
+
+    it('should generate a random state code', () => {
+      expect(client.generateStateCode()).toBeDefined()
+    })
+
+    it('should generate the auth code URL', () => {
+      expect(client.getAuthCodeURL('randomstatetoken', ['io.cozy.todos'])).toEqual(`${REGISTERED_CLIENT_INIT_OPTIONS.uri}/auth/authorize?client_id=${REGISTERED_CLIENT_INIT_OPTIONS.oauth.clientID}&redirect_uri=${encodeURIComponent(REGISTERED_CLIENT_INIT_OPTIONS.oauth.redirectURI)}&state=randomstatetoken&response_type=code&scope=io.cozy.todos`)
+    })
+
+    it('should get the access code from an URL', () => {
+      const stateCode = 'myrandomcode'
+      const accessCode = 'myaccesscode'
+      const url = `http://example.com?state=${stateCode}&access_code=${accessCode}`
+      expect(client.getAccessCodeFromURL(url, stateCode)).toEqual(accessCode)
+    })
+    
+    it('should throw when no access code is provided', () => {
+      expect(() => {
+        client.getAccessCodeFromURL('http://example.com')
+      }).toThrowErrorMatchingSnapshot()
+    })
+    
+    it('should throw when the provided access code is different from the URL', () => {
+      const stateCode = 'myrandomcode'
+      const accessCode = 'myaccesscode'
+      const url = `http://example.com?state=${stateCode}&access_code=${accessCode}`
+      
+      expect(() => {
+        client.getAccessCodeFromURL(url, 'incorrect')
+      }).toThrowErrorMatchingSnapshot()
+    })
+
+    it('should fetch an access token', () => {
+      client.fetchAccessToken('myaccesstoken')
+      expect(fetch.mock.calls[0]).toMatchSnapshot()
+    })
+
+    it('should refresh the access token', () => {
+      client.refreshToken()
+      expect(fetch.mock.calls[0]).toMatchSnapshot()
+    })
+    
+    it('should throw when refreshing the access token without token', () => {
+      client = new OAuthClient(REGISTERED_CLIENT_INIT_OPTIONS)
+      expect(client.refreshToken()).rejects.toThrowErrorMatchingSnapshot()
+    })
+    
+    it('should update the internal credentials', () => {
+      const camelCredentials = {
+        tokenType: 'Camel', 
+        accessToken: 'Cased',
+        refreshToken: 'refresh-me',
+        scope: 'io.cozy.todos'
+      }
+      const snakeCredentials = {
+        token_type: 'Snake', 
+        access_token: 'DoubleCased',
+        refresh_token: 'refresh-you',
+        scope: 'io.cozy.todos'
+      }
+      client.setCredentials(camelCredentials)
+      expect(client.token).toBeInstanceOf(AccessToken)
+      expect(client.token.tokenType).toEqual(camelCredentials.tokenType)
+      expect(client.token.accessToken).toEqual(camelCredentials.accessToken)
+      expect(client.token.refreshToken).toEqual(camelCredentials.refreshToken)
+      expect(client.token.scope).toEqual(camelCredentials.scope)
+      
+      client.setCredentials(JSON.stringify(snakeCredentials))
+      expect(client.token).toBeInstanceOf(AccessToken)
+      expect(client.token.tokenType).toEqual(snakeCredentials.token_type)
+      expect(client.token.accessToken).toEqual(snakeCredentials.access_token)
+      expect(client.token.refreshToken).toEqual(snakeCredentials.refresh_token)
+      expect(client.token.scope).toEqual(snakeCredentials.scope)
+    })
+    
+    it('should call getCredentials for usual requests', () => {
+      const spy = jest.spyOn(client, 'getCredentials')
+      client.fetch('GET', 'http://example.com')
+      expect(spy).toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
@@ -16,31 +16,31 @@ const REGISTERED_CLIENT_INIT_OPTIONS = {
     ...CLIENT_INIT_OPTIONS.oauth,
     clientID: '1',
     clientsecret: '1',
-    registrationAccessToken: '1234',
+    registrationAccessToken: '1234'
   }
 }
 
-describe('OAuthClient', () => {  
+describe('OAuthClient', () => {
   beforeAll(() => {
     global.fetch = require('jest-fetch-mock')
   })
-  
+
   beforeEach(() => {
     fetch.resetMocks()
   })
-  
+
   let client
-  
+
   describe('without registration', () => {
     beforeEach(() => {
       client = new OAuthClient(CLIENT_INIT_OPTIONS)
     })
-    
+
     it('should register a client', () => {
       client.register()
       expect(fetch.mock.calls[0]).toMatchSnapshot()
     })
-    
+
     it('should throw on other server interactions', () => {
       expect(client.unregister()).rejects.toThrowErrorMatchingSnapshot()
       expect(client.fetchInformations()).rejects.toThrowErrorMatchingSnapshot()
@@ -48,29 +48,29 @@ describe('OAuthClient', () => {
       expect(client.fetchAccessToken()).rejects.toThrowErrorMatchingSnapshot()
       expect(client.refreshToken()).rejects.toThrowErrorMatchingSnapshot()
     })
-    
+
     it('should not generate a auth code URL', () => {
       expect(() => {
         client.getAuthCodeURL('statecode')
       }).toThrowErrorMatchingSnapshot()
     })
   })
-  
+
   describe('with registration', () => {
     beforeEach(() => {
       client = new OAuthClient(REGISTERED_CLIENT_INIT_OPTIONS)
-      client.setCredentials({ 
-        tokenType: 'type', 
+      client.setCredentials({
+        tokenType: 'type',
         accessToken: 'abcd',
         refreshToken: 'refresh-789',
         scope: 'io.cozy.todos'
       })
     })
-    
+
     it('should throw when trying to register again', () => {
       expect(client.register()).rejects.toThrowErrorMatchingSnapshot()
     })
-    
+
     it('should unregister a client', () => {
       client.unregister()
       expect(fetch.mock.calls[0]).toMatchSnapshot()
@@ -93,7 +93,15 @@ describe('OAuthClient', () => {
     })
 
     it('should generate the auth code URL', () => {
-      expect(client.getAuthCodeURL('randomstatetoken', ['io.cozy.todos'])).toEqual(`${REGISTERED_CLIENT_INIT_OPTIONS.uri}/auth/authorize?client_id=${REGISTERED_CLIENT_INIT_OPTIONS.oauth.clientID}&redirect_uri=${encodeURIComponent(REGISTERED_CLIENT_INIT_OPTIONS.oauth.redirectURI)}&state=randomstatetoken&response_type=code&scope=io.cozy.todos`)
+      expect(
+        client.getAuthCodeURL('randomstatetoken', ['io.cozy.todos'])
+      ).toEqual(
+        `${REGISTERED_CLIENT_INIT_OPTIONS.uri}/auth/authorize?client_id=${
+          REGISTERED_CLIENT_INIT_OPTIONS.oauth.clientID
+        }&redirect_uri=${encodeURIComponent(
+          REGISTERED_CLIENT_INIT_OPTIONS.oauth.redirectURI
+        )}&state=randomstatetoken&response_type=code&scope=io.cozy.todos`
+      )
     })
 
     it('should get the access code from an URL', () => {
@@ -102,18 +110,18 @@ describe('OAuthClient', () => {
       const url = `http://example.com?state=${stateCode}&access_code=${accessCode}`
       expect(client.getAccessCodeFromURL(url, stateCode)).toEqual(accessCode)
     })
-    
+
     it('should throw when no access code is provided', () => {
       expect(() => {
         client.getAccessCodeFromURL('http://example.com')
       }).toThrowErrorMatchingSnapshot()
     })
-    
+
     it('should throw when the provided access code is different from the URL', () => {
       const stateCode = 'myrandomcode'
       const accessCode = 'myaccesscode'
       const url = `http://example.com?state=${stateCode}&access_code=${accessCode}`
-      
+
       expect(() => {
         client.getAccessCodeFromURL(url, 'incorrect')
       }).toThrowErrorMatchingSnapshot()
@@ -128,21 +136,21 @@ describe('OAuthClient', () => {
       client.refreshToken()
       expect(fetch.mock.calls[0]).toMatchSnapshot()
     })
-    
+
     it('should throw when refreshing the access token without token', () => {
       client = new OAuthClient(REGISTERED_CLIENT_INIT_OPTIONS)
       expect(client.refreshToken()).rejects.toThrowErrorMatchingSnapshot()
     })
-    
+
     it('should update the internal credentials', () => {
       const camelCredentials = {
-        tokenType: 'Camel', 
+        tokenType: 'Camel',
         accessToken: 'Cased',
         refreshToken: 'refresh-me',
         scope: 'io.cozy.todos'
       }
       const snakeCredentials = {
-        token_type: 'Snake', 
+        token_type: 'Snake',
         access_token: 'DoubleCased',
         refresh_token: 'refresh-you',
         scope: 'io.cozy.todos'
@@ -153,7 +161,7 @@ describe('OAuthClient', () => {
       expect(client.token.accessToken).toEqual(camelCredentials.accessToken)
       expect(client.token.refreshToken).toEqual(camelCredentials.refreshToken)
       expect(client.token.scope).toEqual(camelCredentials.scope)
-      
+
       client.setCredentials(JSON.stringify(snakeCredentials))
       expect(client.token).toBeInstanceOf(AccessToken)
       expect(client.token.tokenType).toEqual(snakeCredentials.token_type)
@@ -161,7 +169,7 @@ describe('OAuthClient', () => {
       expect(client.token.refreshToken).toEqual(snakeCredentials.refresh_token)
       expect(client.token.scope).toEqual(snakeCredentials.scope)
     })
-    
+
     it('should call getCredentials for usual requests', () => {
       const spy = jest.spyOn(client, 'getCredentials')
       client.fetch('GET', 'http://example.com')

--- a/packages/cozy-stack-client/src/__tests__/__snapshots__/OAuthClient.spec.js.snap
+++ b/packages/cozy-stack-client/src/__tests__/__snapshots__/OAuthClient.spec.js.snap
@@ -1,0 +1,159 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OAuthClient with registration should fetch an access token 1`] = `
+Array [
+  "http://cozy.tools:8080/auth/access_token",
+  Object {
+    "body": URLSearchParams {
+      Symbol(impl): URLSearchParamsImpl {
+        "_list": Array [
+          Array [
+            "grant_type",
+            "authorization_code",
+          ],
+          Array [
+            "code",
+            "myaccesstoken",
+          ],
+          Array [
+            "client_id",
+            "1",
+          ],
+          Array [
+            "client_secret",
+            "",
+          ],
+        ],
+        "_url": null,
+        Symbol(wrapper): [Circular],
+      },
+    },
+    "credentials": "include",
+    "headers": Object {
+      "Accept": "application/json",
+      "Authorization": "Bearer abcd",
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    "method": "POST",
+  },
+]
+`;
+
+exports[`OAuthClient with registration should fetch client informations 1`] = `
+Array [
+  "http://cozy.tools:8080/auth/register/1",
+  Object {
+    "credentials": "include",
+    "headers": Object {
+      "Accept": "application/json",
+      "Authorization": "Bearer 1234",
+    },
+    "method": "GET",
+  },
+]
+`;
+
+exports[`OAuthClient with registration should refresh the access token 1`] = `
+Array [
+  "http://cozy.tools:8080/auth/access_token",
+  Object {
+    "body": URLSearchParams {
+      Symbol(impl): URLSearchParamsImpl {
+        "_list": Array [
+          Array [
+            "grant_type",
+            "refresh_token",
+          ],
+          Array [
+            "refresh_token",
+            "refresh-789",
+          ],
+          Array [
+            "client_id",
+            "1",
+          ],
+          Array [
+            "client_secret",
+            "",
+          ],
+        ],
+        "_url": null,
+        Symbol(wrapper): [Circular],
+      },
+    },
+    "credentials": "include",
+    "headers": Object {
+      "Accept": "application/json",
+      "Authorization": "Bearer abcd",
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    "method": "POST",
+  },
+]
+`;
+
+exports[`OAuthClient with registration should throw when no access code is provided 1`] = `"Missing state code"`;
+
+exports[`OAuthClient with registration should throw when refreshing the access token without token 1`] = `"No token to refresh"`;
+
+exports[`OAuthClient with registration should throw when the provided access code is different from the URL 1`] = `"Given state does not match url query state"`;
+
+exports[`OAuthClient with registration should throw when trying to register again 1`] = `"Client already registered"`;
+
+exports[`OAuthClient with registration should unregister a client 1`] = `
+Array [
+  "http://cozy.tools:8080/auth/register/1",
+  Object {
+    "body": "null",
+    "credentials": "include",
+    "headers": Object {
+      "Accept": "application/json",
+      "Authorization": "Bearer 1234",
+      "Content-Type": "application/json",
+    },
+    "method": "DELETE",
+  },
+]
+`;
+
+exports[`OAuthClient with registration should update client informations 1`] = `
+Array [
+  "http://cozy.tools:8080/auth/register/1",
+  Object {
+    "body": "{\\"client_id\\":\\"1\\",\\"client_name\\":\\"TestClientName\\",\\"redirect_uris\\":[\\"http://localhost\\"],\\"software_id\\":\\"TestSofwareID\\",\\"policy_url\\":\\"http://example.com\\"}",
+    "credentials": "include",
+    "headers": Object {
+      "Accept": "application/json",
+      "Authorization": "Bearer 1234",
+      "Content-Type": "application/json",
+    },
+    "method": "PUT",
+  },
+]
+`;
+
+exports[`OAuthClient without registration should not generate a auth code URL 1`] = `"Client not registered or missing OAuth informations"`;
+
+exports[`OAuthClient without registration should register a client 1`] = `
+Array [
+  "http://cozy.tools:8080/auth/register",
+  Object {
+    "body": "{\\"redirect_uris\\":[\\"http://localhost\\"],\\"client_name\\":\\"TestClientName\\",\\"software_id\\":\\"TestSofwareID\\",\\"client_kind\\":\\"\\",\\"client_uri\\":\\"\\",\\"logo_uri\\":\\"\\",\\"policy_uri\\":\\"\\",\\"software_version\\":\\"\\",\\"notification_platform\\":\\"\\",\\"notification_device_token\\":\\"\\"}",
+    "headers": Object {
+      "Accept": "application/json",
+      "Content-Type": "application/json",
+    },
+    "method": "POST",
+  },
+]
+`;
+
+exports[`OAuthClient without registration should throw on other server interactions 1`] = `"Client not registered or missing OAuth informations"`;
+
+exports[`OAuthClient without registration should throw on other server interactions 2`] = `"Client not registered or missing OAuth informations"`;
+
+exports[`OAuthClient without registration should throw on other server interactions 3`] = `"Client not registered or missing OAuth informations"`;
+
+exports[`OAuthClient without registration should throw on other server interactions 4`] = `"Client not registered or missing OAuth informations"`;
+
+exports[`OAuthClient without registration should throw on other server interactions 5`] = `"Client not registered or missing OAuth informations"`;

--- a/packages/cozy-stack-client/src/index.js
+++ b/packages/cozy-stack-client/src/index.js
@@ -1,1 +1,2 @@
 export { default } from './CozyStackClient'
+export { default as OAuthClient } from './OAuthClient'


### PR DESCRIPTION
*Please ignore the changes right now, i just made them to get the PR started.*

The goal of this PR is to add OAuth support to Cozy Client. I'll base my work in large parts on the [cozy-client-js](https://github.com/cozy/cozy-client-js/blob/master/src/auth_v3.js) version, and we should get feature parity. Maybe.

I haven't written any code yet, but I'd like some feedback on the general plan.

### Public API

Here are the things I'd like to keep from the public API — maybe renaming a few things in the process, we'll see:

- `registerClient`: well, registers a new OAuth client with the stack. Sends general information like client name, type, etc. This is required for the rest of the OAuth flow anyway
- `getClient` : gets the registered information from the stack for a given client. To be confirmed, but I think it gets different info whether or not you provide a token.
- `updateClient` : not sure if it's actually used by any app, but allows to update the registered information
- `unregisterClient` : duh, opposite of register. Used when we're revoking a client

So essentially, CRUDing for clients.

Also, purely OAuth things:

- `getAuthCodeURL` : gets the page that you send the user to
- `getAccessToken` : exchange a code for an access token
- `refreshToken` : exchange a refresh token for an access token

These 3 functions are wrapped in the more abstracted function `client.authorize`, and we'll probably have something similar.

### Integration

[`CozyStackClient`](https://github.com/cozy/cozy-client/blob/master/packages/cozy-stack-client/src/CozyStackClient.js#L66) wants a token to make requests. So eventually, that's what we want to provide.

I think we'll allow a new `OAuth` constructor parameter, and then probably expose the functions listed above as methods — that way we can re-use some of the cozy-client-js code.

I still need to look into the Storage thing — `cozy-client-js` stored some information in a `localStorage` for re-use, I want to understand exactly why.

Let me know if this sounds sensible to you.

Looping in @goldoraf @ptbrowne @jinroh 