### PR TITLE
feat: Use two way replication

### DIFF
--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -13,7 +13,7 @@ const startReplication = (pouch, getReplicationURL) => {
   let replication
   const promise = new Promise((resolve, reject) => {
     const url = getReplicationURL()
-    replication = pouch.replicate.from(url, {
+    replication = pouch.sync(url, {
       batch_size: 1000 // we have mostly small documents
     })
     const docs = {}

--- a/packages/cozy-pouch-link/src/PouchManager.spec.js
+++ b/packages/cozy-pouch-link/src/PouchManager.spec.js
@@ -32,9 +32,7 @@ describe('PouchManager', () => {
         ]
       }
     })
-    pouch.replicate = {
-      from: jest.fn().mockImplementation(replication)
-    }
+    pouch.sync = jest.fn().mockImplementation(replication)
   })
 
   afterEach(() => {
@@ -49,7 +47,7 @@ describe('PouchManager', () => {
     manager.startReplicationLoop()
     await sleep(1000)
     const pouch = manager.getPouch('io.cozy.todos')
-    expect(pouch.replicate.from.mock.calls.length).toBeGreaterThan(5)
+    expect(pouch.sync.mock.calls.length).toBeGreaterThan(5)
   })
 
   it('should stop in case of error', async () => {


### PR DESCRIPTION
The PouchDB synchronization was only being done remote to local. Now it is done in two way.