### PR TITLE
Fix Query's mutations prop

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -173,7 +173,7 @@ import { Query } from 'cozy-client'
 
 const query = client => client.find('io.cozy.todos').where({ checked: false })
 
-const createMutations = (client, ownProps) => ({
+const createMutations = (client, query, ownProps) => ({
   addTodo: label => client.create('io.cozy.todos', { label })
 })
 

--- a/packages/cozy-client/src/Query.jsx
+++ b/packages/cozy-client/src/Query.jsx
@@ -25,8 +25,8 @@ export default class Query extends Component {
     const { mutations, ...rest } = props
     this.mutations =
       typeof mutations === 'function'
-        ? mutations(this.observableQuery, rest)
-        : {}
+        ? mutations(this.client, this.observableQuery, rest)
+        : mutations
 
     const query = this.observableQuery
     this.createDocument = client.create.bind(client)

--- a/packages/cozy-client/src/Query.spec.jsx
+++ b/packages/cozy-client/src/Query.spec.jsx
@@ -119,4 +119,70 @@ describe('Query', () => {
       )
     })
   })
+
+  describe('mutations', () => {
+    let store, client, mutations, mutationsArgument, query
+    beforeEach(async () => {
+      const assets = createTestAssets()
+      store = assets.store
+      client = assets.client
+      query = queryDef(client)
+      await store.dispatch(initQuery('allTodos', query))
+
+      mutations = jest.fn().mockReturnValue({
+        create: jest.fn(),
+        update: jest.fn()
+      })
+
+      mount(
+        <CozyProvider client={client}>
+          <Query
+            fetchPolicy="cache-only"
+            query={queryDef}
+            mutations={mutations}
+          >
+            {(result, mutations) => {
+              mutationsArgument = mutations
+              return null
+            }}
+          </Query>
+        </CozyProvider>
+      )
+    })
+
+    it('should call mutation function with client', () => {
+      expect(mutations.mock.calls.length).toBe(1)
+      expect(mutations.mock.calls[0][0]).toBe(client)
+    })
+
+    it('should pass mutations', () => {
+      expect(typeof mutationsArgument.create).toBe('function')
+      expect(typeof mutationsArgument.update).toBe('function')
+    })
+
+    it('should pass mutations as object', () => {
+      const mutations = {
+        create: jest.fn(),
+        update: jest.fn()
+      }
+
+      mount(
+        <CozyProvider client={client}>
+          <Query
+            fetchPolicy="cache-only"
+            query={queryDef}
+            mutations={mutations}
+          >
+            {(result, mutations) => {
+              mutationsArgument = mutations
+              return null
+            }}
+          </Query>
+        </CozyProvider>
+      )
+
+      expect(typeof mutationsArgument.create).toBe('function')
+      expect(typeof mutationsArgument.update).toBe('function')
+    })
+  })
 })


### PR DESCRIPTION
It seems that the client parameter was missing and that the code and behaviour were not consistent with the documentation.