### PR TITLE
chore: publish improvements

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -1,0 +1,31 @@
+Publishing
+----------
+
+We use lerna for publishing. 
+
+```
+lerna publish
+```
+
+These options are useful
+
+* `--scope` to only care about one package
+
+```
+lerna publish --scope cozy-client
+```
+
+* `--npm-tag` to change the default npm-tag (latest). Useful if you are testing
+and don't want your users to end up with your changes.
+
+```
+$ lerna publish --scope cozy-client --npm-tag beta
+$ npm install cozy-client@beta
+```
+
+* `--force-publish` to force publication even if there were no changes
+
+```
+lerna publish --scope cozy-client --force-publish cozy-client
+```
+

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,5 @@
 {
   "lerna": "2.8.0",
-  "npmClient": "yarn",
   "packages": [
     "packages/*"
   ],

--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "watch": "webpack --config ../../webpack.config.js --env.package=cozy-client --watch",
+    "prepublish": "yarn build",
     "build": "webpack --config ../../webpack.config.js --env.package=cozy-client"
   }
 }


### PR DESCRIPTION
* add prepublish script in cozy-client not to publish package without the `dist` folder
* switch to npm as yarn does not ask the login when publishing
* added doc in `docs/dev.md` as a reference for manual publication