### PR TITLE
fix(stack-client): Map redirect_uris to camelcase

### DIFF
--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -88,7 +88,8 @@ export default class OAuthClient extends CozyStackClient {
       client_name: 'clientName',
       client_secret: 'clientSecret',
       registration_access_token: 'registrationAccessToken',
-      software_id: 'softwareID'
+      software_id: 'softwareID',
+      redirect_uris: 'redirectURI'
     }
 
     const result = {}

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -111,6 +111,18 @@ export default class OAuthClient extends CozyStackClient {
   async register() {
     if (this.isRegistered()) throw new Error('Client already registered')
 
+    const mandatoryFields = ['redirectURI']
+    const fields = Object.keys(this.oauthOptions)
+    const missingMandatoryFields = mandatoryFields.filter(
+      fieldName => fields[fieldName]
+    )
+
+    if (missingMandatoryFields.length > 0) {
+      throw new Error(
+        `Can't register client : missing ${missingMandatoryFields} fields`
+      )
+    }
+
     const data = await this.fetchJSON(
       'POST',
       '/auth/register',


### PR DESCRIPTION
This property was not mapped in `camelCaseOAuthData`, but we need it to be present in `register`, otherwise we send `undefined` to the stack, and we receive an error telling us that the `redirect_uris` parameter is mandatory.