### PR TITLE
feat(pouch): Destroy databases when login on another instance

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -80,7 +80,7 @@ export default class CozyClient {
 
   registerClientOnLinks() {
     for (const link of this.links) {
-      if (!link.client && link.registerClient) {
+      if (link.registerClient) {
         try {
           link.registerClient(this)
         } catch (e) {
@@ -90,13 +90,13 @@ export default class CozyClient {
     }
   }
 
-  login() {
+  async login() {
     this.registerClientOnLinks()
 
     for (const link of this.links) {
       if (link.onLogin) {
         try {
-          link.onLogin()
+          await link.onLogin()
         } catch (e) {
           console.warn(e)
         }

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -124,18 +124,18 @@ describe('CozyClient login', () => {
     client = new CozyClient({ links, schema: SCHEMA })
   })
 
-  it('Should call `registerClientOnLinks`', () => {
+  it('Should call `registerClientOnLinks`', async () => {
     client.registerClientOnLinks = jest.fn()
-    client.login()
+    await client.login()
 
     expect(client.registerClientOnLinks).toHaveBeenCalled()
   })
 
-  it('Should call `onLogin` on every link that implements it', () => {
+  it('Should call `onLogin` on every link that implements it', async () => {
     links[0].onLogin = jest.fn()
     links[2].onLogin = jest.fn()
 
-    client.login()
+    await client.login()
 
     expect(links[0].onLogin).toHaveBeenCalledTimes(1)
     expect(links[2].onLogin).toHaveBeenCalledTimes(1)

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -80,14 +80,17 @@ export const LOCALSTORAGE_SYNCED_KEY = 'cozy-client-pouch-link-synced'
  */
 export default class PouchManager {
   constructor(doctypes, options) {
+    this.options = options
     const pouchPlugins = get(options, 'pouch.plugins', [])
     const pouchOptions = get(options, 'pouch.options', {})
     forEach(pouchPlugins, plugin => PouchDB.plugin(plugin))
     this.pouches = fromPairs(
-      doctypes.map(doctype => [doctype, new PouchDB(doctype, pouchOptions)])
+      doctypes.map(doctype => [
+        doctype,
+        new PouchDB(this.getDatabaseName(doctype, options.prefix), pouchOptions)
+      ])
     )
     this.syncedDoctypes = this.getPersistedSyncedDoctypes()
-    this.options = options
     this.getReplicationURL = options.getReplicationURL
     this.listenerLaunched = false
 
@@ -311,5 +314,13 @@ export default class PouchManager {
 
   destroyPersistedSyncedDoctypes() {
     window.localStorage.removeItem(LOCALSTORAGE_SYNCED_KEY)
+  }
+
+  getDatabaseName(doctype, prefix) {
+    if (!prefix) {
+      return doctype
+    }
+
+    return `${prefix}_${doctype}`
   }
 }


### PR DESCRIPTION
We destroy all pouch dbs when the user logouts. But it happens asynchronously and can take several seconds. So during this time, the user can kill the app, aborting this process.

To avoid data leak between instances, this PR introduce two things:

* The Pouch databases are now named after the instance they correspond to
* If we still have references to some databases and we login on another instance, we destroy them