### PR TITLE
docs: Fix link chain usage 🐛

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ const client = new CozyClient({
 Links are designed to be composed together to form chains:
 
 ```js
-import CozyClient, { StackLink, chain } from 'cozy-client'
+import CozyClient, { StackLink } from 'cozy-client'
 import PouchDBLink from 'cozy-pouch-link'
 import LogLink from '../LogLink'
 
@@ -233,11 +233,11 @@ const pouchLink = new PouchDBLink({
 const logLink = new LogLink()
 
 const client = new CozyClient({
-  link: chain([
+  link: [
     logLink,
     pouchLink,
     stackLink
-  ])
+  ]
 })
 ```
 


### PR DESCRIPTION
`chain` is automatic with cozy-client when `link` are an array.

```
    if (Array.isArray(this.link)) {
      this.link = chain(this.link)
    }
```

You can see [here](https://github.com/cozy/cozy-client/blob/6c93bc715e01f7373a7539dcf4d0dd9c8c4913f3/packages/cozy-client/src/CozyClient.js#L26-L28)
See https://github.com/cozy/cozy-client/pull/82