### PR TITLE
chore: Auto release using travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,17 @@ cache:
   directories:
   - node_modules
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.7.0
-  - export PATH=$HOME/.yarn/bin:$PATH
-  - yarn --version
+- curl -o- -L https://yarnpkg.com/install.sh | bash -s
+- export PATH=$HOME/.yarn/bin:$PATH
+- echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 before_script:
-  - lerna run build
+- lerna run build
 script:
 - yarn lint
 - yarn test --runInBand
+after_success:
+- test $TRAVIS_BRANCH = "master" && test $TRAVIS_REPO_SLUG = "cozy/cozy-client" && $TRAVIS_TAG && !$TRAVIS_PULL_REQUEST &&
+  && lerna run publish --repo-version $TRAVIS_TAG --skip-git --yes
+env:
+  global:
+    secure: pJsHFx7r9866G+XYDwr8+5lPmHG15hV3D9ltdG5gP0Xdwg707fwc/G50PwQk3eBTEXw44y5QAnWiMJnyLpKki8gi3xjmXmWVY8x+ceHdN17uHte69YyK7r9hE2z6BRwLb2HABK+MzKX1zCHrz7HSOo7Ft1TwUid7onTqHhVzbYsAE9WurkAR2ytk1SO/9fwM9lalyDbYnEUdrkDDPU5NfZkK4HEofzu9FYwF05e0tjloEAOa/oyWrgr1q+18fgYPB5LlL/hsb5yBDs6JmnJVp/nMxE8aSdeSWC4x/ENbvrV0qVBRrl+oUJMpRMIefDoUICpfq3fHN3O5ds91ImVLL22XFRBRhISCHF0k8YP6Lzkn8XFxc9vGigYxBtbrtL72WAQJX5g0mP2UgJIRmMPfQGM2bOlU/dI98Yw8SmI1BtLfJ4McnMLAHIke3IS0o4Gj9QLXDLjOXte4yjAc1iX3v2TZxzUwo9oIF6QFb3gGIJ7uXRhTVDZ016NEq95vAMKuOrM7mBc79CeBNVsYAMqP+8LsVjFQ1snQWWaGpkxVx/CJMVq/U+569pA6JDvn9GXt81aVvgQ2j7FnyaGXnVnsnO6ic3SU7fLihYUTd7RHWVDGDwiJkzHxvVuw83BPDgIPydcr+Kz7tWOfjJYPjHrgBCevUxxYs7PgJ+Zn6rlqhMQ= # NPM_TOKEN

--- a/lerna.json
+++ b/lerna.json
@@ -4,6 +4,5 @@
     "packages/*"
   ],
   "version": "1.0.0-beta.16",
-  "useWorkspaces": true,
-  "npmClient": "yarn"
+  "useWorkspaces": true
 }


### PR DESCRIPTION
Adresses #20 .

Warning — this is experimental as fuck.

If everything goes according to plan, travis will generate a `.npmrc` file containing a token that lerna will use to publish to npm. This should happen on git tags only and the git tag will be used as version number.

The main problem that I don't know how to fix just yet is that the new version number won't be commited. The real version number will be in the git tags, and we should try to keep the code up to date.
If this PR works as intended, I'll try to work out a solution to that. Maybe semantic release or something like that.