### PR TITLE
fix(pouch): Set sync to false on reset

### DIFF
--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -93,6 +93,7 @@ export default class PouchLink extends CozyLink {
   async reset() {
     await this.pouches.destroy()
     this.client = undefined
+    this.synced = false
   }
 
   onSync() {

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -155,6 +155,11 @@ describe('CozyPouchLink', () => {
       await link.reset()
       expect(link.client).toBeUndefined()
     })
+
+    it('should set the `synced` property to false', async () => {
+      await link.reset()
+      expect(link.synced).toBe(false)
+    })
   })
 
   describe('onLogin', () => {


### PR DESCRIPTION
Not resetting `this.sync` was making `PouchLink` intercept all the requests even if it has been resetted and thus can't return anything.