### PR TITLE
feat: Use a lighter mime library

### DIFF
--- a/packages/cozy-stack-client/package.json
+++ b/packages/cozy-stack-client/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "detect-node": "2.0.4",
-    "mime-types": "2.1.24",
+    "mime": "2.4.0",
     "qs": "6.7.0"
   },
   "scripts": {

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -1,4 +1,4 @@
-import mime from 'mime-types'
+import mime from 'mime/lite'
 import has from 'lodash/has'
 import DocumentCollection, { normalizeDoc } from './DocumentCollection'
 import { uri, slugify, forceFileDownload } from './utils'
@@ -14,7 +14,7 @@ const normalizeFile = file => ({
 const sanitizeFileName = name => name && name.trim()
 
 const getFileTypeFromName = name =>
-  mime.lookup(name) || CONTENT_TYPE_OCTET_STREAM
+  mime.getType(name) || CONTENT_TYPE_OCTET_STREAM
 
 export const isFile = ({ _type, type }) =>
   _type === 'io.cozy.files' || type === 'directory' || type === 'file'

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -302,18 +302,18 @@ describe('FileCollection', () => {
     })
 
     it('should update a file without metadata', async () => {
-      const data = new File([''], 'mydoc.odt')
+      const data = new File([''], 'mydoc.epub')
       const params = {
         fileId: '59140416-b95f',
         checksum: 'a6dabd99832b270468e254814df2ed20'
       }
       const result = await collection.updateFile(data, params)
       const expectedPath =
-        '/files/59140416-b95f?Name=mydoc.odt&Type=file&Executable=false'
+        '/files/59140416-b95f?Name=mydoc.epub&Type=file&Executable=false'
       const expectedOptions = {
         headers: {
           'Content-MD5': 'a6dabd99832b270468e254814df2ed20',
-          'Content-Type': 'application/vnd.oasis.opendocument.text'
+          'Content-Type': 'application/epub+zip'
         }
       }
       expect(client.fetchJSON).toHaveBeenCalledWith(
@@ -339,18 +339,18 @@ describe('FileCollection', () => {
           id: metadataId
         }
       })
-      const data = new File([''], 'mydoc.odt')
+      const data = new File([''], 'mydoc.epub')
       const params = {
         fileId: '59140416-b95f',
         checksum: 'a6dabd99832b270468e254814df2ed20',
         metadata: { type: 'bill' }
       }
       const result = await collection.updateFile(data, params)
-      const expectedPath = `/files/59140416-b95f?Name=mydoc.odt&Type=file&Executable=false&MetadataID=${metadataId}`
+      const expectedPath = `/files/59140416-b95f?Name=mydoc.epub&Type=file&Executable=false&MetadataID=${metadataId}`
       const expectedOptions = {
         headers: {
           'Content-MD5': 'a6dabd99832b270468e254814df2ed20',
-          'Content-Type': 'application/vnd.oasis.opendocument.text'
+          'Content-Type': 'application/epub+zip'
         }
       }
       expect(client.fetchJSON).toHaveBeenCalledWith(
@@ -426,7 +426,7 @@ describe('FileCollection', () => {
   })
 
   describe('createFile', () => {
-    const data = new File([''], 'mydoc.odt')
+    const data = new File([''], 'mydoc.epub')
     const id = '59140416-b95f'
     const dirId = '41686c35-9d8e'
 
@@ -449,10 +449,10 @@ describe('FileCollection', () => {
         dirId: '41686c35-9d8e'
       }
       const result = await collection.createFile(data, params)
-      const expectedPath = `/files/${dirId}?Name=mydoc.odt&Type=file&Executable=false&MetadataID=`
+      const expectedPath = `/files/${dirId}?Name=mydoc.epub&Type=file&Executable=false&MetadataID=`
       const expectedOptions = {
         headers: {
-          'Content-Type': 'application/vnd.oasis.opendocument.text'
+          'Content-Type': 'application/epub+zip'
         }
       }
       expect(client.fetchJSON).toHaveBeenCalledWith(
@@ -483,10 +483,10 @@ describe('FileCollection', () => {
         metadata: { type: 'bill' }
       }
       const result = await collection.createFile(data, params)
-      const expectedPath = `/files/${dirId}?Name=mydoc.odt&Type=file&Executable=false&MetadataID=${metadataId}`
+      const expectedPath = `/files/${dirId}?Name=mydoc.epub&Type=file&Executable=false&MetadataID=${metadataId}`
       const expectedOptions = {
         headers: {
-          'Content-Type': 'application/vnd.oasis.opendocument.text'
+          'Content-Type': 'application/epub+zip'
         }
       }
       expect(client.fetchJSON).toHaveBeenCalledWith(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8606,22 +8606,10 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@1.40.0:
-  version "1.40.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
-  integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
-
 mime-db@~1.35.0:
   version "1.35.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
   integrity sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==
-
-mime-types@2.1.24:
-  version "2.1.24"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
-  integrity sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
-  dependencies:
-    mime-db "1.40.0"
 
 mime-types@^2.1.12, mime-types@~2.1.19:
   version "2.1.19"
@@ -8634,6 +8622,11 @@ mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
   integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
+
+mime@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.0.tgz#e051fd881358585f3279df333fe694da0bcffdd6"
+  integrity sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==
 
 mimic-fn@^1.0.0:
   version "1.2.0"


### PR DESCRIPTION
Mime-types depends of mime-db, which is mostly a 160kb JSON file. It is heavy, as it is embedded in most of our webapps. Mime is a lighter alternative: https://www.npmjs.com/package/mime.

Please note that I have made this change without testing anything! Be careful before merging it.