### PR TITLE
Fix destroy update

### DIFF
--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -96,6 +96,7 @@ const filterForQuery = query => {
     if (selectorFilterFn && !selectorFilterFn(datum)) {
       return false
     }
+    if (datum._deleted) return false
     return true
   }
 }

--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -1,5 +1,4 @@
 import mapValues from 'lodash/mapValues'
-import groupBy from 'lodash/groupBy'
 import union from 'lodash/union'
 import difference from 'lodash/difference'
 import intersection from 'lodash/intersection'
@@ -83,16 +82,14 @@ const query = (state = queryInitialState, action) => {
   }
 }
 
-const filterForQuery = query => {
+const getQueryDocumentsChecker = query => {
   const qdoctype = query.definition.doctype
   const selectorFilterFn = query.definition.selector
     ? selectorFilter(query.definition.selector)
     : null
   return datum => {
     const ddoctype = datum._type
-    if (ddoctype != qdoctype) {
-      return false
-    }
+    if (ddoctype !== qdoctype) return false
     if (selectorFilterFn && !selectorFilterFn(datum)) {
       return false
     }
@@ -104,18 +101,14 @@ const filterForQuery = query => {
 const _id = x => x._id
 
 const updateData = (query, newData) => {
-  const filter = filterForQuery(query)
-  let { good, bad } = groupBy(newData, doc => (filter(doc) ? 'good' : 'bad'))
-  good = good ? good : []
-  bad = bad ? bad : []
-
-  const goodIds = good.map(_id)
-  const badIds = bad.map(_id)
+  const isFulfilled = getQueryDocumentsChecker(query)
+  const matchedIds = newData.filter(doc => isFulfilled(doc)).map(_id)
+  const unmatchedIds = newData.filter(doc => !isFulfilled(doc)).map(_id)
 
   const originalIds = query.data
-  const toRemove = intersection(originalIds, badIds)
-  const toAdd = difference(goodIds, originalIds)
-  const toUpdate = intersection(originalIds, goodIds)
+  const toRemove = intersection(originalIds, unmatchedIds)
+  const toAdd = difference(matchedIds, originalIds)
+  const toUpdate = intersection(originalIds, matchedIds)
 
   const changed = toRemove.length || toAdd.length || toUpdate.length
 


### PR DESCRIPTION
Using `withMutations`, the method `deleteDocument()` was not working correctly, it does remove from the database but it was not removed from the app state.

I don't know if this is the good way to do that or if this is the good place to check that but it does the job. What do you think @drazik or @y-lohse?

Fix #201 