### PR TITLE
fix: Really force file download

### DIFF
--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -178,7 +178,7 @@ export default class FileCollection extends DocumentCollection {
 
   async download(file) {
     const href = await this.getDownloadLinkById(file._id)
-    forceFileDownload(href, file.name)
+    forceFileDownload(`${href}?Dl=1`, file.name)
   }
 
   async downloadArchive(fileIds, notSecureFilename = 'files') {


### PR DESCRIPTION
Some file types will be opened by the browser directly, even with a `download` attribute in the link — unless the server sends the correct header. Adding `Dl=1` does just that.