### PR TITLE
Association pagination

### DIFF
--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -18,6 +18,7 @@
     "react": "16.7.0",
     "react-redux": "5.0.7",
     "redux": "3.7.2",
+    "redux-thunk": "^2.3.0",
     "sift": "7.0.1"
   },
   "scripts": {

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -505,6 +505,7 @@ export default class CozyClient {
       this.storeAccessors = {
         get: this.getDocumentFromState.bind(this),
         save: (document, opts) => this.save.call(this, document, opts),
+        dispatch: this.dispatch.bind(this),
         query: (def, opts) => this.query.call(this, def, opts),
         mutate: (def, opts) => this.mutate.call(this, def, opts)
       }

--- a/packages/cozy-client/src/associations/Association.js
+++ b/packages/cozy-client/src/associations/Association.js
@@ -108,6 +108,10 @@ export default class Association {
      * @type {[type]}
      */
     this.save = save
+    /**
+     * Dispatch an action on the store.
+     * @type {[type]}
+     */
     this.dispatch = dispatch
   }
 

--- a/packages/cozy-client/src/associations/Association.js
+++ b/packages/cozy-client/src/associations/Association.js
@@ -69,7 +69,7 @@
  * @module Association
  */
 export default class Association {
-  constructor(target, name, doctype, { get, query, mutate, save }) {
+  constructor(target, name, doctype, { dispatch, get, query, mutate, save }) {
     /**
      * The original document declaring the relationship
      * @type {object}
@@ -108,6 +108,7 @@ export default class Association {
      * @type {[type]}
      */
     this.save = save
+    this.dispatch = dispatch
   }
 
   /**

--- a/packages/cozy-client/src/associations/HasMany.js
+++ b/packages/cozy-client/src/associations/HasMany.js
@@ -1,6 +1,7 @@
 import get from 'lodash/get'
 import Association from './Association'
 import { QueryDefinition } from '../queries/dsl'
+import { receiveQueryResult, getDocumentFromState } from '../store'
 
 const empty = () => ({
   data: [],
@@ -139,6 +140,30 @@ export default class HasMany extends Association {
         }
       }
     }
+  }
+
+  updateRelationshipData = getUpdatedRelationshipData => (
+    dispatch,
+    getState
+  ) => {
+    const previousRelationship = getDocumentFromState(
+      getState(),
+      this.target._type,
+      this.target._id
+    )
+    dispatch(
+      receiveQueryResult(null, {
+        data: {
+          ...previousRelationship,
+          relationships: {
+            ...previousRelationship.relationships,
+            [this.name]: getUpdatedRelationshipData(
+              previousRelationship.relationships[this.name]
+            )
+          }
+        }
+      })
+    )
   }
 
   static query(document, client, assoc) {

--- a/packages/cozy-client/src/store/index.js
+++ b/packages/cozy-client/src/store/index.js
@@ -111,8 +111,6 @@ export const getQueryFromState = (state, queryId) =>
 export const getRawQueryFromState = (state, queryId) =>
   getQueryFromSlice(getStateRoot(state).queries, queryId)
 
-export { receiveDocumentUpdate } from './documents'
-
 export { initQuery, receiveQueryResult, receiveQueryError } from './queries'
 
 export {

--- a/packages/cozy-client/src/store/index.js
+++ b/packages/cozy-client/src/store/index.js
@@ -1,4 +1,8 @@
-import { createStore as createReduxStore, combineReducers, applyMiddleware } from 'redux'
+import {
+  createStore as createReduxStore,
+  combineReducers,
+  applyMiddleware
+} from 'redux'
 import thunk from 'redux-thunk'
 
 import documents, { getDocumentFromSlice } from './documents'
@@ -84,7 +88,10 @@ const combinedReducer = (state = { documents: {}, queries: {} }, action) => {
 export default combinedReducer
 
 export const createStore = () =>
-  createReduxStore(combineReducers({ cozy: combinedReducer }), applyMiddleware(thunk))
+  createReduxStore(
+    combineReducers({ cozy: combinedReducer }),
+    applyMiddleware(thunk)
+  )
 
 export const getStateRoot = state => state.cozy || {}
 

--- a/packages/cozy-client/src/store/index.js
+++ b/packages/cozy-client/src/store/index.js
@@ -1,4 +1,5 @@
-import { createStore as createReduxStore, combineReducers } from 'redux'
+import { createStore as createReduxStore, combineReducers, applyMiddleware } from 'redux'
+import thunk from 'redux-thunk'
 
 import documents, { getDocumentFromSlice } from './documents'
 import queries, { getQueryFromSlice, isQueryAction } from './queries'
@@ -83,7 +84,7 @@ const combinedReducer = (state = { documents: {}, queries: {} }, action) => {
 export default combinedReducer
 
 export const createStore = () =>
-  createReduxStore(combineReducers({ cozy: combinedReducer }))
+  createReduxStore(combineReducers({ cozy: combinedReducer }), applyMiddleware(thunk))
 
 export const getStateRoot = state => state.cozy || {}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9757,6 +9757,11 @@ redux-mock-store@1.5.3:
   dependencies:
     lodash.isplainobject "^4.0.6"
 
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+
 redux@3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"


### PR DESCRIPTION
Right now, if I have a query like `client.get('io.cozy.todos', myTodoId).includes('files')`, we will load the first 100 associated files. There will be a `fetchMore` method exposed and if we call it, the store will be properly updated BUT the Query will not be re-rendered.

It took me a while to figure out why so let me explain:

1. [Calling `fetchMore`](https://github.com/cozy/cozy-client/blob/assoc-pagination/packages/cozy-client/src/associations/HasManyFiles.js#L5) will start a new query
2. Eventually we dispatch a `RECEIVE_QUERY_RESULT` which goes [through the main reducer](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/store/index.js#L60)
3. The action response contains the new *files*, but we still need to update the parent *todo*. 
4. To do this, we call the [`update` method attached to the query](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/store/index.js#L65)
5. This update method [*directly* updates the todo in the store](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L128)
6. The original action is [fed to the queries reducer](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/store/index.js#L70), but since the doctypes aren't matching (`files` vs `todo`), it is ignored by our main query
7. Nothing more happens, which is the problem

_______

There are different ways to solve this, none of which I really love. My proposal is in the PR and is the best I came up with.
Basically I think there are 2 options:

1. The main query should listen for changes on several doctypes — it's main doctypes as well as all associated doctypes. It's tricky because right now, the DSL only contains something like `includes: ['files']`, ie. the associations name and not the doctype. And then the query reducer would need to determine which documents are part of a relationship. So it's doable but adds a lot of coupling and complexity.
2. In the `update` method, we update a `todo` document — but we do it silently. If we do it in a more normal way, the query reducers can get a chance to look at the update. We can't `dispatch` a new action because we are in a reducer, but we can emulate it. It's a non-breaking change, but suddenly the `update` function passed to queries can return things, and they have an effect.

If this approach is ok for you, I'll add the relevant tests. Let me know what you think.