### PR TITLE
feat: Remove resign cordova event

### DIFF
--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -106,7 +106,6 @@ export default class PouchManager {
     if (!this.listenerLaunched) {
       if (isMobileApp()) {
         document.addEventListener('pause', this.stopReplicationLoop)
-        document.addEventListener('resign', this.stopReplicationLoop)
         document.addEventListener('resume', this.startReplicationLoop)
       }
       document.addEventListener('online', this.startReplicationLoop)
@@ -119,7 +118,6 @@ export default class PouchManager {
     if (this.listenerLaunched) {
       if (isMobileApp()) {
         document.removeEventListener('pause', this.stopReplicationLoop)
-        document.removeEventListener('resign', this.stopReplicationLoop)
         document.removeEventListener('resume', this.startReplicationLoop)
       }
       document.removeEventListener('online', this.startReplicationLoop)

--- a/packages/cozy-pouch-link/src/PouchManager.spec.js
+++ b/packages/cozy-pouch-link/src/PouchManager.spec.js
@@ -279,7 +279,7 @@ describe('PouchManager', () => {
         })
       }
 
-      for (const eventName of ['resign', 'pause', 'offline']) {
+      for (const eventName of ['pause', 'offline']) {
         it(`check ${eventName} listener to start replication`, () => {
           document.dispatchEvent(new Event(eventName))
           expect(startReplicationLoop).not.toHaveBeenCalled()


### PR DESCRIPTION
This event is only on iOS when you open settings bottom bar.
Replication must not stop when it does.
https://cordova.apache.org/docs/en/latest/cordova/events/events.html