### PR TITLE
feat(DocCollection): Use _normal_docs route

### DIFF
--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -60,7 +60,7 @@ export default class DocumentCollection {
       ),
       meta: { count: resp.total_rows },
       skip: skip,
-      next: skip + resp.rows.length <= resp.total_rows
+      next: skip + resp.rows.length < resp.total_rows
     }
   }
 

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -117,6 +117,22 @@ describe('DocumentCollection', () => {
       )
     })
 
+    it('should paginate results', async () => {
+      client.fetchJSON.mockReturnValue({
+        rows: [{}, {}],
+        total_rows: 3
+      })
+      const respWithNext = await collection.all({ skip: 0, limit: 2 })
+      expect(respWithNext.next).toBe(true)
+
+      client.fetchJSON.mockReturnValue({
+        rows: [{}],
+        total_rows: 3
+      })
+      const respWithoutNext = await collection.all({ skip: 2, limit: 2 })
+      expect(respWithoutNext.next).toBe(false)
+    })
+
     it('should accept keys option', async () => {
       client.fetchJSON.mockReturnValue(Promise.resolve(ALL_RESPONSE_FIXTURE))
       await collection.all({ keys: ['abc', 'def'] })


### PR DESCRIPTION
When fetching all the documents of a certain type without any criteria, we were using the `_all_docs` route. This route also returns design documents, which we had to remove from the results and would mess up the pagination.

Instead, there's now a new route called `_normal_docs`, which doesn't take into account design docs - so we're using that one instead.
Unfortunately, it doesn't support the `keys` option and the response is slightly different than the `_all_docs` response, but these difference can be abstracted away.