### PR TITLE
Restored keys option for DocumentCollection.all()

### DIFF
--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -29,13 +29,14 @@ export default class DocumentCollection {
    * @throws {FetchError}
    */
   async all(options = {}) {
-    const { limit, skip = 0 } = options
+    const { limit, skip = 0, keys } = options
 
     const url = uri`/data/${this.doctype}/_all_docs`
     const params = {
       include_docs: true,
       limit,
-      skip
+      skip,
+      keys
     }
     const path = querystring.buildURL(url, params)
 

--- a/packages/cozy-stack-client/src/__tests__/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/DocumentCollection.spec.js
@@ -101,6 +101,14 @@ describe('DocumentCollection', () => {
       )
     })
 
+    it('should accept keys option', async () => {
+      await collection.all({ keys: ['abc', 'def'] })
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'GET',
+        '/data/io.cozy.todos/_all_docs?include_docs=true&keys=[%22abc%22%2C%22def%22]'
+      )
+    })
+
     it('should return a correct JSON API response', async () => {
       const resp = await collection.all()
       expect(resp).toConformToJSONAPI()

--- a/packages/cozy-stack-client/src/querystring.js
+++ b/packages/cozy-stack-client/src/querystring.js
@@ -7,7 +7,11 @@ import pickBy from 'lodash/pickBy'
 export const encode = data => {
   return Object.entries(data)
     .map(([k, v]) => {
-      const encodedValue = encodeURIComponent(v)
+      const encodedValue = Array.isArray(v)
+        ? '[' +
+          encodeURIComponent(v.map(arrayVal => `"${arrayVal}"`).join(',')) +
+          ']'
+        : encodeURIComponent(v)
       return `${k}=${encodedValue}`
     })
     .join('&')


### PR DESCRIPTION
The ability to provide this `keys` option was broken by [this commit](https://github.com/cozy/cozy-client/commit/a7d414371d982c424409f4081d2d441fffdb35fa)