### PR TITLE
Fix double query

### DIFF
--- a/packages/cozy-client/src/Query.jsx
+++ b/packages/cozy-client/src/Query.jsx
@@ -41,7 +41,7 @@ export default class Query extends Component {
   componentDidMount() {
     this.queryUnsubscribe = this.observableQuery.subscribe(this.onQueryChange)
     if (this.props.fetchPolicy !== 'cache-only') {
-      this.client.query(this.queryDefinition, { queryId: this.observableQuery.queryId })
+      this.client.query(this.queryDefinition, { as: this.observableQuery.queryId })
     }
   }
 


### PR DESCRIPTION
When not using `cache-only`, queries would en up being created twice — once through the call to `client.watchQuery`, and once through the actual call to `client.query`.

I've also moved the Query test file in the same folder as the other tests.

This would lead to infinite loading on the apps.