### PR TITLE
fix: Filter design and deleted docs in replication

### DIFF
--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -5,6 +5,7 @@ import fromPairs from 'lodash/fromPairs'
 import map from 'lodash/map'
 import zip from 'lodash/zip'
 import * as promises from './promises'
+import { isDesignDocument, isDeletedDocument } from './helpers'
 
 const DEFAULT_DELAY = 30 * 1000
 
@@ -19,9 +20,11 @@ const startReplication = (pouch, getReplicationURL) => {
     const docs = {}
     replication.on('change', ({ change }) => {
       if (change.docs) {
-        change.docs.forEach(doc => {
-          docs[doc._id] = doc
-        })
+        change.docs
+          .filter(doc => !isDesignDocument(doc) && !isDeletedDocument(doc))
+          .forEach(doc => {
+            docs[doc._id] = doc
+          })
       }
     })
     replication.on('error', reject).on('complete', () => {

--- a/packages/cozy-pouch-link/src/helpers.js
+++ b/packages/cozy-pouch-link/src/helpers.js
@@ -9,3 +9,7 @@ export const withoutDesignDocuments = res => {
     total_rows: rows.length
   }
 }
+
+export const isDesignDocument = doc => startsWith(doc._id, '_design')
+
+export const isDeletedDocument = doc => doc._deleted

--- a/packages/cozy-pouch-link/src/helpers.spec.js
+++ b/packages/cozy-pouch-link/src/helpers.spec.js
@@ -1,4 +1,8 @@
-import { withoutDesignDocuments } from './helpers.js'
+import {
+  withoutDesignDocuments,
+  isDesignDocument,
+  isDeletedDocument
+} from './helpers.js'
 
 describe('Helpers', () => {
   describe('withoutDesignDocuments', () => {
@@ -23,6 +27,26 @@ describe('Helpers', () => {
       const responseCopy = { ...response }
       withoutDesignDocuments(response)
       expect(response).toEqual(responseCopy)
+    })
+  })
+
+  describe('isDesignDocument', () => {
+    it('should return true when given a design document', () => {
+      expect(isDesignDocument({ _id: '_design/something' })).toBe(true)
+    })
+
+    it('should return false when given a non design document', () => {
+      expect(isDesignDocument({ _id: 'something' })).toBe(false)
+    })
+  })
+
+  describe('isDeletedDocument', () => {
+    it('should return true when given a deleted document', () => {
+      expect(isDeletedDocument({ _deleted: true })).toBe(true)
+    })
+
+    it('should return false when given a non deleted document', () => {
+      expect(isDeletedDocument({ _id: 'notdeleted' })).toBeFalsy()
     })
   })
 })


### PR DESCRIPTION
The replication process gets design and deleted documents. We filter them so they are not stored in the cozy client's store