### PR TITLE
Use babel preset for browsers

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": [["cozy-app", { "node": true }], "react"]
+  "presets": ["cozy-app"]
 }


### PR DESCRIPTION
It was previously for node only and it can breaks some webpack build.
We can remove "react" here since it's handled by default in [`babel-preset-cozy-app`](https://github.com/CPatchane/create-cozy-app/tree/master/packages/babel-preset-cozy-app#react-boolean-true-by-default) for browsers.