### PR TITLE
feat: Remove client on Link initialisation 🔥 

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ const query = client => client.find('io.cozy.todos').where({ checked: false })
 
 const createMutations = (client, ownProps) => ({
   addTodo: label => client.create('io.cozy.todos', { label })
-}) 
+})
 
 const App = () => (
   <Query query={query} mutations={createMutations}>
@@ -190,7 +190,7 @@ export default withMutation(
 
 Cozy Link is a simple yet powerful way to describe how you want to get the result of a query. Think of it as a sort of "middleware".
 
-Links are units that you can chain together to define how each query should be handled: this allows us to use different sources of data, or to control the request lifecycle in a way that makes sense for your app. The first link operates on an operation object and each subsequent link operates on the result of the previous link: 
+Links are units that you can chain together to define how each query should be handled: this allows us to use different sources of data, or to control the request lifecycle in a way that makes sense for your app. The first link operates on an operation object and each subsequent link operates on the result of the previous link:
 
 ![links chain](docs/cozy-client-links.png)
 
@@ -203,12 +203,11 @@ To create a link to use with Cozy Client, you can import one from `cozy-client` 
 ```js
 import CozyClient, { StackLink } from 'cozy-client'
 
-const link = new StackLink({
-  uri: 'http://cozy.tools:8080',
-  token: '...'
-})
+const link = new StackLink()
 
 const client = new CozyClient({
+  uri: 'http://cozy.tools:8080',
+  token: '...',
   link
 })
 ```
@@ -220,10 +219,7 @@ import CozyClient, { StackLink } from 'cozy-client'
 import PouchDBLink from 'cozy-pouch-link'
 import LogLink from '../LogLink'
 
-const stackLink = new StackLink({
-  uri: 'http://cozy.tools:8080',
-  token: '...'
-})
+const stackLink = new StackLink()
 
 const pouchLink = new PouchDBLink({
   doctypes: [...]
@@ -232,7 +228,9 @@ const pouchLink = new PouchDBLink({
 const logLink = new LogLink()
 
 const client = new CozyClient({
-  link: [
+  uri: 'http://cozy.tools:8080',
+  token: '...',
+  links: [
     logLink,
     pouchLink,
     stackLink

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -19,14 +19,26 @@ import { chain } from './CozyLink'
 import ObservableQuery from './ObservableQuery'
 
 export default class CozyClient {
-  constructor({ link, schema = {}, ...options }) {
+  constructor({ link, links, schema = {}, ...options }) {
     this.options = options
     this.idCounter = 1
-    this.link = link || new StackLink({ client: this.getOrCreateStackClient() })
+    this.link = link || links || new StackLink()
+
+    this.getOrCreateStackClient()
+    this.registerClientOnLinks(this.link)
     if (Array.isArray(this.link)) {
       this.link = chain(this.link)
     }
     this.schema = schema
+  }
+
+  registerClientOnLinks(links) {
+    links = Array.isArray(links) ? links : [links]
+    for (let link of links) {
+      if (!link.client && link.registerClient) {
+        link.registerClient(this.client)
+      }
+    }
   }
 
   /**

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -484,6 +484,13 @@ export default class CozyClient {
     }
   }
 
+  getOrCreateStackClient() {
+    console.warn(
+      `getOrCreateStackClient is deprecated, you can used getClient function.`
+    )
+    return this.getClient()
+  }
+
   getClient() {
     if (!this.client) {
       this.createClient()

--- a/packages/cozy-client/src/StackLink.js
+++ b/packages/cozy-client/src/StackLink.js
@@ -2,8 +2,12 @@ import { MutationTypes } from './dsl'
 import CozyLink from './CozyLink'
 
 export default class StackLink extends CozyLink {
-  constructor({ client }) {
+  constructor({ client } = {}) {
     super()
+    this.client = client
+  }
+
+  registerClient(client) {
     this.client = client
   }
 

--- a/packages/cozy-client/src/__tests__/CozyClient.spec.js
+++ b/packages/cozy-client/src/__tests__/CozyClient.spec.js
@@ -16,21 +16,35 @@ import {
 import HasManyFilesAssociation from '../associations/HasManyFilesAssociation'
 
 describe('CozyClient initialization', () => {
-  const links = [
-    new CozyLink((operation, result = '', forward) => {
-      return forward(operation, result + 'foo')
-    }),
-    new CozyLink((operation, result, forward) => {
-      return forward(operation, result + 'bar')
-    }),
-    (operation, result) => {
-      return result + 'baz'
-    }
-  ]
-  const client = new CozyClient({ link: links })
+  let client, links
+
+  beforeEach(() => {
+    links = [
+      new CozyLink((operation, result = '', forward) => {
+        return forward(operation, result + 'foo')
+      }),
+      new CozyLink((operation, result, forward) => {
+        return forward(operation, result + 'bar')
+      }),
+      (operation, result) => {
+        return result + 'baz'
+      }
+    ]
+    links.forEach(link => {
+      link.registerClient = jest.fn()
+    })
+    client = new CozyClient({ link: links })
+  })
+
   it('should have chained links', async () => {
     const res = await client.requestQuery({})
     expect(res).toBe('foobarbaz')
+  })
+
+  it('should have registered the client on all links ', () => {
+    for (const link of links) {
+      expect(link.registerClient).toHaveBeenCalledWith(client.client)
+    }
   })
 })
 

--- a/packages/cozy-client/src/__tests__/StackLink.spec.js
+++ b/packages/cozy-client/src/__tests__/StackLink.spec.js
@@ -1,13 +1,16 @@
-import CozyStackClient from 'cozy-stack-client'
 import CozyClient from '../CozyClient'
 import StackLink from '../StackLink'
 
 import { TODO_SCHEMA } from './fixtures'
 
 describe('StackLink', () => {
-  const stackClient = new CozyStackClient()
-  const link = new StackLink({ client: stackClient })
-  const client = new CozyClient({ link, schema: TODO_SCHEMA })
+  let stackClient, link, client
+
+  beforeEach(() => {
+    link = new StackLink()
+    client = new CozyClient({ link, schema: TODO_SCHEMA })
+    stackClient = client.getStackClient()
+  })
 
   describe('query execution', () => {
     it('should execute queries without a selector', async () => {

--- a/packages/cozy-client/src/__tests__/StackLink.spec.js
+++ b/packages/cozy-client/src/__tests__/StackLink.spec.js
@@ -9,7 +9,7 @@ describe('StackLink', () => {
   beforeEach(() => {
     link = new StackLink()
     client = new CozyClient({ link, schema: TODO_SCHEMA })
-    stackClient = client.getStackClient()
+    stackClient = client.getClient()
   })
 
   describe('query execution', () => {

--- a/packages/cozy-pouch-link/__tests__/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/__tests__/CozyPouchLink.spec.js
@@ -4,25 +4,25 @@ import { TODO_SCHEMA, TODO_1, TODO_2, TODO_3, TODO_4 } from './fixtures'
 import omit from 'lodash/omit'
 
 const mockClient = {
-  uri: 'http://cozy.tools:8080',
-  token: {
-    toBasicAuth: () => 'user:token@'
+  client: {
+    uri: 'http://cozy.tools:8080',
+    token: {
+      toBasicAuth: () => 'user:token@'
+    }
   }
 }
 
 const TODO_DOCTYPE = TODO_SCHEMA.todos.doctype
 
 describe('CozyPouchLink', () => {
-  let link
-  const client = new CozyClient({
-    link,
-    schema: TODO_SCHEMA
-  })
+  let client, link
 
   beforeEach(() => {
-    link = new CozyPouchLink({
-      doctypes: [TODO_DOCTYPE],
-      client: mockClient
+    link = new CozyPouchLink({ doctypes: [TODO_DOCTYPE] })
+    client = new CozyClient({
+      ...mockClient,
+      link,
+      schema: TODO_SCHEMA
     })
   })
 

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -71,21 +71,23 @@ const doNothing = () => {}
  * and mutations.
  */
 export default class PouchLink extends CozyLink {
-  constructor({ doctypes, client, initialSync } = {}) {
+  constructor(options = {}) {
+    super(options)
+    const { doctypes } = options
+    this.options = options
     if (!doctypes) {
       throw new Error(
         "PouchLink must be instantiated with doctypes it manages. Ex: ['io.cozy.bills']"
       )
     }
-    if (!client) {
-      throw new Error('PouchLink must be instantiated with a client.')
-    }
-    super()
     this.doctypes = doctypes
-    this.client = client
     this.pouches = createPouches(this.doctypes)
     this.indexes = {}
-    if (initialSync) {
+  }
+
+  registerClient(client) {
+    this.client = client
+    if (this.options.initialSync) {
       this.syncAll()
     }
   }


### PR DESCRIPTION
Nous continuons notre travail pour intégrer `cozy-client` dans Cozy Banks et lors de l'implémentation du link `pouch` nous avons pensé à une simplification pour l'instanciation du client. Il est possible maintenant d'instancier des Link sans créer de client.

Avant:
```js
import CozyStackClient from 'cozy-stack-client'
import CozyClient, { StackLink } from 'cozy-client'
import PouchLink from 'cozy-pouch-link'

const stackClient = new CozyStackClient({ uri, token })
const stackLink = new StackLink({ client: stackClient })
const pouchLink = new PouchLink({ client: stackClient, doctypes: [...] })
const client = new CozyClient({ client: stackClient, links: [stackLink, pouchLink] })
```

Après:
```js
import CozyClient, { StackLink } from 'cozy-client'
import PouchLink from 'cozy-pouch-link'

const stackLink = new StackLink()
const pouchLink = new PouchLink({ doctypes: [...] })
const client = new CozyClient({ uri, token, links: [stackLink, pouchLink] })
```