### PR TITLE
[client] Remove a forgotten console.log

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -473,7 +473,6 @@ export default class CozyClient {
         createAssociation(document, assoc, methods)
       ])
     )
-    console.log('assocs', res)
     return res
   }
 


### PR DESCRIPTION
I think this `console.log` was pushed by mistake.