### PR TITLE
fix(pouch): Avoid to destroy dbs already destroyed

### DIFF
--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -92,7 +92,11 @@ export default class PouchLink extends CozyLink {
   }
 
   async reset() {
-    await this.pouches.destroy()
+    if (this.pouches) {
+      await this.pouches.destroy()
+    }
+
+    this.pouches = null
     this.client = undefined
     this.synced = false
   }

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -145,8 +145,9 @@ describe('CozyPouchLink', () => {
     })
 
     it('should delete all databases', async () => {
+      const pouches = link.pouches
       await link.reset()
-      expect(link.pouches.destroy).toHaveBeenCalledTimes(1)
+      expect(pouches.destroy).toHaveBeenCalledTimes(1)
     })
 
     it('should delete client', async () => {
@@ -159,6 +160,11 @@ describe('CozyPouchLink', () => {
     it('should set the `synced` property to false', async () => {
       await link.reset()
       expect(link.synced).toBe(false)
+    })
+
+    it('should forget the PouchManager instance', async () => {
+      await link.reset()
+      expect(link.pouches).toBeNull()
     })
   })
 


### PR DESCRIPTION
We already destroy Pouch dbs when we reset the pouch link. But when we register a new client on it, we also re-create the databases. It happens that when we logout then login, we tried to destroy databases already destroyed, throwing an error. This error was catched and displayed without breaking everything. But there still was a problem with the replication after that.