### PR TITLE
feat: Add pouch parameters

### DIFF
--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -90,6 +90,7 @@ export default class PouchLink extends CozyLink {
       }
     }
     this.pouches = new PouchManager(this.doctypes, {
+      pouch: this.options.pouch,
       getReplicationURL: this.getReplicationURL.bind(this),
       onError: err => this.onSyncError(err),
       onSync: this.handleOnSync.bind(this)

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -2,6 +2,8 @@
 
 import PouchDB from 'pouchdb'
 import fromPairs from 'lodash/fromPairs'
+import forEach from 'lodash/forEach'
+import get from 'lodash/get'
 import map from 'lodash/map'
 import zip from 'lodash/zip'
 import * as promises from './promises'
@@ -76,8 +78,11 @@ const startReplication = (pouch, getReplicationURL) => {
  */
 export default class PouchManager {
   constructor(doctypes, options) {
+    const pouchPlugins = get(options, 'pouch.plugins', [])
+    const pouchOptions = get(options, 'pouch.options', {})
+    forEach(pouchPlugins, plugin => PouchDB.plugin(plugin))
     this.pouches = fromPairs(
-      doctypes.map(doctype => [doctype, new PouchDB(doctype)])
+      doctypes.map(doctype => [doctype, new PouchDB(doctype, pouchOptions)])
     )
     this.options = options
     this.getReplicationURL = options.getReplicationURL


### PR DESCRIPTION
You can instanciate CozyPouchLink with pouchPlugins and pouchOptions

Example:
```js
const cozyPouchLink = new CozyPouchLink({
  doctypes: offlineDoctypes,
  pouch: {
    plugins: [require('pouchdb-adapter-cordova-sqlite')],
    options: { adapter: 'cordova-sqlite', location: 'default' }
  }
})
```