### PR TITLE
fix(ReferencedFiles): Properly detect next pages

### DIFF
--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -1,4 +1,5 @@
 import mime from 'mime-types'
+import has from 'lodash/has'
 import DocumentCollection, { normalizeDoc } from './DocumentCollection'
 import { uri, slugify, forceFileDownload } from './utils'
 import * as querystring from './querystring'
@@ -86,7 +87,7 @@ export default class FileCollection extends DocumentCollection {
     return {
       data: resp.data.map(f => normalizeFile(f)),
       included: resp.included ? resp.included.map(f => normalizeFile(f)) : [],
-      next: resp.meta.count > skip + resp.data.rows,
+      next: has(resp, 'links.next'),
       meta: resp.meta,
       skip
     }

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -204,6 +204,28 @@ describe('FileCollection', () => {
       collection.findReferencedBy(doc)
       expect(spy).toMatchSnapshot()
     })
+
+    it('should detect a next page', async () => {
+      spy.mockReturnValue({
+        data: [],
+        links: {
+          next: 'http://example.com/next'
+        },
+        meta: {}
+      })
+      const result = await collection.findReferencedBy(doc)
+      expect(result.next).toBe(true)
+    })
+
+    it('should detect the abscence of a next page', async () => {
+      spy.mockReturnValue({
+        data: [],
+        links: {},
+        meta: {}
+      })
+      const result = await collection.findReferencedBy(doc)
+      expect(result.next).toBe(false)
+    })
   })
 
   describe('updateFileMetadata', () => {


### PR DESCRIPTION
Responses to the `/relationships/references` don't have a `rows` attribute, but they have a `next` property in the `links` when there is more content, as per the JSONAPi spec.