### PR TITLE
Automatic metadata

### DIFF
--- a/docs/how-tos.md
+++ b/docs/how-tos.md
@@ -132,10 +132,11 @@ export default withMutation(
 
 ## How to specify a schema ?
 
-Each doctypes accessed via cozy-client needs to have a schema declared. It is useful for 
+Each doctype accessed via cozy-client needs to have a schema declared. It is useful for
 
 * Validation
 * Relationships
+* Automatic metadata maintenance
 
 Here is a sample of a schema used in the Banks application.
 
@@ -168,6 +169,24 @@ const schema = {
         type: HasManyReimbursements,
         doctype: 'io.cozy.bills'
       }
+    },
+    cozyMetadata: {
+      createdByApp: {
+        trigger: 'creation',
+        value: 'cozy-banks'
+      },
+      updatedByApps: {
+        trigger: 'update',
+        value: ['cozy-banks']
+      },
+      createdAt: {
+        trigger: 'creation',
+        useCurrentDate: true
+      },
+      updatedAt: {
+        trigger: 'update',
+        useCurrentDate: true
+      },
     }
   }
 }
@@ -179,6 +198,8 @@ const client = new CozyClient({
 })
 ```
 
+### Relationships
+
 Here we can see that banking transactions are linked to
 
 - their *account* via a "belongs to" relationship
@@ -186,5 +207,17 @@ Here we can see that banking transactions are linked to
 - *reimbursements* via a custom "has many" relationship
 
 Custom relationships are useful if the relationship data is not stored in a built-in way.
+
+### Metadata
+
+cozy-client will also automatically insert and update the standard document metadata if you provide a `cozyMetadata` object to the schema.
+
+Each metadata field can be configured with the following options:
+
+- `trigger`: Can be `creation` or `update`, and determines whether to update this value every time the document changes, or only on creation.
+- `value`: The value to use when setting the metadata field. If `value` is an array, the values will be appended to the array on each update.
+- `useCurrentDate`: Instead of a fixed value, use the current execution date for this field.
+
+### Validation
 
 Validation is not yet implemented in cozy-client.

--- a/packages/cozy-client/src/__tests__/fixtures.js
+++ b/packages/cozy-client/src/__tests__/fixtures.js
@@ -65,6 +65,10 @@ export const FILE_2 = {
   _type: 'io.cozy.files',
   label: 'File 2'
 }
+export const APP_NAME = 'cozy-client-test'
+export const APP_VERSION = 2
+export const DOCTYPE_VERSION = 1
+export const SOURCE_ACCOUNT_ID = '123-456-abc'
 export const SCHEMA = {
   todos: {
     doctype: 'io.cozy.todos',
@@ -76,6 +80,44 @@ export const SCHEMA = {
       authors: {
         type: 'has-many',
         doctype: 'io.cozy.persons'
+      }
+    },
+    cozyMetadata: {
+      doctypeVersion: {
+        trigger: 'creation',
+        value: DOCTYPE_VERSION
+      },
+      createdByApp: {
+        trigger: 'creation',
+        value: APP_NAME
+      },
+      createdByAppVersion: {
+        trigger: 'creation',
+        value: APP_VERSION
+      },
+      importedFrom: {
+        trigger: 'creation',
+        value: APP_NAME
+      },
+      updatedByApps: {
+        trigger: 'update',
+        value: [APP_NAME]
+      },
+      createdAt: {
+        trigger: 'creation',
+        useCurrentDate: true
+      },
+      importedAt: {
+        trigger: 'creation',
+        useCurrentDate: true
+      },
+      updatedAt: {
+        trigger: 'update',
+        useCurrentDate: true
+      },
+      sourceAccount: {
+        trigger: 'creation',
+        value: SOURCE_ACCOUNT_ID
       }
     }
   }

--- a/packages/cozy-client/src/__tests__/mockDate.js
+++ b/packages/cozy-client/src/__tests__/mockDate.js
@@ -1,0 +1,14 @@
+const _Date = Date
+
+export function mockDate(isoDate) {
+  global.Date = class extends _Date {
+    constructor() {
+      super()
+      return new _Date(isoDate)
+    }
+  }
+}
+
+export function restoreDate() {
+  global.Date = _Date
+}

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -19,11 +19,12 @@ let client, link
 
 async function setup(linkOpts = {}) {
   link = new CozyPouchLink({ doctypes: [TODO_DOCTYPE], ...linkOpts })
+
   client = new CozyClient({
     ...mockClient,
     links: [link],
     schema: {
-      todos: omit(TODO_DOCTYPE, 'relationships')
+      todos: omit(SCHEMA.todos, ['relationships'])
     }
   })
 


### PR DESCRIPTION
Implements #363 — automatically inserting and updating `cozyMetadata`. I will add the relevant documentation after the first round of review.

Basically: if the app provides a `cozyMetadata` object in the schema, the keys will be added / updated to the documents. The schema also contains the values to use and when to update the various metadata fields.