### PR TITLE
Support cozy-to-cozy files sharing

### DIFF
--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -1,6 +1,8 @@
 import AppToken from './AppToken'
 import DocumentCollection from './DocumentCollection'
 import FileCollection from './FileCollection'
+import SharingCollection from './SharingCollection'
+import PermissionCollection from './PermissionCollection'
 
 const normalizeUri = uri => {
   while (uri[uri.length - 1] === '/') {
@@ -31,6 +33,10 @@ export default class CozyStackClient {
     switch (doctype) {
       case 'io.cozy.files':
         return new FileCollection(doctype, this)
+      case 'io.cozy.sharings':
+        return new SharingCollection(doctype, this)
+      case 'io.cozy.permissions':
+        return new PermissionCollection(doctype, this)
       default:
         return new DocumentCollection(doctype, this)
     }

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -120,7 +120,6 @@ export default class DocumentCollection {
   }
 
   async destroy({ _id, _rev, ...document }) {
-    await this.revokeSharingLink({ _id, ...document })
     const resp = await this.client.fetch(
       'DELETE',
       uri`/data/${this.doctype}/${_id}?rev=${_rev}`
@@ -131,91 +130,6 @@ export default class DocumentCollection {
         this.doctype
       )
     }
-  }
-
-  async getSharingLink(document) {
-    // This shouldn't have happened, but unfortunately some duplicate sharing links have been created in the past
-    const perms = await this.getSharingLinks(document)
-    if (perms.length === 0) return null
-    const perm = perms[0]
-    if (
-      perm &&
-      perm.attributes &&
-      perm.attributes.codes &&
-      perm.attributes.codes.email
-    ) {
-      return await this.buildSharingLink(document, perm.attributes.codes.email)
-    }
-    return null
-  }
-
-  async buildSharingLink(document, sharecode) {
-    const appUrl = await this.getAppUrlForDoctype()
-    return `${appUrl}public?sharecode=${sharecode}&id=${document._id}`
-  }
-
-  async getAppUrlForDoctype() {
-    const apps = await this.getApps()
-    switch (this.doctype) {
-      case 'io.cozy.files':
-        return getAppUrl(apps, 'drive')
-      case 'io.cozy.photos.albums':
-        return getAppUrl(apps, 'photos')
-      default:
-        throw new Error(
-          `Sharing link: don't know which app to use for doctype ${
-            this.doctype
-          }`
-        )
-    }
-  }
-
-  async getApps() {
-    const resp = await this.client.fetch('GET', '/apps/')
-    return resp.data.map(a => ({ _id: a.id, ...a }))
-  }
-
-  async getSharingLinks(document) {
-    const byDoctype = await this.getAllSharingLinks()
-    const type = isFile(document) ? 'files' : 'collection'
-    return byDoctype.data.filter(
-      p =>
-        p.attributes &&
-        p.attributes.permissions &&
-        p.attributes.permissions[type] &&
-        p.attributes.permissions[type].values.indexOf(document._id) !== -1
-    )
-  }
-
-  getAllSharingLinks() {
-    return this.client.fetch(
-      'GET',
-      uri`/permissions/doctype/${this.doctype}/sharedByLink`
-    )
-  }
-
-  async createSharingLink(document) {
-    const resp = await this.client.fetch('POST', `/permissions?codes=email`, {
-      data: {
-        type: 'io.cozy.permissions',
-        attributes: {
-          permissions: getPermissionsFor(document, true)
-        }
-      }
-    })
-    return await this.buildSharingLink(
-      document,
-      resp.data.attributes.codes.email
-    )
-  }
-
-  async revokeSharingLink(document) {
-    // Because some duplicate links have been created in the past, we must ensure
-    // we revoke all of them
-    const perms = await this.getSharingLinks(document)
-    return Promise.all(
-      perms.map(p => this.client.fetch('DELETE', uri`/permissions/${p.id}`))
-    )
   }
 
   async toMangoOptions(selector, options = {}) {
@@ -297,45 +211,4 @@ export default class DocumentCollection {
   getIndexFields({ selector, sort = {} }) {
     return Array.from(new Set([...Object.keys(selector), ...Object.keys(sort)]))
   }
-}
-
-const isFile = ({ _type, type }) =>
-  _type === 'io.cozy.files' || type === 'directory' || type === 'file'
-
-const getPermissionsFor = (document, publicLink = false) => {
-  const { _id, _type } = document
-  const verbs = publicLink ? ['GET'] : ['ALL']
-  // TODO: this works for albums, but it needs to be generalized and integrated
-  // with cozy-client ; some sort of doctype "schema" will be needed here
-  return isFile(document)
-    ? {
-        files: {
-          type: 'io.cozy.files',
-          verbs,
-          values: [_id]
-        }
-      }
-    : {
-        collection: {
-          type: _type,
-          verbs,
-          values: [_id]
-        },
-        files: {
-          type: 'io.cozy.files',
-          verbs,
-          values: [`${_type}/${_id}`],
-          selector: 'referenced_by'
-        }
-      }
-}
-
-const getAppUrl = (apps, appName) => {
-  const app = apps.find(
-    a => a.attributes.slug === appName && a.attributes.state === 'ready'
-  )
-  if (!app) {
-    throw new Error(`Sharing link: app ${appName} not installed`)
-  }
-  return app.links.related
 }

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -19,6 +19,11 @@ const getFileTypeFromName = name => {
   else return null
 }
 
+export const isFile = ({ _type, type }) =>
+  _type === 'io.cozy.files' || type === 'directory' || type === 'file'
+
+export const isDirectory = ({ type }) => type === 'directory'
+
 /**
  * Abstracts a collection of files
  *
@@ -30,6 +35,10 @@ export default class FileCollection extends DocumentCollection {
   constructor(doctype, client) {
     super(doctype, client)
     this.specialDirectories = {}
+  }
+
+  get(id) {
+    return this.statById(id)
   }
 
   /**

--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -1,0 +1,86 @@
+import DocumentCollection, { normalizeDoc } from './DocumentCollection'
+import { isFile, isDirectory } from './FileCollection'
+import { uri } from './utils'
+
+const normalizePermission = perm => normalizeDoc(perm, 'io.cozy.permissions')
+
+export default class PermissionCollection extends DocumentCollection {
+  async get(id) {
+    const resp = await this.client.fetch('GET', uri`/permissions/${id}`)
+    return {
+      data: normalizePermission(resp.data)
+    }
+  }
+
+  async create({ _id, _type, ...attributes }) {
+    const resp = await this.client.fetch('POST', uri`/permissions/`, {
+      data: {
+        type: 'io.cozy.permissions',
+        attributes
+      }
+    })
+    return {
+      data: normalizePermission(resp.data)
+    }
+  }
+
+  destroy(permission) {
+    return this.client.fetch('DELETE', uri`/permissions/${permission.id}`)
+  }
+
+  async findLinksByDoctype(doctype) {
+    const resp = await this.client.fetch(
+      'GET',
+      uri`/permissions/doctype/${doctype}/shared-by-link`
+    )
+    return {
+      ...resp,
+      data: resp.data.map(normalizePermission)
+    }
+  }
+
+  async findApps() {
+    const resp = await this.client.fetch('GET', '/apps/')
+    return { ...resp, data: resp.data.map(a => ({ _id: a.id, ...a })) }
+  }
+
+  async createSharingLink(document) {
+    const resp = await this.client.fetch('POST', `/permissions?codes=email`, {
+      data: {
+        type: 'io.cozy.permissions',
+        attributes: {
+          permissions: getPermissionsFor(document, true)
+        }
+      }
+    })
+    return { data: normalizePermission(resp.data) }
+  }
+}
+
+const getPermissionsFor = (document, publicLink = false) => {
+  const { _id, _type } = document
+  const verbs = publicLink ? ['GET'] : ['ALL']
+  // TODO: this works for albums, but it needs to be generalized and integrated
+  // with cozy-client ; some sort of doctype "schema" will be needed here
+  return isFile(document)
+    ? {
+        files: {
+          type: 'io.cozy.files',
+          verbs,
+          values: [_id]
+        }
+      }
+    : {
+        collection: {
+          type: _type,
+          verbs,
+          values: [_id]
+        },
+        files: {
+          type: 'io.cozy.files',
+          verbs,
+          values: [`${_type}/${_id}`],
+          selector: 'referenced_by'
+        }
+      }
+}

--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -1,0 +1,96 @@
+import DocumentCollection, { normalizeDoc } from './DocumentCollection'
+import { isFile, isDirectory } from './FileCollection'
+import { uri } from './utils'
+
+const normalizeSharing = sharing => normalizeDoc(sharing, 'io.cozy.sharings')
+
+export default class SharingCollection extends DocumentCollection {
+  async findByDoctype(doctype) {
+    const resp = await this.client.fetch(
+      'GET',
+      uri`/sharings/doctype/${doctype}`
+    )
+    return {
+      ...resp,
+      data: resp.data.map(normalizeSharing)
+    }
+  }
+
+  async share(document, recipients, sharingType, description) {
+    const resp = await this.client.fetch('POST', '/sharings/', {
+      data: {
+        type: 'io.cozy.sharings',
+        attributes: {
+          description,
+          rules: getSharingRules(document, sharingType)
+        },
+        relationships: {
+          recipients: {
+            data: recipients.map(({ _id, _type }) => ({ id: _id, type: _type }))
+          }
+        }
+      }
+    })
+    return { data: normalizeSharing(resp.data) }
+  }
+
+  revokeRecipient(sharing, recipientEmail) {
+    const memberIndex = sharing.attributes.members.findIndex(
+      m => m.email === recipientEmail
+    )
+    return this.client.fetch(
+      'DELETE',
+      uri`/sharings/${sharing._id}/recipients/${memberIndex}`
+    )
+  }
+
+  revokeSelf(sharing) {
+    return this.client.fetch(
+      'DELETE',
+      uri`/sharings/${sharing._id}/recipients/self`
+    )
+  }
+}
+
+// Rules determine the behavior of the sharing when changes are made to the shared document
+// See https://github.com/cozy/cozy-stack/blob/master/docs/sharing-design.md#description-of-a-sharing
+const getSharingRules = (document, sharingType) => {
+  const { _id, _type } = document
+  return isFile(document)
+    ? [
+        {
+          title: document.name,
+          doctype: 'io.cozy.files',
+          values: [_id],
+          ...getSharingPolicy(document, sharingType)
+        }
+      ]
+    : [
+        {
+          title: 'collection',
+          doctype: _type,
+          values: [_id],
+          ...getSharingPolicy(document, sharingType)
+        },
+        {
+          title: 'items',
+          doctype: 'io.cozy.files',
+          values: [`${_type}/${_id}`],
+          selector: 'referenced_by',
+          ...(sharingType === 'two-way'
+            ? { add: 'sync', update: 'sync', remove: 'sync' }
+            : { add: 'push', update: 'none', remove: 'push' })
+        }
+      ]
+}
+
+const getSharingPolicy = (document, sharingType) => {
+  if (isFile(document) && isDirectory(document)) {
+    return sharingType === 'two-way'
+      ? { add: 'sync', update: 'sync', remove: 'sync' }
+      : { add: 'none', update: 'none', remove: 'revoke' }
+  }
+  return sharingType === 'two-way'
+    ? { update: 'sync', remove: 'sync' }
+    : { update: 'none', remove: 'revoke' }
+}

--- a/packages/cozy-stack-client/src/__tests__/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/SharingCollection.spec.js
@@ -1,0 +1,71 @@
+jest.mock('../CozyStackClient')
+
+import CozyStackClient from '../CozyStackClient'
+import SharingCollection from '../SharingCollection'
+
+const FOLDER = {
+  _type: 'io.cozy.files',
+  _id: 'folder_1',
+  type: 'directory',
+  name: 'bills'
+}
+
+const RECIPIENT = {
+  _type: 'io.cozy.contacts',
+  _id: 'contact_1',
+  attributes: {
+    email: [{ address: 'jdoe@doe.com', primary: true }]
+  }
+}
+
+describe('SharingCollection', () => {
+  const client = new CozyStackClient()
+  const collection = new SharingCollection('io.cozy.sharings', client)
+
+  describe('findByDoctype', () => {
+    beforeAll(() => {
+      client.fetch.mockReturnValue(Promise.resolve({ data: [] }))
+    })
+
+    it('should call the right route', async () => {
+      await collection.findByDoctype('io.cozy.files')
+      expect(client.fetch).toHaveBeenCalledWith(
+        'GET',
+        '/sharings/doctype/io.cozy.files'
+      )
+    })
+  })
+
+  describe('share', () => {
+    beforeAll(() => {
+      client.fetch.mockReset()
+      client.fetch.mockReturnValue(Promise.resolve({ data: [] }))
+    })
+
+    it('should call the right route with the right payload', async () => {
+      await collection.share(FOLDER, [RECIPIENT], 'one-way', 'foo')
+      expect(client.fetch).toHaveBeenCalledWith('POST', '/sharings/', {
+        data: {
+          attributes: {
+            description: 'foo',
+            rules: [
+              {
+                doctype: 'io.cozy.files',
+                title: 'bills',
+                update: 'none',
+                remove: 'revoke',
+                values: ['folder_1']
+              }
+            ]
+          },
+          relationships: {
+            recipients: {
+              data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
+            }
+          },
+          type: 'io.cozy.sharings'
+        }
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR aims to support basic sharing features in Cozy apps. As the backend implementation is not complete right now (only files are fully supported for instance), this work shouldn't be considered as complete: there is still work to do, but we'll have to wait for the API to stabilize.

Regarding the changes:
 - initially, I chose to put sharing by link code into the `DocumentCollection`, mainly because sharing by link uses some special kind of permissions documents. After discussing the matter with @y-lohse, we decided it was better to implement this in a specific `PermissionCollection`.
 - sharing documents are some kind of a special beast too, therefore they needed their own `SharingCollection`.
 - I added some tests, but clearly we need more.