### PR TITLE
feat: getIcon from stack or registry for apps and konnectors

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -36,6 +36,12 @@ through OAuth.</p>
 ## Functions
 
 <dl>
+<dt><a href="#garbageCollect">garbageCollect()</a></dt>
+<dd><p>Delete outdated results from cache</p>
+</dd>
+<dt><a href="#memoize">memoize()</a></dt>
+<dd><p>Memoize with maxDuration and custom key</p>
+</dd>
 <dt><a href="#getCozyURL">getCozyURL()</a></dt>
 <dd><p>Get a uniform formatted URL and SSL information according to a provided URL</p>
 </dd>
@@ -547,6 +553,18 @@ Force given trigger execution.
 | --- | --- | --- |
 | Trigger | <code>object</code> | to launch |
 
+<a name="garbageCollect"></a>
+
+## garbageCollect()
+Delete outdated results from cache
+
+**Kind**: global function  
+<a name="memoize"></a>
+
+## memoize()
+Memoize with maxDuration and custom key
+
+**Kind**: global function  
 <a name="getCozyURL"></a>
 
 ## getCozyURL()

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -4,7 +4,11 @@ import DocumentCollection from './DocumentCollection'
 import FileCollection from './FileCollection'
 import SharingCollection from './SharingCollection'
 import PermissionCollection from './PermissionCollection'
+<<<<<<< HEAD
 import TriggerCollection, { TRIGGERS_DOCTYPE } from './TriggerCollection'
+=======
+import getIconURL from './getIconURL'
+>>>>>>> feat: Get icon from stack or registry for apps and konnectors
 
 const normalizeUri = uri => {
   while (uri[uri.length - 1] === '/') {
@@ -125,6 +129,10 @@ class CozyStackClient {
 
   setUri(uri) {
     this.uri = normalizeUri(uri)
+  }
+
+  getIconURL(opts) {
+    return getIconURL(this, opts)
   }
 }
 

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -4,11 +4,8 @@ import DocumentCollection from './DocumentCollection'
 import FileCollection from './FileCollection'
 import SharingCollection from './SharingCollection'
 import PermissionCollection from './PermissionCollection'
-<<<<<<< HEAD
 import TriggerCollection, { TRIGGERS_DOCTYPE } from './TriggerCollection'
-=======
 import getIconURL from './getIconURL'
->>>>>>> feat: Get icon from stack or registry for apps and konnectors
 
 const normalizeUri = uri => {
   while (uri[uri.length - 1] === '/') {

--- a/packages/cozy-stack-client/src/getIconURL.js
+++ b/packages/cozy-stack-client/src/getIconURL.js
@@ -1,0 +1,115 @@
+import memoize from './memoize'
+
+const mimeTypes = {
+  gif: 'image/gif',
+  ico: 'image/vnd.microsoft.icon',
+  jpeg: 'image/jpeg',
+  jpg: 'image/jpeg',
+  png: 'image/png',
+  svg: 'image/svg+xml'
+}
+
+const fetchOptions = stackClient => {
+  return {
+    headers: {
+      Authorization: 'Bearer ' + stackClient.token
+    },
+    credentials: true
+  }
+}
+
+const getIconExtensionFromApp = app => {
+  if (!app.icon) {
+    throw new Error(
+      `${app.name}: Cannot detect icon mime type since app has no icon`
+    )
+  }
+
+  const extension = app.icon.split('.').pop()
+
+  if (!extension) {
+    throw new Error(
+      `${app.name}: Unable to detect icon mime type from extension (${
+        app.icon
+      })`
+    )
+  }
+
+  return extension
+}
+
+const fallbacks = async (tries, check) => {
+  let err
+  for (let _try of tries) {
+    try {
+      const res = await _try()
+      check && check(res)
+      return res
+    } catch (e) {
+      err = e
+    }
+  }
+  throw err
+}
+
+const _getIconURL = async (stackClient, opts) => {
+  const { type, slug, appData, priority = 'stack' } = opts
+  const fetchOpts = fetchOptions(stackClient)
+  const iconDataFetchers = [
+    () => stackClient.fetch('GET', `/${type}s/${slug}/icon`, null, fetchOpts),
+    () => stackClient.fetch('GET', `/registry/${slug}/icon`, null, fetchOpts)
+  ]
+  if (priority === 'registry') {
+    iconDataFetchers.reverse()
+  }
+  const resp = await fallbacks(iconDataFetchers, resp => {
+    if (!resp.ok) {
+      throw new Error(`Error while fetching icon ${resp.statusText}`)
+    }
+  })
+
+  let icon = await resp.blob()
+  let app
+  if (!icon.type) {
+    // iOS10 does not set correctly mime type for images, so we assume
+    // that an empty mime type could mean that the app is running on iOS10.
+    // For regular images like jpeg, png or gif it still works well in the
+    // Safari browser but not for SVG.
+    // So let's set a mime type manually. We cannot always set it to
+    // image/svg+xml and must guess the mime type based on the icon attribute
+    // from app/manifest
+    // See https://stackoverflow.com/questions/38318411/uiwebview-on-ios-10-beta-not-loading-any-svg-images
+    const appDataFetchers = [
+      () => stackClient.fetchJSON('GET', `/${type}s/${slug}`, null, fetchOpts),
+      () => stackClient.fetchJSON('GET', `/registry/${slug}`, null, fetchOpts)
+    ]
+    if (priority === 'registry') {
+      appDataFetchers.reverse()
+    }
+    app = appData || (await fallbacks(appDataFetchers)).data || {}
+    const ext = getIconExtensionFromApp(app)
+    if (!mimeTypes[ext]) {
+      throw new Error(`Unknown image extension "${ext}" for app ${app.name}`)
+    }
+    icon = new Blob([icon], { type: mimeTypes[ext] })
+  }
+
+  return URL.createObjectURL(icon)
+}
+
+const getIconURL = function() {
+  return _getIconURL.apply(this, arguments).catch(e => {
+    console.warn(e)
+    return ''
+  })
+}
+
+export default memoize(getIconURL, {
+  maxDuration: 300 * 1000,
+  key: (stackClient, opts) => {
+    const { type, slug, priority } = opts
+    return stackClient.uri + +':' + type + ':' + slug + ':' + priority
+  }
+})
+
+export { getIconURL }

--- a/packages/cozy-stack-client/src/getIconURL.spec.js
+++ b/packages/cozy-stack-client/src/getIconURL.spec.js
@@ -1,0 +1,125 @@
+import { getIconURL } from './getIconURL'
+
+const FakeBlob = (data, options) => {
+  return { data, ...options }
+}
+
+describe('get icon', () => {
+  let stackClient = {},
+    responses
+  beforeEach(() => {
+    responses = {}
+    const fakeResp = (method, url) => {
+      const resp = responses[url]
+      return resp
+        ? Promise.resolve(resp)
+        : Promise.reject(`404: ${url} (not found in fake server)`)
+    }
+    stackClient.fetch = jest.fn().mockImplementation(fakeResp)
+    stackClient.fetchJSON = jest.fn().mockImplementation(fakeResp)
+    global.URL.createObjectURL = jest.fn(blob => {
+      return blob
+    })
+  })
+
+  afterEach(() => {
+    global.URL.createObjectURL = undefined
+  })
+
+  const svgData = '<svg></svg>'
+  const defaultOpts = {
+    type: 'konnector',
+    slug: 'caissedepargne1'
+  }
+
+  it('should build a url when app is installed', async () => {
+    responses['/konnectors/caissedepargne1/icon'] = {
+      ok: true,
+      blob: () => FakeBlob([svgData], { type: 'image/svg+xml' })
+    }
+    const url = await getIconURL(stackClient, defaultOpts)
+    expect(global.URL.createObjectURL).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'image/svg+xml'
+      })
+    )
+    expect(url.data[0]).toBe('<svg></svg>')
+  })
+
+  it('should build a url when app is not installed', async () => {
+    responses['/registry/caissedepargne1/icon'] = {
+      ok: true,
+      blob: () => FakeBlob([svgData], { type: 'image/svg+xml' })
+    }
+    const url = await getIconURL(stackClient, defaultOpts)
+    expect(global.URL.createObjectURL).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'image/svg+xml'
+      })
+    )
+    expect(url.data[0]).toBe('<svg></svg>')
+  })
+
+  it('should build a url when app is installed but no mime type is sent in response', async () => {
+    responses['/konnectors/caissedepargne1/icon'] = {
+      ok: true,
+      blob: () => new FakeBlob([svgData], {})
+    }
+    responses['/registry/caissedepargne1'] = { data: { icon: 'icon.svg' } }
+    await getIconURL(stackClient, defaultOpts)
+    expect(global.URL.createObjectURL).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'image/svg+xml'
+      })
+    )
+  })
+
+  it('should build a url when app is not installed and no mime type is sent in response', async () => {
+    responses['/konnectors/caissedepargne1/icon'] = {
+      ok: true,
+      blob: () => new FakeBlob([svgData], {})
+    }
+    responses['/registry/caissedepargne1'] = {
+      data: { icon: 'icon.svg' }
+    }
+    await getIconURL(stackClient, defaultOpts)
+    expect(global.URL.createObjectURL).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'image/svg+xml'
+      })
+    )
+  })
+
+  it('should return nothing for unknown file type', async () => {
+    responses['/konnectors/caissedepargne1/icon'] = {
+      ok: true,
+      blob: () => new FakeBlob([svgData], {})
+    }
+    responses['/registry/caissedepargne1'] = {
+      data: { name: 'caissedepargne1', icon: 'icon.mp4' }
+    }
+    const url = await getIconURL(stackClient, defaultOpts)
+    expect(url).toEqual('')
+  })
+
+  it('should respect priority', async () => {
+    responses['/konnectors/caissedepargne1/icon'] = {
+      ok: true,
+      blob: () => new FakeBlob([svgData], { type: 'image/svg+xml' })
+    }
+    responses['/registry/caissedepargne1/icon'] = {
+      ok: true,
+      blob: () =>
+        new FakeBlob(['<svg id="2"></svg>'], { type: 'image/svg+xml' })
+    }
+    const url = await getIconURL(stackClient, {
+      ...defaultOpts,
+      priority: 'registry'
+    })
+    expect(global.URL.createObjectURL).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: ['<svg id="2"></svg>']
+      })
+    )
+  })
+})

--- a/packages/cozy-stack-client/src/memoize.js
+++ b/packages/cozy-stack-client/src/memoize.js
@@ -1,0 +1,37 @@
+/**
+ * Delete outdated results from cache
+ */
+const garbageCollect = (cache, maxDuration) => {
+  const now = Date.now()
+  for (const key of Object.keys(cache)) {
+    const delta = now - cache[key].date
+    if (delta > maxDuration) {
+      delete cache[key]
+    }
+  }
+}
+
+/**
+ * Memoize with maxDuration and custom key
+ */
+const memoize = (fn, options) => {
+  const cache = {}
+
+  return function() {
+    const key = options.key.apply(null, arguments)
+    garbageCollect(cache, options.maxDuration)
+    const existing = cache[key]
+    if (existing) {
+      return existing.result
+    } else {
+      const result = fn.apply(this, arguments)
+      cache[key] = {
+        result,
+        date: Date.now()
+      }
+      return result
+    }
+  }
+}
+
+export default memoize

--- a/packages/cozy-stack-client/src/memoize.spec.js
+++ b/packages/cozy-stack-client/src/memoize.spec.js
@@ -1,0 +1,22 @@
+import memoize from './memoize'
+
+describe('memoize', () => {
+  let now
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockImplementation(() => now)
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+  it('should remember results ', () => {
+    now = 0
+    let c = 0
+    const counter = () => c++
+    const mcounter = memoize(counter, { key: () => 'A', maxDuration: 5 })
+    expect(mcounter()).toBe(0)
+    expect(mcounter()).toBe(0)
+    now = 6
+    expect(mcounter()).toBe(1)
+    expect(mcounter()).toBe(1)
+  })
+})


### PR DESCRIPTION
- Get icon content (need to XHR to send cookies on mobile)
- Return URL with URL.createObjectURL

If icon type cannot be determined or is not available (ios10), the app manifest is downloaded and the mime type is determined from the icon filename.

### Usage

```
stackClient.getIcon({ type: 'konnector', slug: 'caissedepargne1' })
stackClient.getIcon({ type: 'app', slug: 'drive' })
stackClient.getIcon({ type: 'app', slug: 'drive', priority: 'registry' })
```