### PR TITLE
feat: Links receive CozyClient

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -45,11 +45,10 @@ const ensureArray = arr => (Array.isArray(arr) ? arr : [arr])
 
 const deprecatedHandler = msg => ({
   get(target, prop) {
-    console.warn(msg);
-    return target[prop];
-  },
-});
-
+    console.warn(msg)
+    return target[prop]
+  }
+})
 
 /**
  * @module CozyClient

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -572,7 +572,9 @@ export default class CozyClient {
 
   createClient() {
     if (this.options.client) {
-      console.warn('CozyClient: Using options.client is deprecated, please use options.stackClient.')
+      console.warn(
+        'CozyClient: Using options.client is deprecated, please use options.stackClient.'
+      )
     }
     const stackClient = this.options.client || this.options.stackClient
     if (stackClient) {
@@ -583,11 +585,18 @@ export default class CozyClient {
         : new CozyStackClient(this.options)
     }
 
-    this.client = new Proxy(this.stackClient, deprecatedHandler('Using cozyClient.client is deprecated, please use cozyClient.stackClient.'))
+    this.client = new Proxy(
+      this.stackClient,
+      deprecatedHandler(
+        'Using cozyClient.client is deprecated, please use cozyClient.stackClient.'
+      )
+    )
   }
 
   getClient() {
-    console.warn('CozyClient: getClient() is deprecated, please use getStackClient().')
+    console.warn(
+      'CozyClient: getClient() is deprecated, please use getStackClient().'
+    )
     return this.getStackClient()
   }
 

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -53,7 +53,7 @@ describe('CozyClient initialization', () => {
 
   it('should have registered the client on all links ', () => {
     for (const link of links) {
-      expect(link.registerClient).toHaveBeenCalledWith(client.client)
+      expect(link.registerClient).toHaveBeenCalledWith(client)
     }
   })
 

--- a/packages/cozy-client/src/StackLink.js
+++ b/packages/cozy-client/src/StackLink.js
@@ -2,17 +2,20 @@ import { MutationTypes } from './queries/dsl'
 import CozyLink from './CozyLink'
 
 export default class StackLink extends CozyLink {
-  constructor({ client } = {}) {
+  constructor({ client, stackClient } = {}) {
     super()
-    this.client = client
+    if (client) {
+      console.info('Using options.client is deprecated, prefer options.stackClient')
+    }
+    this.stackClient = stackClient || client
   }
 
   registerClient(client) {
-    this.client = client
+    this.stackClient = client.stackClient || client.client
   }
 
   reset() {
-    this.client = undefined
+    this.stackClient = null
   }
 
   request(operation) {
@@ -28,7 +31,7 @@ export default class StackLink extends CozyLink {
       console.warn('Bad query', query)
       throw new Error('No doctype found in a query definition')
     }
-    const collection = this.client.collection(doctype)
+    const collection = this.stackClient.collection(doctype)
     if (id) {
       return collection.get(id)
     }
@@ -46,27 +49,27 @@ export default class StackLink extends CozyLink {
   executeMutation({ mutationType, ...props }) {
     switch (mutationType) {
       case MutationTypes.CREATE_DOCUMENT:
-        return this.client
+        return this.stackClient
           .collection(props.document._type)
           .create(props.document)
       case MutationTypes.UPDATE_DOCUMENT:
-        return this.client
+        return this.stackClient
           .collection(props.document._type)
           .update(props.document)
       case MutationTypes.DELETE_DOCUMENT:
-        return this.client
+        return this.stackClient
           .collection(props.document._type)
           .destroy(props.document)
       case MutationTypes.ADD_REFERENCES_TO:
-        return this.client
+        return this.stackClient
           .collection(props.referencedDocuments[0]._type)
           .addReferencesTo(props.document, props.referencedDocuments)
       case MutationTypes.REMOVE_REFERENCES_TO:
-        return this.client
+        return this.stackClient
           .collection(props.referencedDocuments[0]._type)
           .removeReferencesTo(props.document, props.referencedDocuments)
       case MutationTypes.UPLOAD_FILE:
-        return this.client
+        return this.stackClient
           .collection('io.cozy.files')
           .upload(props.file, props.dirPath)
       default:

--- a/packages/cozy-client/src/StackLink.js
+++ b/packages/cozy-client/src/StackLink.js
@@ -5,7 +5,9 @@ export default class StackLink extends CozyLink {
   constructor({ client, stackClient } = {}) {
     super()
     if (client) {
-      console.info('Using options.client is deprecated, prefer options.stackClient')
+      console.info(
+        'Using options.client is deprecated, prefer options.stackClient'
+      )
     }
     this.stackClient = stackClient || client
   }

--- a/packages/cozy-client/src/__tests__/StackLink.spec.js
+++ b/packages/cozy-client/src/__tests__/StackLink.spec.js
@@ -9,7 +9,7 @@ describe('StackLink', () => {
   beforeEach(() => {
     link = new StackLink()
     client = new CozyClient({ links: [link], schema: SCHEMA })
-    stackClient = client.getClient()
+    stackClient = client.getStackClient()
   })
 
   describe('query execution', () => {
@@ -34,9 +34,9 @@ describe('StackLink', () => {
 
   describe('reset', () => {
     it('should delete client', async () => {
-      expect(link.client).not.toBeUndefined()
+      expect(link.stackClient).not.toBeNull()
       await link.reset()
-      expect(link.client).toBeUndefined()
+      expect(link.stackClient).toBeNull()
     })
   })
 })

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -188,21 +188,20 @@ describe('CozyPouchLink', () => {
   describe('onSync', () => {
     it('should call setData with normalized data', () => {
       link.handleOnSync({
-        'io.cozy.todos': [
-          {...TODO_1, rev: '1-deadbeef' }
-        ]
+        'io.cozy.todos': [{ ...TODO_1, rev: '1-deadbeef' }]
       })
       expect(client.setData).toHaveBeenCalledTimes(1)
       expect(client.setData).toHaveBeenCalledWith({
-        "io.cozy.todos": [{
-          "_id": "1",
-          "_rev": "1-deadbeef",
-          "_type": "io.cozy.todos",
-          "done": false,
-          "id": "1",
-          "label": "Buy bread",
-          "rev": "1-deadbeef"
-        }]
+        'io.cozy.todos': [
+          {
+            _id: '1',
+            _rev: '1-deadbeef',
+            _type: 'io.cozy.todos',
+            done: false,
+            id: '1',
+            label: 'Buy bread'
+          }
+        ]
       })
     })
   })

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -1,11 +1,11 @@
-import CozyClient from 'cozy-client'
+import CozyClient from '../../cozy-client/src'
 import omit from 'lodash/omit'
 
 import CozyPouchLink from '.'
 import { SCHEMA, TODO_1, TODO_2, TODO_3, TODO_4 } from './__tests__/fixtures'
 
 const mockClient = {
-  client: {
+  stackClient: {
     uri: 'http://cozy.tools:8080',
     token: {
       toBasicAuth: () => 'user:token@'
@@ -27,10 +27,7 @@ describe('CozyPouchLink', () => {
         todos: omit(TODO_DOCTYPE, 'relationships')
       }
     })
-  })
-
-  afterEach(async () => {
-    await link.reset()
+    client.setData = jest.fn()
   })
 
   afterEach(async () => {
@@ -172,9 +169,9 @@ describe('CozyPouchLink', () => {
 
     it('should delete client', async () => {
       link.registerClient(jest.fn())
-      expect(link.client).not.toBeUndefined()
+      expect(link.client).not.toBeNull()
       await link.reset()
-      expect(link.client).toBeUndefined()
+      expect(link.client).toBeNull()
     })
 
     it('should set the `synced` property to false', async () => {
@@ -185,6 +182,28 @@ describe('CozyPouchLink', () => {
     it('should forget the PouchManager instance', async () => {
       await link.reset()
       expect(link.pouches).toBeNull()
+    })
+  })
+
+  describe('onSync', () => {
+    it('should call setData with normalized data', () => {
+      link.handleOnSync({
+        'io.cozy.todos': [
+          {...TODO_1, rev: '1-deadbeef' }
+        ]
+      })
+      expect(client.setData).toHaveBeenCalledTimes(1)
+      expect(client.setData).toHaveBeenCalledWith({
+        "io.cozy.todos": [{
+          "_id": "1",
+          "_rev": "1-deadbeef",
+          "_type": "io.cozy.todos",
+          "done": false,
+          "id": "1",
+          "label": "Buy bread",
+          "rev": "1-deadbeef"
+        }]
+      })
     })
   })
 

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -11,7 +11,7 @@ import { isMobileApp } from 'cozy-device-helper'
 const DEFAULT_DELAY = 30 * 1000
 
 const TIME_UNITS = [['ms', 1000], ['s', 60], ['m', 60], ['h', 24]]
-const humanTimeDelta = (timeMs) => {
+const humanTimeDelta = timeMs => {
   let cur = timeMs
   let unitIndex = 0
   let str = ''
@@ -50,7 +50,11 @@ const startReplication = (pouch, getReplicationURL) => {
     replication.on('error', reject).on('complete', () => {
       const end = new Date()
       if (process.env.NODE_ENV !== 'production') {
-        console.info(`PouchManager: replication for ${url} took ${humanTimeDelta(end - start)}`)
+        console.info(
+          `PouchManager: replication for ${url} took ${humanTimeDelta(
+            end - start
+          )}`
+        )
       }
       resolve(Object.values(docs))
     })

--- a/packages/cozy-stack-client/src/AppCollection.js
+++ b/packages/cozy-stack-client/src/AppCollection.js
@@ -11,8 +11,8 @@ export const normalizeApp = app => {
  * @module AppCollection
  */
 export default class AppCollection {
-  constructor(client) {
-    this.client = client
+  constructor(stackClient) {
+    this.stackClient = stackClient
   }
 
   /**
@@ -25,7 +25,7 @@ export default class AppCollection {
    */
   async all() {
     const path = uri`/apps/`
-    const resp = await this.client.fetchJSON('GET', path)
+    const resp = await this.stackClient.fetchJSON('GET', path)
     return {
       data: resp.data.map(app => normalizeApp(app)),
       meta: {

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -15,9 +15,9 @@ const isDesignDoc = doc => doc.hasOwnProperty('views')
  * @module DocumentCollection
  */
 export default class DocumentCollection {
-  constructor(doctype, client) {
+  constructor(doctype, stackClient) {
     this.doctype = doctype
-    this.client = client
+    this.stackClient = stackClient
     this.indexes = {}
   }
 
@@ -46,7 +46,7 @@ export default class DocumentCollection {
     // so we need to try/catch and return an empty response object in case of a 404
     let resp
     try {
-      resp = await this.client.fetchJSON('GET', path)
+      resp = await this.stackClient.fetchJSON('GET', path)
     } catch (error) {
       if (error.message.match(/not_found/)) {
         return { data: [], meta: { count: 0 }, skip: 0, next: false }
@@ -78,7 +78,7 @@ export default class DocumentCollection {
     const { skip = 0 } = options
     let resp
     try {
-      resp = await this.client.fetchJSON(
+      resp = await this.stackClient.fetchJSON(
         'POST',
         uri`/data/${this.doctype}/_find`,
         await this.toMangoOptions(selector, options)
@@ -105,7 +105,7 @@ export default class DocumentCollection {
   async get(id) {
     let resp
     try {
-      resp = await this.client.fetchJSON(
+      resp = await this.stackClient.fetchJSON(
         'GET',
         uri`/data/${this.doctype}/${id}`
       )
@@ -122,7 +122,7 @@ export default class DocumentCollection {
   async getAll(ids) {
     let resp
     try {
-      resp = await this.client.fetchJSON(
+      resp = await this.stackClient.fetchJSON(
         'POST',
         uri`/data/${this.doctype}/_all_docs?include_docs=true`,
         {
@@ -145,7 +145,7 @@ export default class DocumentCollection {
   }
 
   async create({ _id, _type, ...document }) {
-    const resp = await this.client.fetchJSON(
+    const resp = await this.stackClient.fetchJSON(
       'POST',
       uri`/data/${this.doctype}/`,
       document
@@ -156,7 +156,7 @@ export default class DocumentCollection {
   }
 
   async update(document) {
-    const resp = await this.client.fetchJSON(
+    const resp = await this.stackClient.fetchJSON(
       'PUT',
       uri`/data/${this.doctype}/${document._id}`,
       document
@@ -167,7 +167,7 @@ export default class DocumentCollection {
   }
 
   async destroy({ _id, _rev, ...document }) {
-    const resp = await this.client.fetchJSON(
+    const resp = await this.stackClient.fetchJSON(
       'DELETE',
       uri`/data/${this.doctype}/${_id}?rev=${_rev}`
     )
@@ -244,7 +244,7 @@ export default class DocumentCollection {
 
   async createIndex(fields) {
     const indexDef = { index: { fields } }
-    const resp = await this.client.fetchJSON(
+    const resp = await this.stackClient.fetchJSON(
       'POST',
       uri`/data/${this.doctype}/_index`,
       indexDef

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -379,7 +379,9 @@ export default class FileCollection extends DocumentCollection {
     if (lastModifiedDate) headers['Date'] = lastModifiedDate.toGMTString()
     if (ifMatch) headers['If-Match'] = ifMatch
 
-    const resp = await this.stackClient.fetchJSON('POST', path, data, { headers })
+    const resp = await this.stackClient.fetchJSON('POST', path, data, {
+      headers
+    })
     return {
       data: normalizeFile(resp.data)
     }

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -30,8 +30,8 @@ export const isDirectory = ({ type }) => type === 'directory'
  * @module FileCollection
  */
 export default class FileCollection extends DocumentCollection {
-  constructor(doctype, client) {
-    super(doctype, client)
+  constructor(doctype, stackClient) {
+    super(doctype, stackClient)
     this.specialDirectories = {}
   }
 
@@ -51,7 +51,7 @@ export default class FileCollection extends DocumentCollection {
    */
   async find(selector, options = {}) {
     const { skip = 0 } = options
-    const resp = await this.client.fetchJSON(
+    const resp = await this.stackClient.fetchJSON(
       'POST',
       '/files/_find',
       await this.toMangoOptions(selector, options)
@@ -83,7 +83,7 @@ export default class FileCollection extends DocumentCollection {
       document._id
     }/relationships/references`
     const path = querystring.buildURL(url, params)
-    const resp = await this.client.fetchJSON('GET', path)
+    const resp = await this.stackClient.fetchJSON('GET', path)
     return {
       data: resp.data.map(f => normalizeFile(f)),
       included: resp.included ? resp.included.map(f => normalizeFile(f)) : [],
@@ -95,7 +95,7 @@ export default class FileCollection extends DocumentCollection {
 
   addReferencesTo(document, documents) {
     const refs = documents.map(d => ({ id: d._id, type: 'io.cozy.files' }))
-    return this.client.fetchJSON(
+    return this.stackClient.fetchJSON(
       'POST',
       uri`/data/${document._type}/${document._id}/relationships/references`,
       { data: refs }
@@ -104,7 +104,7 @@ export default class FileCollection extends DocumentCollection {
 
   removeReferencesTo(document, documents) {
     const refs = documents.map(d => ({ id: d._id, type: 'io.cozy.files' }))
-    return this.client.fetchJSON(
+    return this.stackClient.fetchJSON(
       'DELETE',
       uri`/data/${document._type}/${document._id}/relationships/references`,
       { data: refs }
@@ -123,7 +123,7 @@ export default class FileCollection extends DocumentCollection {
         ])
       }
     }
-    const resp = await this.client.fetchJSON(
+    const resp = await this.stackClient.fetchJSON(
       'DELETE',
       uri`/files/${_id}`,
       undefined,
@@ -160,13 +160,13 @@ export default class FileCollection extends DocumentCollection {
   }
 
   getDownloadLinkById(id) {
-    return this.client
+    return this.stackClient
       .fetchJSON('POST', uri`/files/downloads?Id=${id}`)
       .then(this.extractResponseLinkRelated)
   }
 
   getDownloadLinkByPath(path) {
-    return this.client
+    return this.stackClient
       .fetchJSON('POST', uri`/files/downloads?Path=${path}`)
       .then(this.extractResponseLinkRelated)
   }
@@ -174,7 +174,7 @@ export default class FileCollection extends DocumentCollection {
   extractResponseLinkRelated = res => {
     let href = res.links && res.links.related
     if (!href) throw new Error('No related link in server response')
-    return this.client.fullpath(href)
+    return this.stackClient.fullpath(href)
   }
 
   async download(file) {
@@ -185,12 +185,12 @@ export default class FileCollection extends DocumentCollection {
   async downloadArchive(fileIds, notSecureFilename = 'files') {
     const filename = slugify(notSecureFilename)
     const href = await this.getArchiveLinkByIds(fileIds, filename)
-    const fullpath = this.client.fullpath(href)
+    const fullpath = this.stackClient.fullpath(href)
     forceFileDownload(fullpath, filename + '.zip')
   }
 
   async getArchiveLinkByIds(ids, name = 'files') {
-    const resp = await this.client.fetchJSON('POST', '/files/archive', {
+    const resp = await this.stackClient.fetchJSON('POST', '/files/archive', {
       data: {
         type: 'io.cozy.archives',
         attributes: {
@@ -210,7 +210,7 @@ export default class FileCollection extends DocumentCollection {
     }
     const url = `/files/${id}`
     const path = querystring.buildURL(url, params)
-    const resp = await this.client.fetchJSON('GET', path)
+    const resp = await this.stackClient.fetchJSON('GET', path)
     return {
       data: normalizeFile(resp.data),
       included: resp.included && resp.included.map(f => normalizeFile(f))
@@ -218,7 +218,7 @@ export default class FileCollection extends DocumentCollection {
   }
 
   async statByPath(path) {
-    const resp = await this.client.fetchJSON(
+    const resp = await this.stackClient.fetchJSON(
       'GET',
       uri`/files/metadata?Path=${path}`
     )
@@ -240,7 +240,7 @@ export default class FileCollection extends DocumentCollection {
         ? new Date(lastModifiedDate)
         : lastModifiedDate)
 
-    const resp = await this.client.fetchJSON(
+    const resp = await this.stackClient.fetchJSON(
       'POST',
       uri`/files/${dirId}?Name=${safeName}&Type=directory`,
       undefined,
@@ -313,7 +313,7 @@ export default class FileCollection extends DocumentCollection {
    * @returns {object}            Updated document
    */
   async updateFileMetadata(id, attributes) {
-    const resp = await this.client.fetchJSON('PATCH', uri`/files/${id}`, {
+    const resp = await this.stackClient.fetchJSON('PATCH', uri`/files/${id}`, {
       data: {
         type: 'io.cozy.files',
         id,
@@ -379,7 +379,7 @@ export default class FileCollection extends DocumentCollection {
     if (lastModifiedDate) headers['Date'] = lastModifiedDate.toGMTString()
     if (ifMatch) headers['If-Match'] = ifMatch
 
-    const resp = await this.client.fetchJSON('POST', path, data, { headers })
+    const resp = await this.stackClient.fetchJSON('POST', path, data, { headers })
     return {
       data: normalizeFile(resp.data)
     }

--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -11,7 +11,10 @@ const normalizePermission = perm => normalizeDoc(perm, 'io.cozy.permissions')
  */
 export default class PermissionCollection extends DocumentCollection {
   async get(id) {
-    const resp = await this.stackClient.fetchJSON('GET', uri`/permissions/${id}`)
+    const resp = await this.stackClient.fetchJSON(
+      'GET',
+      uri`/permissions/${id}`
+    )
     return {
       data: normalizePermission(resp.data)
     }
@@ -30,7 +33,10 @@ export default class PermissionCollection extends DocumentCollection {
   }
 
   destroy(permission) {
-    return this.stackClient.fetchJSON('DELETE', uri`/permissions/${permission.id}`)
+    return this.stackClient.fetchJSON(
+      'DELETE',
+      uri`/permissions/${permission.id}`
+    )
   }
 
   async findLinksByDoctype(doctype) {

--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -11,14 +11,14 @@ const normalizePermission = perm => normalizeDoc(perm, 'io.cozy.permissions')
  */
 export default class PermissionCollection extends DocumentCollection {
   async get(id) {
-    const resp = await this.client.fetchJSON('GET', uri`/permissions/${id}`)
+    const resp = await this.stackClient.fetchJSON('GET', uri`/permissions/${id}`)
     return {
       data: normalizePermission(resp.data)
     }
   }
 
   async create({ _id, _type, ...attributes }) {
-    const resp = await this.client.fetchJSON('POST', uri`/permissions/`, {
+    const resp = await this.stackClient.fetchJSON('POST', uri`/permissions/`, {
       data: {
         type: 'io.cozy.permissions',
         attributes
@@ -30,11 +30,11 @@ export default class PermissionCollection extends DocumentCollection {
   }
 
   destroy(permission) {
-    return this.client.fetchJSON('DELETE', uri`/permissions/${permission.id}`)
+    return this.stackClient.fetchJSON('DELETE', uri`/permissions/${permission.id}`)
   }
 
   async findLinksByDoctype(doctype) {
-    const resp = await this.client.fetchJSON(
+    const resp = await this.stackClient.fetchJSON(
       'GET',
       uri`/permissions/doctype/${doctype}/shared-by-link`
     )
@@ -45,12 +45,12 @@ export default class PermissionCollection extends DocumentCollection {
   }
 
   async findApps() {
-    const resp = await this.client.fetchJSON('GET', '/apps/')
+    const resp = await this.stackClient.fetchJSON('GET', '/apps/')
     return { ...resp, data: resp.data.map(a => ({ _id: a.id, ...a })) }
   }
 
   async createSharingLink(document) {
-    const resp = await this.client.fetchJSON(
+    const resp = await this.stackClient.fetchJSON(
       'POST',
       `/permissions?codes=email`,
       {
@@ -81,7 +81,7 @@ export default class PermissionCollection extends DocumentCollection {
    * @returns {object}
    */
   async getOwnPermissions() {
-    const resp = await this.client.fetchJSON('GET', '/permissions/self')
+    const resp = await this.stackClient.fetchJSON('GET', '/permissions/self')
     return {
       data: normalizePermission(resp.data)
     }

--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -11,7 +11,7 @@ const normalizeSharing = sharing => normalizeDoc(sharing, 'io.cozy.sharings')
  */
 export default class SharingCollection extends DocumentCollection {
   async findByDoctype(doctype) {
-    const resp = await this.client.fetchJSON(
+    const resp = await this.stackClient.fetchJSON(
       'GET',
       uri`/sharings/doctype/${doctype}`
     )
@@ -37,7 +37,7 @@ export default class SharingCollection extends DocumentCollection {
     description,
     previewPath = null
   ) {
-    const resp = await this.client.fetchJSON('POST', '/sharings/', {
+    const resp = await this.stackClient.fetchJSON('POST', '/sharings/', {
       data: {
         type: 'io.cozy.sharings',
         attributes: {
@@ -64,7 +64,7 @@ export default class SharingCollection extends DocumentCollection {
    * @returns {string}
    */
   getDiscoveryLink(sharingId, sharecode) {
-    return this.client.fullpath(
+    return this.stackClient.fullpath(
       `/sharings/${sharingId}/discovery?sharecode=${sharecode}`
     )
   }
@@ -76,7 +76,7 @@ export default class SharingCollection extends DocumentCollection {
         type: _type
       }))
     }
-    const resp = await this.client.fetchJSON(
+    const resp = await this.stackClient.fetchJSON(
       'POST',
       uri`/sharings/${sharing._id}/recipients`,
       {
@@ -98,14 +98,14 @@ export default class SharingCollection extends DocumentCollection {
   }
 
   revokeRecipient(sharing, recipientIndex) {
-    return this.client.fetchJSON(
+    return this.stackClient.fetchJSON(
       'DELETE',
       uri`/sharings/${sharing._id}/recipients/${recipientIndex}`
     )
   }
 
   revokeSelf(sharing) {
-    return this.client.fetchJSON(
+    return this.stackClient.fetchJSON(
       'DELETE',
       uri`/sharings/${sharing._id}/recipients/self`
     )

--- a/packages/cozy-stack-client/src/__tests__/setup.js
+++ b/packages/cozy-stack-client/src/__tests__/setup.js
@@ -35,6 +35,17 @@ expect.extend({
   }
 })
 
+beforeEach(() => {
+  jest.spyOn(global.console, 'log').mockImplementation(() => {})
+  jest.spyOn(global.console, 'info').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  global.console.log.mockRestore && global.console.log.mockRestore()
+  global.console.info.mockRestore && global.console.info.mockRestore()
+})
+
+
 // In Node v7 unhandled promise rejections will terminate the process
 if (!process.env.LISTENING_TO_UNHANDLED_REJECTION) {
   process.on('unhandledRejection', reason => {

--- a/packages/cozy-stack-client/src/__tests__/setup.js
+++ b/packages/cozy-stack-client/src/__tests__/setup.js
@@ -45,7 +45,6 @@ afterEach(() => {
   global.console.info.mockRestore && global.console.info.mockRestore()
 })
 
-
 // In Node v7 unhandled promise rejections will terminate the process
 if (!process.env.LISTENING_TO_UNHANDLED_REJECTION) {
   process.on('unhandledRejection', reason => {


### PR DESCRIPTION
This PR supersedes https://github.com/cozy/cozy-client/pull/247.

The goal of this PR was for a link to be able to inject data in the store of CozyClient. This is necessary for the PouchLink that receives data asynchronously after a synchronization.

Previously, in Banks, the onSync handler was used to manually `setData`.
https://github.com/cozy/cozy-banks/blob/697ac7f8bb328cbc7d83f34145b811f0c7d34831/src/ducks/client/mobile.js#L80

This was done as a temporary solution. Now, this solution is backported into CozyClient. The link receives a reference to the CozyClient at registration time, saves the reference, and call `setData` when it receives new data asynchronously.

The links already received a `StackClient` at registration time but it was wrongly named `client` which caused confusion between CozyClient and CozyStackClient. To clear this confusion, this PR renames all places where a StackClient is used under the name `client` into `stackClient`. This addresses the concerns in https://github.com/cozy/cozy-client/issues/246.

## Discussions

I am not very happy with the name `setData`, I have the feeling that a link should
not directly call a method like this. I could be called `requestSetData`, or `onReceiveData`.

Should the links receive a full blown client or just a subset of its API (`getToken`, `getURL`, `requestSetData`, `refreshToken`) in order to respect the Law of Demeter ? I am not very happy that the links know that there is a stack client in the client they receive.

Should the links instantiate their own stack client when they need it instead of using the one from the cozy client ? This would make the coupling between the links and the client less strong.