### PR TITLE
feat: Saner internal API for stackClient/OAuthClient

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -294,7 +294,7 @@ through OAuth.
     * [.getAccessCodeFromURL(pageURL, stateCode)](#OAuthClient+getAccessCodeFromURL) ⇒ <code>string</code>
     * [.fetchAccessToken(accessCode)](#OAuthClient+fetchAccessToken) ⇒ <code>Promise</code>
     * [.refreshToken()](#OAuthClient+refreshToken) ⇒ <code>Promise</code>
-    * [.setCredentials(token)](#OAuthClient+setCredentials)
+    * [.setToken(token)](#OAuthClient+setToken)
     * [.setOAuthOptions(options)](#OAuthClient+setOAuthOptions)
     * [.resetClient()](#OAuthClient+resetClient)
 
@@ -414,9 +414,9 @@ Retrieves a new access token by refreshing the currently used token.
 - <code>NotRegisteredException</code> When the client doesn't have it's registration information
 - <code>Error</code> The client should already have an access token to use this function
 
-<a name="OAuthClient+setCredentials"></a>
+<a name="OAuthClient+setToken"></a>
 
-### oAuthClient.setCredentials(token)
+### oAuthClient.setToken(token)
 Updates the client's stored token
 
 **Kind**: instance method of [<code>OAuthClient</code>](#OAuthClient)  

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -609,7 +609,7 @@ class CozyClient {
       const code = stackClient.getAccessCodeFromURL(redirectedURL, stateCode)
       const token = await stackClient.fetchAccessToken(code)
 
-      stackClient.setCredentials(token)
+      stackClient.setToken(token)
       return {
         token,
         infos: stackClient.oauthOptions,

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -6,6 +6,7 @@ import SharingCollection from './SharingCollection'
 import PermissionCollection from './PermissionCollection'
 import TriggerCollection, { TRIGGERS_DOCTYPE } from './TriggerCollection'
 import getIconURL from './getIconURL'
+import logDeprecate from './logDeprecate'
 
 const normalizeUri = uri => {
   if (uri === null) return null
@@ -22,7 +23,7 @@ const normalizeUri = uri => {
 class CozyStackClient {
   constructor({ token, uri = '' }) {
     this.setUri(uri)
-    this.setCredentials(token)
+    this.setToken(token)
   }
 
   /**
@@ -124,6 +125,13 @@ class CozyStackClient {
     return this.token ? this.token.toAuthHeader() : null
   }
 
+  setCredentials(token) {
+    logDeprecate(
+      'CozyStackClient::setCredentials is deprecated, use CozyStackClient::setToken'
+    )
+    return this.setToken(token)
+  }
+
   getCredentials() {
     logDeprecate(
       'CozyStackClient::getCredentials is deprecated, use CozyStackClient::getAuthorizationHeader'
@@ -131,7 +139,7 @@ class CozyStackClient {
     return this.getAuthorizationHeader()
   }
 
-  setCredentials(token) {
+  setToken(token) {
     this.token = token ? new AppToken(token) : null
   }
 

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -15,9 +15,6 @@ const normalizeUri = uri => {
   return uri
 }
 
-const logDeprecate = (...args) => {
-  console.warn(...args)
-}
 
 /**
  * Main API against the `cozy-stack` server.

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -67,7 +67,7 @@ class CozyStackClient {
   async fetch(method, path, body, opts = {}) {
     const options = { ...opts }
     options.method = method
-    const headers = (options.headers = options.headers || {})
+    const headers = (options.headers = { ...opts.headers })
 
     if (method !== 'GET' && method !== 'HEAD' && body !== undefined) {
       if (headers['Content-Type']) {

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -15,6 +15,10 @@ const normalizeUri = uri => {
   return uri
 }
 
+const logDeprecate = (...args) => {
+  console.warn(...args)
+}
+
 /**
  * Main API against the `cozy-stack` server.
  */
@@ -71,7 +75,7 @@ class CozyStackClient {
       }
     }
 
-    const credentials = options.credentials || this.getCredentials()
+    const credentials = options.credentials || this.getAuthorizationHeader()
     if (credentials) {
       headers['Authorization'] = credentials
       // the option credentials:include tells fetch to include the cookies in the
@@ -118,8 +122,15 @@ class CozyStackClient {
     return this.uri + path
   }
 
-  getCredentials() {
+  getAuthorizationHeader() {
     return this.token ? this.token.toAuthHeader() : null
+  }
+
+  getCredentials() {
+    logDeprecate(
+      'CozyStackClient::getCredentials is deprecated, use CozyStackClient::getAuthorizationHeader'
+    )
+    return this.getAuthorizationHeader()
   }
 
   setCredentials(token) {

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -78,10 +78,11 @@ class CozyStackClient {
     const credentials = options.credentials || this.getAuthorizationHeader()
     if (credentials) {
       headers['Authorization'] = credentials
-      // the option credentials:include tells fetch to include the cookies in the
-      // request even for cross-origin requests
-      options.credentials = 'include'
     }
+
+    // the option credentials:include tells fetch to include the cookies in the
+    // request even for cross-origin requests
+    options.credentials = 'include'
 
     return fetch(this.fullpath(path), options)
   }

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -16,7 +16,6 @@ const normalizeUri = uri => {
   return uri
 }
 
-
 /**
  * Main API against the `cozy-stack` server.
  */
@@ -73,9 +72,8 @@ class CozyStackClient {
       }
     }
 
-    const credentials = options.credentials || this.getAuthorizationHeader()
-    if (credentials) {
-      headers['Authorization'] = credentials
+    if (!headers.Authorization) {
+      headers.Authorization = this.getAuthorizationHeader()
     }
 
     // the option credentials:include tells fetch to include the cookies in the

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -1,5 +1,6 @@
 import CozyStackClient from './CozyStackClient'
 import AccessToken from './AccessToken'
+import logDeprecate from './logDeprecate'
 
 const defaultoauthOptions = {
   clientID: '',
@@ -369,12 +370,17 @@ class OAuthClient extends CozyStackClient {
    * Updates the client's stored token
    * @param {string} token = null The new token to use — can be a string, a json object or an AccessToken instance.
    */
-  setCredentials(token) {
+  setToken(token) {
     if (token) {
       this.token = token instanceof AccessToken ? token : new AccessToken(token)
     } else {
       this.token = null
     }
+  }
+
+  setCredentials(token) {
+    logDeprecate('setCredentials is deprecated, please replace by setToken')
+    return this.setToken(token)
   }
 
   /**
@@ -395,7 +401,7 @@ class OAuthClient extends CozyStackClient {
   resetClient() {
     this.resetClientId()
     this.setUri(null)
-    this.setCredentials(null)
+    this.setToken(null)
   }
 
   async fetchJSON(method, path, body, options) {
@@ -404,7 +410,7 @@ class OAuthClient extends CozyStackClient {
     } catch (e) {
       if (/Expired token/.test(e.message)) {
         const token = await this.refreshToken()
-        this.setCredentials(token)
+        this.setToken(token)
         return await super.fetchJSON(method, path, body, options)
       } else {
         throw e

--- a/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
@@ -60,7 +60,7 @@ describe('OAuthClient', () => {
   describe('with registration', () => {
     beforeEach(() => {
       client = new OAuthClient(REGISTERED_CLIENT_INIT_OPTIONS)
-      client.setCredentials({
+      client.setToken({
         tokenType: 'type',
         accessToken: 'abcd',
         refreshToken: 'refresh-789',
@@ -165,14 +165,14 @@ describe('OAuthClient', () => {
         refresh_token: 'refresh-you',
         scope: 'io.cozy.todos'
       }
-      client.setCredentials(camelCredentials)
+      client.setToken(camelCredentials)
       expect(client.token).toBeInstanceOf(AccessToken)
       expect(client.token.tokenType).toEqual(camelCredentials.tokenType)
       expect(client.token.accessToken).toEqual(camelCredentials.accessToken)
       expect(client.token.refreshToken).toEqual(camelCredentials.refreshToken)
       expect(client.token.scope).toEqual(camelCredentials.scope)
 
-      client.setCredentials(JSON.stringify(snakeCredentials))
+      client.setToken(JSON.stringify(snakeCredentials))
       expect(client.token).toBeInstanceOf(AccessToken)
       expect(client.token.tokenType).toEqual(snakeCredentials.token_type)
       expect(client.token.accessToken).toEqual(snakeCredentials.access_token)

--- a/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
@@ -180,12 +180,6 @@ describe('OAuthClient', () => {
       expect(client.token.scope).toEqual(snakeCredentials.scope)
     })
 
-    it('should call getAuthorizationHeader for usual requests', () => {
-      const spy = jest.spyOn(client, 'getAuthorizationHeader')
-      client.fetchJSON('GET', 'http://example.com')
-      expect(spy).toHaveBeenCalled()
-    })
-
     it('should reset the client', () => {
       client.setUri('test')
       expect(client.uri).toEqual('test')

--- a/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
@@ -180,8 +180,8 @@ describe('OAuthClient', () => {
       expect(client.token.scope).toEqual(snakeCredentials.scope)
     })
 
-    it('should call getCredentials for usual requests', () => {
-      const spy = jest.spyOn(client, 'getCredentials')
+    it('should call getAuthorizationHeader for usual requests', () => {
+      const spy = jest.spyOn(client, 'getAuthorizationHeader')
       client.fetchJSON('GET', 'http://example.com')
       expect(spy).toHaveBeenCalled()
     })

--- a/packages/cozy-stack-client/src/__tests__/__snapshots__/OAuthClient.spec.js.snap
+++ b/packages/cozy-stack-client/src/__tests__/__snapshots__/OAuthClient.spec.js.snap
@@ -93,6 +93,7 @@ Array [
   "http://cozy.tools:8080/auth/register",
   Object {
     "body": "{\\"redirect_uris\\":[\\"http://localhost\\"],\\"client_name\\":\\"TestClientName\\",\\"software_id\\":\\"TestSofwareID\\",\\"client_kind\\":\\"\\",\\"client_uri\\":\\"\\",\\"logo_uri\\":\\"\\",\\"policy_uri\\":\\"\\",\\"software_version\\":\\"\\",\\"notification_platform\\":\\"\\",\\"notification_device_token\\":\\"\\"}",
+    "credentials": "include",
     "headers": Object {
       "Accept": "application/json",
       "Content-Type": "application/json",

--- a/packages/cozy-stack-client/src/__tests__/__snapshots__/OAuthClient.spec.js.snap
+++ b/packages/cozy-stack-client/src/__tests__/__snapshots__/OAuthClient.spec.js.snap
@@ -23,7 +23,7 @@ Array [
     "credentials": "include",
     "headers": Object {
       "Accept": "application/json",
-      "Authorization": "Bearer 1234",
+      "Authorization": "Bearer abcd",
     },
     "method": "GET",
   },
@@ -62,7 +62,7 @@ Array [
     "credentials": "include",
     "headers": Object {
       "Accept": "application/json",
-      "Authorization": "Bearer 1234",
+      "Authorization": "Bearer abcd",
       "Content-Type": "application/json",
     },
     "method": "DELETE",
@@ -78,7 +78,7 @@ Array [
     "credentials": "include",
     "headers": Object {
       "Accept": "application/json",
-      "Authorization": "Bearer 1234",
+      "Authorization": "Bearer abcd",
       "Content-Type": "application/json",
     },
     "method": "PUT",
@@ -96,6 +96,7 @@ Array [
     "credentials": "include",
     "headers": Object {
       "Accept": "application/json",
+      "Authorization": null,
       "Content-Type": "application/json",
     },
     "method": "POST",

--- a/packages/cozy-stack-client/src/logDeprecate.js
+++ b/packages/cozy-stack-client/src/logDeprecate.js
@@ -1,0 +1,8 @@
+const logDeprecate = (...args) => {
+  if (process.env.NODE_ENV === 'test') {
+    throw new Error('Deprecation error: ' + args[0])
+  }
+  console.warn(...args)
+}
+
+export default logDeprecate


### PR DESCRIPTION
Fix #368

- Deprecate CozyStackClient::setCredentials in favor of setToken
- Deprecate CozyStackClient::getCredentials in favor of getToken
- Put credentials='include' as `fetch` option even if the Authorization header
is not set.
- Override the default Authorization header via headers.Authorization