### PR TITLE
fix(client): Handle undefined relationships

### DIFF
--- a/packages/cozy-client/src/associations/helpers.js
+++ b/packages/cozy-client/src/associations/helpers.js
@@ -24,6 +24,7 @@ export const responseToRelationship = response =>
 const attachRelationship = (doc, relationships) => {
   if (
     doc.relationships &&
+    relationships &&
     isEqual(Object.keys(doc.relationships), Object.keys(relationships))
   ) {
     return doc


### PR DESCRIPTION
We were trying to apply `Object.keys` on something that could be undefined. I just added a check to avoid a `can't convert undefined to object` error.