### PR TITLE
fix(pouch): Wait end of replication before triggering another one

### DIFF
--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -116,9 +116,10 @@ export default class PouchManager {
     delay = delay || this.options.replicationDelay || DEFAULT_DELAY
     this._stopReplicationLoop = promises.setInterval(() => {
       if (window.navigator.onLine) {
-        this.replicateOnce()
+        return this.replicateOnce()
       } else {
         console.info('The device is offline replication is abort')
+        return Promise.resolve()
       }
     }, delay)
     this.addListener()
@@ -167,7 +168,7 @@ export default class PouchManager {
       return
     }
     Object.values(this.replications).forEach(replication => {
-      return replication.cancel()
+      return replication.cancel && replication.cancel()
     })
   }
 

--- a/packages/cozy-pouch-link/src/promises.js
+++ b/packages/cozy-pouch-link/src/promises.js
@@ -11,7 +11,16 @@ const setIntervalPromise = (fn, delay) => {
   let timeout, canceled
 
   const round = async () => {
-    await fn()
+    const res = fn()
+
+    if (res && res.then) {
+      await res
+    } else {
+      throw new Error(
+        'The function passed to setIntervalPromise should return a thenable'
+      )
+    }
+
     if (!canceled) {
       timeout = setTimeout(round, delay)
     }


### PR DESCRIPTION
We had an issue because the promise was not returned. It means that the replication loop was not waiting for the current iteration to be finished before triggering the next one.

Now, the behavior is the one intended: when we start the loop, the first replication is done, then we wait for a delay (30 seconds by default), then the second replication is done, and so on.