### PR TITLE
Add logout function 👋

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -439,3 +439,8 @@ if (!storedToken) {
   localStorage.setItem('infos', JSON.stringify(infos))
 }
 ```
+
+### Logout a client
+
+When a user logout, we would like remove all references on this instance and
+remove all user data. You can just use `cozyClient.logout()`.

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -76,10 +76,35 @@ export default class CozyClient {
   }
 
   registerClientOnLinks(links) {
-    links = Array.isArray(links) ? links : [links]
-    for (let link of links) {
+    this.links = Array.isArray(links) ? links : [links]
+    for (const link of this.links) {
       if (!link.client && link.registerClient) {
-        link.registerClient(this.client)
+        try {
+          link.registerClient(this.client)
+        } catch (e) {
+          console.warn(e)
+        }
+      }
+    }
+  }
+
+  async logout() {
+    // unregister client on stack
+    if (
+      this.client.unregister &&
+      (!this.client.isRegistered || this.client.isRegistered())
+    ) {
+      await this.client.unregister()
+    }
+
+    // clean information on links
+    for (const link of this.links) {
+      if (link.reset) {
+        try {
+          await link.reset()
+        } catch (e) {
+          console.warn(e)
+        }
       }
     }
   }

--- a/packages/cozy-client/src/StackLink.js
+++ b/packages/cozy-client/src/StackLink.js
@@ -11,6 +11,10 @@ export default class StackLink extends CozyLink {
     this.client = client
   }
 
+  reset() {
+    this.client = undefined
+  }
+
   request(operation) {
     if (operation.mutationType) {
       return this.executeMutation(operation)

--- a/packages/cozy-client/src/__tests__/StackLink.spec.js
+++ b/packages/cozy-client/src/__tests__/StackLink.spec.js
@@ -31,4 +31,12 @@ describe('StackLink', () => {
       )
     })
   })
+
+  describe('reset', () => {
+    it('should delete client', async () => {
+      expect(link.client).not.toBeUndefined()
+      await link.reset()
+      expect(link.client).toBeUndefined()
+    })
+  })
 })

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -87,9 +87,14 @@ export default class PouchLink extends CozyLink {
 
   registerClient(client) {
     this.client = client
-    if (this.options.initialSync) {
+    if (client && this.options.initialSync) {
       this.syncAll()
     }
+  }
+
+  async reset() {
+    await this.resetAllDBs()
+    this.client = undefined
   }
 
   getAllDBs() {

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -136,4 +136,28 @@ describe('CozyPouchLink', () => {
       })
     })
   })
+
+  describe('reset', async () => {
+    let spy
+
+    beforeEach(() => {
+      spy = jest.spyOn(link, 'resetAllDBs').mockReturnValue(jest.fn())
+    })
+
+    afterEach(async () => {
+      spy.mockRestore()
+    })
+
+    it('should delete all databases', async () => {
+      await link.reset()
+      expect(link.resetAllDBs).toHaveBeenCalledTimes(1)
+    })
+
+    it('should delete client', async () => {
+      link.registerClient(jest.fn())
+      expect(link.client).not.toBeUndefined()
+      await link.reset()
+      expect(link.client).toBeUndefined()
+    })
+  })
 })

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -147,14 +147,12 @@ export default class OAuthClient extends CozyStackClient {
   async unregister() {
     if (!this.isRegistered()) throw new NotRegisteredException()
 
-    return this.fetchJSON(
-      'DELETE',
-      `/auth/register/${this.oauthOptions.clientID}`,
-      null,
-      {
-        credentials: this.registrationAccessTokenToAuthHeader()
-      }
-    )
+    const clientID = this.oauthOptions.clientID
+    this.oauthOptions.clientID = ''
+
+    return this.fetchJSON('DELETE', `/auth/register/${clientID}`, null, {
+      credentials: this.registrationAccessTokenToAuthHeader()
+    })
   }
 
   /**

--- a/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
@@ -73,8 +73,10 @@ describe('OAuthClient', () => {
     })
 
     it('should unregister a client', () => {
+      expect(client.isRegistered()).toBeTruthy()
       client.unregister()
       expect(fetch.mock.calls[0]).toMatchSnapshot()
+      expect(client.isRegistered()).toBeFalsy()
     })
 
     it('should fetch client informations', () => {


### PR DESCRIPTION
### Logout a client
When a user logout, we would like remove all references on this instance and
remove all user data. You can just use `cozyClient.logout()`.

This function make 3 actions:
- Delete OAuth Client on stack
- Remove pouch databases
- Remove all references on client