### PR TITLE
fix(DocCollection): Correct pagination limits

### DIFF
--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -60,7 +60,7 @@ export default class DocumentCollection {
       ),
       meta: { count: resp.total_rows },
       skip: skip,
-      next: skip + resp.rows.length <= resp.total_rows
+      next: skip + resp.rows.length < resp.total_rows
     }
   }
 

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -117,6 +117,22 @@ describe('DocumentCollection', () => {
       )
     })
 
+    it('should paginate results', async () => {
+      client.fetchJSON.mockReturnValue({
+        rows: [{}, {}],
+        total_rows: 3
+      })
+      const respWithNext = await collection.all({ skip: 0, limit: 2 })
+      expect(respWithNext.next).toBe(true)
+
+      client.fetchJSON.mockReturnValue({
+        rows: [{}],
+        total_rows: 3
+      })
+      const respWithoutNext = await collection.all({ skip: 2, limit: 2 })
+      expect(respWithoutNext.next).toBe(false)
+    })
+
     it('should accept keys option', async () => {
       client.fetchJSON.mockReturnValue(Promise.resolve(ALL_RESPONSE_FIXTURE))
       await collection.all({ keys: ['abc', 'def'] })


### PR DESCRIPTION
I don't understand how this hasn't been found before, but I think I've double checked everything and this really appears to be a bug.

If there are 10 rows in total, and we have a skip of `0` and no limit, we will get 10 rows in the result. This will evaluate to `0 + 10 <= 10`, which is `true`… but of course there are no next pages.