### PR TITLE
fix: HasManyFiles relationships

### DIFF
--- a/packages/cozy-client/src/associations/helpers.js
+++ b/packages/cozy-client/src/associations/helpers.js
@@ -1,5 +1,6 @@
 import pick from 'lodash/pick'
 import pickBy from 'lodash/pickBy'
+import isEqual from 'lodash/isEqual'
 import Association from './Association'
 import HasOne from './HasOne'
 import HasOneInPlace from './HasOneInPlace'
@@ -21,7 +22,10 @@ export const responseToRelationship = response =>
   })
 
 const attachRelationship = (doc, relationships) => {
-  if (doc.relationships) {
+  if (
+    doc.relationships &&
+    isEqual(Object.keys(doc.relationships), Object.keys(relationships))
+  ) {
     return doc
   }
   return {

--- a/packages/cozy-client/src/store/documents.js
+++ b/packages/cozy-client/src/store/documents.js
@@ -28,13 +28,28 @@ const storeDocument = (state, document) => {
       ...state,
       [type]: {
         ...state[type],
-        [document._id]: {
-          ...existingDoc,
-          ...document
-        }
+        [document._id]: mergeDocumentsWithRelationships(existingDoc, document)
       }
     }
   }
+}
+
+export const mergeDocumentsWithRelationships = (
+  prevDocument = {},
+  nextDocument = {}
+) => {
+  const merged = {
+    ...prevDocument,
+    ...nextDocument
+  }
+
+  if (prevDocument.relationships || nextDocument.relationships)
+    merged.relationships = {
+      ...prevDocument.relationships,
+      ...nextDocument.relationships
+    }
+
+  return merged
 }
 
 const properId = doc => {

--- a/packages/cozy-client/src/store/documents.spec.js
+++ b/packages/cozy-client/src/store/documents.spec.js
@@ -1,5 +1,8 @@
-import { extractAndMergeDocument } from './documents'
-describe('documents', () => {
+import {
+  extractAndMergeDocument,
+  mergeDocumentsWithRelationships
+} from './documents'
+describe('extractAndMerge', () => {
   it('should return the right data', () => {
     const data = {
       0: {
@@ -111,5 +114,62 @@ describe('documents', () => {
       }
     }
     expect(returnedDatas).toEqual(manuallyMergedData)
+  })
+})
+
+describe('mergeDocumentsWithRelationships', () => {
+  it('should merge 2 documents', () => {
+    const prev = {
+      a: 1
+    }
+    const next = {
+      a: 2,
+      b: 3
+    }
+    const merged = mergeDocumentsWithRelationships(prev, next)
+    expect(merged).toEqual({
+      a: 2,
+      b: 3
+    })
+    expect(merged.relationships).toBeUndefined()
+  })
+
+  it('should update relationships', () => {
+    const prev = {
+      relationships: {
+        a: [1]
+      }
+    }
+    const next = {
+      relationships: {
+        a: [2],
+        b: [3]
+      }
+    }
+    const merged = mergeDocumentsWithRelationships(prev, next)
+    expect(merged).toEqual({
+      relationships: {
+        a: [2],
+        b: [3]
+      }
+    })
+  })
+
+  it('should keep previously existing relationships', () => {
+    // this is especially important for HasManyFiles relationships, where documents coming from the stack don't have the `relationships` property, because the relationship info is stored on the other side (on the io.cozy.files documents)
+    const prev = {
+      relationships: {
+        a: [1]
+      }
+    }
+    const next = {
+      relationships: {}
+    }
+    const merged = mergeDocumentsWithRelationships(prev, next)
+    expect(merged).toEqual({
+      relationships: {
+        a: [1]
+      }
+    })
   })
 })


### PR DESCRIPTION
This is an alternative solution to #337 — we make sure the `relationships` attribute is kept in documents in the redux store when they are updated.