### PR TITLE
feat: autoupdate queries when receiving document

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.26",
   "useWorkspaces": true
 }

--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-client",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.26",
   "license": "MIT",
   "main": "dist/cozy-client.js",
   "repository": {


### PR DESCRIPTION
When receiving a document, touch all the queries containing this
document.

Partially addresses https://github.com/cozy/cozy-client/issues/55