### PR TITLE
chore: don't lint before tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
 	],
 	"scripts": {
 		"lint": "eslint 'packages/*/src/**/*.js'",
-		"pretest": "npm run lint",
 		"test": "jest",
 		"watch": "npm-run-all --parallel watch:cozy-client watch:cozy-stack-client watch:cozy-pouch-link",
 		"watch:cozy-client": "webpack --config webpack.config.js --env.package=cozy-client --watch",


### PR DESCRIPTION
Just a suggestion, but I don't think we should lint files before running tests. 
I assume we all sometimes write some crap code while writing tests, and it's really annoying if the test don't even run because the temporary code has linting errors.