### PR TITLE
fix(DocumentCollection): Check if the doc is not null

### DIFF
--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -9,7 +9,6 @@ export const normalizeDoc = (doc, doctype) => {
   const id = doc._id || doc.id
   return { id, _id: id, _type: doctype, ...doc }
 }
-
 /**
  * Abstracts a collection of documents of the same doctype, providing CRUD methods and other helpers.
  * @module DocumentCollection
@@ -58,10 +57,16 @@ export default class DocumentCollection {
     }
 
     const data = resp.rows
-      .map(row =>
-        normalizeDoc(isUsingAllDocsRoute ? row.doc : row, this.doctype)
-      )
-      .filter(doc => !startsWith(doc.id, '_design'))
+      .filter(doc => {
+        if (isUsingAllDocsRoute) {
+          return doc && doc.doc !== null && !startsWith(doc.id, '_design')
+        } else {
+          return doc && doc.id && !startsWith(doc.id, '_design')
+        }
+      })
+      .map(row => {
+        return normalizeDoc(isUsingAllDocsRoute ? row.doc : row, this.doctype)
+      })
 
     return {
       data,

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -55,18 +55,23 @@ export default class DocumentCollection {
       }
       throw error
     }
-
-    const data = resp.rows
-      .filter(doc => {
-        if (isUsingAllDocsRoute) {
+    let data
+    /* If using `all_docs` we need to filter our design documents and check if 
+    the document is not null. If we use `normal_doc` we can't have any design doc
+     */
+    if (isUsingAllDocsRoute) {
+      data = resp.rows
+        .filter(doc => {
           return doc && doc.doc !== null && !startsWith(doc.id, '_design')
-        } else {
-          return doc && doc.id && !startsWith(doc.id, '_design')
-        }
+        })
+        .map(row => {
+          return normalizeDoc(row.doc, this.doctype)
+        })
+    } else {
+      data = resp.rows.map(row => {
+        return normalizeDoc(row, this.doctype)
       })
-      .map(row => {
-        return normalizeDoc(isUsingAllDocsRoute ? row.doc : row, this.doctype)
-      })
+    }
 
     return {
       data,

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -206,9 +206,11 @@ describe('DocumentCollection', () => {
       }
     })
 
-    it('should not return design documents', async () => {
-      client.fetchJSON.mockResolvedValueOnce(ALL_RESPONSE_FIXTURE)
-      const docs = await collection.all()
+    it('should not return design documents if we intentionnally define limit=null', async () => {
+      client.fetchJSON.mockResolvedValueOnce(
+        Promise.resolve(ALL_RESPONSE_FIXTURE)
+      )
+      const docs = await collection.all({ limit: null })
 
       expect(docs.data.length).toBe(2)
     })

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -212,6 +212,22 @@ describe('DocumentCollection', () => {
 
       expect(docs.data.length).toBe(2)
     })
+
+    it('should works even if the key references an empty doc', async () => {
+      const responsesWithEmptyDoc = {
+        ...ALL_RESPONSE_FIXTURE,
+        rows: [
+          ...ALL_RESPONSE_FIXTURE.rows,
+          {
+            id: '11111',
+            doc: null
+          }
+        ]
+      }
+      client.fetchJSON.mockReturnValue(Promise.resolve(responsesWithEmptyDoc))
+      const docs = await collection.all({ keys: ['12345', '67890', '11111'] })
+      expect(docs.data.length).toBe(2)
+    })
   })
 
   describe('createIndex', () => {


### PR DESCRIPTION
2 things in this PR : 

- First: filtering only when needed (ie all_docs)
- Second: We don't know yet, but sometimes on Drive (sharing) we receive an "null doc". So we need to check if doc !== null 