### PR TITLE
Dehydratation has one

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -516,7 +516,12 @@ class CozyClient {
   }
 
   getDocumentFromState(type, id) {
-    return getDocumentFromState(this.store.getState(), type, id)
+    try {
+      return getDocumentFromState(this.store.getState(), type, id)
+    } catch (e) {
+      console.warn('Could not getDocumentFromState', type, id, e.message)
+      return null
+    }
   }
 
   /**

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -198,6 +198,15 @@ describe('CozyClient', () => {
     })
   })
 
+  describe('getDocumentFromState', () => {
+    it('should return null in case of error', () => {
+      jest.spyOn(client.store, 'getState').mockImplementation(() => {
+        throw new Error('Problem with store')
+      })
+      expect(client.getDocumentFromState('io.cozy.people', 1)).toBe(null)
+    })
+  })
+
   describe('find', () => {
     it('should return a QueryDefinition', () => {
       expect(

--- a/packages/cozy-client/src/associations/HasOneInPlace.js
+++ b/packages/cozy-client/src/associations/HasOneInPlace.js
@@ -20,6 +20,13 @@ export default class HasOneInPlace extends Association {
       client.get(assoc.doctype, id)
     )
   }
+
+  dehydrate(doc) {
+    return {
+      ...doc,
+      [this.name]: this.raw || undefined
+    }
+  }
 }
 
 export const BelongsToInPlace = HasOneInPlace

--- a/packages/cozy-client/src/associations/helpers.js
+++ b/packages/cozy-client/src/associations/helpers.js
@@ -1,6 +1,5 @@
 import pick from 'lodash/pick'
 import pickBy from 'lodash/pickBy'
-import isEqual from 'lodash/isEqual'
 import Association from './Association'
 import HasOne from './HasOne'
 import HasOneInPlace from './HasOneInPlace'

--- a/packages/cozy-client/src/helpers.js
+++ b/packages/cozy-client/src/helpers.js
@@ -7,6 +7,10 @@ export const dehydrate = document => {
         document[key] = value
       } else if (value.dehydrate) {
         document = value.dehydrate(document)
+      } else {
+        throw new Error(
+          `Association on key ${key} should have a dehydrate method`
+        )
       }
       return document
     },

--- a/packages/cozy-client/src/helpers.spec.js
+++ b/packages/cozy-client/src/helpers.spec.js
@@ -4,6 +4,7 @@ import {
   HasManyInPlace,
   HasMany,
   HasManyFiles,
+  HasOneInPlace,
   create as createAssociation
 } from './associations'
 
@@ -13,6 +14,7 @@ describe('dehydrate', () => {
   const intialDocument = {
     regularKey: 'foo',
     manyInPlace: [1, 2],
+    oneInPlace: '1',
     relationships: {
       hasMany: {
         data: [{ _id: 1, _type: 'has.many' }, { _id: 2, _type: 'has.many' }]
@@ -31,6 +33,11 @@ describe('dehydrate', () => {
       name: 'manyInPlace',
       type: HasManyInPlace,
       doctype: 'many.in.place'
+    },
+    {
+      name: 'oneInPlace',
+      type: HasOneInPlace,
+      doctype: 'one.in.place'
     },
     {
       name: 'hasMany',
@@ -60,6 +67,12 @@ describe('dehydrate', () => {
 
   it('should dehydrate HasManyInPlace relationships', () => {
     expect(dehydrate(document).manyInPlace).toEqual(intialDocument.manyInPlace)
+  })
+
+  it('should dehydrate HasOneInPlace relationships', () => {
+    const dehydrated = dehydrate(document)
+    expect(dehydrated.oneInPlace).toEqual(intialDocument.oneInPlace)
+    expect(dehydrated.oneInPlace).not.toBeUndefined()
   })
 
   it('should dehydrate HasMany relationships', () => {

--- a/packages/cozy-client/src/helpers.spec.js
+++ b/packages/cozy-client/src/helpers.spec.js
@@ -5,7 +5,8 @@ import {
   HasMany,
   HasManyFiles,
   HasOneInPlace,
-  create as createAssociation
+  create as createAssociation,
+  Association
 } from './associations'
 
 describe('dehydrate', () => {
@@ -27,6 +28,8 @@ describe('dehydrate', () => {
       }
     }
   }
+
+  class BadAssociation extends Association {}
 
   const relationships = [
     {
@@ -87,5 +90,22 @@ describe('dehydrate', () => {
     const dehydrated = dehydrate(document)
     expect(dehydrated.relationships.hasManyFiles).toBeUndefined()
     expect(dehydrated.hasManyFiles).toBeUndefined()
+  })
+
+  it('should throw if a relationship is not dehydratable', () => {
+    document.badAssociation = createAssociation(
+      document,
+      {
+        name: 'BadAssociation',
+        type: BadAssociation,
+        doctype: 'bad.association'
+      },
+      {}
+    )
+    expect(() => {
+      dehydrate(document)
+    }).toThrowError(
+      `Association on key badAssociation should have a dehydrate method`
+    )
   })
 })


### PR DESCRIPTION
- Added `dehydrate` method for HasOne

Without dehydrate method, the association was left
as is during dehydratation and during JSON serialization (while saving),
the value disappeared since the Association class
has no toJSON method.

- Throw if a relation is not dehydratable

This will prevent the `save` if a document has a relationship that is not dehydratable.

- Be more lenient when using `getDocumentFromState`

Since we have the bug in production, some documents were left without the id inside the relationship attribute (precisely, bank operations were left without their `account` attribute containing the id of the account they belong to). This led to a white screen since `getDocumentFromState` throws heavily when trying to access a document without id. With this change, `getDocumentFromState` returns `null` if an error occurs. `null`s should be managed by applications since sometimes linked documents are deleted or do not yet exist in the store.
