### PR TITLE
Allow multiple mutations as parameters for withMutations()

### DIFF
--- a/packages/cozy-client/src/withMutations.jsx
+++ b/packages/cozy-client/src/withMutations.jsx
@@ -1,7 +1,17 @@
+import merge from 'lodash/merge'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
-const withMutations = (mutations = {}) => WrappedComponent => {
+/**
+ * @function
+ * @description HOC to provide mutations to components. Needs client in context
+ * or as prop.
+ * @param  {function} mutations One ore more mutations, which are function
+ * taking CozyClient as parameter and returning an object containing one or
+ * more mutations as attributes.
+ * @return {function} - Component that will receive mutations as props
+ */
+const withMutations = (...mutations) => WrappedComponent => {
   const wrappedDisplayName =
     WrappedComponent.displayName || WrappedComponent.name || 'Component'
 
@@ -24,9 +34,14 @@ const withMutations = (mutations = {}) => WrappedComponent => {
           saveDocument: client.save.bind(client),
           deleteDocument: client.destroy.bind(client)
         },
-        ...(typeof mutations === 'function'
-          ? mutations(client, props)
-          : mutations)
+        ...merge(
+          ...mutations.map(
+            mutations =>
+              typeof mutations === 'function'
+                ? mutations(client, props)
+                : mutations
+          )
+        )
       }
     }
 

--- a/packages/cozy-client/src/withMutations.spec.jsx
+++ b/packages/cozy-client/src/withMutations.spec.jsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import CozyClient from '../CozyClient'
+import CozyLink from '../CozyLink'
+import withMutations from '../withMutations'
+
+describe('withMutations', () => {
+  const clientMock = {
+    create: jest.fn(),
+    destroy: jest.fn(),
+    save: jest.fn(),
+    mutate: jest.fn()
+  }
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should inject base mutations props into wrapped component', async () => {
+    const Foo = () => <div />
+    const ConnectedFoo = withMutations()(Foo)
+
+    const wrapper = shallow(<ConnectedFoo />, { context: { client: clientMock } })
+
+    const {
+      createDocument,
+      saveDocument,
+      deleteDocument
+    } = wrapper.props()
+
+    expect(typeof createDocument).toBe('function')
+    expect(typeof saveDocument).toBe('function')
+    expect(typeof deleteDocument).toBe('function')
+  })
+
+  it('should inject mutations props from one source into wrapped component', async () => {
+    const Foo = () => <div />
+
+    const ConnectedFoo = withMutations(client => ({
+      mutate: client => client.mutate()
+    }))(Foo)
+
+    const wrapper = shallow(<ConnectedFoo />, { context: { client: clientMock } })
+
+    const {
+      mutate
+    } = wrapper.props()
+    expect(typeof mutate).toBe('function')
+
+    mutate(clientMock)
+    expect(clientMock.mutate).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Useful for passing mutations from different modules.