### PR TITLE
fix: client.get query will return only 1 result

### DIFF
--- a/packages/cozy-client/src/ObservableQuery.js
+++ b/packages/cozy-client/src/ObservableQuery.js
@@ -1,3 +1,9 @@
+/**
+ * ObservableQueries are the glue between the store and observers
+ * of the store. They know about the QueryDefinition, the client and
+ * know how to hydrate documents.
+ */
+
 import { getQueryFromState, getRawQueryFromState } from './store'
 
 const hasOwn = Object.prototype.hasOwnProperty

--- a/packages/cozy-client/src/ObservableQuery.js
+++ b/packages/cozy-client/src/ObservableQuery.js
@@ -11,7 +11,9 @@ const hasOwn = Object.prototype.hasOwnProperty
 export default class ObservableQuery {
   constructor(queryId, definition, client) {
     if (!queryId || !definition || !client) {
-      throw new Error('ObservableQuery takes 3 arguments: queryId, definition and client')
+      throw new Error(
+        'ObservableQuery takes 3 arguments: queryId, definition and client'
+      )
     }
     this.queryId = queryId
     this.definition = definition

--- a/packages/cozy-client/src/ObservableQuery.js
+++ b/packages/cozy-client/src/ObservableQuery.js
@@ -38,6 +38,9 @@ function shallowEqual(objA, objB) {
 
 export default class ObservableQuery {
   constructor(queryId, definition, client) {
+    if (!queryId || !definition || !client) {
+      throw new Error('ObservableQuery takes 3 arguments: queryId, definition and client')
+    }
     this.queryId = queryId
     this.definition = definition
     this.client = client

--- a/packages/cozy-client/src/ObservableQuery.js
+++ b/packages/cozy-client/src/ObservableQuery.js
@@ -37,13 +37,14 @@ export default class ObservableQuery {
     if (result.fetchStatus !== 'loaded') {
       return result
     }
+    const data = this.client.hydrateDocuments(
+      this.definition.doctype,
+      result.data,
+      this.queryId
+    )
     return {
       ...result,
-      data: this.client.hydrateDocuments(
-        this.definition.doctype,
-        result.data,
-        this.queryId
-      )
+      data: this.definition.id ? data[0] : data
     }
   }
 

--- a/packages/cozy-client/src/ObservableQuery.js
+++ b/packages/cozy-client/src/ObservableQuery.js
@@ -2,40 +2,6 @@ import { getQueryFromState, getRawQueryFromState } from './store'
 
 const hasOwn = Object.prototype.hasOwnProperty
 
-function is(x, y) {
-  if (x === y) {
-    return x !== 0 || y !== 0 || 1 / x === 1 / y
-  } else {
-    return x !== x && y !== y
-  }
-}
-
-function shallowEqual(objA, objB) {
-  if (is(objA, objB)) return true
-
-  if (
-    typeof objA !== 'object' ||
-    objA === null ||
-    typeof objB !== 'object' ||
-    objB === null
-  ) {
-    return false
-  }
-
-  const keysA = Object.keys(objA)
-  const keysB = Object.keys(objB)
-
-  if (keysA.length !== keysB.length) return false
-
-  for (let i = 0; i < keysA.length; i++) {
-    if (!hasOwn.call(objB, keysA[i]) || !is(objA[keysA[i]], objB[keysA[i]])) {
-      return false
-    }
-  }
-
-  return true
-}
-
 export default class ObservableQuery {
   constructor(queryId, definition, client) {
     if (!queryId || !definition || !client) {
@@ -140,4 +106,38 @@ export default class ObservableQuery {
   getStore() {
     return this.client.getOrCreateStore()
   }
+}
+
+function is(x, y) {
+  if (x === y) {
+    return x !== 0 || y !== 0 || 1 / x === 1 / y
+  } else {
+    return x !== x && y !== y
+  }
+}
+
+function shallowEqual(objA, objB) {
+  if (is(objA, objB)) return true
+
+  if (
+    typeof objA !== 'object' ||
+    objA === null ||
+    typeof objB !== 'object' ||
+    objB === null
+  ) {
+    return false
+  }
+
+  const keysA = Object.keys(objA)
+  const keysB = Object.keys(objB)
+
+  if (keysA.length !== keysB.length) return false
+
+  for (let i = 0; i < keysA.length; i++) {
+    if (!hasOwn.call(objB, keysA[i]) || !is(objA[keysA[i]], objB[keysA[i]])) {
+      return false
+    }
+  }
+
+  return true
 }

--- a/packages/cozy-client/src/Query.jsx
+++ b/packages/cozy-client/src/Query.jsx
@@ -22,10 +22,13 @@ export default class Query extends Component {
       typeof mutations === 'function'
         ? mutations(this.observableQuery, rest)
         : {}
-    this.createDocument = this.observableQuery.create.bind(this.observableQuery)
-    this.saveDocument = this.observableQuery.save.bind(this.observableQuery)
-    this.deleteDocument = this.observableQuery.destroy.bind(this.observableQuery)
-    this.getAssociation = this.observableQuery.getAssociation.bind(this.observableQuery)
+
+    const query = this.observableQuery
+    this.createDocument = query.create.bind(query)
+    this.saveDocument = query.save.bind(query)
+    this.deleteDocument = query.destroy.bind(query)
+    this.getAssociation = query.getAssociation.bind(this.observableQuery)
+    this.fetchMore = query.fetchMore.bind(query)
   }
 
   componentDidMount() {
@@ -49,7 +52,7 @@ export default class Query extends Component {
     const query = this.observableQuery
     return children(
       {
-        fetchMore: query.fetchMore.bind(query),
+        fetchMore: this.fetchMore,
         ...query.currentResult()
       },
       {

--- a/packages/cozy-client/src/__tests__/ObservableQuery.spec.js
+++ b/packages/cozy-client/src/__tests__/ObservableQuery.spec.js
@@ -65,7 +65,28 @@ describe('ObservableQuery', () => {
     })
   })
 
+  describe('current result', () => {
+    let query
 
+    it('should be able to return its results', async () => {
+      const def = client.all('io.cozy.todos')
+      await store.dispatch(initQuery('allTodos', def))
+      query = new ObservableQuery('allTodos', def, client)
+      await store.dispatch(
+        receiveQueryResult('allTodos', queryResultFromData([TODO_1, TODO_2]))
+      )
+      expect(query.currentResult().data).toEqual([TODO_1, TODO_2])
+    })
+
+    it('should be able to return its results', async () => {
+      const def = client.get('io.cozy.todos', TODO_1._id)
+      await store.dispatch(initQuery('oneTodo', def))
+      query = new ObservableQuery('oneTodo', def, client)
+      await store.dispatch(
+        receiveQueryResult('oneTodo', queryResultFromData([TODO_1]))
+      )
+      expect(query.currentResult().data).toBe(TODO_1)
+    })
   })
 
   it('should return an unsubscribe function', () => {})

--- a/packages/cozy-client/src/__tests__/ObservableQuery.spec.js
+++ b/packages/cozy-client/src/__tests__/ObservableQuery.spec.js
@@ -42,7 +42,7 @@ describe('ObservableQuery', () => {
       observer.mockReset()
       query = new ObservableQuery('allTodos', def, client)
       query.subscribe(observer)
-      await store.dispatch(initQuery('allTodos', {}))
+      await store.dispatch(initQuery('allTodos', def))
     })
 
     it('should notify observers when the fetchStatus change', async () => {

--- a/packages/cozy-client/src/__tests__/store.spec.js
+++ b/packages/cozy-client/src/__tests__/store.spec.js
@@ -87,13 +87,15 @@ describe('Store', () => {
     })
 
     it('should have a `loading` status when the query has been initiated', async () => {
-      await store.dispatch(initQuery('allTodos', {}))
+      const queryDef = { doctype: 'io.cozy.todos' }
+      await store.dispatch(initQuery('allTodos', queryDef))
       const query = getQueryFromState(store.getState(), 'allTodos')
       expect(query.fetchStatus).toBe('loading')
     })
 
     it('should have a `failed` status when an error occur', async () => {
-      await store.dispatch(initQuery('allTodos', {}))
+      const queryDef = { doctype: 'io.cozy.todos' }
+      await store.dispatch(initQuery('allTodos', queryDef))
       await store.dispatch(
         receiveQueryError('allTodos', new Error('fake error'))
       )

--- a/packages/cozy-client/src/store/documents.js
+++ b/packages/cozy-client/src/store/documents.js
@@ -51,5 +51,21 @@ export default documents
 
 // selector
 export const getDocumentFromSlice = (state = {}, doctype, id) => {
-  return state[doctype] ? state[doctype][id] || null : null
+  if (!doctype) {
+    throw new Error(
+      'getDocumentFromSlice: Cannot retrieve document with undefined doctype'
+    )
+  }
+  if (!state[doctype]) {
+    console.warn(
+      `getDocumentFromSlice: ${doctype} is absent from the store documents`
+    )
+    return null
+  } else if (!state[doctype][id]) {
+    console.warn(
+      `getDocumentFromSlice: ${doctype}:${id} is absent from the store documents`
+    )
+    return null
+  }
+  return state[doctype][id]
 }

--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -159,11 +159,16 @@ const queries = (state = {}, action, documents = {}) => {
 export default queries
 
 // actions
-export const initQuery = (queryId, queryDefinition) => ({
-  type: INIT_QUERY,
-  queryId,
-  queryDefinition
-})
+export const initQuery = (queryId, queryDefinition) => {
+  if (!queryDefinition.doctype) {
+    throw new Error('Cannot init query with no doctype')
+  }
+  return {
+    type: INIT_QUERY,
+    queryId,
+    queryDefinition
+  }
+}
 
 export const receiveQueryResult = (queryId, response, options = {}) => ({
   type: RECEIVE_QUERY_RESULT,


### PR DESCRIPTION
BREAKING CHANGE: before applications had to select the first item of the
 results themselves, now it is done in the library

 ```diff
 <Query query={client.get('doctype', 'id')}>
 -  { ({ data: documents }) => {
 -     const myDoc = documents[0]
 +  { ({ data: myDoc }) => {
     ...
   }}
 />
 ```