### PR TITLE
fix: ID case typo

### DIFF
--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -281,7 +281,7 @@ export default class FileCollection extends DocumentCollection {
       if (errors && errors.length && errors[0].status === '404') {
         return this.createDirectory({
           name: safeName,
-          dirID: parentDirectory && parentDirectory._id
+          dirId: parentDirectory && parentDirectory._id
         })
       }
       throw errors

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -180,7 +180,7 @@ describe('FileCollection', () => {
       expect(collection.statByPath).toHaveBeenCalledTimes(3)
       expect(collection.createDirectory).toHaveBeenCalledTimes(2)
       expect(collection.createDirectory).toHaveBeenLastCalledWith({
-        dirID: '9c217f9bf5e7118a34627f1ab800243b',
+        dirId: '9c217f9bf5e7118a34627f1ab800243b',
         name: 'baz'
       })
     })


### PR DESCRIPTION
`createDirectory` was called with a `dirID` but was expecting a `dirId`.