### PR TITLE
URl encode parameters in pathes

### DIFF
--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -79,7 +79,7 @@ export default class FileCollection extends DocumentCollection {
       'page[limit]': limit,
       'page[skip]': skip
     }
-    const url = `/data/${document._type}/${
+    const url = uri`/data/${document._type}/${
       document._id
     }/relationships/references`
     const path = querystring.buildURL(url, params)
@@ -208,7 +208,7 @@ export default class FileCollection extends DocumentCollection {
       limit,
       skip
     }
-    const url = `/files/${id}`
+    const url = uri`/files/${id}`
     const path = querystring.buildURL(url, params)
     const resp = await this.stackClient.fetchJSON('GET', path)
     return {


### PR DESCRIPTION
The problem might be more pervasive than just the `FileCollection`, but at least there we didn't encode some strings in our urls.