### PR TITLE
fix: Use only one sorting order

### DIFF
--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -1,4 +1,5 @@
 import { uri, attempt, sleep } from './utils'
+import uniq from 'lodash/uniq'
 
 export const FETCH_LIMIT = 50
 
@@ -161,9 +162,15 @@ export default class DocumentCollection {
     const indexFields = this.getIndexFields({ ...options, selector })
     const indexId = options.indexId || (await this.getIndexId(indexFields))
     const { fields, skip = 0, limit = FETCH_LIMIT } = options
-    // Mango wants an array of single-property-objects...
+    // Mango wants an array of single-property-objects..
+    const sortOrders = options.sort
+      ? uniq(Object.values(options.sort))
+      : ['asc']
+    if (sortOrders.length > 1)
+      throw new Error('Mango sort can only use a single order (asc or desc).')
+    const sortOrder = sortOrders[0]
     const sort = options.sort
-      ? indexFields.map(f => ({ [f]: options.sort[f] || 'desc' }))
+      ? indexFields.map(f => ({ [f]: sortOrder }))
       : undefined
 
     return {

--- a/packages/cozy-stack-client/src/__tests__/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/DocumentCollection.spec.js
@@ -243,6 +243,44 @@ describe('DocumentCollection', () => {
       )
     })
 
+    it('should use a valid default sorting option', async () => {
+      const collection = new DocumentCollection('io.cozy.todos', client)
+      await collection.find({ done: false }, { sort: { label: 'asc' } })
+      expect(client.fetchJSON).toHaveBeenLastCalledWith(
+        'POST',
+        '/data/io.cozy.todos/_find',
+        {
+          limit: 50,
+          skip: 0,
+          selector: { done: false },
+          sort: [{ done: 'asc' }, { label: 'asc' }],
+          use_index: '_design/123456'
+        }
+      )
+      await collection.find({ done: false }, { sort: { label: 'desc' } })
+      expect(client.fetchJSON).toHaveBeenLastCalledWith(
+        'POST',
+        '/data/io.cozy.todos/_find',
+        {
+          limit: 50,
+          skip: 0,
+          selector: { done: false },
+          sort: [{ done: 'desc' }, { label: 'desc' }],
+          use_index: '_design/123456'
+        }
+      )
+    })
+
+    it('should throw when using different sort orders', async () => {
+      const collection = new DocumentCollection('io.cozy.todos', client)
+      await expect(
+        collection.find(
+          { done: false },
+          { sort: { label: 'asc', _id: 'desc' } }
+        )
+      ).rejects.toThrow()
+    })
+
     it('should return a correct JSON API response', async () => {
       const collection = new DocumentCollection('io.cozy.todos', client)
       const resp = await collection.find({ done: false })


### PR DESCRIPTION
Mango queries can't have opposing sorting orders (ie. one field `asc` and the other `desc`). But we had a default value of `desc`, so sorting by `asc` was impossible.