### PR TITLE
Add package name in package.json

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,24 @@
-[*.js]
-indent_size=2
+# editorconfig.org
+# editorconfig is a unified configuration file that all editors can take
+# into account
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.coffee]
+indent_size = 4
+
+[*.jade]
+trim_trailing_whitespace = false
+
+[*.pug]
+trim_trailing_whitespace = false
+
+[*.styl]
+indent_size = 4

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "cozy-client",
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-jest": "^22.1.0",

--- a/package.json
+++ b/package.json
@@ -1,47 +1,47 @@
 {
-	"devDependencies": {
-		"babel-core": "^6.26.0",
-		"babel-jest": "^22.1.0",
-		"babel-loader": "^7.1.3",
-		"babel-preset-cozy-app": "^0.8.0",
-		"babel-preset-react": "^6.24.1",
-		"enzyme": "^3.3.0",
-		"enzyme-adapter-react-16": "^1.1.1",
-		"eslint": "^4.16.0",
-		"eslint-config-cozy-app": "^0.8.0",
-		"eslint-loader": "^2.0.0",
-		"eslint-plugin-prettier": "^2.6.0",
-		"jest": "^22.1.4",
-		"jest-fetch-mock": "^1.4.1",
-		"lerna": "^2.8.0",
-		"prettier": "1.10.2",
-		"react": "^16.2.0",
-		"react-dom": "^16.2.0",
-		"redux-mock-store": "^1.5.1",
-		"webpack": "^4.0.1",
-		"webpack-cli": "^2.0.9"
-	},
-	"private": true,
-	"workspaces": [
-		"packages/*"
-	],
-	"scripts": {
-		"lint": "eslint 'packages/*/src/**/*.js'",
-		"test": "jest",
-		"watch": "lerna run watch",
-		"build": "lerna run build"
-	},
-	"prettier": {
-		"semi": false,
-		"singleQuote": true
-	},
-	"jest": {
-		"setupFiles": [
-			"<rootDir>/packages/cozy-client/src/__tests__/setup.js"
-		],
-		"setupTestFrameworkScriptFile": "<rootDir>/packages/cozy-stack-client/src/__tests__/setup.js",
-		"testMatch": [
-			"**/__tests__/**/(*.)(spec|test).js?(x)"
-		]
-	}
+  "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-jest": "^22.1.0",
+    "babel-loader": "^7.1.3",
+    "babel-preset-cozy-app": "^0.8.0",
+    "babel-preset-react": "^6.24.1",
+    "enzyme": "^3.3.0",
+    "enzyme-adapter-react-16": "^1.1.1",
+    "eslint": "^4.16.0",
+    "eslint-config-cozy-app": "^0.8.0",
+    "eslint-loader": "^2.0.0",
+    "eslint-plugin-prettier": "^2.6.0",
+    "jest": "^22.1.4",
+    "jest-fetch-mock": "^1.4.1",
+    "lerna": "^2.8.0",
+    "prettier": "1.10.2",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
+    "redux-mock-store": "^1.5.1",
+    "webpack": "^4.0.1",
+    "webpack-cli": "^2.0.9"
+  },
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "lint": "eslint 'packages/*/src/**/*.js'",
+    "test": "jest",
+    "watch": "lerna run watch",
+    "build": "lerna run build"
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true
+  },
+  "jest": {
+    "setupFiles": [
+      "<rootDir>/packages/cozy-client/src/__tests__/setup.js"
+    ],
+    "setupTestFrameworkScriptFile": "<rootDir>/packages/cozy-stack-client/src/__tests__/setup.js",
+    "testMatch": [
+      "**/__tests__/**/(*.)(spec|test).js?(x)"
+    ]
+  }
 }


### PR DESCRIPTION
This makes easier to `yarn link`

Also, package.json was indented with tabs, so this PR also:
* updates .editorconfig to match cozy-collect one
* replaces tabs with spaces in package.json