### PR TITLE
fix(pouch): Call onSync when sync is done

### DIFF
--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -79,7 +79,8 @@ export default class PouchLink extends CozyLink {
     }
     this.pouches = new PouchManager(this.doctypes, {
       getReplicationURL: this.getReplicationURL.bind(this),
-      onError: err => this.onSyncError(err)
+      onError: err => this.onSyncError(err),
+      onSync: this.onSync.bind(this)
     })
   }
 


### PR DESCRIPTION
This `onSync` method was not passed as an option to the `PouchManager`, so it was never called, thus `synced` was never passed to `true`.