### PR TITLE
feat: Stop Start replication when device is online/offline

### DIFF
--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -105,12 +105,12 @@ export default class PouchManager {
   addListeners() {
     if (!this.listenerLaunched) {
       if (isMobileApp()) {
-        document.addEventListener('pause', this.stopReplicationLoop, false)
-        document.addEventListener('resign', this.stopReplicationLoop, false)
-        document.addEventListener('resume', this.startReplicationLoop, false)
+        document.addEventListener('pause', this.stopReplicationLoop)
+        document.addEventListener('resign', this.stopReplicationLoop)
+        document.addEventListener('resume', this.startReplicationLoop)
       }
-      document.addEventListener('online', this.startReplicationLoop, false)
-      document.addEventListener('offline', this.stopReplicationLoop, false)
+      document.addEventListener('online', this.startReplicationLoop)
+      document.addEventListener('offline', this.stopReplicationLoop)
       this.listenerLaunched = true
     }
   }
@@ -118,12 +118,12 @@ export default class PouchManager {
   removeListeners() {
     if (this.listenerLaunched) {
       if (isMobileApp()) {
-        document.removeEventListener('pause', this.stopReplicationLoop, false)
-        document.removeEventListener('resign', this.stopReplicationLoop, false)
-        document.removeEventListener('resume', this.startReplicationLoop, false)
+        document.removeEventListener('pause', this.stopReplicationLoop)
+        document.removeEventListener('resign', this.stopReplicationLoop)
+        document.removeEventListener('resume', this.startReplicationLoop)
       }
-      document.removeEventListener('online', this.startReplicationLoop, false)
-      document.removeEventListener('offline', this.stopReplicationLoop, false)
+      document.removeEventListener('online', this.startReplicationLoop)
+      document.removeEventListener('offline', this.stopReplicationLoop)
       this.listenerLaunched = false
     }
   }

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -97,66 +97,33 @@ export default class PouchManager {
     // We must ensure databases exist on the remote before
     // starting replications
     this.ensureDatabasesExistDone = false
+
+    this.startReplicationLoop = this.startReplicationLoop.bind(this)
+    this.stopReplicationLoop = this.stopReplicationLoop.bind(this)
   }
 
   addListener() {
-    if (isMobileApp() && !this.listenerLaunched) {
-      document.addEventListener(
-        'pause',
-        () => this.stopReplicationLoop(),
-        false
-      )
-      document.addEventListener(
-        'resign',
-        () => this.stopReplicationLoop(),
-        false
-      )
-      document.addEventListener(
-        'resume',
-        () => this.startReplicationLoop(),
-        false
-      )
-      document.addEventListener(
-        'offline',
-        () => this.stopReplicationLoop(),
-        false
-      )
-      document.addEventListener(
-        'online',
-        () => this.startReplicationLoop(),
-        false
-      )
+    if (!this.listenerLaunched) {
+      if (isMobileApp()) {
+        document.addEventListener('pause', this.stopReplicationLoop, false)
+        document.addEventListener('resign', this.stopReplicationLoop, false)
+        document.addEventListener('resume', this.startReplicationLoop, false)
+      }
+      document.addEventListener('online', this.startReplicationLoop, false)
+      document.addEventListener('offline', this.stopReplicationLoop, false)
       this.listenerLaunched = true
     }
   }
 
   removeListener() {
-    if (isMobileApp() && this.listenerLaunched) {
-      document.removeEventListener(
-        'pause',
-        () => this.stopReplicationLoop(),
-        false
-      )
-      document.removeEventListener(
-        'resign',
-        () => this.stopReplicationLoop(),
-        false
-      )
-      document.removeEventListener(
-        'resume',
-        () => this.startReplicationLoop(),
-        false
-      )
-      document.removeEventListener(
-        'offline',
-        () => this.stopReplicationLoop(),
-        false
-      )
-      document.removeEventListener(
-        'online',
-        () => this.startReplicationLoop(),
-        false
-      )
+    if (this.listenerLaunched) {
+      if (isMobileApp()) {
+        document.removeEventListener('pause', this.stopReplicationLoop, false)
+        document.removeEventListener('resign', this.stopReplicationLoop, false)
+        document.removeEventListener('resume', this.startReplicationLoop, false)
+      }
+      document.removeEventListener('online', this.startReplicationLoop, false)
+      document.removeEventListener('offline', this.stopReplicationLoop, false)
       this.listenerLaunched = false
     }
   }

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -116,12 +116,22 @@ export default class PouchManager {
         () => this.startReplicationLoop(),
         false
       )
+      document.addEventListener(
+        'offline',
+        () => this.stopReplicationLoop(),
+        false
+      )
+      document.addEventListener(
+        'online',
+        () => this.startReplicationLoop(),
+        false
+      )
       this.listenerLaunched = true
     }
   }
 
   removeListener() {
-    if (this.listenerLaunched) {
+    if (isMobileApp() && this.listenerLaunched) {
       document.removeEventListener(
         'pause',
         () => this.stopReplicationLoop(),
@@ -134,6 +144,16 @@ export default class PouchManager {
       )
       document.removeEventListener(
         'resume',
+        () => this.startReplicationLoop(),
+        false
+      )
+      document.removeEventListener(
+        'offline',
+        () => this.stopReplicationLoop(),
+        false
+      )
+      document.removeEventListener(
+        'online',
         () => this.startReplicationLoop(),
         false
       )

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -102,7 +102,7 @@ export default class PouchManager {
     this.stopReplicationLoop = this.stopReplicationLoop.bind(this)
   }
 
-  addListener() {
+  addListeners() {
     if (!this.listenerLaunched) {
       if (isMobileApp()) {
         document.addEventListener('pause', this.stopReplicationLoop, false)
@@ -115,7 +115,7 @@ export default class PouchManager {
     }
   }
 
-  removeListener() {
+  removeListeners() {
     if (this.listenerLaunched) {
       if (isMobileApp()) {
         document.removeEventListener('pause', this.stopReplicationLoop, false)
@@ -130,7 +130,7 @@ export default class PouchManager {
 
   destroy() {
     this.stopReplicationLoop()
-    this.removeListener()
+    this.removeListeners()
     this.destroyPersistedSyncedDoctypes()
     return Promise.all(
       Object.values(this.pouches).map(pouch => pouch.destroy())
@@ -182,7 +182,7 @@ export default class PouchManager {
         return Promise.resolve()
       }
     }, delay)
-    this.addListener()
+    this.addListeners()
     return this._stopReplicationLoop
   }
 

--- a/packages/cozy-pouch-link/src/PouchManager.spec.js
+++ b/packages/cozy-pouch-link/src/PouchManager.spec.js
@@ -238,20 +238,20 @@ describe('PouchManager', () => {
 
       it('adds listeners only one time', () => {
         expect(addEventListener).not.toHaveBeenCalled()
-        manager.addListener()
+        manager.addListeners()
         expect(addEventListener).toHaveBeenCalled()
         const calls = addEventListener.mock.calls
-        manager.addListener()
+        manager.addListeners()
         expect(addEventListener).toHaveBeenCalledTimes(calls.length)
       })
 
       it('removes listeners only one time', () => {
         expect(removeEventListener).not.toHaveBeenCalled()
-        manager.addListener()
-        manager.removeListener()
+        manager.addListeners()
+        manager.removeListeners()
         expect(removeEventListener).toHaveBeenCalled()
         const calls = addEventListener.mock.calls
-        manager.removeListener()
+        manager.removeListeners()
         expect(removeEventListener).toHaveBeenCalledTimes(calls.length)
       })
     })
@@ -263,7 +263,7 @@ describe('PouchManager', () => {
         isMobileApp.mockResolvedValue(true)
         startReplicationLoop = jest.spyOn(manager, 'startReplicationLoop')
         stopReplicationLoop = jest.spyOn(manager, 'stopReplicationLoop')
-        manager.addListener()
+        manager.addListeners()
       })
 
       afterEach(() => {


### PR DESCRIPTION
Currently when a device goes offline in the middle of a replication the replication ends with an error and never restart.

With this PR during online / offline events we stop and restart replication explicitly