### PR TITLE
fix: Watch command 🐛

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-babel -c ../../.babelrc src/ -d dist/ --ignore '*.spec.js','*.spec.jsx'
+babel -c ../../.babelrc src/ -d dist/ --ignore '*.spec.js','*.spec.jsx' $@

--- a/bin/build
+++ b/bin/build
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-babel -c ../../.babelrc src/ -d dist/ --ignore '*.spec.js','*.spec.jsx' $@
+babel -c ../../.babelrc src/ -d dist/ --ignore '*.spec.js','*.spec.jsx' "$@"


### PR DESCRIPTION
This script is used by the watch command "bin/build --watch". To work, it needs to forward the arguments.