### PR TITLE
feat(stack-client): Always use all_docs when fetching all docs

### DIFF
--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -32,9 +32,7 @@ export default class DocumentCollection {
   async all(options = {}) {
     const { limit, skip = 0, keys } = options
 
-    const isUsingAllDocsRoute = !!keys
-    const route = isUsingAllDocsRoute ? '_all_docs' : '_normal_docs'
-    const url = uri`/data/${this.doctype}/${route}`
+    const url = uri`/data/${this.doctype}/_all_docs`
     const params = {
       include_docs: true,
       limit,
@@ -54,10 +52,11 @@ export default class DocumentCollection {
       }
       throw error
     }
+
     return {
-      data: resp.rows.map(row =>
-        normalizeDoc(isUsingAllDocsRoute ? row.doc : row, this.doctype)
-      ),
+      data: resp.rows
+        .filter(row => row.doc._id.indexOf('_design') !== 0)
+        .map(row => normalizeDoc(row.doc, this.doctype)),
       meta: { count: resp.total_rows },
       skip: skip,
       next: skip + resp.rows.length < resp.total_rows


### PR DESCRIPTION
The usage of `_normal_docs` is very confusing. It doesn't act like a `_all_docs` but like a `_find` (see https://docs.cozy.io/en/cozy-stack/data-system/#list-all-the-documents-alternative). Thus, it is subject to the 100 documents limit from the stack. So we didn't fetch **all** docs when using `_normal_docs`. I think always using `_all_docs` and filter design docs by hand is better than fetching multiple `_normal_docs` to get all docs, because it makes it less confusing (using `all` method fetches all documents).

That's potentially a breaking change and maybe we need another method that uses `_normal_docs` to keep the paginated results ?

Tests are broken, but I want your feedbacks on the proposition itself before fixing it.