### PR TITLE
Add AppCollection

### DIFF
--- a/packages/cozy-stack-client/src/AppCollection.js
+++ b/packages/cozy-stack-client/src/AppCollection.js
@@ -1,0 +1,33 @@
+import { uri } from './utils'
+import { normalizeDoc } from './DocumentCollection'
+
+export const APP_DOCTYPE = 'io.cozy.apps'
+
+/**
+ * Abstracts a collection of documents of the same doctype, providing
+ * CRUD methods and other helpers.
+ */
+export default class AppCollection {
+  constructor(client) {
+    this.client = client
+  }
+
+  /**
+   * Lists all documents of the collection, without filters.
+   *
+   * The returned documents are not paginated by the stack.
+   *
+   * @return {{data, meta, skip, next}} The JSON API conformant response.
+   * @throws {FetchError}
+   */
+  async all() {
+    const path = uri`/apps/`
+    const resp = await this.client.fetch('GET', path)
+    return {
+      data: resp.rows.map(row => normalizeDoc(row.doc, APP_DOCTYPE)),
+      meta: { count: resp.total_rows },
+      skip: 0,
+      next: false
+    }
+  }
+}

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -1,3 +1,4 @@
+import AppCollection, { APP_DOCTYPE } from './AppCollection'
 import AppToken from './AppToken'
 import DocumentCollection from './DocumentCollection'
 import FileCollection from './FileCollection'
@@ -31,6 +32,8 @@ export default class CozyStackClient {
       throw new Error('CozyStackClient.collection() called without a doctype')
     }
     switch (doctype) {
+      case APP_DOCTYPE:
+        return new AppCollection(this)
       case 'io.cozy.files':
         return new FileCollection(doctype, this)
       case 'io.cozy.sharings':


### PR DESCRIPTION
As apps are retrieved with a specific endpoint, they need a custom implementation into an AppCollection class.

At this time, the only method needed is `all()`