### PR TITLE
Disable regenerator transform in babel preset

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["cozy-app"]
+  "presets": [["cozy-app", { "transformRegenerator": false }]]
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 		"babel-core": "^6.26.0",
 		"babel-jest": "^22.1.0",
 		"babel-loader": "^7.1.3",
-		"babel-preset-cozy-app": "^0.8.0",
+		"babel-preset-cozy-app": "^0.10.1",
 		"babel-preset-react": "^6.24.1",
 		"enzyme": "^3.3.0",
 		"enzyme-adapter-react-16": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,9 +1107,9 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-preset-cozy-app@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-cozy-app/-/babel-preset-cozy-app-0.8.0.tgz#58c00c89d1290d5b1c7487c6353fbe6a0162d6e6"
+babel-preset-cozy-app@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-cozy-app/-/babel-preset-cozy-app-0.10.1.tgz#2d67cba1226328cd13ba134a2f938233124d40b7"
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0-beta.46"
     babel-plugin-transform-class-properties "^6.24.1"
@@ -4931,7 +4931,7 @@ left-pad@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
 
-lerna@^2.8.0:
+lerna@2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.11.0.tgz#89b5681e286d388dda5bbbdbbf6b84c8094eff65"
   dependencies:


### PR DESCRIPTION
It is breaking CSPs with cozy-client, the new version of the preset has an option to disable this plugin.
We will see in the future how things will happen.