### PR TITLE
Added lib to detect file mimetypes from the extension

### DIFF
--- a/packages/cozy-stack-client/package.json
+++ b/packages/cozy-stack-client/package.json
@@ -6,5 +6,8 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cozy/cozy-client.git"
+  },
+  "dependencies": {
+    "mimetype": "^0.0.8"
   }
 }

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -1,3 +1,4 @@
+import mimetype from 'mimetype'
 import DocumentCollection, {
   normalizeDoc,
   FETCH_LIMIT
@@ -16,7 +17,7 @@ const sanitizeFileName = name => name && name.trim()
 const getFileTypeFromName = name => {
   if (/\.heic$/i.test(name)) return 'image/heic'
   else if (/\.heif$/i.test(name)) return 'image/heif'
-  else return null
+  else return mimetype.lookup(name)
 }
 
 export const isFile = ({ _type, type }) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5356,6 +5356,10 @@ mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.7:
   dependencies:
     mime-db "~1.33.0"
 
+mimetype@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mimetype/-/mimetype-0.0.8.tgz#fb30022794bbf7725cb7b46df820e87dd91fd086"
+
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"


### PR DESCRIPTION
When trying to upload a directory in Firefox, there is a bug that prevents to get the directory files' mimetypes. Consequently, it's necessary to try to guess the mimetype from the extension so that files are not uploaded with a `application/octet-stream` mimetype. I chose to use a rather simple and light lib to do that.