### PR TITLE
Add login method on client

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -74,12 +74,14 @@ export default class CozyClient {
   constructor({ link, links, schema = {}, ...options }) {
     this.options = options
     this.idCounter = 1
-    this.link = link || links || new StackLink()
+    const lnk = link || links || new StackLink()
 
     this.createClient()
-    this.registerClientOnLinks(this.link)
-    if (Array.isArray(this.link)) {
-      this.link = chain(this.link)
+    this.registerClientOnLinks(lnk)
+    if (Array.isArray(lnk)) {
+      this.chain = chain(lnk)
+    } else {
+      this.chain = lnk
     }
     this.schema = schema
   }
@@ -296,7 +298,7 @@ export default class CozyClient {
   }
 
   async requestQuery(definition) {
-    const mainResponse = await this.link.request(definition)
+    const mainResponse = await this.chain.request(definition)
     if (!definition.includes) {
       return mainResponse
     }
@@ -337,7 +339,7 @@ export default class CozyClient {
     )
 
     const requests = mapValues(definitions, definition =>
-      this.link.request(definition)
+      this.chain.request(definition)
     )
     const responses = await allValues(requests)
     const relationships = mapValues(responses, responseToRelationship)
@@ -383,7 +385,7 @@ export default class CozyClient {
       )
       return firstResponse
     }
-    return this.link.request(definition)
+    return this.chain.request(definition)
   }
 
   getIncludesAssociations(queryDefinition) {

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -71,7 +71,12 @@ const allValues = async x => {
  * @module CozyClient
  */
 export default class CozyClient {
+  // `link` exist for retrocompatibility
   constructor({ link, links, schema = {}, ...options }) {
+    if (link) {
+      console.warn('`link` is deprecated, use `links`')
+    }
+
     this.options = options
     this.idCounter = 1
     const lnk = link || links || new StackLink()

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -82,17 +82,20 @@ export default class CozyClient {
     const lnk = link || links || new StackLink()
 
     this.createClient()
-    this.registerClientOnLinks(lnk)
+
+    this.links = Array.isArray(lnk) ? lnk : [lnk]
+    this.registerClientOnLinks()
+
     if (Array.isArray(lnk)) {
       this.chain = chain(lnk)
     } else {
       this.chain = lnk
     }
+
     this.schema = schema
   }
 
-  registerClientOnLinks(links) {
-    this.links = Array.isArray(links) ? links : [links]
+  registerClientOnLinks() {
     for (const link of this.links) {
       if (!link.client && link.registerClient) {
         try {

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -67,6 +67,8 @@ const allValues = async x => {
   return res
 }
 
+const ensureArray = arr => (Array.isArray(arr) ? arr : [arr])
+
 /**
  * @module CozyClient
  */
@@ -79,11 +81,10 @@ export default class CozyClient {
 
     this.options = options
     this.idCounter = 1
-    const lnk = link || links || new StackLink()
 
     this.createClient()
 
-    this.links = Array.isArray(lnk) ? lnk : [lnk]
+    this.links = ensureArray(link || links || new StackLink())
     this.registerClientOnLinks()
 
     this.chain = chain(this.links)

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -86,11 +86,7 @@ export default class CozyClient {
     this.links = Array.isArray(lnk) ? lnk : [lnk]
     this.registerClientOnLinks()
 
-    if (Array.isArray(lnk)) {
-      this.chain = chain(lnk)
-    } else {
-      this.chain = lnk
-    }
+    this.chain = chain(this.links)
 
     this.schema = schema
   }

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -107,6 +107,10 @@ export default class CozyClient {
     }
   }
 
+  login() {
+    this.registerClientOnLinks()
+  }
+
   async logout() {
     // unregister client on stack
     if (


### PR DESCRIPTION
Add a `login` method that is the opposite of `logout`: it (re)initializes things. Actually for now it is a public interface to `registerClientOnLinks`, which have an internal purpose.

I also refactored a little the links initialization.