### PR TITLE
fix: Guard against rows containing errors

### DIFF
--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -56,13 +56,18 @@ export default class DocumentCollection {
       throw error
     }
     let data
-    /* If using `all_docs` we need to filter our design documents and check if 
+    /* If using `all_docs` we need to filter our design documents and check if
     the document is not null. If we use `normal_doc` we can't have any design doc
      */
     if (isUsingAllDocsRoute) {
       data = resp.rows
         .filter(doc => {
-          return doc && doc.doc !== null && !startsWith(doc.id, '_design')
+          return (
+            doc &&
+            doc.doc !== null &&
+            !doc.error &&
+            !startsWith(doc.id, '_design')
+          )
         })
         .map(row => {
           return normalizeDoc(row.doc, this.doctype)

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -230,6 +230,22 @@ describe('DocumentCollection', () => {
       const docs = await collection.all({ keys: ['12345', '67890', '11111'] })
       expect(docs.data.length).toBe(2)
     })
+
+    it('should ignore rows with errors', async () => {
+      const responsesWithEmptyDoc = {
+        ...ALL_RESPONSE_FIXTURE,
+        rows: [
+          ...ALL_RESPONSE_FIXTURE.rows,
+          {
+            key: '11111',
+            error: 'not_found'
+          }
+        ]
+      }
+      client.fetchJSON.mockReturnValue(Promise.resolve(responsesWithEmptyDoc))
+      const docs = await collection.all({ keys: ['12345', '67890', '11111'] })
+      expect(docs.data.length).toBe(2)
+    })
   })
 
   describe('createIndex', () => {


### PR DESCRIPTION
If we use the `keys` option on the `_all_docs` route and specify an invalid key, the row has an `error` field but no `id` or `doc`. This caused the normalisation function to crash.