### PR TITLE
[cozy-pouch-link] fix(pouch): Resolve with result after replication

### DIFF
--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -135,9 +135,9 @@ export default class PouchLink extends CozyLink {
           console.warn('Error while syncing', err)
           reject('Error while syncing')
         })
-        info.syncing = replication.on('complete', () => {
+        info.syncing = replication.on('complete', result => {
           info.syncing = null
-          resolve()
+          resolve(result)
         })
       }
     })


### PR DESCRIPTION
The replication was resolving with undefined value because we didn't pass the result of the replication to the `resolve` function.