### PR TITLE
fix: Sleep function was not imported

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -41,6 +41,9 @@ query to work</p>
 <dd><p>Helps to avoid nested try/catch when using async/await</p>
 <p>Inspired by a Go pattern: <a href="http://blog.grossman.io/how-to-write-async-await-without-try-catch-blocks-in-javascript/">http://blog.grossman.io/how-to-write-async-await-without-try-catch-blocks-in-javascript/</a></p>
 </dd>
+<dt><a href="#sleep">sleep()</a></dt>
+<dd><p>Helps to avoid nested try/catch when using async/await — see documentation for attemp</p>
+</dd>
 </dl>
 
 <a name="module_CozyClient"></a>
@@ -459,3 +462,9 @@ if (await attempt(collection.all()) return
 await sleep(1000)
 return
 ```
+<a name="sleep"></a>
+
+## sleep()
+Helps to avoid nested try/catch when using async/await — see documentation for attemp
+
+**Kind**: global function  

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -1,6 +1,4 @@
-/* global sleep */
-
-import { uri, attempt } from './utils'
+import { uri, attempt, sleep } from './utils'
 
 export const FETCH_LIMIT = 50
 

--- a/packages/cozy-stack-client/src/utils.js
+++ b/packages/cozy-stack-client/src/utils.js
@@ -34,6 +34,10 @@ export const uri = (strings, ...values) => {
  */
 export const attempt = promise => promise.then(() => true).catch(() => false)
 
+/**
+ * @function
+ * @description Helps to avoid nested try/catch when using async/await — see documentation for attemp
+ */
 export const sleep = (time, args) =>
   new Promise(resolve => {
     setTimeout(resolve, time, args)


### PR DESCRIPTION
We were missing an import, causing a bug when an index is created for the first time. I

- fixed it
- added test coverage
- completed the docs