### PR TITLE
Add add() method to PermissionCollection

### DIFF
--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -32,6 +32,57 @@ export default class PermissionCollection extends DocumentCollection {
     }
   }
 
+  /**
+   * Adds a permission to the given document. Document type must be
+   * `io.cozy.apps`, `io.cozy.konnectors` or `io.cozy.permissions`
+   *
+   * @param  {object}  document
+   * @param  {object}  permission
+   * @return {Promise}
+   *
+   * @example
+   * ```
+   * const permissions = await client
+   *   .collection('io.cozy.permissions')
+   *   .add(konnector, {
+   *     folder: {
+   *       type: 'io.cozy.files',
+   *       verbs: ['GET', 'PUT'],
+   *       values: [`io.cozy.files.bc57b60eb2954537b0dcdc6ebd8e9d23`]
+   *     }
+   *  })
+   * ```
+   */
+  async add(document, permission) {
+    let endpoint
+    switch (document._type) {
+      case 'io.cozy.apps':
+        endpoint = `/permissions/apps/${document.slug}`
+        break
+      case 'io.cozy.konnectors':
+        endpoint = `/permissions/konnectors/${document.slug}`
+        break
+      case 'io.cozy.permissions':
+        endpoint = `/permissions/${document._id}`
+        break
+      default:
+        throw new Error(
+          'Permissions can only be added on existing permissions, apps and konnectors.'
+        )
+    }
+
+    const resp = await this.stackClient.fetchJSON('PATCH', endpoint, {
+      data: {
+        type: 'io.cozy.permissions',
+        attributes: {
+          permissions: permission
+        }
+      }
+    })
+
+    return resp.data
+  }
+
   destroy(permission) {
     return this.stackClient.fetchJSON(
       'DELETE',

--- a/packages/cozy-stack-client/src/PermissionCollection.spec.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.spec.js
@@ -3,6 +3,15 @@ jest.mock('./CozyStackClient')
 import CozyStackClient from './CozyStackClient'
 import PermissionCollection from './PermissionCollection'
 
+const fixtures = {
+  permission: {
+    test: {
+      type: 'io.cozy.todos',
+      verbs: ['GET', 'PUT', 'DELETE']
+    }
+  }
+}
+
 describe('PermissionCollection', () => {
   const client = new CozyStackClient()
   const collection = new PermissionCollection('io.cozy.permissions', client)
@@ -16,6 +25,85 @@ describe('PermissionCollection', () => {
     it('should get its own permissions', async () => {
       await collection.getOwnPermissions()
       expect(client.fetchJSON).toHaveBeenCalledWith('GET', '/permissions/self')
+    })
+
+    describe('add', () => {
+      it('uses expected permissions endpoint', async () => {
+        await collection.add(
+          {
+            _type: 'io.cozy.permissions',
+            _id: 'a340d5e0d64711e6b66c5fc9ce1e17c6'
+          },
+          fixtures.permission
+        )
+
+        expect(client.fetchJSON).toHaveBeenCalledWith(
+          'PATCH',
+          '/permissions/a340d5e0d64711e6b66c5fc9ce1e17c6',
+          {
+            data: {
+              type: 'io.cozy.permissions',
+              attributes: {
+                permissions: fixtures.permission
+              }
+            }
+          }
+        )
+      })
+
+      it('uses expected apps endpoint', async () => {
+        await collection.add(
+          {
+            _type: 'io.cozy.apps',
+            slug: 'test-app'
+          },
+          fixtures.permission
+        )
+
+        expect(client.fetchJSON).toHaveBeenCalledWith(
+          'PATCH',
+          '/permissions/apps/test-app',
+          {
+            data: {
+              type: 'io.cozy.permissions',
+              attributes: {
+                permissions: fixtures.permission
+              }
+            }
+          }
+        )
+      })
+
+      it('uses expected konnectors endpoint', async () => {
+        await collection.add(
+          {
+            _type: 'io.cozy.konnectors',
+            slug: 'test-konnector'
+          },
+          fixtures.permission
+        )
+
+        expect(client.fetchJSON).toHaveBeenCalledWith(
+          'PATCH',
+          '/permissions/konnectors/test-konnector',
+          {
+            data: {
+              type: 'io.cozy.permissions',
+              attributes: {
+                permissions: fixtures.permission
+              }
+            }
+          }
+        )
+      })
+
+      it('throws an error if document does not have expected doctype', () => {
+        expect(collection.add({ _type: 'io.cozy.todos' })).rejects.toEqual(
+          new Error(
+            'Permissions can only be added on existing permissions, apps and konnectors.'
+          )
+        )
+      })
     })
   })
 })


### PR DESCRIPTION
The add method allows to add a permission for a given permissions document, app or konnector.

This method tests the type of the first parameter and call the related endpoint.

It throws an error if this type is unexpected.

Needed in https://github.com/cozy/cozy-home/pull/1041.