### PR TITLE
fix: Discard rev from PouchDB results

### DIFF
--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -33,6 +33,10 @@ describe('CozyPouchLink', () => {
     await link.reset()
   })
 
+  afterEach(async () => {
+    await link.reset()
+  })
+
   it('should generate replication url', async () => {
     const url = await link.getReplicationURL(TODO_DOCTYPE)
     expect(url).toBe('http://user:token@cozy.tools:8080/data/io.cozy.todos')
@@ -126,7 +130,7 @@ describe('CozyPouchLink', () => {
         data: {
           id: expect.any(String),
           _id: expect.any(String),
-          rev: expect.any(String),
+          _rev: expect.any(String),
           label: 'Build stuff',
           _type: TODO_DOCTYPE
         }
@@ -134,13 +138,17 @@ describe('CozyPouchLink', () => {
     })
 
     it('should be possible to update a document', async () => {
-      const mutation = client.getDocumentSavePlan(TODO_3)
-      const res = await link.request(mutation)
-      expect(res).toMatchObject({
-        data: {
-          id: '3',
-          label: 'Build stuff'
-        }
+      const { _id, ...NEW_TODO } = TODO_3
+      const saveMutation = client.getDocumentSavePlan(NEW_TODO)
+      const saved = (await link.request(saveMutation)).data
+      const updateMutation = client.getDocumentSavePlan({
+        ...saved,
+        done: false
+      })
+      const updated = (await link.request(updateMutation)).data
+      expect(updated).toMatchObject({
+        label: 'Build stuff',
+        done: false
       })
     })
   })

--- a/packages/cozy-pouch-link/src/jsonapi.js
+++ b/packages/cozy-pouch-link/src/jsonapi.js
@@ -1,6 +1,21 @@
 export const normalizeDoc = (doc, doctype) => {
   const id = doc._id || doc.id
-  return { id, _id: id, _type: doctype, ...doc }
+
+  // PouchDB sends back .rev attribute but we do not want to
+  // keep it on the server. It is potentially higher than the
+  // _rev.
+  const _rev = doc.rev || doc._rev
+  const normalizedDoc = {
+    ...doc,
+    id,
+    _id: id,
+    _rev,
+    _type: doctype
+  }
+  if (normalizedDoc.rev) {
+    delete normalizedDoc.rev
+  }
+  return normalizedDoc
 }
 
 export const fromPouchResult = (res, withRows, doctype) => {

--- a/packages/cozy-pouch-link/src/jsonapi.spec.js
+++ b/packages/cozy-pouch-link/src/jsonapi.spec.js
@@ -1,4 +1,24 @@
-import { fromPouchResult } from './jsonapi'
+import { fromPouchResult, normalizeDoc } from './jsonapi'
+
+describe('doc normalization', () => {
+  it('keeps the highest between rev and _rev and removes the rev attribute', () => {
+    const normalized = normalizeDoc({
+      _id: 1234,
+      _rev: '3-deadbeef',
+      rev: '4-cffee',
+      firstName: 'Bobba',
+      lastName: 'Fett'
+    })
+    expect(normalized).toEqual({
+      _id: 1234,
+      id: 1234,
+      _rev: '4-cffee',
+      firstName: 'Bobba',
+      lastName: 'Fett'
+    })
+  })
+})
+
 describe('jsonapi', () => {
   it('should return a response understandable by cozy-client', () => {
     const res = {


### PR DESCRIPTION
PouchDB sends .rev attribute on documents. To avoid conflicts, it is
necessary to replace the ._rev on the document (that is lower in case
of a change on the document done by PouchDB). To remove confusion, we
keep only the _rev in our store and in CouchDB.