### PR TITLE
fix: generate query string without URLSearchParams

### DIFF
--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -246,15 +246,17 @@ export default class OAuthClient extends CozyStackClient {
   getAuthCodeURL(stateCode, scopes = this.scope) {
     if (!this.isRegistered()) throw new NotRegisteredException()
 
-    const query = new URLSearchParams({
+    const query = {
       client_id: this.oauthOptions.clientID,
       redirect_uri: this.oauthOptions.redirectURI,
       state: stateCode,
       response_type: 'code',
       scope: scopes.join(' ')
-    })
+    }
 
-    return `${this.uri}/auth/authorize?${query.toString()}`
+    return `${this.uri}/auth/authorize?${Object.keys(query)
+      .map(param => `${param}=${encodeURIComponent(query[param])}`)
+      .join('&')}`
   }
 
   /**


### PR DESCRIPTION
I couldn't reproduce the initial problem so I don't have many details, but it appears `URLSearchParams.toString()` sometimes returns `[Object object]` — at least recently. Using a plain object seems to solve the problem.