### PR TITLE
fix: Clean syncedDoctypes

### DIFF
--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -130,7 +130,7 @@ export default class PouchManager {
   destroy() {
     this.stopReplicationLoop()
     this.removeListeners()
-    this.destroyPersistedSyncedDoctypes()
+    this.destroySyncedDoctypes()
     return Promise.all(
       Object.values(this.pouches).map(pouch => pouch.destroy())
     )
@@ -298,7 +298,8 @@ export default class PouchManager {
     return this.syncedDoctypes.includes(doctype)
   }
 
-  destroyPersistedSyncedDoctypes() {
+  destroySyncedDoctypes() {
+    this.syncedDoctypes = []
     window.localStorage.removeItem(LOCALSTORAGE_SYNCED_KEY)
   }
 

--- a/packages/cozy-pouch-link/src/PouchManager.spec.js
+++ b/packages/cozy-pouch-link/src/PouchManager.spec.js
@@ -210,13 +210,18 @@ describe('PouchManager', () => {
     })
   })
 
-  describe('destroyPersistedSyncedDoctypes', () => {
+  describe('destroySyncedDoctypes', () => {
     it('Should destroy the local storage item', () => {
-      manager.destroyPersistedSyncedDoctypes()
+      manager.destroySyncedDoctypes()
 
       expect(localStorage.removeItem).toHaveBeenLastCalledWith(
         LOCALSTORAGE_SYNCED_KEY
       )
+    })
+    it('Should reset syncedDoctypes', () => {
+      manager.syncedDoctypes = ['io.cozy.todos']
+      manager.destroySyncedDoctypes()
+      expect(manager.syncedDoctypes).toEqual([])
     })
   })
 


### PR DESCRIPTION
When we destroy localStorage we should remove `syncedDoctypes` data also