### PR TITLE
feat: Save state of login to not start replication twice

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -67,6 +67,7 @@ export default class CozyClient {
 
     this.options = options
     this.idCounter = 1
+    this.isLogged = false
 
     this.createClient()
 
@@ -91,6 +92,12 @@ export default class CozyClient {
   }
 
   async login() {
+    if (this.isLogged) {
+      console.warn(`CozyClient is already logged.`)
+      return
+    }
+
+    this.isLogged = true
     this.registerClientOnLinks()
 
     for (const link of this.links) {
@@ -105,6 +112,12 @@ export default class CozyClient {
   }
 
   async logout() {
+    if (!this.isLogged) {
+      console.warn(`CozyClient isn't logged.`)
+      return
+    }
+
+    this.isLogged = false
     // unregister client on stack
     if (
       this.stackClient.unregister &&

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -87,7 +87,14 @@ describe('CozyClient logout', () => {
   it('should call reset on each link that can be reset', async () => {
     links[0].reset = jest.fn()
     links[2].reset = jest.fn()
+    await client.login()
     await client.logout()
+    expect(links[0].reset).toHaveBeenCalledTimes(1)
+    expect(links[2].reset).toHaveBeenCalledTimes(1)
+
+    // test if we launch twice logout, it doesn't launch twice reset.
+    await client.logout()
+
     expect(links[0].reset).toHaveBeenCalledTimes(1)
     expect(links[2].reset).toHaveBeenCalledTimes(1)
   })
@@ -96,6 +103,7 @@ describe('CozyClient logout', () => {
     const spy = jest.spyOn(global.console, 'warn').mockReturnValue(jest.fn())
     links[0].reset = jest.fn().mockRejectedValue(new Error('Async error'))
     links[2].reset = jest.fn()
+    await client.login()
     await client.logout()
     expect(links[0].reset).toHaveBeenCalledTimes(1)
     expect(links[2].reset).toHaveBeenCalledTimes(1)
@@ -135,6 +143,12 @@ describe('CozyClient login', () => {
     links[0].onLogin = jest.fn()
     links[2].onLogin = jest.fn()
 
+    await client.login()
+
+    expect(links[0].onLogin).toHaveBeenCalledTimes(1)
+    expect(links[2].onLogin).toHaveBeenCalledTimes(1)
+
+    // test if we launch twice login, it doesn't launch twice onLogin.
     await client.login()
 
     expect(links[0].onLogin).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
In banks, we run `cozyClient.login()` several times without doing it on purpose, I think that cozyClient must know how to manage its login state.