### PR TITLE
fix: Keep relationship info in HasManyFiles dehydration

### DIFF
--- a/packages/cozy-client/src/associations/HasManyFiles.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.js
@@ -93,8 +93,9 @@ export default class HasManyFiles extends HasMany {
   }
 
   dehydrate(doc) {
-    // HasManyFiles relationships are stored on the file doctype, not the document the files are related to
-    return omit(doc, [this.name, `relationships.${this.name}`])
+    // HasManyFiles relationships are stored on the io.cozy.files doctype, so we shouldnt have to save the relationship on the parent document.
+    // But we are still doing it because cozy-client needs this information in the store to be abble to hydrate the parent document.
+    return super.dehydrate(doc)
   }
 
   static query(document, client, assoc) {

--- a/packages/cozy-client/src/helpers.spec.js
+++ b/packages/cozy-client/src/helpers.spec.js
@@ -72,7 +72,9 @@ describe('dehydrate', () => {
 
   it('should dehydrate HasManyFiles relationships', () => {
     const dehydrated = dehydrate(document)
-    expect(dehydrated.relationships.hasManyFiles).toBeUndefined()
+    expect(dehydrated.relationships.hasManyFiles).toEqual(
+      intialDocument.relationships.hasManyFiles
+    )
     expect(dehydrated.hasManyFiles).toBeUndefined()
   })
 })


### PR DESCRIPTION
`HasManyFiles` are a special sort of relationship, because unlike most others, the information is stored on the `io.cozy.files`, and not the parent object — say `io.cozy.photos.albums`.

However, to make it convenient for front-end apps, cozy-client will create a `relationships` object in the redux store holding the data. This is done [during the initial query](https://github.com/cozy/cozy-client/blob/hasmanyfiles-dehydrate/packages/cozy-client/src/CozyClient.js#L331) and Associations rely on this field to work.

Before #328, we were actually sending this `relationships` object back to the stack / CouchDB. But after correctly dehydrating HasManyFiles relationships in #328, this is no longer the case.

An unintended consequence is that if we update an album (for example changing it's name), we use the server's response [to update the store](https://github.com/cozy/cozy-client/blob/hasmanyfiles-dehydrate/packages/cozy-client/src/CozyClient.js#L311), and this updated version no longer has the `relationships` field that is needed. A `<Query />` component will be re-rendered, the album will have the new name, but there won't be any photos attached to it. If we reload the page everything is back to normal because we recreate the fake relationships field, as I said during the initial query.

_________

It already took us a while to figure out what was going on here, so the proposed solution is basically a revert — we keep storing the `relationships` object in CouchDB, even though it's only purpose is to make cozy-client happy.

The deeper problem is that the document we want to send to the server and the document we want to store in the redux store are not the same thing, but only in the case of `HasManyFiles` associations. So maybe [here](https://github.com/cozy/cozy-client/blob/hasmanyfiles-dehydrate/packages/cozy-client/src/CozyClient.js#L311) instead of dispatching the plain result , we could somehow rehydrate the result..? I don't really see a clean way to do this at the moment though.