### PR TITLE
fix: Support $gt null in query selectors

### DIFF
--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -19,7 +19,7 @@
     "react-redux": "5.0.7",
     "redux": "3.7.2",
     "redux-thunk": "2.3.0",
-    "sift": "7.0.1"
+    "sift": "6.0.0"
   },
   "scripts": {
     "build": "../../bin/build",

--- a/packages/cozy-client/src/store/__snapshots__/queries.spec.js.snap
+++ b/packages/cozy-client/src/store/__snapshots__/queries.spec.js.snap
@@ -59,6 +59,66 @@ Object {
 }
 `;
 
+exports[`queries reducer updates should correctly update a query with a $gt: null selector 1`] = `
+Object {
+  "a": Object {
+    "count": 1,
+    "data": Array [
+      "54321",
+    ],
+    "definition": QueryDefinition {
+      "doctype": "io.cozy.todos",
+      "fields": undefined,
+      "id": undefined,
+      "ids": undefined,
+      "includes": undefined,
+      "indexedFields": undefined,
+      "limit": undefined,
+      "referenced": undefined,
+      "selector": undefined,
+      "skip": undefined,
+      "sort": undefined,
+    },
+    "fetchStatus": "loaded",
+    "hasMore": false,
+    "id": "a",
+    "lastError": null,
+    "lastFetch": 1337,
+    "lastUpdate": 1337,
+  },
+  "b": Object {
+    "count": 1,
+    "data": Array [
+      "54321",
+    ],
+    "definition": QueryDefinition {
+      "doctype": "io.cozy.todos",
+      "fields": undefined,
+      "id": undefined,
+      "ids": undefined,
+      "includes": undefined,
+      "indexedFields": undefined,
+      "limit": undefined,
+      "referenced": undefined,
+      "selector": Object {
+        "_id": Object {
+          "$gt": null,
+        },
+        "done": true,
+      },
+      "skip": undefined,
+      "sort": undefined,
+    },
+    "fetchStatus": "loading",
+    "hasMore": false,
+    "id": "b",
+    "lastError": null,
+    "lastFetch": null,
+    "lastUpdate": 1337,
+  },
+}
+`;
+
 exports[`queries reducer updates should correctly update a query with a selector 1`] = `
 Object {
   "a": Object {

--- a/packages/cozy-client/src/store/queries.spec.js
+++ b/packages/cozy-client/src/store/queries.spec.js
@@ -1,4 +1,8 @@
-import queries, { initQuery, receiveQueryResult } from './queries'
+import queries, {
+  initQuery,
+  receiveQueryResult,
+  convert$gtNullSelectors
+} from './queries'
 import { QueryDefinition as Q } from '../queries/dsl'
 import { TODO_1, TODO_2, TODO_3 } from '../__tests__/fixtures'
 
@@ -77,6 +81,29 @@ describe('queries reducer', () => {
       expect(state).toMatchSnapshot()
     })
 
+    it('should correctly update a query with a $gt: null selector', () => {
+      const query = new Q({
+        doctype: 'io.cozy.todos'
+      })
+      applyAction(
+        initQuery(
+          'b',
+          query.where({
+            done: true,
+            _id: {
+              $gt: null
+            }
+          })
+        )
+      )
+      applyAction(
+        receiveQueryResult('a', {
+          data: [TODO_3]
+        })
+      )
+      expect(state).toMatchSnapshot()
+    })
+
     it('should not update a query not concerned even with a selector', () => {
       const query = new Q({
         doctype: 'io.cozy.todos'
@@ -122,6 +149,40 @@ describe('queries reducer', () => {
         })
       )
       expect(state.b.lastUpdate).not.toBe(null)
+    })
+  })
+})
+
+describe('selectors', () => {
+  it('should convert $gt selectors when their value is null', () => {
+    const selector = {
+      somefield: 'somevalue',
+      convertMe: {
+        $gt: null
+      },
+      nested: {
+        convertMeToo: {
+          $gt: null
+        }
+      },
+      notNull: {
+        $gt: 2
+      }
+    }
+    const converted = convert$gtNullSelectors(selector)
+    expect(converted).toEqual({
+      somefield: 'somevalue',
+      convertMe: {
+        $gtnull: null
+      },
+      nested: {
+        convertMeToo: {
+          $gtnull: null
+        }
+      },
+      notNull: {
+        $gt: 2
+      }
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -10429,10 +10429,10 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-sift@7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/sift/-/sift-7.0.1.tgz#47d62c50b159d316f1372f8b53f9c10cd21a4b08"
-  integrity sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g==
+sift@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/sift/-/sift-6.0.0.tgz#f93a778e5cbf05a5024ebc391e6b32511a6d1f82"
+  integrity sha1-+Tp3jly/BaUCTrw5HmsyURptH4I=
 
 sigmund@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Ok, so:

- A common practice when working with couchdb is to include a `{ $gt: null }` selector — telling couch to use that field as an index, but not using it as a real filter, since almost any value passes the `{ $gt: null }` filter. We do this every now and then in our queries and [it's all over their docs](http://docs.couchdb.org/en/latest/api/database/find.html#find-selectors).
- When documents in the cozy-client store change, we run the updated documents against the selectors of the `queries` to know which ones to update.
- We use [sift.js](https://github.com/crcn/sift.js) to run the selectors, but contrary to couchdb, sift returns no documents when using `{ $gt: null }` .
- Sift is mirroring mongodb behaviour, so it's not a bug on their side. [It might be a bug in mongo](https://stackoverflow.com/questions/29835829/mongodb-comparison-operators-with-null), but better not hold our breath on that.

Sucks for us. Since I don't want to fork / reimplement sift, I looked for a workaround.

[Sift supports custom operators](https://github.com/crcn/sift.js#custom-expressions). We can't override `$gt`, so I created a new `$gtnull` operator that behaves like couchdb.  
Before running the selector function, I convert all `$gt: null` to `$gtnull: null` in the selector, so the user doesn't need to worry about this quirk.

Last thing to note, I actually *downgraded* sift to v6.0.0:

- sift v6 supports custom operators through `sift.use`
- sift v7 (our current version) does not support custom operators at all
- sift v8 (currently in beta) has a new API for custom operators as mentioned in their readme, but has [a change we really don't want](https://github.com/crcn/sift.js/issues/117)

So I'm afraid we'll be stuck with sift v6 for the foreseeable future.