### PR TITLE
Add proptypes to query

### DIFF
--- a/packages/cozy-client/src/Query.jsx
+++ b/packages/cozy-client/src/Query.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { getQueryFromStore } from './store'
 import { QueryDefinition } from './dsl'
+import PropTypes from 'prop-types'
 
 const dummyState = {}
 
@@ -53,4 +54,10 @@ export default class Query extends Component {
       this.mutations
     )
   }
+}
+
+Query.propTypes = {
+  query: PropTypes.func.isRequired,
+  as: PropTypes.string,
+  children: PropTypes.func.isRequired
 }


### PR DESCRIPTION
Adding PropTypes helps to understand errors more quickly. IMHO it is essential for a library.