### PR TITLE
Schema class fixes

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -70,7 +70,7 @@ export default class CozyClient {
 
     this.chain = chain(this.links)
 
-    this.schema = new Schema(schema)
+    this.schema = new Schema(schema, this.getClient())
   }
 
   registerClientOnLinks() {

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -158,7 +158,7 @@ export default class CozyClient {
   }
 
   validate(document) {
-    return this.schema(document)
+    return this.schema.validate(document)
   }
 
   async save(document, mutationOptions = {}) {


### PR DESCRIPTION
Some stuff we missed in  #158.

The first commit is just a typo, but the second one is more important — to validate the uniqueness of an attribute, the `Schema` class needs a client. Not a CozyClient (so we still keep the separation we wanted), but one of the underlying clients (`StackClient` for example).

I don't like my fix too much because it doesn't remove the existing coupling between the 2 classes, but hopefully we can come up with something better next time.