### PR TITLE
Fix stackClient:getIcon

### DIFF
--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -59,7 +59,8 @@ class CozyStackClient {
    * @return {Object}
    * @throws {FetchError}
    */
-  async fetch(method, path, body, options = {}) {
+  async fetch(method, path, body, opts = {}) {
+    const options = { ...opts }
     options.method = method
     const headers = (options.headers = options.headers || {})
 

--- a/packages/cozy-stack-client/src/getIconURL.js
+++ b/packages/cozy-stack-client/src/getIconURL.js
@@ -9,15 +9,6 @@ const mimeTypes = {
   svg: 'image/svg+xml'
 }
 
-const fetchOptions = stackClient => {
-  return {
-    headers: {
-      Authorization: 'Bearer ' + stackClient.token
-    },
-    credentials: true
-  }
-}
-
 const getIconExtensionFromApp = app => {
   if (!app.icon) {
     throw new Error(
@@ -54,10 +45,9 @@ const fallbacks = async (tries, check) => {
 
 const _getIconURL = async (stackClient, opts) => {
   const { type, slug, appData, priority = 'stack' } = opts
-  const fetchOpts = fetchOptions(stackClient)
   const iconDataFetchers = [
-    () => stackClient.fetch('GET', `/${type}s/${slug}/icon`, null, fetchOpts),
-    () => stackClient.fetch('GET', `/registry/${slug}/icon`, null, fetchOpts)
+    () => stackClient.fetch('GET', `/${type}s/${slug}/icon`),
+    () => stackClient.fetch('GET', `/registry/${slug}/icon`)
   ]
   if (priority === 'registry') {
     iconDataFetchers.reverse()
@@ -80,8 +70,8 @@ const _getIconURL = async (stackClient, opts) => {
     // from app/manifest
     // See https://stackoverflow.com/questions/38318411/uiwebview-on-ios-10-beta-not-loading-any-svg-images
     const appDataFetchers = [
-      () => stackClient.fetchJSON('GET', `/${type}s/${slug}`, null, fetchOpts),
-      () => stackClient.fetchJSON('GET', `/registry/${slug}`, null, fetchOpts)
+      () => stackClient.fetchJSON('GET', `/${type}s/${slug}`),
+      () => stackClient.fetchJSON('GET', `/registry/${slug}`)
     ]
     if (priority === 'registry') {
       appDataFetchers.reverse()

--- a/packages/cozy-stack-client/src/getIconURL.spec.js
+++ b/packages/cozy-stack-client/src/getIconURL.spec.js
@@ -112,7 +112,7 @@ describe('get icon', () => {
       blob: () =>
         new FakeBlob(['<svg id="2"></svg>'], { type: 'image/svg+xml' })
     }
-    const url = await getIconURL(stackClient, {
+    await getIconURL(stackClient, {
       ...defaultOpts,
       priority: 'registry'
     })


### PR DESCRIPTION
- Passing options to fetch was unnecessary and actually led to a bug since the credentials options of stackClient::fetch is supposed to be the Authorization header
- Options object is modified during the fetch, this is why it is copied