### PR TITLE
Sharing previews

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -18,6 +18,12 @@ files associated to a specific document</p>
 </dd>
 <dt><a href="#module_OAuthClient">OAuthClient</a></dt>
 <dd></dd>
+<dt><a href="#module_PermissionCollection">PermissionCollection</a></dt>
+<dd><p>Interact with permissions</p>
+</dd>
+<dt><a href="#module_SharingCollection">SharingCollection</a></dt>
+<dd><p>Interact with sharing doctypes</p>
+</dd>
 </dl>
 
 ## Constants
@@ -85,6 +91,7 @@ continue.</p>
     * [.register(cozyURL)](#module_CozyClient+register) ⇒ <code>object</code>
     * [.startOAuthFlow(openURLCallback)](#module_CozyClient+startOAuthFlow) ⇒ <code>object</code>
     * [.renewAuthorization()](#module_CozyClient+renewAuthorization) ⇒ <code>object</code>
+    * [.setData(data)](#module_CozyClient+setData)
 
 <a name="module_CozyClient+collection"></a>
 
@@ -153,6 +160,19 @@ Renews the token if, for instance, new permissions are required.
 
 **Kind**: instance method of [<code>CozyClient</code>](#module_CozyClient)  
 **Returns**: <code>object</code> - Contains the fetched token and the client information.  
+<a name="module_CozyClient+setData"></a>
+
+### cozyClient.setData(data)
+Directly set the data in the store, without using a query
+This is useful for cases like Pouch replication, which wants to
+set some data in the store.
+
+**Kind**: instance method of [<code>CozyClient</code>](#module_CozyClient)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| data | <code>Object</code> | { doctype: [data] } |
+
 <a name="module_AppCollection"></a>
 
 ## AppCollection
@@ -365,7 +385,7 @@ Fetches the complete set of client information from the server after it has been
 <a name="module_OAuthClient+updateInformation"></a>
 
 ### oAuthClient.updateInformation(information, resetSecret) ⇒ <code>promise</code>
-Updates the client own information. This method will update both the local information and the remote information on the OAuth server.
+Overwrites the client own information. This method will update both the local information and the remote information on the OAuth server.
 
 **Kind**: instance method of [<code>OAuthClient</code>](#module_OAuthClient)  
 **Returns**: <code>promise</code> - A promise that resolves to a complete, updated list of client information  
@@ -468,6 +488,54 @@ Updates the OAuth informations
 | Param | Type | Description |
 | --- | --- | --- |
 | options | <code>object</code> | Map of OAuth options |
+
+<a name="module_PermissionCollection"></a>
+
+## PermissionCollection
+Interact with permissions
+
+<a name="module_PermissionCollection+getOwnPermissions"></a>
+
+### permissionCollection.getOwnPermissions() ⇒ <code>object</code>
+async getOwnPermissions - Gets the permission for the current token
+
+**Kind**: instance method of [<code>PermissionCollection</code>](#module_PermissionCollection)  
+<a name="module_SharingCollection"></a>
+
+## SharingCollection
+Interact with sharing doctypes
+
+
+* [SharingCollection](#module_SharingCollection)
+    * [.share(document, recipients, sharingType, description, [previewPath])](#module_SharingCollection+share)
+    * [.getDiscoveryLink(sharingId, sharecode)](#module_SharingCollection+getDiscoveryLink) ⇒ <code>string</code>
+
+<a name="module_SharingCollection+share"></a>
+
+### sharingCollection.share(document, recipients, sharingType, description, [previewPath])
+share - Creates a new sharing. See https://docs.cozy.io/en/cozy-stack/sharing/#post-sharings
+
+**Kind**: instance method of [<code>SharingCollection</code>](#module_SharingCollection)  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| document | <code>object</code> |  | The document to share. Should have and _id and a name. |
+| recipients | <code>array</code> |  | A list of io.cozy.contacts |
+| sharingType | <code>string</code> |  |  |
+| description | <code>string</code> |  |  |
+| [previewPath] | <code>string</code> | <code>null</code> | Relative URL of the sharings preview page |
+
+<a name="module_SharingCollection+getDiscoveryLink"></a>
+
+### sharingCollection.getDiscoveryLink(sharingId, sharecode) ⇒ <code>string</code>
+getDiscoveryLink - Returns the URL of the page that can be used to accept a sharing. See https://docs.cozy.io/en/cozy-stack/sharing/#get-sharingssharing-iddiscovery
+
+**Kind**: instance method of [<code>SharingCollection</code>](#module_SharingCollection)  
+
+| Param | Type |
+| --- | --- |
+| sharingId | <code>string</code> | 
+| sharecode | <code>string</code> | 
 
 <a name="encode"></a>
 

--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -4,6 +4,11 @@ import { uri } from './utils'
 
 const normalizePermission = perm => normalizeDoc(perm, 'io.cozy.permissions')
 
+/**
+ * Interact with permissions
+ *
+ * @module PermissionCollection
+ */
 export default class PermissionCollection extends DocumentCollection {
   async get(id) {
     const resp = await this.client.fetchJSON('GET', uri`/permissions/${id}`)
@@ -67,6 +72,18 @@ export default class PermissionCollection extends DocumentCollection {
     )
     for (let perm of links) {
       await this.destroy(perm)
+    }
+  }
+
+  /**
+   * async getOwnPermissions - Gets the permission for the current token
+   *
+   * @returns {object}
+   */
+  async getOwnPermissions() {
+    const resp = await this.client.fetchJSON('GET', '/permissions/self')
+    return {
+      data: normalizePermission(resp.data)
     }
   }
 }

--- a/packages/cozy-stack-client/src/PermissionCollection.spec.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.spec.js
@@ -1,0 +1,21 @@
+jest.mock('./CozyStackClient')
+
+import CozyStackClient from './CozyStackClient'
+import PermissionCollection from './PermissionCollection'
+
+describe('PermissionCollection', () => {
+  const client = new CozyStackClient()
+  const collection = new PermissionCollection('io.cozy.permissions', client)
+
+  describe('Permissions', () => {
+    beforeAll(() => {
+      client.fetch.mockReset()
+      client.fetchJSON.mockReturnValue(Promise.resolve({ data: [] }))
+    })
+
+    it('should get its own permissions', async () => {
+      await collection.getOwnPermissions()
+      expect(client.fetchJSON).toHaveBeenCalledWith('GET', '/permissions/self')
+    })
+  })
+})

--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -4,6 +4,11 @@ import { uri } from './utils'
 
 const normalizeSharing = sharing => normalizeDoc(sharing, 'io.cozy.sharings')
 
+/**
+ * Interact with sharing doctypes
+ *
+ * @module SharingCollection
+ */
 export default class SharingCollection extends DocumentCollection {
   async findByDoctype(doctype) {
     const resp = await this.client.fetchJSON(
@@ -16,12 +21,28 @@ export default class SharingCollection extends DocumentCollection {
     }
   }
 
-  async share(document, recipients, sharingType, description) {
+  /**
+   * share - Creates a new sharing. See https://docs.cozy.io/en/cozy-stack/sharing/#post-sharings
+   *
+   * @param  {object} document The document to share. Should have and _id and a name.
+   * @param  {array} recipients A list of io.cozy.contacts
+   * @param  {string} sharingType
+   * @param  {string} description
+   * @param  {string=} previewPath Relative URL of the sharings preview page
+   */
+  async share(
+    document,
+    recipients,
+    sharingType,
+    description,
+    previewPath = null
+  ) {
     const resp = await this.client.fetchJSON('POST', '/sharings/', {
       data: {
         type: 'io.cozy.sharings',
         attributes: {
           description,
+          preview_path: previewPath,
           open_sharing: sharingType === 'two-way',
           rules: getSharingRules(document, sharingType)
         },
@@ -33,6 +54,19 @@ export default class SharingCollection extends DocumentCollection {
       }
     })
     return { data: normalizeSharing(resp.data) }
+  }
+
+  /**
+   * getDiscoveryLink - Returns the URL of the page that can be used to accept a sharing. See https://docs.cozy.io/en/cozy-stack/sharing/#get-sharingssharing-iddiscovery
+   *
+   * @param  {string} sharingId
+   * @param  {string} sharecode
+   * @returns {string}
+   */
+  getDiscoveryLink(sharingId, sharecode) {
+    return this.client.fullpath(
+      `/sharings/${sharingId}/discovery?sharecode=${sharecode}`
+    )
   }
 
   async addRecipients(sharing, recipients, sharingType) {

--- a/packages/cozy-stack-client/src/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/SharingCollection.spec.js
@@ -46,5 +46,10 @@ describe('SharingCollection', () => {
       await collection.share(FOLDER, [RECIPIENT], 'one-way', 'foo')
       expect(client.fetchJSON).toMatchSnapshot()
     })
+
+    it('should call the right route with the right payload', async () => {
+      await collection.share(FOLDER, [RECIPIENT], 'one-way', 'foo', '/preview')
+      expect(client.fetchJSON).toMatchSnapshot()
+    })
   })
 })

--- a/packages/cozy-stack-client/src/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/SharingCollection.spec.js
@@ -1,7 +1,7 @@
-jest.mock('../CozyStackClient')
+jest.mock('./CozyStackClient')
 
-import CozyStackClient from '../CozyStackClient'
-import SharingCollection from '../SharingCollection'
+import CozyStackClient from './CozyStackClient'
+import SharingCollection from './SharingCollection'
 
 const FOLDER = {
   _type: 'io.cozy.files',

--- a/packages/cozy-stack-client/src/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/SharingCollection.spec.js
@@ -44,30 +44,7 @@ describe('SharingCollection', () => {
 
     it('should call the right route with the right payload', async () => {
       await collection.share(FOLDER, [RECIPIENT], 'one-way', 'foo')
-      expect(client.fetchJSON).toHaveBeenCalledWith('POST', '/sharings/', {
-        data: {
-          attributes: {
-            description: 'foo',
-            open_sharing: false,
-            rules: [
-              {
-                doctype: 'io.cozy.files',
-                title: 'bills',
-                add: 'push',
-                update: 'push',
-                remove: 'push',
-                values: ['folder_1']
-              }
-            ]
-          },
-          relationships: {
-            recipients: {
-              data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
-            }
-          },
-          type: 'io.cozy.sharings'
-        }
-      })
+      expect(client.fetchJSON).toMatchSnapshot()
     })
   })
 })

--- a/packages/cozy-stack-client/src/__snapshots__/SharingCollection.spec.js.snap
+++ b/packages/cozy-stack-client/src/__snapshots__/SharingCollection.spec.js.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SharingCollection share should call the right route with the right payload 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "GET",
+      "/sharings/doctype/io.cozy.files",
+    ],
+    Array [
+      "POST",
+      "/sharings/",
+      Object {
+        "data": Object {
+          "attributes": Object {
+            "description": "foo",
+            "open_sharing": false,
+            "rules": Array [
+              Object {
+                "add": "push",
+                "doctype": "io.cozy.files",
+                "remove": "push",
+                "title": "bills",
+                "update": "push",
+                "values": Array [
+                  "folder_1",
+                ],
+              },
+            ],
+          },
+          "relationships": Object {
+            "recipients": Object {
+              "data": Array [
+                Object {
+                  "id": "contact_1",
+                  "type": "io.cozy.contacts",
+                },
+              ],
+            },
+          },
+          "type": "io.cozy.sharings",
+        },
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;

--- a/packages/cozy-stack-client/src/__snapshots__/SharingCollection.spec.js.snap
+++ b/packages/cozy-stack-client/src/__snapshots__/SharingCollection.spec.js.snap
@@ -15,6 +15,7 @@ exports[`SharingCollection share should call the right route with the right payl
           "attributes": Object {
             "description": "foo",
             "open_sharing": false,
+            "preview_path": null,
             "rules": Array [
               Object {
                 "add": "push",

--- a/packages/cozy-stack-client/src/__snapshots__/SharingCollection.spec.js.snap
+++ b/packages/cozy-stack-client/src/__snapshots__/SharingCollection.spec.js.snap
@@ -56,3 +56,100 @@ exports[`SharingCollection share should call the right route with the right payl
   ],
 }
 `;
+
+exports[`SharingCollection share should call the right route with the right payload 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "GET",
+      "/sharings/doctype/io.cozy.files",
+    ],
+    Array [
+      "POST",
+      "/sharings/",
+      Object {
+        "data": Object {
+          "attributes": Object {
+            "description": "foo",
+            "open_sharing": false,
+            "preview_path": null,
+            "rules": Array [
+              Object {
+                "add": "push",
+                "doctype": "io.cozy.files",
+                "remove": "push",
+                "title": "bills",
+                "update": "push",
+                "values": Array [
+                  "folder_1",
+                ],
+              },
+            ],
+          },
+          "relationships": Object {
+            "recipients": Object {
+              "data": Array [
+                Object {
+                  "id": "contact_1",
+                  "type": "io.cozy.contacts",
+                },
+              ],
+            },
+          },
+          "type": "io.cozy.sharings",
+        },
+      },
+    ],
+    Array [
+      "POST",
+      "/sharings/",
+      Object {
+        "data": Object {
+          "attributes": Object {
+            "description": "foo",
+            "open_sharing": false,
+            "preview_path": "/preview",
+            "rules": Array [
+              Object {
+                "add": "push",
+                "doctype": "io.cozy.files",
+                "remove": "push",
+                "title": "bills",
+                "update": "push",
+                "values": Array [
+                  "folder_1",
+                ],
+              },
+            ],
+          },
+          "relationships": Object {
+            "recipients": Object {
+              "data": Array [
+                Object {
+                  "id": "contact_1",
+                  "type": "io.cozy.contacts",
+                },
+              ],
+            },
+          },
+          "type": "io.cozy.sharings",
+        },
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;


### PR DESCRIPTION
This PR adds the necessary routes to handle preview pages in sharings:

- Providing a `preview_path` to the `share` function
- Fetching the current set of permissions

The rest of the changes are docs and tests.