### PR TITLE
feat(client): Add setData method

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -612,4 +612,17 @@ export default class CozyClient {
     this.idCounter++
     return id
   }
+
+  /**
+   * Directly set the data in the store, without using a query
+   * This is useful for cases like Pouch replication, which wants to
+   * set some data in the store.
+   *
+   * @param data {Object} { doctype: [data] }
+   */
+  setData(data) {
+    Object.entries(data).forEach(([doctype, data]) => {
+      this.dispatch(receiveQueryResult(null, { data }))
+    })
+  }
 }

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -151,6 +151,20 @@ describe('CozyClient', () => {
     })
   })
 
+  describe('setData', () => {
+    it('should dispatch RECEIVE_QUERY_RESULT actions', () => {
+      const data = {
+        'io.cozy.todos': [{ id: 1, done: true }, { id: 2, done: false }],
+        'io.cozy.people': [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }]
+      }
+
+      client.setData(data)
+
+      expect(store.getActions().length).toBe(Object.keys(data).length)
+      expect(store.getActions()[0].type).toBe('RECEIVE_QUERY_RESULT')
+    })
+  })
+
   describe('find', () => {
     it('should return a QueryDefinition', () => {
       expect(


### PR DESCRIPTION
When using PouchLink replication, we need something to pass the result of the replication to the client. The idea is to provide a `setData` method that we can call when the pouch synced successfuly. The link passes the data synced during the replication process to `setData` and the internal store is updated accordingly.