### PR TITLE
fix: Hydrating null documents failed

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -454,6 +454,9 @@ class CozyClient {
    * the relationship
    */
   hydrateDocument(document, schema) {
+    if (!document) {
+      return document
+    }
     schema = schema || this.schema.getDoctypeSchema(document._type)
     return {
       ...document,

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -515,5 +515,12 @@ describe('CozyClient', () => {
       expect(newTodo.attachments).not.toBe(undefined)
       expect(newTodo.attachments instanceof HasManyFiles).toBe(true)
     })
+
+    it('should not fail on null (when getting absent documents from the store)', () => {
+      const doc = client
+        .hydrateDocuments('io.cozy.todos', [null], 'allTodos')
+        .shift()
+      expect(doc).toBe(null)
+    })
   })
 })


### PR DESCRIPTION
Get documents from state can return null documents when queries contain references to documents that are absent and/or have not been fetched yet