### PR TITLE
feat(StackLink): Use find instead of all if a sort option is given

### DIFF
--- a/packages/cozy-client/src/StackLink.js
+++ b/packages/cozy-client/src/StackLink.js
@@ -43,7 +43,7 @@ export default class StackLink extends CozyLink {
     if (referenced) {
       return collection.findReferencedBy(referenced, options)
     }
-    return !selector
+    return !selector && !options.sort
       ? collection.all(options)
       : collection.find(selector, options)
   }

--- a/packages/cozy-client/src/__tests__/StackLink.spec.js
+++ b/packages/cozy-client/src/__tests__/StackLink.spec.js
@@ -30,6 +30,22 @@ describe('StackLink', () => {
         {}
       )
     })
+
+    it('should use find if a sort option is given', async () => {
+      const query = client.all('io.cozy.todos').sortBy([{ name: 'asc' }])
+      stackClient.collection().find.mockReset()
+      await link.request(query)
+      expect(stackClient.collection().find).toHaveBeenCalled()
+      expect(stackClient.collection).toHaveBeenCalledWith('io.cozy.todos')
+    })
+
+    it('should use all if a no sort option is given', async () => {
+      const query = client.all('io.cozy.todos')
+      stackClient.collection().all.mockReset()
+      await link.request(query)
+      expect(stackClient.collection().all).toHaveBeenCalled()
+      expect(stackClient.collection).toHaveBeenCalledWith('io.cozy.todos')
+    })
   })
 
   describe('reset', () => {


### PR DESCRIPTION
Before this change : 
```
const query = query.all(DOCTYPE).sortBy([{name: 'asc'}])
``` 
used the `_normal_docs` route and no use my sort option. And if we wanted to have a sortBy, we had to add a selector : 
 ```
const query = query.all(DOCTYPE).where({ _id: { $gt: null } }).sortBy([{name: 'asc'}])
``` 

Now, if a sort option is given (even without a selector) we will use the `find` route and the sortBy argument. 