### PR TITLE
Fix sharing policy

### DIFF
--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -88,9 +88,9 @@ const getSharingPolicy = (document, sharingType) => {
   if (isFile(document) && isDirectory(document)) {
     return sharingType === 'two-way'
       ? { add: 'sync', update: 'sync', remove: 'sync' }
-      : { add: 'none', update: 'none', remove: 'revoke' }
+      : { add: 'push', update: 'push', remove: 'push' }
   }
   return sharingType === 'two-way'
-    ? { update: 'sync', remove: 'sync' }
-    : { update: 'none', remove: 'revoke' }
+    ? { update: 'sync', remove: 'revoke' }
+    : { update: 'push', remove: 'revoke' }
 }

--- a/packages/cozy-stack-client/src/__tests__/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/SharingCollection.spec.js
@@ -52,8 +52,9 @@ describe('SharingCollection', () => {
               {
                 doctype: 'io.cozy.files',
                 title: 'bills',
-                update: 'none',
-                remove: 'revoke',
+                add: 'push',
+                update: 'push',
+                remove: 'push',
                 values: ['folder_1']
               }
             ]


### PR DESCRIPTION
An 'one-way' sharing should use 'push' rules for a folder, and a sharing
for a single item should be revoked when this item is deleted.