### PR TITLE
Changed revokeRecipient() signature

### DIFF
--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -63,13 +63,10 @@ export default class SharingCollection extends DocumentCollection {
     return { data: normalizeSharing(resp.data) }
   }
 
-  revokeRecipient(sharing, recipientEmail) {
-    const memberIndex = sharing.attributes.members.findIndex(
-      m => m.email === recipientEmail
-    )
+  revokeRecipient(sharing, recipientIndex) {
     return this.client.fetchJSON(
       'DELETE',
-      uri`/sharings/${sharing._id}/recipients/${memberIndex}`
+      uri`/sharings/${sharing._id}/recipients/${recipientIndex}`
     )
   }
 


### PR DESCRIPTION
We need to pass the recipient index, because it's not impossible to have many recipients with the same email...