### PR TITLE
fix: Repair HasMany files relationships

### DIFF
--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -342,7 +342,35 @@ describe('CozyClient', () => {
 
       expect(requestHandler).toHaveBeenCalledTimes(4)
       expect(resp).toEqual({
-        data: [TODO_1, TODO_2, TODO_3],
+        data: [
+          {
+            ...TODO_1,
+            relationships: {
+              attachments: {
+                data: [
+                  { _id: 'abc', _type: 'io.cozy.files' },
+                  { _id: 'def', _type: 'io.cozy.files' }
+                ]
+              }
+            }
+          },
+          {
+            ...TODO_2,
+            relationships: {
+              attachments: {
+                data: []
+              }
+            }
+          },
+          {
+            ...TODO_3,
+            relationships: {
+              attachments: {
+                data: []
+              }
+            }
+          }
+        ],
         included: [
           { _id: 'abc', _type: 'io.cozy.files', name: 'abc.png' },
           { _id: 'def', _type: 'io.cozy.files', name: 'def.png' }


### PR DESCRIPTION
In https://github.com/cozy/cozy-client/commit/a9fa010ed15c8b3c28fab426e78a47059d71968b, relationships filling was broken : the relationships attribute was no longer filled at fetch time. This was particularly important for documents whose relationship data was "on the other side" of the relation.

For example, for photo albums, relationship data for the photos, is on the file side of the relationship and this is returned in the `referencedBy` queries. This data needs to be stored on the album side, in the `relationships` attribute, for it to be easily managed on the client.