### PR TITLE
Custom requests

### DIFF
--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -311,7 +311,7 @@ describe('CozyClient', () => {
     it('should call the link with the query', async () => {
       await client.query(query)
       expect(requestHandler).toHaveBeenCalledTimes(1)
-      expect(requestHandler).toHaveBeenCalledWith(query)
+      expect(requestHandler.mock.calls[0][0]).toBe(query)
     })
 
     it('should handle queries with includes', async () => {
@@ -394,7 +394,7 @@ describe('CozyClient', () => {
 
     it('should call the link with the mutation', async () => {
       await client.mutate(mutation)
-      expect(requestHandler).toHaveBeenCalledWith(mutation)
+      expect(requestHandler.mock.calls[0][0]).toBe(mutation)
     })
 
     it('should then dispatch a RECEIVE_MUTATION_RESULT action', async () => {

--- a/packages/cozy-client/src/CozyLink.js
+++ b/packages/cozy-client/src/CozyLink.js
@@ -15,6 +15,7 @@ const toLink = handler =>
 
 const defaultLinkHandler = (operation, result) => {
   if (result) return result
+  else if (operation.execute) return operation.execute()
   else
     throw new Error(
       `No link could handle operation ${JSON.stringify(operation)}`

--- a/packages/cozy-client/src/CozyLink.js
+++ b/packages/cozy-client/src/CozyLink.js
@@ -13,7 +13,16 @@ export default class CozyLink {
 const toLink = handler =>
   typeof handler === 'function' ? new CozyLink(handler) : handler
 
-export const chain = links => links.map(toLink).reduce(concat)
+const defaultLinkHandler = (operation, result) => {
+  if (result) return result
+  else
+    throw new Error(
+      `No link could handle operation ${JSON.stringify(operation)}`
+    )
+}
+
+export const chain = links =>
+  [...links, defaultLinkHandler].map(toLink).reduce(concat)
 
 const concat = (firstLink, nextLink) => {
   return new CozyLink((operation, result, forward) => {

--- a/packages/cozy-client/src/CozyLink.spec.js
+++ b/packages/cozy-client/src/CozyLink.spec.js
@@ -1,4 +1,4 @@
-import CozyLink, { chain } from '../CozyLink'
+import CozyLink, { chain } from './CozyLink'
 
 describe('CozyLink', () => {
   it('should be chainable', () => {

--- a/packages/cozy-client/src/CozyLink.spec.js
+++ b/packages/cozy-client/src/CozyLink.spec.js
@@ -15,4 +15,43 @@ describe('CozyLink', () => {
     ])
     expect(link.request('dummyOperation')).toBe('foobarbaz')
   })
+
+  describe('default last link', () => {
+    it('should throw an error when called without result', () => {
+      const link = chain([
+        new CozyLink((operation, result = '', forward) => {
+          return forward(operation)
+        })
+      ])
+      expect(() =>
+        link.request('dummyOperation')
+      ).toThrowErrorMatchingSnapshot()
+    })
+
+    it('should return the final result if tehre is one', () => {
+      const link = chain([
+        new CozyLink((operation, result, forward) => {
+          return forward(operation, 'foo')
+        })
+      ])
+
+      expect(link.request('dummyOperation')).toBe('foo')
+    })
+
+    it('should call the custom execution function', () => {
+      const link = chain([
+        new CozyLink((operation, result = '', forward) => {
+          return forward(operation)
+        })
+      ])
+      const spyFn = jest.fn(() => 'bar')
+      expect(
+        link.request({
+          type: 'dummyOperation',
+          execute: spyFn
+        })
+      ).toBe('bar')
+      expect(spyFn).toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/cozy-client/src/StackLink.js
+++ b/packages/cozy-client/src/StackLink.js
@@ -20,9 +20,9 @@ export default class StackLink extends CozyLink {
     this.stackClient = null
   }
 
-  request(operation) {
+  request(operation, result, forward) {
     if (operation.mutationType) {
-      return this.executeMutation(operation)
+      return this.executeMutation(operation, result, forward)
     }
     return this.executeQuery(operation)
   }
@@ -48,7 +48,8 @@ export default class StackLink extends CozyLink {
       : collection.find(selector, options)
   }
 
-  executeMutation({ mutationType, ...props }) {
+  executeMutation(mutation, result, forward) {
+    const { mutationType, ...props } = mutation
     switch (mutationType) {
       case MutationTypes.CREATE_DOCUMENT:
         return this.stackClient
@@ -75,7 +76,7 @@ export default class StackLink extends CozyLink {
           .collection('io.cozy.files')
           .upload(props.file, props.dirPath)
       default:
-        throw new Error(`Unknown mutation type: ${mutationType}`)
+        return forward(mutation, result)
     }
   }
 }

--- a/packages/cozy-client/src/__snapshots__/CozyLink.spec.js.snap
+++ b/packages/cozy-client/src/__snapshots__/CozyLink.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CozyLink default last link should throw an error when called without result 1`] = `"No link could handle operation \\"dummyOperation\\""`;

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -213,7 +213,7 @@ export default class PouchLink extends CozyLink {
     }
 
     if (operation.mutationType) {
-      return this.executeMutation(operation)
+      return this.executeMutation(operation, result, forward)
     } else {
       return this.executeQuery(operation)
     }
@@ -282,10 +282,8 @@ export default class PouchLink extends CozyLink {
       case MutationTypes.ADD_REFERENCES_TO:
         pouchRes = await this.addReferencesTo(mutation)
         break
-      case MutationTypes.UPLOAD_FILE:
-        return forward(mutation, result)
       default:
-        throw new Error(`Unknown mutation type: ${mutation.mutationType}`)
+        return forward(mutation, result)
     }
     return jsonapi.fromPouchResult(
       pouchRes,


### PR DESCRIPTION
### Problem

I needed to make a change to the [`upload`](https://github.com/cozy/cozy-client/blob/custom-requests/packages/cozy-client/src/CozyClient.js#L235) mutation function, but after consideration, I think it shouldn't be there at all.

Mutations like create/read/update/delete make perfect sense, and even adding/removing references is ok, as those are common across doctypes. But some doctypes have special behaviors — files, apps, settings, etc. If we want to support all these behaviors, we will need a lot of custom functions in the main CozyClient, and we will have [to integrate every one of them in all our Links](https://github.com/cozy/cozy-client/blob/custom-requests/packages/cozy-client/src/StackLink.js#L69). I think this will make cozy-client bloated and it's maintenance complicated. So I want us to be able to execute a mutation function outside of cozy-client.

### Solution

[The first change I made](https://github.com/cozy/cozy-client/commit/235e12fa866cb0f5f465000a2dbc4b3fb69c0798) is that Links don't have to know about all mutations anymore. If they don't know how to handle one, they should just forward it to the next link (instead of throwing an error).

Instead, there is now a default "last link" that will be called if all previous links forward a request or mutation. This link does the final error-throwing when all hope is lost.

In the [second commit](https://github.com/cozy/cozy-client/commit/a32be8f4ebe4a2dcec92a0f1ce70ea0a26095162), I added a new feature: mutations and requests can have a `execute` property which acts as a callback, and the result of that function will be returned by the default link.

### Downsides

The callback function can return anything, whereas before we had more control over what it did. I don't think it's a big problem though — most of the time you'll want to call a collection from cozy-client anyway, and if the function returns non-sense… the queries and documents will ignore it.

I'm not super happy with the `execute` name, as I find it too generic.

Links handle `requests` and `mutations` but doesn't differenciate much between the 2. I mostly wanted the ability to execute custom mutations, but as a side effect it also becomes possible for regular requests. I think it's ok, but in the longer term having a stronger separation between queries and mutations might make sense.

### Next ?

What do you think about this change? If it's ok for you, I'll add tests and docs before merging the PR.