### PR TITLE
Queries with id selector

### DIFF
--- a/packages/cozy-client/src/store/__snapshots__/queries.spec.js.snap
+++ b/packages/cozy-client/src/store/__snapshots__/queries.spec.js.snap
@@ -28,6 +28,151 @@ Object {
 }
 `;
 
+exports[`queries reducer updates should correctly update 1`] = `
+Object {
+  "a": Object {
+    "count": 2,
+    "data": Array [
+      "12345",
+      "67890",
+    ],
+    "definition": QueryDefinition {
+      "doctype": "io.cozy.todos",
+      "fields": undefined,
+      "id": undefined,
+      "ids": undefined,
+      "includes": undefined,
+      "indexedFields": undefined,
+      "limit": undefined,
+      "referenced": undefined,
+      "selector": undefined,
+      "skip": undefined,
+      "sort": undefined,
+    },
+    "fetchStatus": "loaded",
+    "hasMore": false,
+    "id": "a",
+    "lastError": null,
+    "lastFetch": 1337,
+    "lastUpdate": 1337,
+  },
+}
+`;
+
+exports[`queries reducer updates should correctly update a query with a selector 1`] = `
+Object {
+  "a": Object {
+    "count": 1,
+    "data": Array [
+      "54321",
+    ],
+    "definition": QueryDefinition {
+      "doctype": "io.cozy.todos",
+      "fields": undefined,
+      "id": undefined,
+      "ids": undefined,
+      "includes": undefined,
+      "indexedFields": undefined,
+      "limit": undefined,
+      "referenced": undefined,
+      "selector": undefined,
+      "skip": undefined,
+      "sort": undefined,
+    },
+    "fetchStatus": "loaded",
+    "hasMore": false,
+    "id": "a",
+    "lastError": null,
+    "lastFetch": 1337,
+    "lastUpdate": 1337,
+  },
+  "b": Object {
+    "count": 1,
+    "data": Array [
+      "54321",
+    ],
+    "definition": QueryDefinition {
+      "doctype": "io.cozy.todos",
+      "fields": undefined,
+      "id": undefined,
+      "ids": undefined,
+      "includes": undefined,
+      "indexedFields": undefined,
+      "limit": undefined,
+      "referenced": undefined,
+      "selector": Object {
+        "done": true,
+      },
+      "skip": undefined,
+      "sort": undefined,
+    },
+    "fetchStatus": "loading",
+    "hasMore": false,
+    "id": "b",
+    "lastError": null,
+    "lastFetch": null,
+    "lastUpdate": 1337,
+  },
+}
+`;
+
+exports[`queries reducer updates should correctly update two queries 1`] = `
+Object {
+  "a": Object {
+    "count": 2,
+    "data": Array [
+      "12345",
+      "67890",
+    ],
+    "definition": QueryDefinition {
+      "doctype": "io.cozy.todos",
+      "fields": undefined,
+      "id": undefined,
+      "ids": undefined,
+      "includes": undefined,
+      "indexedFields": undefined,
+      "limit": undefined,
+      "referenced": undefined,
+      "selector": undefined,
+      "skip": undefined,
+      "sort": undefined,
+    },
+    "fetchStatus": "loaded",
+    "hasMore": false,
+    "id": "a",
+    "lastError": null,
+    "lastFetch": 1337,
+    "lastUpdate": 1337,
+  },
+  "b": Object {
+    "count": 2,
+    "data": Array [
+      "12345",
+      "67890",
+    ],
+    "definition": QueryDefinition {
+      "doctype": "io.cozy.todos",
+      "fields": undefined,
+      "id": undefined,
+      "ids": undefined,
+      "includes": undefined,
+      "indexedFields": undefined,
+      "limit": undefined,
+      "referenced": undefined,
+      "selector": undefined,
+      "skip": undefined,
+      "sort": undefined,
+    },
+    "fetchStatus": "loading",
+    "hasMore": false,
+    "id": "b",
+    "lastError": null,
+    "lastFetch": null,
+    "lastUpdate": 1337,
+  },
+}
+`;
+
 exports[`queries reducer updates should not crash if data is null 1`] = `
 Object {
   "a": Object {
@@ -130,151 +275,6 @@ Object {
     "lastError": null,
     "lastFetch": null,
     "lastUpdate": null,
-  },
-}
-`;
-
-exports[`queries reducer updates should update correctly 1`] = `
-Object {
-  "a": Object {
-    "count": 2,
-    "data": Array [
-      "12345",
-      "67890",
-    ],
-    "definition": QueryDefinition {
-      "doctype": "io.cozy.todos",
-      "fields": undefined,
-      "id": undefined,
-      "ids": undefined,
-      "includes": undefined,
-      "indexedFields": undefined,
-      "limit": undefined,
-      "referenced": undefined,
-      "selector": undefined,
-      "skip": undefined,
-      "sort": undefined,
-    },
-    "fetchStatus": "loaded",
-    "hasMore": false,
-    "id": "a",
-    "lastError": null,
-    "lastFetch": 1337,
-    "lastUpdate": 1337,
-  },
-}
-`;
-
-exports[`queries reducer updates should update correctly a query with a selector 1`] = `
-Object {
-  "a": Object {
-    "count": 1,
-    "data": Array [
-      "54321",
-    ],
-    "definition": QueryDefinition {
-      "doctype": "io.cozy.todos",
-      "fields": undefined,
-      "id": undefined,
-      "ids": undefined,
-      "includes": undefined,
-      "indexedFields": undefined,
-      "limit": undefined,
-      "referenced": undefined,
-      "selector": undefined,
-      "skip": undefined,
-      "sort": undefined,
-    },
-    "fetchStatus": "loaded",
-    "hasMore": false,
-    "id": "a",
-    "lastError": null,
-    "lastFetch": 1337,
-    "lastUpdate": 1337,
-  },
-  "b": Object {
-    "count": 1,
-    "data": Array [
-      "54321",
-    ],
-    "definition": QueryDefinition {
-      "doctype": "io.cozy.todos",
-      "fields": undefined,
-      "id": undefined,
-      "ids": undefined,
-      "includes": undefined,
-      "indexedFields": undefined,
-      "limit": undefined,
-      "referenced": undefined,
-      "selector": Object {
-        "done": true,
-      },
-      "skip": undefined,
-      "sort": undefined,
-    },
-    "fetchStatus": "loading",
-    "hasMore": false,
-    "id": "b",
-    "lastError": null,
-    "lastFetch": null,
-    "lastUpdate": 1337,
-  },
-}
-`;
-
-exports[`queries reducer updates should update correctly two queries 1`] = `
-Object {
-  "a": Object {
-    "count": 2,
-    "data": Array [
-      "12345",
-      "67890",
-    ],
-    "definition": QueryDefinition {
-      "doctype": "io.cozy.todos",
-      "fields": undefined,
-      "id": undefined,
-      "ids": undefined,
-      "includes": undefined,
-      "indexedFields": undefined,
-      "limit": undefined,
-      "referenced": undefined,
-      "selector": undefined,
-      "skip": undefined,
-      "sort": undefined,
-    },
-    "fetchStatus": "loaded",
-    "hasMore": false,
-    "id": "a",
-    "lastError": null,
-    "lastFetch": 1337,
-    "lastUpdate": 1337,
-  },
-  "b": Object {
-    "count": 2,
-    "data": Array [
-      "12345",
-      "67890",
-    ],
-    "definition": QueryDefinition {
-      "doctype": "io.cozy.todos",
-      "fields": undefined,
-      "id": undefined,
-      "ids": undefined,
-      "includes": undefined,
-      "indexedFields": undefined,
-      "limit": undefined,
-      "referenced": undefined,
-      "selector": undefined,
-      "skip": undefined,
-      "sort": undefined,
-    },
-    "fetchStatus": "loading",
-    "hasMore": false,
-    "id": "b",
-    "lastError": null,
-    "lastFetch": null,
-    "lastUpdate": 1337,
   },
 }
 `;

--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -85,11 +85,19 @@ const query = (state = queryInitialState, action) => {
   }
 }
 
+const getSelectorFilterFn = queryDefinition => {
+  if (queryDefinition.selector) {
+    return sift(queryDefinition.selector)
+  } else if (queryDefinition.id) {
+    return sift({ _id: queryDefinition.id })
+  } else {
+    return null
+  }
+}
+
 const getQueryDocumentsChecker = query => {
   const qdoctype = query.definition.doctype
-  const selectorFilterFn = query.definition.selector
-    ? sift(query.definition.selector)
-    : null
+  const selectorFilterFn = getSelectorFilterFn(query.definition)
   return datum => {
     const ddoctype = datum._type
     if (ddoctype !== qdoctype) return false

--- a/packages/cozy-client/src/store/queries.spec.js
+++ b/packages/cozy-client/src/store/queries.spec.js
@@ -39,7 +39,7 @@ describe('queries reducer', () => {
         )
       )
     })
-    it('should update correctly', () => {
+    it('should correctly update', () => {
       applyAction(
         receiveQueryResult('a', {
           data: [TODO_1, TODO_2]
@@ -47,7 +47,7 @@ describe('queries reducer', () => {
       )
       expect(state).toMatchSnapshot()
     })
-    it('should update correctly two queries', () => {
+    it('should correctly update two queries', () => {
       applyAction(
         initQuery(
           'b',
@@ -64,7 +64,7 @@ describe('queries reducer', () => {
       expect(state).toMatchSnapshot()
     })
 
-    it('should update correctly a query with a selector', () => {
+    it('should correctly update a query with a selector', () => {
       const query = new Q({
         doctype: 'io.cozy.todos'
       })

--- a/packages/cozy-client/src/store/queries.spec.js
+++ b/packages/cozy-client/src/store/queries.spec.js
@@ -103,5 +103,25 @@ describe('queries reducer', () => {
       )
       expect(state).toMatchSnapshot()
     })
+
+    it('should only update queries with the right id selector', () => {
+      const query = new Q({
+        doctype: 'io.cozy.todos',
+        id: TODO_3._id
+      })
+      applyAction(initQuery('b', query))
+      applyAction(
+        receiveQueryResult('a', {
+          data: [TODO_2]
+        })
+      )
+      expect(state.b.lastUpdate).toBe(null)
+      applyAction(
+        receiveQueryResult('a', {
+          data: [TODO_3]
+        })
+      )
+      expect(state.b.lastUpdate).not.toBe(null)
+    })
   })
 })


### PR DESCRIPTION
So far, we only use the `selector` field of the DSL to compare results with queries, but there are other fields that can contain filtering information, such as `id`, `ids`, `referenced`, and possibly more.

I think some bigger changes are needed in the DSL, but in the meantime this PR fixes the problem for queries with an `id` field.