### PR TITLE
Granular access to query results

### DIFF
--- a/packages/cozy-client/src/__tests__/store.spec.js
+++ b/packages/cozy-client/src/__tests__/store.spec.js
@@ -65,7 +65,9 @@ describe('Store', () => {
       )
       const stateAfter = store.getState().cozy.documents
       expect(stateBefore).not.toBe(stateAfter)
-      expect(getDocumentFromState(store.getState(), 'io.cozy.todos', TODO_1._id)).toEqual(TODO_WITH_REV_2)
+      expect(
+        getDocumentFromState(store.getState(), 'io.cozy.todos', TODO_1._id)
+      ).toEqual(TODO_WITH_REV_2)
     })
 
     it('should update the state when receiving a doc without a rev', () => {
@@ -89,7 +91,9 @@ describe('Store', () => {
       )
       const stateAfter = store.getState().cozy.documents
       expect(stateBefore).not.toBe(stateAfter)
-      expect(getDocumentFromState(store.getState(), 'io.cozy.todos', TODO_1._id)).toEqual(TODO_1)
+      expect(
+        getDocumentFromState(store.getState(), 'io.cozy.todos', TODO_1._id)
+      ).toEqual(TODO_1)
     })
   })
 
@@ -305,6 +309,30 @@ describe('Store', () => {
             getDocumentFromState(store.getState(), 'io.cozy.files', 'abc')
           ).toEqual({ _id: 'abc', _type: 'io.cozy.files', name: 'abc.png' })
         })
+      })
+
+      it('should not update queries when the documents have not changed', async () => {
+        const TODO_WITH_REV = { ...TODO_1, meta: { rev: 1 } }
+
+        await store.dispatch(
+          receiveQueryResult('allTodos', {
+            data: TODO_WITH_REV,
+            meta: { count: 1 },
+            skip: 0
+          })
+        )
+        const queryBefore = getQueryFromStore(store, 'allTodos')
+
+        await store.dispatch(
+          receiveQueryResult('allTodos', {
+            data: TODO_WITH_REV,
+            meta: { count: 1 },
+            skip: 0
+          })
+        )
+        const queryAfter = getQueryFromStore(store, 'allTodos')
+
+        expect(queryBefore).toEqual(queryAfter)
       })
     })
   })

--- a/packages/cozy-client/src/__tests__/store.spec.js
+++ b/packages/cozy-client/src/__tests__/store.spec.js
@@ -19,6 +19,80 @@ describe('Store', () => {
     store = createStore(combineReducers({ cozy: reducer }))
   })
 
+  describe('documents state', () => {
+    it('should not update the state when receiving a doc with an identical rev', () => {
+      const TODO_WITH_REV = { ...TODO_1, meta: { rev: 1 } }
+      store.dispatch(
+        receiveQueryResult('allTodos', {
+          data: TODO_WITH_REV,
+          meta: { count: 1 },
+          skip: 0,
+          next: false
+        })
+      )
+      const stateBefore = store.getState().cozy.documents
+      store.dispatch(
+        receiveQueryResult('allTodos', {
+          data: TODO_WITH_REV,
+          meta: { count: 1 },
+          skip: 0,
+          next: false
+        })
+      )
+      const stateAfter = store.getState().cozy.documents
+      expect(stateBefore).toBe(stateAfter)
+    })
+
+    it('should update the state when receiving a doc with a different rev', () => {
+      const TODO_WITH_REV_1 = { ...TODO_1, meta: { rev: 1 } }
+      const TODO_WITH_REV_2 = { ...TODO_1, meta: { rev: 2 } }
+      store.dispatch(
+        receiveQueryResult('allTodos', {
+          data: TODO_WITH_REV_1,
+          meta: { count: 1 },
+          skip: 0,
+          next: false
+        })
+      )
+      const stateBefore = store.getState().cozy.documents
+      store.dispatch(
+        receiveQueryResult('allTodos', {
+          data: TODO_WITH_REV_2,
+          meta: { count: 1 },
+          skip: 0,
+          next: false
+        })
+      )
+      const stateAfter = store.getState().cozy.documents
+      expect(stateBefore).not.toBe(stateAfter)
+      expect(getDocumentFromState(store.getState(), 'io.cozy.todos', TODO_1._id)).toEqual(TODO_WITH_REV_2)
+    })
+
+    it('should update the state when receiving a doc without a rev', () => {
+      const TODO_WITH_REV = { ...TODO_1, meta: { rev: 1 } }
+      store.dispatch(
+        receiveQueryResult('allTodos', {
+          data: TODO_WITH_REV,
+          meta: { count: 1 },
+          skip: 0,
+          next: false
+        })
+      )
+      const stateBefore = store.getState().cozy.documents
+      store.dispatch(
+        receiveQueryResult('allTodos', {
+          data: TODO_1,
+          meta: { count: 1 },
+          skip: 0,
+          next: false
+        })
+      )
+      const stateAfter = store.getState().cozy.documents
+      expect(stateBefore).not.toBe(stateAfter)
+      expect(getDocumentFromState(store.getState(), 'io.cozy.todos', TODO_1._id)).toEqual(TODO_1)
+    })
+  })
+
   describe('getDocumentFromState', () => {
     it('should return null when the store is empty', () => {
       const spy = jest.spyOn(global.console, 'warn').mockReturnValue(jest.fn())

--- a/packages/cozy-client/src/store/documents.js
+++ b/packages/cozy-client/src/store/documents.js
@@ -1,6 +1,7 @@
 import { isReceivingData } from './queries'
 import { isReceivingMutationResult } from './mutations'
 import keyBy from 'lodash/keyBy'
+import get from 'lodash/get'
 
 const storeDocument = (state, document) => {
   const type = document._type
@@ -10,6 +11,12 @@ const storeDocument = (state, document) => {
   if (!document._id) {
     throw new Error('Document without _id', document)
   }
+
+  const existingDoc = get(state, [type, document._id])
+  const existingRev = get(existingDoc, 'meta.rev')
+  const newRev = get(document, 'meta.rev')
+  if (newRev && existingRev === newRev) return state
+
   return {
     ...state,
     [type]: {

--- a/packages/cozy-client/src/store/index.js
+++ b/packages/cozy-client/src/store/index.js
@@ -72,21 +72,12 @@ const combinedReducer = (state = { documents: {}, queries: {} }, action) => {
       )
     }
   }
-<<<<<<< Updated upstream
-  const updatedDocuments = documents(state.documents, action)
-  const documentsChanged = updatedDocuments !== state.documents
-
-  return {
-    documents: updatedDocuments,
-    queries: queries(state.queries, action, state.documents, documentsChanged)
-=======
   const nextDocuments = documents(state.documents, action)
   const haveDocumentsChanged = nextDocuments !== state.documents
 
   return {
     documents: nextDocuments,
     queries: queries(state.queries, action, nextDocuments, haveDocumentsChanged)
->>>>>>> Stashed changes
   }
 }
 export default combinedReducer

--- a/packages/cozy-client/src/store/index.js
+++ b/packages/cozy-client/src/store/index.js
@@ -72,9 +72,21 @@ const combinedReducer = (state = { documents: {}, queries: {} }, action) => {
       )
     }
   }
+<<<<<<< Updated upstream
+  const updatedDocuments = documents(state.documents, action)
+  const documentsChanged = updatedDocuments !== state.documents
+
   return {
-    documents: documents(state.documents, action),
-    queries: queries(state.queries, action, state.documents)
+    documents: updatedDocuments,
+    queries: queries(state.queries, action, state.documents, documentsChanged)
+=======
+  const nextDocuments = documents(state.documents, action)
+  const haveDocumentsChanged = nextDocuments !== state.documents
+
+  return {
+    documents: nextDocuments,
+    queries: queries(state.queries, action, nextDocuments, haveDocumentsChanged)
+>>>>>>> Stashed changes
   }
 }
 export default combinedReducer

--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -162,13 +162,8 @@ const manualQueryUpdater = (action, documents) => query => {
 const queries = (
   state = {},
   action,
-<<<<<<< Updated upstream
-  documents = {},
-  documentsChanged = true
-=======
   nextDocuments = {},
   haveDocumentsChanged = true
->>>>>>> Stashed changes
 ) => {
   if (action.type == INIT_QUERY) {
     return {
@@ -190,7 +185,7 @@ const queries = (
   }
   if (isReceivingMutationResult(action)) {
     const updater = action.updateQueries
-      ? manualQueryUpdater(action, documents)
+      ? manualQueryUpdater(action, nextDocuments)
       : autoQueryUpdater(action)
     return mapValues(state, updater)
   }

--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -159,7 +159,17 @@ const manualQueryUpdater = (action, documents) => query => {
   }
 }
 
-const queries = (state = {}, action, documents = {}) => {
+const queries = (
+  state = {},
+  action,
+<<<<<<< Updated upstream
+  documents = {},
+  documentsChanged = true
+=======
+  nextDocuments = {},
+  haveDocumentsChanged = true
+>>>>>>> Stashed changes
+) => {
   if (action.type == INIT_QUERY) {
     return {
       ...state,
@@ -171,8 +181,10 @@ const queries = (state = {}, action, documents = {}) => {
     return mapValues(state, queryState => {
       if (queryState.id == action.queryId) {
         return query(queryState, action)
-      } else {
+      } else if (haveDocumentsChanged) {
         return updater(queryState)
+      } else {
+        return queryState
       }
     })
   }

--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -175,7 +175,8 @@ const queries = (state = {}, action, documents = {}) => {
         return updater(queryState)
       }
     })
-  } else if (isReceivingMutationResult(action) || isReceivingData(action)) {
+  }
+  if (isReceivingMutationResult(action)) {
     const updater = action.updateQueries
       ? manualQueryUpdater(action, documents)
       : autoQueryUpdater(action)


### PR DESCRIPTION
This PR has no content for now, I'm just going to explain what the problem is.

One very common use case we have is displaying lists of things — bank transactions, files, contacts, whatever. Doing this with the `Query` API is quite easy:

```
const query = client => client.find('io.cozy.todos')

const TodoList = () => (
  <Query query={query}>
    {({ data }) =>
      <ul>{data.map(todo => <Todo data={todo} />)}</ul>
    }
  </Query>
```

One problem with this is that if any of the documents change in the store, we re-render the whole list. This happens if we actually alter the document, for example by changing the label — but it also happens if we simply re-fetch the document, because in that case we blindly override the one in the store without checking for actual differences (to be confirmed).

To mitigate this, we'd like to only get a list of ids, something like this:

```
const query = client => client.find('io.cozy.todos').onlyIds()

const TodoList = () => (
  <Query query={query}>
    {({ data }) =>
      <ul>{data.map(todoId => <Todo todoId={todoId} />)}</ul>
    }
  </Query>
```

The actual document data can then be re-queried inside the `Todo` component:

```
const Todo = ({ todoId }) => (
  <Query query={client => client.get('io.cozy.todos', todoId)}>
    {({ data }) =>
      <li>{data.label}</li>
    }
  </Query>
)
```

in that case the main query only changes and re-renders when the list of matched documents changes, but not when one document changes. If only one document changes, only the sub-query will be re-rendered.

So here's what I plan to do:

- [x] Confirm that after fetching a document we already have in memory we're overriding it without checking for changes — and if so, correct that
- [ ] Figure out how to express that we only want the ids of a query result. Should we support other fields than just ids?
- [ ] Figure out if the "subqueries" are ok as they stand, or if we want to change their API. Maybe it should be explicit that we're asking for a subset of a particular query?

Early comments and suggestions are very welcome, especially if you have other use cases that tie into these problems, or if you have ideas about what the API should look like.