### PR TITLE
Breaking change: Respecting the sort order

### DIFF
--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -207,7 +207,7 @@ export default class DocumentCollection {
 
       for (const field of indexedFields) {
         if (!sort.find(sortOption => head(Object.keys(sortOption)) === field))
-          sort.unshift({ [field]: sortOrder })
+          sort.push({ [field]: sortOrder })
       }
     }
 

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -251,7 +251,7 @@ describe('DocumentCollection', () => {
 
     it('should accept a sort option', async () => {
       const collection = new DocumentCollection('io.cozy.todos', client)
-      await collection.find({ done: false }, { sort: { label: 'desc' } })
+      await collection.find({ done: false }, { sort: [{ label: 'desc' }] })
       expect(client.fetchJSON).toHaveBeenLastCalledWith(
         'POST',
         '/data/io.cozy.todos/_find',
@@ -266,7 +266,7 @@ describe('DocumentCollection', () => {
 
     it('should use a valid default sorting option', async () => {
       const collection = new DocumentCollection('io.cozy.todos', client)
-      await collection.find({ done: false }, { sort: { label: 'asc' } })
+      await collection.find({ done: false }, { sort: [{ label: 'asc' }] })
       expect(client.fetchJSON).toHaveBeenLastCalledWith(
         'POST',
         '/data/io.cozy.todos/_find',
@@ -277,7 +277,7 @@ describe('DocumentCollection', () => {
           use_index: '_design/123456'
         }
       )
-      await collection.find({ done: false }, { sort: { label: 'desc' } })
+      await collection.find({ done: false }, { sort: [{ label: 'desc' }] })
       expect(client.fetchJSON).toHaveBeenLastCalledWith(
         'POST',
         '/data/io.cozy.todos/_find',
@@ -298,6 +298,24 @@ describe('DocumentCollection', () => {
           { sort: { label: 'asc', _id: 'desc' } }
         )
       ).rejects.toThrow()
+    })
+
+    it('should respect the sorting order', async () => {
+      const collection = new DocumentCollection('io.cozy.todos', client)
+      await collection.find(
+        { done: false },
+        { sort: [{ label: 'desc' }, { _id: 'desc' }] }
+      )
+      expect(client.fetchJSON).toHaveBeenLastCalledWith(
+        'POST',
+        '/data/io.cozy.todos/_find',
+        {
+          skip: 0,
+          selector: { done: false },
+          sort: [{ done: 'desc' }, { label: 'desc' }, { _id: 'desc' }],
+          use_index: '_design/123456'
+        }
+      )
     })
 
     it('should return a correct JSON API response', async () => {

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -1,7 +1,7 @@
-jest.mock('../CozyStackClient')
+jest.mock('./CozyStackClient')
 
-import CozyStackClient from '../CozyStackClient'
-import DocumentCollection from '../DocumentCollection'
+import CozyStackClient from './CozyStackClient'
+import DocumentCollection from './DocumentCollection'
 
 const ALL_RESPONSE_FIXTURE = {
   offset: 0,

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -258,7 +258,7 @@ describe('DocumentCollection', () => {
         {
           skip: 0,
           selector: { done: false },
-          sort: [{ done: 'desc' }, { label: 'desc' }],
+          sort: [{ label: 'desc' }, { done: 'desc' }],
           use_index: '_design/123456'
         }
       )
@@ -273,7 +273,7 @@ describe('DocumentCollection', () => {
         {
           skip: 0,
           selector: { done: false },
-          sort: [{ done: 'asc' }, { label: 'asc' }],
+          sort: [{ label: 'asc' }, { done: 'asc' }],
           use_index: '_design/123456'
         }
       )
@@ -284,7 +284,7 @@ describe('DocumentCollection', () => {
         {
           skip: 0,
           selector: { done: false },
-          sort: [{ done: 'desc' }, { label: 'desc' }],
+          sort: [{ label: 'desc' }, { done: 'desc' }],
           use_index: '_design/123456'
         }
       )
@@ -295,7 +295,7 @@ describe('DocumentCollection', () => {
       await expect(
         collection.find(
           { done: false },
-          { sort: { label: 'asc', _id: 'desc' } }
+          { sort: [{ label: 'asc' }, { _id: 'desc' }] }
         )
       ).rejects.toThrow()
     })
@@ -312,7 +312,7 @@ describe('DocumentCollection', () => {
         {
           skip: 0,
           selector: { done: false },
-          sort: [{ done: 'desc' }, { label: 'desc' }, { _id: 'desc' }],
+          sort: [{ label: 'desc' }, { _id: 'desc' }, { done: 'desc' }],
           use_index: '_design/123456'
         }
       )


### PR DESCRIPTION
Until now, sorting options where passed as a single object, like `{ zebras: 'asc', abyssinian: 'asc' }`. The problem is that the order of the sort usually matters, but with an object the order of keys is not guaranteed. Typically the example above would end up sorting on `abyssinian` first and `zebra` second.

The new format is the same as what mango expects: `[{ zebras: 'asc' }, { 'abyssinian': 'asc' }]`. 

The old format is *still* supported, although you'll get a deprecation warning. 

The breaking change comes from the usage of selectors combined with sorting order. A query with `{ selector: { done: true }, sort: { name: 'asc' } }` would previously resolve to a sorting order of `[{ done: 'asc' }, { name: 'asc' }]`, but now it becomes `[{ name: 'asc' }, { done: 'asc' }]`. This is *probably* what you wanted anyway, but still, it's a breaking change.