### PR TITLE
fix(client): Don't check skip property

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -288,7 +288,7 @@ export default class CozyClient {
     this.ensureStore()
     const existingQuery = getQueryFromState(this.store.getState(), queryId)
     // Don't trigger the INIT_QUERY for fetchMore() calls
-    if (existingQuery.fetchStatus !== 'loaded' || !queryDefinition.skip) {
+    if (existingQuery.fetchStatus !== 'loaded') {
       this.dispatch(initQuery(queryId, queryDefinition))
     }
   }

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -287,8 +287,7 @@ export default class CozyClient {
   ensureQueryExists(queryId, queryDefinition) {
     this.ensureStore()
     const existingQuery = getQueryFromState(this.store.getState(), queryId)
-    // Don't trigger the INIT_QUERY for fetchMore() calls
-    if (existingQuery.fetchStatus !== 'loaded') {
+    if (existingQuery) {
       this.dispatch(initQuery(queryId, queryDefinition))
     }
   }


### PR DESCRIPTION
This leaded to an infinite loop creating `INIT_QUERY` actions endlessly