### PR TITLE
feat: Remove design document on response 🤪

### DIFF
--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -3,6 +3,8 @@ import PouchDB from 'pouchdb'
 import PouchDBFind from 'pouchdb-find'
 import fromPairs from 'lodash/fromPairs'
 import omit from 'lodash/omit'
+
+import { withoutDesignDocuments } from './helpers'
 import { getIndexNameFromFields, getIndexFields } from './mango'
 
 PouchDB.plugin(PouchDBFind)
@@ -208,6 +210,7 @@ export default class PouchLink extends CozyLink {
       res = await db.allDocs({
         include_docs: true
       })
+      res = withoutDesignDocuments(res)
     } else {
       const findOpts = {
         sort,

--- a/packages/cozy-pouch-link/src/helpers.js
+++ b/packages/cozy-pouch-link/src/helpers.js
@@ -1,0 +1,11 @@
+import startsWith from 'lodash/startsWith'
+
+export const withoutDesignDocuments = res => {
+  const rows = res.rows.filter(doc => !startsWith(doc.id, '_design/'))
+
+  return {
+    ...res,
+    rows,
+    total_rows: rows.length
+  }
+}

--- a/packages/cozy-pouch-link/src/helpers.spec.js
+++ b/packages/cozy-pouch-link/src/helpers.spec.js
@@ -1,0 +1,28 @@
+import { withoutDesignDocuments } from './helpers.js'
+
+describe('Helpers', () => {
+  describe('withoutDesignDocuments', () => {
+    let response
+    beforeEach(() => {
+      response = {
+        offset: 0,
+        rows: [{ id: 'goodId' }, { id: '_design/wrongId' }],
+        total_rows: 2
+      }
+    })
+    it('should remove design document', () => {
+      const filteredResponse = withoutDesignDocuments(response)
+      expect(filteredResponse.rows.length).toEqual(1)
+      expect(filteredResponse.rows[0].id).toEqual('goodId')
+    })
+    it('should update total rows number', () => {
+      const filteredResponse = withoutDesignDocuments(response)
+      expect(filteredResponse.total_rows).toEqual(1)
+    })
+    it('should not mute response', () => {
+      const responseCopy = { ...response }
+      withoutDesignDocuments(response)
+      expect(response).toEqual(responseCopy)
+    })
+  })
+})


### PR DESCRIPTION
Acutellement on peut se retrouver avec des documents de design de pouchDB dans nos collections:
```
client.all(GROUP_DOCTYPE)
```
me retourne un document avec l'id `_design/...`

Le but de cette PR est de filtrer le retour de pouch pour supprimer ses documents inutils.

