### PR TITLE
feat: Update changes route to match all couch parameters

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -127,7 +127,7 @@ Abstracts a collection of documents of the same doctype, providing CRUD methods 
     * [.all(options)](#DocumentCollection+all) ⇒ <code>Object</code>
     * [.find(selector, options)](#DocumentCollection+find) ⇒ <code>Object</code>
     * [.getIndexFields(options)](#DocumentCollection+getIndexFields) ⇒ <code>Array</code>
-    * [.fetchChanges(since, options)](#DocumentCollection+fetchChanges)
+    * [.fetchChanges(couchOptions, options)](#DocumentCollection+fetchChanges)
 
 <a name="DocumentCollection+all"></a>
 
@@ -181,14 +181,14 @@ query to work
 
 <a name="DocumentCollection+fetchChanges"></a>
 
-### documentCollection.fetchChanges(since, options)
+### documentCollection.fetchChanges(couchOptions, options)
 Use Couch _changes API
 
 **Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| since | <code>String</code> | Starting sequence for changes |
+| couchOptions | <code>Object</code> | Couch options for changes https://kutt.it/5r7MNQ |
 | options | <code>Object</code> | { includeDesign: false, includeDeleted: false } |
 
 <a name="FileCollection"></a>

--- a/packages/cozy-stack-client/package.json
+++ b/packages/cozy-stack-client/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "detect-node": "2.0.4",
-    "mime-types": "2.1.20"
+    "mime-types": "2.1.20",
+    "qs": "6.6.0"
   },
   "scripts": {
     "build": "../../bin/build",

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -342,19 +342,10 @@ class DocumentCollection {
         .join('&')}`
     }
 
-    let result
-    if (haveDocsIds) {
-      result = await this.stackClient.fetchJSON(
-        'POST',
-        `/data/${this.doctype}/_changes${urlParams}`,
-        { doc_ids: couchOptions.doc_ids }
-      )
-    } else {
-      result = await this.stackClient.fetchJSON(
-        'GET',
-        `/data/${this.doctype}/_changes${urlParams}`
-      )
-    }
+    const method = haveDocsIds ? 'POST' : 'GET'
+    const endpoint = `/data/${this.doctype}/_changes${urlParams}`
+    const params = haveDocsIds ? { doc_ids: couchOptions.doc_ids } : undefined
+    const result = await this.stackClient.fetchJSON(method, endpoint, params)
 
     const newLastSeq = result.last_seq
     let docs = result.results.map(x => x.doc).filter(Boolean)

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -1,9 +1,10 @@
 import { uri, attempt, sleep } from './utils'
 import uniq from 'lodash/uniq'
 import transform from 'lodash/transform'
-import map from 'lodash/map'
 import head from 'lodash/head'
+import omit from 'lodash/omit'
 import startsWith from 'lodash/startsWith'
+import qs from 'qs'
 import * as querystring from './querystring'
 
 export const normalizeDoc = (doc, doctype) => {
@@ -329,15 +330,12 @@ class DocumentCollection {
         'fetchChanges use couchOptions as Object not a string, since is deprecated, please use fetchChanges({include_docs: true, since: 0}).'
       )
     } else if (Object.keys(couchOptions).length > 0) {
-      urlParams = `?${map(couchOptions, (value, key) => {
-        if (haveDocsIds && key === 'doc_ids') {
-          if (couchOptions.filter === undefined) {
-            return 'filter=_doc_ids'
-          }
-          return false
-        }
-        return `${key}=${value}`
-      })
+      urlParams = `?${[
+        qs.stringify(omit(couchOptions, 'doc_ids')),
+        haveDocsIds && couchOptions.filter === undefined
+          ? 'filter=_doc_ids'
+          : undefined
+      ]
         .filter(Boolean)
         .join('&')}`
     }

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -521,6 +521,7 @@ describe('DocumentCollection', () => {
 
   describe('changes', () => {
     const collection = new DocumentCollection('io.cozy.todos', client)
+    const defaultCouchOptions = { include_docs: true, since: 'my-seq' }
     beforeEach(() => {
       client.fetchJSON.mockReturnValueOnce(
         Promise.resolve({
@@ -535,8 +536,32 @@ describe('DocumentCollection', () => {
       )
     })
 
+    it('should call the right route without parameter', async () => {
+      await collection.fetchChanges()
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'GET',
+        '/data/io.cozy.todos/_changes'
+      )
+    })
+
+    it('should call the right route with deprecated parameter', async () => {
+      await collection.fetchChanges('my-seq')
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'GET',
+        '/data/io.cozy.todos/_changes?include_docs=true&since=my-seq'
+      )
+    })
+
+    it('should call the right route with deprecated parameter', async () => {
+      await collection.fetchChanges({ limit: 100 })
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'GET',
+        '/data/io.cozy.todos/_changes?limit=100'
+      )
+    })
+
     it('should call the right route', async () => {
-      const changes = await collection.fetchChanges('my-seq')
+      const changes = await collection.fetchChanges(defaultCouchOptions)
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'GET',
         '/data/io.cozy.todos/_changes?include_docs=true&since=my-seq'
@@ -548,7 +573,7 @@ describe('DocumentCollection', () => {
     })
 
     it('should call support includeDeleted', async () => {
-      const changes = await collection.fetchChanges('my-seq', {
+      const changes = await collection.fetchChanges(defaultCouchOptions, {
         includeDeleted: true
       })
       expect(changes).toEqual({
@@ -561,7 +586,7 @@ describe('DocumentCollection', () => {
     })
 
     it('should call support includeDesign', async () => {
-      const changes = await collection.fetchChanges('my-seq', {
+      const changes = await collection.fetchChanges(defaultCouchOptions, {
         includeDesign: true
       })
       expect(changes).toEqual({

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -560,6 +560,15 @@ describe('DocumentCollection', () => {
       )
     })
 
+    it('should call changes with doc_ids parameters', async () => {
+      await collection.fetchChanges({ doc_ids: [1, 2, 3] })
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        '/data/io.cozy.todos/_changes?filter=_doc_ids',
+        { doc_ids: [1, 2, 3] }
+      )
+    })
+
     it('should call the right route', async () => {
       const changes = await collection.fetchChanges(defaultCouchOptions)
       expect(client.fetchJSON).toHaveBeenCalledWith(

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -540,7 +540,8 @@ describe('DocumentCollection', () => {
       await collection.fetchChanges()
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'GET',
-        '/data/io.cozy.todos/_changes'
+        '/data/io.cozy.todos/_changes',
+        undefined
       )
     })
 
@@ -548,7 +549,8 @@ describe('DocumentCollection', () => {
       await collection.fetchChanges('my-seq')
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'GET',
-        '/data/io.cozy.todos/_changes?include_docs=true&since=my-seq'
+        '/data/io.cozy.todos/_changes?include_docs=true&since=my-seq',
+        undefined
       )
     })
 
@@ -556,7 +558,8 @@ describe('DocumentCollection', () => {
       await collection.fetchChanges({ limit: 100 })
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'GET',
-        '/data/io.cozy.todos/_changes?limit=100'
+        '/data/io.cozy.todos/_changes?limit=100',
+        undefined
       )
     })
 
@@ -573,7 +576,8 @@ describe('DocumentCollection', () => {
       const changes = await collection.fetchChanges(defaultCouchOptions)
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'GET',
-        '/data/io.cozy.todos/_changes?include_docs=true&since=my-seq'
+        '/data/io.cozy.todos/_changes?include_docs=true&since=my-seq',
+        undefined
       )
       expect(changes).toEqual({
         newLastSeq: 'new-seq',

--- a/yarn.lock
+++ b/yarn.lock
@@ -9521,6 +9521,11 @@ q@^1.1.2, q@^1.4.1, q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
+qs@6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.6.0.tgz#a99c0f69a8d26bf7ef012f871cdabb0aee4424c2"
+  integrity sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA==
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"


### PR DESCRIPTION
fetchChanges are not flexible and impose to download docs
With this commit we don't make breaking change and function
are more flexible

Change request when doc_ids parameter is used. Since length of URL is limited, it is better to use POST /{db}/_changes instead.

Documentation links:
- [Couch documentation](https://kutt.it/5r7MNQ)
- [Stack changes source](https://git.io/fhoLW)
- [Couch documentation POST](https://kutt.it/se1oRF)