### PR TITLE
fix: Update queries when references are mutated

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -285,14 +285,19 @@ export default class CozyClient {
     try {
       const response = await this.requestMutation(mutationDefinition)
       this.dispatch(
-        receiveMutationResult(mutationId, response, {
-          update,
-          updateQueries
-        })
+        receiveMutationResult(
+          mutationId,
+          response,
+          {
+            update,
+            updateQueries
+          },
+          mutationDefinition
+        )
       )
       return response
     } catch (error) {
-      this.dispatch(receiveMutationError(mutationId, error))
+      this.dispatch(receiveMutationError(mutationId, error, mutationDefinition))
       throw error
     }
   }

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -401,7 +401,7 @@ describe('CozyClient', () => {
       requestHandler.mockReturnValueOnce(Promise.resolve(fakeResponse))
       await client.mutate(mutation, { as: 'updateTodo' })
       expect(client.store.dispatch.mock.calls[1][0]).toEqual(
-        receiveMutationResult('updateTodo', fakeResponse)
+        receiveMutationResult('updateTodo', fakeResponse, {}, mutation)
       )
     })
 
@@ -418,7 +418,7 @@ describe('CozyClient', () => {
         await client.mutate(mutation, { as: 'updateTodo' })
       } catch (e) {} // eslint-disable-line no-empty
       expect(client.store.dispatch.mock.calls[1][0]).toEqual(
-        receiveMutationError('updateTodo', error)
+        receiveMutationError('updateTodo', error, mutation)
       )
     })
 

--- a/packages/cozy-client/src/__tests__/fixtures.js
+++ b/packages/cozy-client/src/__tests__/fixtures.js
@@ -27,6 +27,37 @@ export const TODO_4 = {
 
 export const TODOS = [TODO_1, TODO_2, TODO_3]
 
+export const TODO_WITH_RELATION = {
+  _id: 5,
+  _type: 'io.cozy.todos',
+  label: 'tototot',
+  relationships: {
+    attachments: {
+      doctype: 'io.cozy.files',
+      files: [
+        {
+          type: 'io.cozy.files',
+          _id: 1
+        },
+        {
+          type: 'io.cozy.files',
+          _id: 2
+        }
+      ]
+    }
+  }
+}
+
+export const FILE_1 = {
+  _id: 1,
+  _type: 'io.cozy.files',
+  label: 'File 1'
+}
+export const FILE_2 = {
+  _id: 2,
+  _type: 'io.cozy.files',
+  label: 'File 2'
+}
 export const SCHEMA = {
   todos: {
     doctype: 'io.cozy.todos',

--- a/packages/cozy-client/src/__tests__/store.spec.js
+++ b/packages/cozy-client/src/__tests__/store.spec.js
@@ -170,16 +170,22 @@ describe('Store', () => {
 
       describe('when a `update` option is given', () => {
         it('should be applied instead of the regular update', async () => {
+          const spy = jest.fn()
           await store.dispatch(
-            receiveQueryResult('allTodos', 'BAR!', {
-              update: (store, response) =>
-                store.writeQuery('allTodos', {
-                  ...store.readQuery('allTodos'),
-                  foo: response
-                })
-            })
+            receiveQueryResult(
+              'allTodos',
+              {
+                data: [TODO_3],
+                meta: { count: 3 },
+                skip: 2,
+                next: false
+              },
+              {
+                update: spy
+              }
+            )
           )
-          expect(getQueryFromStore(store, 'allTodos').foo).toEqual('BAR!')
+          expect(spy).toHaveBeenCalled()
         })
       })
 

--- a/packages/cozy-client/src/store/index.js
+++ b/packages/cozy-client/src/store/index.js
@@ -63,10 +63,14 @@ const combinedReducer = (state = { documents: {}, queries: {} }, action) => {
   if (action.update) {
     const proxy = new StoreProxy(state)
     action.update(proxy, action.response)
-    if (action.contextQueryId) {
-      proxy.touchQuery(action.contextQueryId)
+    return {
+      documents: proxy.getState().documents,
+      queries: queries(
+        proxy.getState().queries,
+        action,
+        proxy.getState().documents
+      )
     }
-    return proxy.getState()
   }
   return {
     documents: documents(state.documents, action),

--- a/packages/cozy-client/src/store/mutations.js
+++ b/packages/cozy-client/src/store/mutations.js
@@ -17,15 +17,22 @@ export const initMutation = (mutationId, definition) => ({
   definition
 })
 
-export const receiveMutationResult = (mutationId, response, options = {}) => ({
+export const receiveMutationResult = (
+  mutationId,
+  response,
+  options = {},
+  definition = {}
+) => ({
   type: RECEIVE_MUTATION_RESULT,
   mutationId,
   response,
-  ...options
+  ...options,
+  definition
 })
 
-export const receiveMutationError = (mutationId, error) => ({
+export const receiveMutationError = (mutationId, error, definition = {}) => ({
   type: RECEIVE_MUTATION_ERROR,
   mutationId,
-  error
+  error,
+  definition
 })

--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -6,7 +6,7 @@ import intersection from 'lodash/intersection'
 import { getDocumentFromSlice } from './documents'
 import { isReceivingMutationResult } from './mutations'
 import { selectorFilter } from './mango'
-
+import get from 'lodash/get'
 const INIT_QUERY = 'INIT_QUERY'
 const RECEIVE_QUERY_RESULT = 'RECEIVE_QUERY_RESULT'
 const RECEIVE_QUERY_ERROR = 'RECEIVE_QUERY_ERROR'
@@ -104,7 +104,6 @@ const updateData = (query, newData) => {
   const isFulfilled = getQueryDocumentsChecker(query)
   const matchedIds = newData.filter(doc => isFulfilled(doc)).map(_id)
   const unmatchedIds = newData.filter(doc => !isFulfilled(doc)).map(_id)
-
   const originalIds = query.data
   const toRemove = intersection(originalIds, unmatchedIds)
   const toAdd = difference(matchedIds, originalIds)
@@ -123,10 +122,10 @@ const updateData = (query, newData) => {
 }
 
 const autoQueryUpdater = action => query => {
-  if (!action.response || !action.response.data) {
-    return query
-  }
-  let data = action.response.data
+  let data = get(action, 'response.data') || get(action, 'definition.document')
+
+  if (!data) return query
+
   if (!Array.isArray(data)) {
     data = [data]
   }


### PR DESCRIPTION
Before the fix, when receiving an `RECEIVE_MUTATION_RESULT` action concerning a reference, `Queries` concerned were not updated. 

To update those queries, we : 
- had add the `mutation definition` to `RECEIVE_MUTATION_RESULT`
- edit `autoQueryUpdater` to check `response.data` or `definition.document` as `response` was empty in that case. 


- [X] fix bug
- [x] fix current tests
- [x] add tests
