### PR TITLE
docs: Update mutation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,8 @@ import { Query } from 'cozy-client'
 
 const query = client => client.find('io.cozy.todos').where({ checked: false })
 
-const createMutations = (mutate, ownProps) => ({
-  addTodo: label =>
-    mutate(client => client.create('io.cozy.todos', { label }))
+const createMutations = (client, ownProps) => ({
+  addTodo: label => client.create('io.cozy.todos', { label })
 }) 
 
 const App = () => (


### PR DESCRIPTION
Fixes #54 , but I'm a bit worried by this — we don't *actually* receive an instance of the client, we receive an [`ObservaleQuery`](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/ObservableQuery.js) which is mostly a proxy for the client, but there are some extra methods, and some are missing.

I still used `client` to avoid adding an extra term and because [that's what it's pretending to be](https://github.com/cozy/cozy-drive/blob/edd7fe1952989ba5b117861ce893774bd6d9462a/src/photos/ducks/timeline/index.js#L22), but maybe there's a better way to handle things here.