### PR TITLE
Split parts of the docs

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -171,11 +171,3 @@ const TodoList = ...
 
 export default connect(query, { as: 'allTodos' })(TodoList)
 ```
-
-
-
-
-
-
-
-

--- a/docs/how-to/existing-store.md
+++ b/docs/how-to/existing-store.md
@@ -1,0 +1,26 @@
+# Integrating with an existing redux store
+
+`cozy-client` uses redux internally to centralize the statuses of the various fetches and replications triggered by the library, and to store locally the data in a normalized way. If you already have a redux store in your app, you can configure `cozy-client` to use this existing store:
+
+```js
+import CozyClient from 'cozy-client'
+import { combineReducers, createStore, applyMiddleware } from 'redux'
+import myReducers from './myapp/reducers'
+import myMiddleware from './myapp/middleware'
+
+const client = new CozyClient({
+  /*...*/
+})
+
+const store = createStore(
+  combineReducers({ ...myReducers, cozy: client.reducer() }),
+  applyMiddleware(myMiddleware)
+)
+
+ReactDOM.render(
+  <CozyProvider client={client} store={store}>
+    <MyApp />
+  </CozyProvider>,
+  document.getElementById('main')
+)
+```

--- a/docs/how-to/hoc.md
+++ b/docs/how-to/hoc.md
@@ -1,0 +1,58 @@
+# Higher-Order Component (HOC)
+
+## Connect
+
+If you prefer HOCs to render-prop components, we provide a higher-order component called `connect`. Basic example of usage:
+
+```jsx
+import React from 'react'
+import { connect } from 'cozy-client'
+
+const query = client => client.find('io.cozy.todos').where({ checked: false })
+
+const TodoList = ({ data, fetchStatus }) =>
+  fetchStatus !== 'loaded'
+    ? <h1>Loading...</h1>
+    : <ul>{data.map(todo => <li>{todo.label}</li>)}</ul>
+
+export default connect(query)(TodoList)
+```
+
+When we use `connect` to bind a query to a component, three things happen:
+ - The query passed as an argument will be executed when the component mounts, resulting in the loading of data from the client-side store, or the server if the data is not in the store ;
+ - Our component subscribes to the store, so that it is updated if the data changes ;
+ - props are injected into the component: if we were to declare `propTypes` they would look like this:
+
+```jsx
+TodoList.propTypes = {
+  fetchStatus: PropTypes.string.isRequired,
+  data: PropTypes.array
+}
+```
+
+## withMutation
+
+Using `withMutation` higher-order component makes it easy to bind actions to your components. `withMutation` provides only a simple function to the wrapper component, in a prop called `mutate`:
+
+```jsx
+import { withMutation } from 'cozy-client'
+
+const AddTodo = ({ mutate }) => {
+  let input
+
+  return (
+    <form onSubmit={e => {
+      e.preventDefault()
+      mutate(input.value)
+      input.value = ''
+    }}>
+      <input ref={node => { input = node }} />
+      <button type="submit">Add Todo</button>
+    </form>
+  )
+}
+
+export default withMutation(
+  label => client => client.create('io.cozy.todos', { label })
+)(AddTodo)
+```

--- a/docs/how-to/link-custom.md
+++ b/docs/how-to/link-custom.md
@@ -1,0 +1,68 @@
+# Links
+
+## Using links
+
+To create a link to use with Cozy Client, you can import one from `cozy-client` or create your own. A `StackLink` will be setup by default, but you can instantiate it yourself:
+
+```js
+import CozyClient, { StackLink } from 'cozy-client'
+
+const link = new StackLink()
+
+const client = new CozyClient({
+  uri: 'http://cozy.tools:8080',
+  token: '...',
+  link
+})
+```
+
+Links are designed to be composed together to form chains:
+
+```js
+import CozyClient, { StackLink } from 'cozy-client'
+import PouchDBLink from 'cozy-pouch-link'
+import LogLink from '../LogLink'
+
+const stackLink = new StackLink()
+const pouchLink = new PouchDBLink({ doctypes: [...] })
+const logLink = new LogLink()
+
+const client = new CozyClient({
+  uri: 'http://cozy.tools:8080',
+  token: '...',
+  links: [
+    logLink,
+    pouchLink,
+    stackLink
+  ]
+})
+```
+
+## Authoring a link
+
+There are two ways of creating a new link. First, you can instantiate a `CozyLink` and pass a request handling function to its constructor:
+
+```js
+const logLink = new CozyLink((operation, result, forward) => {
+  console.log(JSON.stringify(operation))
+  return forward(operation, result)
+})
+```
+
+Or you can subclass `CozyLink`:
+
+```js
+class LogLink extends CozyLink {
+  request(operation, result, forward) {
+    console.log(JSON.stringify(operation))
+    return forward(operation, result)
+  }
+}
+```
+
+At the core of a link is the `request` method. It takes the following arguments:
+ - `operation`: the operation definition being passed through the link ;
+ - `result`: the (maybe incomplete) result processed by the previous link ;
+ - `forward`: (optional) specifies the next link in the chain of links.
+
+When the `request` method is called, the link has to return data back. Depending on where the link is in the chain, and its ability to provide the requested data, it will either use the `forward` callback to defer to the next link the task of providing (or completing) the data, or return back a result on its own.

--- a/docs/how-to/oauth.md
+++ b/docs/how-to/oauth.md
@@ -1,0 +1,108 @@
+# Using the OAuth client
+
+`CozyClient` can also be used as an OAuth client. To get started, configure the OAuth informations when creating the client:
+
+```js
+import CozyClient from 'cozy-client'
+
+const client = new CozyClient({
+  uri: 'http://cozy.tools:8080',
+  scope: ['io.cozy.mydoctype'],
+  oauth: {
+    clientName: 'MyClient',
+    softwareID: 'MyAppId',
+    redirectURI: 'http://localhost'
+  }
+})
+```
+
+`scope` is an array of [permissions](https://github.com/cozy/cozy-stack/blob/master/docs/permissions.md) you require for your client, and `oauth` is a list of fields that identify your client for the user and the server. The complete list of field can be found [here](https://github.com/cozy/cozy-stack/blob/master/docs/permissions.md), although they should be camel-cased instead of snake-cased.
+
+## Obtaining a token
+
+Before you can start making requests to the server, you will need to get a token. `cozy-client` will provide a URL to a page where the user is shown what data you want to access, and asking for his or her permission. After the user accepts these permissions, he or she is redirected to the `oauth.redirectURI` that you declared earlier. You will then have to give this redirected URL back to `cozy-client` as it contains a code, that will be exchanged for the token.
+
+Sounds, tricky, but most of it is taken care of for you. To get started, you call `client.startOAuthFlow` like this:
+
+```js
+import CozyClient from 'cozy-client'
+
+const client = new CozyClient({
+  uri: 'http://cozy.tools:8080',
+  scope: ['io.cozy.mydoctype'],
+  oauth: {
+    clientName: 'MyClient',
+    softwareID: 'MyAppId',
+    redirectURI: 'http://localhost'
+  }
+})
+
+client.startOAuthFlow(openURL)
+```
+
+The `openURL` parameter is a callback. It will receive the URL to the page as a parameter, and it must return a Promise that resolves with the redirected URL. How exactly you do this depends on your environment — for a mobile app you may use a WebView, in a browser maybe a new tab… Here is an example that uses the browser's console and an experienced user:
+
+```js
+const openURL = url => {
+  console.log('Please visit the following URL, accept the permissions and copy the URL you are redirected to, then come back here. you have 10 seconds.', url)
+  return new Promise(resolve => {
+    setTimeout(async () => {
+      const returnUrl = prompt('Paste the new URL here.')
+      resolve(returnUrl)
+    }, 10000)
+  })
+}
+```
+
+And that's it! After the promise is resolved, `cozy-client` finishes the OAuth flow and you can start using it.
+
+## Restoring a client
+
+Of course you don't want to go through this whole process every time your app starts. In order to restore the client from a previous version, you need to give it a token and some extra information about itself. Both of these are returned by the `openURL` function, so you can store them wherever you see fit — in this example we'll use the `localStorag` API.
+
+```js
+import CozyClient from 'cozy-client'
+
+const client = new CozyClient({
+  uri: 'http://cozy.tools:8080',
+  scope: ['io.cozy.mydoctype'],
+  oauth: {
+    clientName: 'MyClient',
+    softwareID: 'MyAppId',
+    redirectURI: 'http://localhost'
+  }
+})
+
+const {token, infos} = client.startOAuthFlow(openURL)
+localStorage.setItem('token', token)
+localStorage.setItem('infos', JSON.stringify(infos))
+```
+
+Next time your app starts, you can pass these informations to the constructor. Here is a complete example of the OAuth client initilisation:
+
+```js
+const storedToken = localStorage.getItem('token') || null
+const storedInfos = JSON.parse(localStorage.getItem('infos')) || {
+  clientName: 'MyClient',
+  softwareID: 'MyAppId',
+  redirectURI: 'http://localhost'
+}
+
+const client = new CozyClient({
+  uri: 'http://cozy.tools:8080',
+  oauth: storedInfos,
+  token: storedToken,
+  scope: ['io.cozy.mydoctype']
+});
+
+if (!storedToken) {
+  const {token, infos} = await client.startOAuthFlow(openURL)
+  localStorage.setItem('token', token)
+  localStorage.setItem('infos', JSON.stringify(infos))
+}
+```
+
+## Logout a client
+
+When a user logout, we would like remove all references on this instance and
+remove all user data. You can just use `cozyClient.logout()`.

--- a/docs/link-design.md
+++ b/docs/link-design.md
@@ -1,0 +1,9 @@
+# Cozy Link
+
+Cozy Link is a simple yet powerful way to describe how you want to get the result of a query. Think of it as a sort of "middleware".
+
+Links are units that you can chain together to define how each query should be handled: this allows us to use different sources of data, or to control the request lifecycle in a way that makes sense for your app. The first link operates on an operation object and each subsequent link operates on the result of the previous link:
+
+![links chain](./cozy-client-links.png)
+
+In the chain example pictured above, the Dedup link would avoid re-fetching the same query, the PouchDB link would try to get the data from a local Pouch instance, and fallback to the Stack link, assisted by the Retry link that will try to fetch again the query in case of a network error.


### PR DESCRIPTION
Takes out some parts of the main guide and puts them in secondary guides.

The part about links will need some rewording, and we have to add links to the various How-to's. I think both can be done in subsequent PRs.