### PR TITLE
refactor: getOrCreateStore no longer called by Provider or ObservableQuery

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -217,7 +217,7 @@ export default class CozyClient {
   }
 
   async query(queryDefinition, { update, ...options } = {}) {
-    this.getOrCreateStore()
+    this.ensureStore()
     const queryId = options.as || this.generateId()
     this.ensureQueryExists(queryId, queryDefinition)
     try {
@@ -235,14 +235,14 @@ export default class CozyClient {
   }
 
   watchQuery(queryDefinition, options = {}) {
-    this.getOrCreateStore()
+    this.ensureStore()
     const queryId = options.as || this.generateId()
     this.ensureQueryExists(queryId, queryDefinition)
     return new ObservableQuery(queryId, queryDefinition, this)
   }
 
   async mutate(mutationDefinition, { update, updateQueries, ...options } = {}) {
-    this.getOrCreateStore()
+    this.ensureStore()
     const mutationId = options.as || this.generateId()
     this.dispatch(initMutation(mutationId, mutationDefinition))
     try {
@@ -502,11 +502,10 @@ export default class CozyClient {
     this.store = store
   }
 
-  getOrCreateStore() {
+  ensureStore() {
     if (!this.store) {
       this.setStore(createStore())
     }
-    return this.store
   }
 
   createClient() {

--- a/packages/cozy-client/src/ObservableQuery.js
+++ b/packages/cozy-client/src/ObservableQuery.js
@@ -101,7 +101,7 @@ export default class ObservableQuery {
   }
 
   getStore() {
-    return this.client.getOrCreateStore()
+    return this.client.store
   }
 }
 

--- a/packages/cozy-client/src/Provider.js
+++ b/packages/cozy-client/src/Provider.js
@@ -33,10 +33,7 @@ export default class CozyProvider extends Component {
 
   getChildContext() {
     return {
-      store:
-        this.props.store ||
-        this.context.store ||
-        this.props.client.getOrCreateStore(),
+      store: this.props.store || this.context.store || this.props.client.store,
       client: this.props.client
     }
   }


### PR DESCRIPTION
Provider or ObservableQuery should not create the store. I try to reduce the number of places the store can be created so that it is obvious.

* For now, `query`, `watchQuery` and `mutate` can create a store if it does not exist
* the user can setStore manually, maybe we should throw if the store has already been created by `query` or `watchQuery` ?
* the provider sets the store of the client when mounted.