### PR TITLE
Has many query

### DIFF
--- a/packages/cozy-client/src/associations/HasMany.js
+++ b/packages/cozy-client/src/associations/HasMany.js
@@ -1,3 +1,4 @@
+import get from 'lodash/get'
 import Association from './Association'
 import { QueryDefinition } from '../queries/dsl'
 
@@ -142,7 +143,8 @@ export default class HasMany extends Association {
   }
 
   static query(document, client, assoc) {
-    const ids = document[assoc.name]
+    const relationships = get(document, `relationships.${assoc.name}.data`, [])
+    const ids = relationships.map(assoc => assoc._id)
     return new QueryDefinition({ doctype: assoc.doctype, ids })
   }
 }

--- a/packages/cozy-client/src/associations/HasMany.js
+++ b/packages/cozy-client/src/associations/HasMany.js
@@ -111,8 +111,7 @@ export default class HasMany extends Association {
 
   getRelationship() {
     const rawData = this.target[this.name]
-    const relationship =
-      this.target.relationships && this.target.relationships[this.name]
+    const relationship = get(this.target, `relationships.${this.name}`)
     if (!relationship) {
       if (rawData && rawData.length) {
         console.warn(

--- a/packages/cozy-client/src/associations/HasMany.spec.js
+++ b/packages/cozy-client/src/associations/HasMany.spec.js
@@ -87,4 +87,15 @@ describe('HasMany', () => {
       hydratedWithNoRelation.tasks.target.relationships['tasks'].data.length
     ).toEqual(1)
   })
+
+  it('transform the relationship into  query', () => {
+    const queryDef = HasMany.query(original, null, {
+      name: 'tasks',
+      doctype: 'io.cozy.tasks'
+    })
+    expect(queryDef.doctype).toEqual('io.cozy.tasks')
+    expect(queryDef.ids).toEqual(
+      original.relationships.tasks.data.map(task => task._id)
+    )
+  })
 })


### PR DESCRIPTION
When using the `include()` option on a `HasMany` relationship, we use `HasMany.query()` to get a QueryDefinition that allows us to fetch the related documents (for example the tasks related to a todo).

At least in our case, this was not working properly — when constructing the QueryDefinition, we would have an array of ids that was looking like `[{ _id: '123', _type: 'io.cozy.tasks' }]`, instead of a plain `['123']` as we need to execute the query.

Note that we were also looking at `myTodo.tasks` instead of `myTodo.relationships.tasks.data` which iI think is odd too.

Was anyone else using `HasMany` relationships with includes? Or are we just the first to find this bug?