### PR TITLE
Fix offline on pouch link

### DIFF
--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -180,11 +180,15 @@ export default class PouchLink extends CozyLink {
 
   request(operation, result = null, forward = doNothing) {
     if (!this.synced) {
+      console.info('Cozy Pouch is not synced.')
       return forward(operation)
     }
 
     // Forwards if doctype not supported
     if (!this.supportsOperation(operation)) {
+      console.info(
+        `The doctype '${getDoctypeFromOperation(operation)}' is not supported`
+      )
       return forward(operation)
     }
 

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -15,6 +15,7 @@ const parseMutationResult = (original, res) => {
   return { ...original, ...omit(res, 'ok') }
 }
 
+const LOCALSTORAGE_SYNCED_KEY = 'cozy-client-pouch-link-synced'
 const DEFAULT_OPTIONS = {
   replicationInterval: 30 * 1000
 }
@@ -53,6 +54,7 @@ export default class PouchLink extends CozyLink {
     }
     this.doctypes = doctypes
     this.indexes = {}
+    this.synced = window.localStorage.getItem(LOCALSTORAGE_SYNCED_KEY) || false
   }
 
   getReplicationURL(doctype) {
@@ -98,6 +100,7 @@ export default class PouchLink extends CozyLink {
 
     this.pouches = null
     this.client = undefined
+    window.localStorage.removeItem(LOCALSTORAGE_SYNCED_KEY)
     this.synced = false
   }
 
@@ -112,6 +115,7 @@ export default class PouchLink extends CozyLink {
 
   onSync(normalizedData) {
     this.synced = true
+    window.localStorage.setItem(LOCALSTORAGE_SYNCED_KEY, true)
     if (this.options.onSync) {
       this.options.onSync.call(this, normalizedData)
     }

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -117,6 +117,8 @@ export default class PouchManager {
     this._stopReplicationLoop = promises.setInterval(() => {
       if (window.navigator.onLine) {
         this.replicateOnce()
+      } else {
+        console.info('The device is offline replication is abort')
       }
     }, delay)
     this.addListener()

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -114,10 +114,11 @@ export default class PouchManager {
     }
     console.info('Start replication loop')
     delay = delay || this.options.replicationDelay || DEFAULT_DELAY
-    this._stopReplicationLoop = promises.setInterval(
-      () => this.replicateOnce(),
-      delay
-    )
+    this._stopReplicationLoop = promises.setInterval(() => {
+      if (window.navigator.onLine) {
+        this.replicateOnce()
+      }
+    }, delay)
     this.addListener()
     return this._stopReplicationLoop
   }


### PR DESCRIPTION
When an application is offline you must be able to query Pouch
A limitation has been put in place to avoid launching replications when device are in offline mode