### PR TITLE
fix: Loop replication witout delay

### DIFF
--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -155,7 +155,7 @@ export default class PouchManager {
   }
 
   /** Starts periodic syncing of the pouches */
-  async startReplicationLoop(delay) {
+  async startReplicationLoop() {
     await this.ensureDatabasesExist()
 
     if (this._stopReplicationLoop) {
@@ -166,7 +166,7 @@ export default class PouchManager {
       console.info('PouchManager: Start replication loop')
     }
 
-    delay = delay || this.options.replicationDelay || DEFAULT_DELAY
+    const delay = this.options.replicationDelay || DEFAULT_DELAY
     this._stopReplicationLoop = promises.setInterval(() => {
       if (window.navigator.onLine) {
         return this.replicateOnce()


### PR DESCRIPTION
When the replication is restarted by an event, it sees as a parameter
an Event and not a delay which had a problem. This parameter is not
really neccesarry, we can pass by `this.options.replicationDelay`.