### PR TITLE
Revert "fix: Use the right param for code in OAuth flow"

### DIFF
--- a/packages/cozy-client/src/authentication/mobile.js
+++ b/packages/cozy-client/src/authentication/mobile.js
@@ -25,7 +25,7 @@ export const authenticateWithCordova = url => {
       }
 
       const onLoadStart = ({ url }) => {
-        const accessCode = /\?code=(.+)$/.test(url)
+        const accessCode = /\?access_code=(.+)$/.test(url)
         const state = /\?state=(.+)$/.test(url)
 
         if (accessCode || state) {

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -277,7 +277,7 @@ export default class OAuthClient extends CozyStackClient {
 
     const params = new URL(pageURL).searchParams
     const urlStateCode = params.get('state')
-    const urlAccessCode = params.get('code')
+    const urlAccessCode = params.get('access_code')
 
     if (stateCode !== urlStateCode)
       throw new Error('Given state does not match url query state')

--- a/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
@@ -110,7 +110,7 @@ describe('OAuthClient', () => {
     it('should get the access code from an URL', () => {
       const stateCode = 'myrandomcode'
       const accessCode = 'myaccesscode'
-      const url = `http://example.com?state=${stateCode}&code=${accessCode}`
+      const url = `http://example.com?state=${stateCode}&access_code=${accessCode}`
       expect(client.getAccessCodeFromURL(url, stateCode)).toEqual(accessCode)
     })
 


### PR DESCRIPTION
This reverts commit 5d5ab5642d2e0c4b7eccea4443fa66015ccd121d.

This is related to https://github.com/cozy/cozy-client/issues/126