### PR TITLE
fix: Update relationship meta count

### DIFF
--- a/packages/cozy-client/src/associations/HasMany.js
+++ b/packages/cozy-client/src/associations/HasMany.js
@@ -105,6 +105,7 @@ class HasMany extends Association {
     }))
 
     this.target.relationships[this.name].data.push(...newRelations)
+    this.updateMetaCount()
 
     if (save) return this.save(this.target)
     else
@@ -119,12 +120,22 @@ class HasMany extends Association {
     this.target.relationships[this.name].data = this.target.relationships[
       this.name
     ].data.filter(({ _id }) => !ids.includes(_id))
+    this.updateMetaCount()
 
     if (save) return this.save(this.target)
     else
       console.warn(
         'HasMany.removeById will automatically perform a save operation in the next version.'
       )
+  }
+
+  updateMetaCount() {
+    if (get(this.target.relationships[this.name], 'meta.count') !== undefined) {
+      this.target.relationships[this.name].meta = {
+        ...this.target.relationships[this.name].meta,
+        count: this.target.relationships[this.name].data.length
+      }
+    }
   }
 
   getRelationship() {

--- a/packages/cozy-client/src/associations/HasMany.spec.js
+++ b/packages/cozy-client/src/associations/HasMany.spec.js
@@ -100,6 +100,17 @@ describe('HasMany', () => {
     expect(hydrated.tasks.data).toEqual([])
   })
 
+  it('updates the count metadata', () => {
+    const initialCount = hydrated.tasks.data.length
+    hydrated.tasks.target.relationships.tasks.meta = {
+      count: initialCount
+    }
+    hydrated.tasks.addById(4)
+    expect(hydrated.tasks.count).toBe(initialCount + 1)
+    hydrated.tasks.removeById(1)
+    expect(hydrated.tasks.count).toBe(initialCount)
+  })
+
   it('checks non existence', () => {
     expect(hydrated.tasks.existsById(3)).toBe(false)
   })


### PR DESCRIPTION
Most relationships in cozy-client look like this:

```
relationships: {
  tasks: {
     data: {…}
  }
}
```

But some have an extra `meta.count` field:

```
relationships: {
  tasks: {
     data: {…},
     meta: { count: 5 }
  }
}
```

In #328, we deprecated `HasManyFiles.add` and `HasManyFiles.remove`, replacing them with the more generic `HasManyFiles.addById`. But the deprecated functions were also updating the `meta.count` field, so this PR adds this behavior to  `addById` and `removeById`