### PR TITLE
feat(pouch): Manage sync status by doctype

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   "jest": {
     "testURL": "http://localhost",
     "setupFiles": [
-      "<rootDir>/packages/cozy-client/src/__tests__/setup.js"
+      "<rootDir>/packages/cozy-client/src/__tests__/setup.js",
+      "jest-localstorage-mock"
     ],
     "setupTestFrameworkScriptFile": "<rootDir>/packages/cozy-stack-client/src/__tests__/setup.js",
     "testMatch": [

--- a/packages/cozy-pouch-link/package.json
+++ b/packages/cozy-pouch-link/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "babel-cli": "6.26.0",
+    "jest-localstorage-mock": "2.3.0",
     "parcel": "1.10.3",
     "react": "16.4.2",
     "react-dom": "16.4.2"

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -15,7 +15,6 @@ const parseMutationResult = (original, res) => {
   return { ...original, ...omit(res, 'ok') }
 }
 
-const LOCALSTORAGE_SYNCED_KEY = 'cozy-client-pouch-link-synced'
 const DEFAULT_OPTIONS = {
   replicationInterval: 30 * 1000
 }
@@ -58,7 +57,6 @@ export default class PouchLink extends CozyLink {
     }
     this.doctypes = doctypes
     this.indexes = {}
-    this.synced = window.localStorage.getItem(LOCALSTORAGE_SYNCED_KEY) || false
   }
 
   getReplicationURL(doctype) {
@@ -110,8 +108,6 @@ export default class PouchLink extends CozyLink {
 
     this.pouches = null
     this.client = null
-    window.localStorage.removeItem(LOCALSTORAGE_SYNCED_KEY)
-    this.synced = false
   }
 
   /**
@@ -121,8 +117,6 @@ export default class PouchLink extends CozyLink {
    */
   handleOnSync(doctypeUpdates) {
     const normalizedData = mapValues(doctypeUpdates, normalizeAll)
-    this.synced = true
-    window.localStorage.setItem(LOCALSTORAGE_SYNCED_KEY, true)
     if (this.client) {
       this.client.setData(normalizedData)
     }
@@ -194,7 +188,7 @@ export default class PouchLink extends CozyLink {
   request(operation, result = null, forward = doNothing) {
     const doctype = getDoctypeFromOperation(operation)
 
-    if (!this.synced) {
+    if (!this.pouches.isSynced(doctype)) {
       if (process.env.NODE_ENV !== 'production') {
         console.info(
           `Tried to access local ${doctype} but Cozy Pouch is not synced yet. Forwarding the operation to next link`

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -42,7 +42,6 @@ describe('CozyPouchLink', () => {
   describe('request handling', () => {
     it('should check if the doctype is supported and forward if not', async () => {
       const query = client.all('io.cozy.rockets')
-      link.synced = true
       await link.request(query, null, () => {
         expect(true).toBe(true)
         return Promise.resolve()
@@ -61,7 +60,7 @@ describe('CozyPouchLink', () => {
   describe('queries', () => {
     const docs = [TODO_1, TODO_2, TODO_3, TODO_4]
     beforeEach(() => {
-      link.synced = true
+      link.pouches.isSynced = jest.fn().mockReturnValue(true)
     })
     it('should be able to execute a query', async () => {
       const db = link.getPouch(TODO_DOCTYPE)
@@ -116,7 +115,7 @@ describe('CozyPouchLink', () => {
 
   describe('mutations', async () => {
     beforeEach(() => {
-      link.synced = true
+      link.pouches.isSynced = jest.fn().mockReturnValue(true)
     })
 
     it('should be possible to save a new document', async () => {
@@ -172,11 +171,6 @@ describe('CozyPouchLink', () => {
       expect(link.client).not.toBeNull()
       await link.reset()
       expect(link.client).toBeNull()
-    })
-
-    it('should set the `synced` property to false', async () => {
-      await link.reset()
-      expect(link.synced).toBe(false)
     })
 
     it('should forget the PouchManager instance', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6860,6 +6860,11 @@ jest-leak-detector@^23.6.0:
   dependencies:
     pretty-format "^23.6.0"
 
+jest-localstorage-mock@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/jest-localstorage-mock/-/jest-localstorage-mock-2.3.0.tgz#86eda98d5af3aed687aebf11dbab3ca0f8fe66ff"
+  integrity sha512-Lk+awEPuIz0PSERHtnsXyMVLvf/4mZ3sZBEjKG5sJHvey2/i2JfQmmb/NHhialMbHXZILBORzuH64YXhWGlLsQ==
+
 jest-matcher-utils@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz#726bcea0c5294261a7417afb6da3186b4b8cac80"


### PR DESCRIPTION
The synchronization status was managed globally (eg set to true when all the doctypes have been synchronized). This lead to issues where some doctypes already synchronized couldn't be returned from Pouch because other doctypes are still synchronizing.

Now, the status is managed for each doctype. So if transactions are synchronizing and accounts already synchronized and we query the accounts, they are fetched from Pouch.