### PR TITLE
feat(pouch): Handle errors for pouches destroy

### DIFF
--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -71,7 +71,11 @@ export default class PouchLink extends CozyLink {
   async registerClient(client) {
     this.client = client
     if (this.pouches) {
-      await this.pouches.destroy()
+      try {
+        await this.pouches.destroy()
+      } catch (e) {
+        console.warn('Error while destroying pouch DBs', e)
+      }
     }
     this.pouches = new PouchManager(this.doctypes, {
       getReplicationURL: this.getReplicationURL.bind(this),


### PR DESCRIPTION
If the databases were already destroyed, this throws an error.