### PR TITLE
fix(DocumentCollection): Return all docs if limit is null

### DIFF
--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -13,9 +13,13 @@ const ALL_RESPONSE_FIXTURE = {
     {
       id: '67890',
       doc: { _id: '67890', label: 'Check email', done: false }
+    },
+    {
+      id: '_design/todo',
+      doc: { _id: '_design/todo' }
     }
   ],
-  total_rows: 2
+  total_rows: 3
 }
 
 const NORMAL_RESPONSE_FIXTURE = {
@@ -103,9 +107,16 @@ describe('DocumentCollection', () => {
 
     it('should call the right route', async () => {
       await collection.all()
-      expect(client.fetchJSON).toHaveBeenCalledWith(
+      expect(client.fetchJSON).toHaveBeenLastCalledWith(
         'GET',
         '/data/io.cozy.todos/_normal_docs?include_docs=true'
+      )
+
+      client.fetchJSON.mockReturnValue(Promise.resolve(ALL_RESPONSE_FIXTURE))
+      await collection.all({ limit: null })
+      expect(client.fetchJSON).toHaveBeenLastCalledWith(
+        'GET',
+        '/data/io.cozy.todos/_all_docs?include_docs=true'
       )
     })
 
@@ -193,6 +204,13 @@ describe('DocumentCollection', () => {
       } catch (e) {
         expect(e).toBeInstanceOf(Error)
       }
+    })
+
+    it('should not return design documents', async () => {
+      client.fetchJSON.mockResolvedValueOnce(ALL_RESPONSE_FIXTURE)
+      const docs = await collection.all()
+
+      expect(docs.data.length).toBe(2)
     })
   })
 


### PR DESCRIPTION
There is a `UNSAFE_noLimit` method in cozy-client. It sets the `limit` to `null` on a query definition. The goal is to be able to fetch all documents of a collection at once. But `DocumentCollection::all` was not handling this case properly. It was making a request to `_normal_docs` route, which has a hard limit of 100 set by the stack.

This PR fixes this behaviour by making a request to `_all_docs` if `limit` is intentionnally `null` (keeping the previous behaviour if it is `undefined`, so not breaking). It also filters design docs, which are present only when using `_all_docs` route.

We talked about adding a `UNSAFE_all` previously. But I think this behaviour is intended to be right inside `all`.