### PR TITLE
Create with fixed id

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -201,7 +201,7 @@ export default class CozyClient {
    * client.getDocumentSavePlan(baseDoc, relationships)
    */
   getDocumentSavePlan(document, relationships) {
-    const newDocument = !document._id
+    const newDocument = !document._rev
     const dehydratedDoc = dehydrate(document)
     const saveMutation = newDocument
       ? Mutations.createDocument(dehydratedDoc)

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -247,6 +247,36 @@ describe('CozyClient', () => {
   })
 
   describe('getDocumentSavePlan', () => {
+    it('should handle missing _rev and _id', () => {
+      const NEW_FOO = {
+        attributes: {
+          bar: 'Zap'
+        }
+      }
+      const mutation = client.getDocumentSavePlan(NEW_FOO)
+      expect(mutation.mutationType).toBe('CREATE_DOCUMENT')
+    })
+
+    it('should handle fixed _id', () => {
+      const NEW_FOO = {
+        _id: '29328139a6ed4320bdd75d28141e8fb2',
+        attributes: {
+          bar: 'Zap'
+        }
+      }
+      const mutation = client.getDocumentSavePlan(NEW_FOO)
+      expect(mutation.mutationType).toBe('CREATE_DOCUMENT')
+    })
+
+    it('should handle _rev for update', () => {
+      const OLD_FOO = {
+        _id: '29328139a6ed4320bdd75d28141e8fb2',
+        _rev: '1-5e3e3c68250747589266c23ce507b1a4'
+      }
+      const mutation = client.getDocumentSavePlan(OLD_FOO)
+      expect(mutation.mutationType).toBe('UPDATE_DOCUMENT')
+    })
+
     it('should handle associations for a new document with mutation creators', () => {
       const NEW_TODO = {
         _type: 'io.cozy.todos',

--- a/packages/cozy-client/src/__tests__/fixtures.js
+++ b/packages/cozy-client/src/__tests__/fixtures.js
@@ -1,5 +1,6 @@
 export const TODO_1 = {
   _id: '12345',
+  _rev: '4-43bdf4f7123f4d748645ba9536a46daa',
   _type: 'io.cozy.todos',
   label: 'Buy bread',
   done: false
@@ -7,6 +8,7 @@ export const TODO_1 = {
 
 export const TODO_2 = {
   _id: '67890',
+  _rev: '2-4e015d830d3246e5a83b3466f437bf1f',
   _type: 'io.cozy.todos',
   label: 'Check email',
   done: false
@@ -14,12 +16,14 @@ export const TODO_2 = {
 
 export const TODO_3 = {
   _id: '54321',
+  _rev: '22-6af94ee48bcc4867aa06b72b635837e9',
   _type: 'io.cozy.todos',
   label: 'Build stuff',
   done: true
 }
 export const TODO_4 = {
   _id: '4',
+  _rev: '19-cc30042f909f4fa7a487c4c7f0a11d19',
   _type: 'io.cozy.todos',
   label: 'Run a semi-marathon',
   done: true
@@ -29,6 +33,7 @@ export const TODOS = [TODO_1, TODO_2, TODO_3]
 
 export const TODO_WITH_RELATION = {
   _id: 5,
+  _rev: '1-7f02bbb542fb4eb0805b130a80b9be1a',
   _type: 'io.cozy.todos',
   label: 'tototot',
   relationships: {
@@ -50,11 +55,13 @@ export const TODO_WITH_RELATION = {
 
 export const FILE_1 = {
   _id: 1,
+  _rev: '3-bd9bb7286a094842b954d9e86429090d',
   _type: 'io.cozy.files',
   label: 'File 1'
 }
 export const FILE_2 = {
   _id: 2,
+  _rev: '2-aa462e9a9867449f916c932fef481c27',
   _type: 'io.cozy.files',
   label: 'File 2'
 }

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -162,11 +162,13 @@ export default class DocumentCollection {
   }
 
   async create({ _id, _type, ...document }) {
-    const resp = await this.stackClient.fetchJSON(
-      'POST',
-      uri`/data/${this.doctype}/`,
-      document
-    )
+    // In case of a fixed id, let's use the dedicated creation endpoint
+    // https://github.com/cozy/cozy-stack/blob/master/docs/data-system.md#create-a-document-with-a-fixed-id
+    const hasFixedId = !!_id
+    const method = hasFixedId ? 'PUT' : 'POST'
+    const endpoint = uri`/data/${this.doctype}/${hasFixedId ? _id : ''}`
+    const resp = await this.stackClient.fetchJSON(method, endpoint, document)
+
     return {
       data: normalizeDoc(resp.data, this.doctype)
     }

--- a/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
@@ -38,6 +38,48 @@ describe('CozyStackClient', () => {
     })
   })
 
+  describe('create', () => {
+    const client = new CozyStackClient(FAKE_INIT_OPTIONS)
+    beforeAll(() => {
+      jest.spyOn(client, 'fetchJSON')
+      client.fetchJSON.mockResolvedValue({ data: {} })
+    })
+
+    afterEach(() => {
+      client.fetchJSON.mockClear()
+    })
+
+    afterAll(() => {
+      client.fetchJSON.mockRestore()
+    })
+
+    it('should send POST resquest', async () => {
+      await client
+        .collection('io.cozy.foos')
+        .create({ attributes: { name: 'Foo' } })
+
+      expect(client.fetchJSON).toHaveBeenCalledTimes(1)
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        '/data/io.cozy.foos/',
+        { attributes: { name: 'Foo' } }
+      )
+    })
+
+    it('should send PUT resquest on fixed _id', async () => {
+      await client
+        .collection('io.cozy.foos')
+        .create({ _id: 'bar', attributes: { name: 'Foo' } })
+
+      expect(client.fetchJSON).toHaveBeenCalledTimes(1)
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'PUT',
+        '/data/io.cozy.foos/bar',
+        { attributes: { name: 'Foo' } }
+      )
+    })
+  })
+
   describe('fetch', () => {
     const client = new CozyStackClient(FAKE_INIT_OPTIONS)
 


### PR DESCRIPTION
Needed to create an agregator account. Agregator account is a single account used by several konnectors to connect on a remote API. An agregator accounts must be created with a fixed `_id`. Example : Budget Insight.

This PR :

* Now rely on _rev existence to determine if the action is an update or a creation
* Call the expected endpoint when created document has fixed _id attribute

__BREAKING CHANGE:__ To be updated, documents now requires a `_rev` attribute.