### PR TITLE
feat: PouchLink calls onSync with updated documents

### DIFF
--- a/packages/cozy-pouch-link/examples/periodic-sync/index.js
+++ b/packages/cozy-pouch-link/examples/periodic-sync/index.js
@@ -23,7 +23,8 @@ const LabeledInput = ({ label, onChange, value }) => (
       type="text"
       className="form-control"
       aria-label={label}
-      aria-describedby="inputGroup-sizing-default" />
+      aria-describedby="inputGroup-sizing-default"
+    />
   </div>
 )
 
@@ -49,6 +50,7 @@ class App extends React.Component {
 
     this.handleStart = this.handleStart.bind(this)
     this.handleStop = this.handleStop.bind(this)
+    this.handleReset = this.handleReset.bind(this)
     this.handleChangeToken = this.handleChangeToken.bind(this)
     this.handleChangeURL = this.handleChangeURL.bind(this)
     this.getReplicationURL = this.getReplicationURL.bind(this)
@@ -130,6 +132,11 @@ class App extends React.Component {
     }
   }
 
+  reset() {
+    this.manager.destroy()
+    this.manager = null
+  }
+
   handleStart(ev) {
     ev.preventDefault()
     this.start()
@@ -138,6 +145,11 @@ class App extends React.Component {
   handleStop(ev) {
     ev.preventDefault()
     this.stop()
+  }
+
+  handleReset(ev) {
+    ev.preventDefault()
+    this.reset()
   }
 
   handleChangeToken({ target: { value } }) {
@@ -176,8 +188,11 @@ class App extends React.Component {
           <button className="btn btn-primary" onClick={this.handleStart}>
             start
           </button>
-          <button className="btn btn-danger" onClick={this.handleStop}>
+          <button className="btn btn-secondary" onClick={this.handleStop}>
             stop
+          </button>
+          <button className="btn btn-danger" onClick={this.handleReset}>
+            reset
           </button>
         </form>
         <div>Replicating: {this.state.replicating + ''}</div>

--- a/packages/cozy-pouch-link/src/__tests__/mocks.js
+++ b/packages/cozy-pouch-link/src/__tests__/mocks.js
@@ -1,8 +1,11 @@
-export const pouchReplication = (url, options) => {
+export const pouchReplication = mockOptions => (url, options) => {
   const replication = {
     on: (event, fn) => {
       if (event == 'complete') {
-        setTimeout(fn, 1)
+        setTimeout(fn, 5)
+      }
+      if (event == 'change') {
+        setTimeout(() => fn(mockOptions.changes), 2)
       }
       return replication
     },


### PR DESCRIPTION
To be able to efficiently update the store with documents from
a replication, it is necessary to call onSync with the documents
that have been updated during the replication.

The 'change' event from pouch allows access to these documents.
They are accumulated during the replication and given to the `onSync`
callback grouped by doctype.

The link then normalize them (add _type and id/_id) before handling them to a callback defined in its options.