### PR TITLE
feat(client): Handle stack client unregister error

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -118,12 +118,17 @@ export default class CozyClient {
     }
 
     this.isLogged = false
-    // unregister client on stack
-    if (
-      this.stackClient.unregister &&
-      (!this.stackClient.isRegistered || this.stackClient.isRegistered())
-    ) {
-      await this.stackClient.unregister()
+
+    try {
+      // unregister client on stack
+      if (
+        this.stackClient.unregister &&
+        (!this.stackClient.isRegistered || this.stackClient.isRegistered())
+      ) {
+        await this.stackClient.unregister()
+      }
+    } catch (err) {
+      console.warn(`Impossible to unregister client on stack: ${err}`)
     }
 
     // clean information on links


### PR DESCRIPTION
When using a mobile app, it can happen that a user wants to logout while being offline. In that case, cozy-client would fail in the middle of the `logout` method because the call to the stack to unregister the client would fail. The method crashes, preventing the links to `logout` themselves. I think we should handle it directly in cozy-client.

Here, I just catch the error and log it. The drawback of this is that the client will never be unregistered and will remain on Settings' sessions page.