### PR TITLE
refactor: Remove unnecessary parameter 🔥

### DIFF
--- a/packages/cozy-client/src/StackLink.js
+++ b/packages/cozy-client/src/StackLink.js
@@ -2,10 +2,9 @@ import { MutationTypes } from './dsl'
 import CozyLink from './CozyLink'
 
 export default class StackLink extends CozyLink {
-  constructor({ client, schema }) {
+  constructor({ client }) {
     super()
     this.client = client
-    this.schema = schema
   }
 
   request(operation) {


### PR DESCRIPTION
J'ai vu que l'on avait un paramètre `schema` dans `StackLink` alors que l'on ne passait pas le paramètre dans [l'initialisation de Cozy client](https://github.com/cozy/cozy-client/blob/6c93bc715e01f7373a7539dcf4d0dd9c8c4913f3/packages/cozy-client/src/CozyClient.js#L25). Après en avoir discuté avec @ptbrowne nous pensons que c'est un paramètre inutil dans StackLink.