### PR TITLE
Dehydrate relationships before saving

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -8,7 +8,12 @@
  */
 
 import StackLink from './StackLink'
-import { create as createAssociation, Association } from './associations'
+import {
+  create as createAssociation,
+  dehydrateDoc,
+  associationsFromModel,
+  responseToRelationship
+} from './associations'
 import { QueryDefinition, Mutations } from './dsl'
 import CozyStackClient, { OAuthClient } from 'cozy-stack-client'
 import { authenticateWithCordova } from './authentication/mobile'
@@ -32,41 +37,9 @@ import keyBy from 'lodash/keyBy'
 import pickBy from 'lodash/pickBy'
 import fromPairs from 'lodash/fromPairs'
 
-const dehydrateDoc = document => {
-  const dehydrated = {}
-  Object.entries(document).forEach(([key, value]) => {
-    if (!(value instanceof Association)) {
-      dehydrated[key] = value
-    } else if (value.raw) {
-      dehydrated[key] = value.raw
-    }
-  })
-  return dehydrated
-}
-
-const associationsFromModel = model => {
-  const relationships = model.relationships || {}
-  return Object.entries(relationships).map(([name, relationship]) => {
-    const { type, doctype, query } = relationship
-    return {
-      name,
-      type,
-      doctype,
-      query
-    }
-  })
-}
-
 const findModelByDoctype = (schema, doctype) => {
   return Object.values(schema).find(m => m.doctype === doctype)
 }
-
-const responseToRelationship = response => ({
-  data: response.data.map(d => ({ _id: d._id, _type: d._type })),
-  meta: response.meta,
-  next: response.next,
-  skip: response.skip
-})
 
 const allValues = async x => {
   const res = {}

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -274,7 +274,7 @@ export default class CozyClient {
     this.ensureStore()
     const existingQuery = getQueryFromState(this.store.getState(), queryId)
     // Don't trigger the INIT_QUERY for fetchMore() calls
-    if (existingQuery.fetchStatus !== 'loaded') {
+    if (existingQuery.fetchStatus !== 'loaded' || !queryDefinition.skip) {
       this.dispatch(initQuery(queryId, queryDefinition))
     }
   }

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -84,7 +84,7 @@ describe('CozyClient logout', () => {
   })
 
   it('should call all reset even if a reset throws an error', async () => {
-    const spy = jest.spyOn(global.console, 'error').mockReturnValue(jest.fn())
+    const spy = jest.spyOn(global.console, 'warn').mockReturnValue(jest.fn())
     links[0].reset = jest.fn().mockRejectedValue(new Error('Async error'))
     links[2].reset = jest.fn()
     await client.logout()

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -13,7 +13,7 @@ import {
   receiveMutationResult,
   receiveMutationError
 } from './store'
-import HasManyFilesAssociation from './associations/HasManyFilesAssociation'
+import { HasManyFilesAssociation, Association } from './associations'
 
 describe('CozyClient initialization', () => {
   let client, links
@@ -167,6 +167,34 @@ describe('CozyClient', () => {
         initMutation('updateTodo', {
           mutationType: 'UPDATE_DOCUMENT',
           document: doc
+        })
+      )
+    })
+
+    it('should dehydrate relationships', async () => {
+      class FakeHasMany extends Association {
+        constructor(data) {
+          super()
+          this.data = data
+        }
+
+        get raw() {
+          return this.data
+        }
+      }
+      const doc = {
+        ...TODO_1,
+        label: 'Buy croissants',
+        authors: new FakeHasMany(['bill'])
+      }
+      await client.save(doc, { as: 'updateTodo' })
+      expect(store.getActions()[0]).toEqual(
+        initMutation('updateTodo', {
+          mutationType: 'UPDATE_DOCUMENT',
+          document: {
+            ...doc,
+            authors: ['bill']
+          }
         })
       )
     })

--- a/packages/cozy-client/src/associations/HasManyAssociation.js
+++ b/packages/cozy-client/src/associations/HasManyAssociation.js
@@ -13,6 +13,10 @@ export default class HasManyAssociation extends Association {
     this.save = save
   }
 
+  get raw() {
+    return this.getRelationship().data
+  }
+
   get data() {
     return this.getRelationship().data.map(({ _id, _type }) =>
       this.get(_type, _id)

--- a/packages/cozy-client/src/associations/HasManyAssociation.js
+++ b/packages/cozy-client/src/associations/HasManyAssociation.js
@@ -1,5 +1,11 @@
 import Association from './Association'
 
+const empty = () => ({
+  data: [],
+  next: true,
+  meta: { count: 0 }
+})
+
 export default class HasManyAssociation extends Association {
   constructor(target, name, doctype, { get, query, mutate, save }) {
     super()
@@ -46,17 +52,18 @@ export default class HasManyAssociation extends Association {
   }
 
   getRelationship() {
-    if (!this.target.relationships || !this.target.relationships[this.name]) {
-      console.warn(
-        "You're trying to access data on a relationship that appear to not be loaded yet. You may want to use 'include()' on your query"
-      )
-      return {
-        data: [],
-        next: true,
-        meta: { count: 0 }
+    const rawData = this.target[this.name]
+    const data =
+      this.target.relationships && this.target.relationships[this.name]
+    if (!data) {
+      if (rawData) {
+        console.warn(
+          "You're trying to access data on a relationship that appear to not be loaded yet. You may want to use 'include()' on your query"
+        )
       }
+      return empty()
     }
-    return this.target.relationships[this.name]
+    return data
   }
 
   updateTargetRelationship(store, updateFn) {

--- a/packages/cozy-client/src/associations/HasManyUNSAFEAssociation.js
+++ b/packages/cozy-client/src/associations/HasManyUNSAFEAssociation.js
@@ -26,6 +26,10 @@ export default class HasManyUNSAFEAssociation extends HasManyAssociation {
     return Array.isArray(this.target[this.name]) ? this.target[this.name] : []
   }
 
+  raw() {
+    return this.getProperty()
+  }
+
   setProperty(value) {
     this.target[this.name] = value
     return this.save(this.target)

--- a/packages/cozy-client/src/associations/helpers.js
+++ b/packages/cozy-client/src/associations/helpers.js
@@ -1,0 +1,33 @@
+import Association from './Association'
+
+export const dehydrateDoc = document => {
+  const dehydrated = {}
+  Object.entries(document).forEach(([key, value]) => {
+    if (!(value instanceof Association)) {
+      dehydrated[key] = value
+    } else if (value.raw) {
+      dehydrated[key] = value.raw
+    }
+  })
+  return dehydrated
+}
+
+export const associationsFromModel = model => {
+  const relationships = model.relationships || {}
+  return Object.entries(relationships).map(([name, relationship]) => {
+    const { type, doctype, query } = relationship
+    return {
+      name,
+      type,
+      doctype,
+      query
+    }
+  })
+}
+
+export const responseToRelationship = response => ({
+  data: response.data.map(d => ({ _id: d._id, _type: d._type })),
+  meta: response.meta,
+  next: response.next,
+  skip: response.skip
+})

--- a/packages/cozy-client/src/associations/index.js
+++ b/packages/cozy-client/src/associations/index.js
@@ -3,6 +3,13 @@ import HasManyAssociation from './HasManyAssociation'
 import HasManyUNSAFEAssociation from './HasManyUNSAFEAssociation'
 import Association from './Association'
 
+export {
+  HasManyUNSAFEAssociation,
+  Association,
+  HasManyFilesAssociation,
+  HasManyAssociation
+}
+
 export const create = (
   target,
   { name, type, doctype },

--- a/packages/cozy-client/src/associations/index.js
+++ b/packages/cozy-client/src/associations/index.js
@@ -4,6 +4,12 @@ import HasManyUNSAFEAssociation from './HasManyUNSAFEAssociation'
 import Association from './Association'
 
 export {
+  dehydrateDoc,
+  associationsFromModel,
+  responseToRelationship
+} from './helpers'
+
+export {
   HasManyUNSAFEAssociation,
   Association,
   HasManyFilesAssociation,


### PR DESCRIPTION
When trying to save documents that had relationships, the relationships object was saved
to the database. The document is now dehydrated before being sent.