### PR TITLE
test: Fix schema in CozyPouchLink tests

### DIFF
--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -19,11 +19,12 @@ let client, link
 
 async function setup(linkOpts = {}) {
   link = new CozyPouchLink({ doctypes: [TODO_DOCTYPE], ...linkOpts })
+
   client = new CozyClient({
     ...mockClient,
     links: [link],
     schema: {
-      todos: omit(TODO_DOCTYPE, 'relationships')
+      todos: omit(SCHEMA.todos, ['relationships'])
     }
   })
 


### PR DESCRIPTION
The broken build of #365 reveals that the schema we provide to cozy client is broken in `CozyPouchLink.spec.js`.

Before this change, schema is equal to:

```
{ todos: { '0': 'i',
      '1': 'o',
      '2': '.',
      '3': 'c',
      '4': 'o',
      '5': 'z',
      '6': 'y',
      '7': '.',
      '8': 't',
      '9': 'o',
      '10': 'd',
      '11': 'o',
      '12': 's' } }
```

After the change:

```
{ todos: { doctype: 'io.cozy.todos' } } }
```
