### PR TITLE
fix: watchQuery calls getOrCreate store to ensure it has a store

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -235,6 +235,7 @@ export default class CozyClient {
   }
 
   watchQuery(queryDefinition, options = {}) {
+    this.getOrCreateStore()
     const queryId = options.as || this.generateId()
     this.ensureQueryExists(queryId, queryDefinition)
     return new ObservableQuery(queryId, queryDefinition, this)

--- a/packages/cozy-client/src/__tests__/CozyClient.spec.js
+++ b/packages/cozy-client/src/__tests__/CozyClient.spec.js
@@ -4,7 +4,7 @@ import { TODO_SCHEMA, TODO_1, TODO_2, TODO_3 } from './fixtures'
 
 import CozyClient from '../CozyClient'
 import CozyLink from '../CozyLink'
-import { Mutations } from '../dsl'
+import { Mutations, QueryDefinition } from '../dsl'
 import {
   initQuery,
   receiveQueryResult,
@@ -45,6 +45,11 @@ describe('CozyClient initialization', () => {
     for (const link of links) {
       expect(link.registerClient).toHaveBeenCalledWith(client.client)
     }
+  })
+
+  it('should create a store when calling watch query', () => {
+    client.watchQuery(new QueryDefinition({ doctype: 'io.cozy.todos' }))
+    expect(client.store).not.toBe(undefined)
   })
 })
 


### PR DESCRIPTION
If watchQuery was called before the execution of the query, the store
was not created yet.