### PR TITLE
test: Add test for setIntervalPromise

### DIFF
--- a/packages/cozy-pouch-link/src/promises.js
+++ b/packages/cozy-pouch-link/src/promises.js
@@ -7,7 +7,7 @@
  * continue.
  *
  */
-const setIntervalPromise = (fn, delay) => {
+const setIntervalPromise = (fn, delay, roundCallback) => {
   let timeout, canceled
 
   const round = async () => {
@@ -15,6 +15,7 @@ const setIntervalPromise = (fn, delay) => {
     if (!canceled) {
       timeout = setTimeout(round, delay)
     }
+    roundCallback && roundCallback()
   }
 
   round()

--- a/packages/cozy-pouch-link/src/promises.spec.js
+++ b/packages/cozy-pouch-link/src/promises.spec.js
@@ -1,0 +1,59 @@
+const { setInterval: setIntervalPromise } = require('./promises')
+
+describe('set interval promises', () => {
+  let fn, stop
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    if (stop) {
+      stop()
+    }
+  })
+
+  it('should wait for the end of a task to schedule another one', done => {
+    let i = 0
+    let time = 0
+    const interval = 100
+    const limit = 900
+    const longTaskDuration = interval * 6
+
+    const scheduleForward = duration => {
+      time = time + duration
+      Promise.resolve().then(() => jest.advanceTimersByTime(duration))
+    }
+
+    // Delay working in conjunction with fakeTimers
+    // https://stackoverflow.com/questions/51126786/jest-fake-timers-with-promises
+    const delay = duration => {
+      scheduleForward(duration)
+      return new Promise(resolve => setTimeout(resolve, duration))
+    }
+
+    const finish = () => {
+      stop()
+
+      // Since a task took longer than the other ones, `fn` was called
+      // less than limit / interval
+      expect(fn).toHaveBeenCalledTimes(4)
+      done()
+    }
+
+    fn = jest.fn().mockImplementation(async () => {
+      i++
+      if (i === 2) {
+        // One task takes longer than expected
+        await delay(longTaskDuration)
+      } else if (time >= limit) {
+        finish()
+      }
+    })
+
+    stop = setIntervalPromise(fn, interval, async () => {
+      await scheduleForward(interval)
+    })
+  })
+})


### PR DESCRIPTION
Long story short : promises and fakeTimers do not play well together.

https://stackoverflow.com/questions/46710564/testing-a-promise-using-settimeout-with-jest

jest.advanceTimersByTime does not advance timers that are created in Promises.

```js
Promise.resolve().then(() => setTimeout(fn, 100))
jest.advanceTimersByTime(100)
// fn is not called since setTimeout is executed after advanceTimersByTime ❌
```

```js
Promise.resolve().then(() => setTimeout(fn, 100))
Promise.resolve().then(() => jest.advanceTimersByTime(100))
// fn is called ✅
```