### PR TITLE
Remove importedAt and importedFrom from fixture/tests

### DIFF
--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -384,8 +384,6 @@ describe('CozyClient', () => {
             createdByApp: APP_NAME,
             createdByAppVersion: APP_VERSION,
             doctypeVersion: DOCTYPE_VERSION,
-            importedAt: MOCKED_DATE,
-            importedFrom: APP_NAME,
             updatedAt: MOCKED_DATE,
             updatedByApps: [APP_NAME],
             sourceAccount: SOURCE_ACCOUNT_ID
@@ -408,10 +406,8 @@ describe('CozyClient', () => {
         createdByApp: APP_NAME,
         sourceAccount: SOURCE_ACCOUNT_ID,
         createdByAppVersion: APP_VERSION,
-        importedFrom: APP_NAME,
         updatedByApps: [APP_NAME],
         createdAt: MOCKED_DATE,
-        importedAt: MOCKED_DATE,
         updatedAt: MOCKED_DATE
       })
     })

--- a/packages/cozy-client/src/__tests__/fixtures.js
+++ b/packages/cozy-client/src/__tests__/fixtures.js
@@ -95,19 +95,11 @@ export const SCHEMA = {
         trigger: 'creation',
         value: APP_VERSION
       },
-      importedFrom: {
-        trigger: 'creation',
-        value: APP_NAME
-      },
       updatedByApps: {
         trigger: 'update',
         value: [APP_NAME]
       },
       createdAt: {
-        trigger: 'creation',
-        useCurrentDate: true
-      },
-      importedAt: {
         trigger: 'creation',
         useCurrentDate: true
       },


### PR DESCRIPTION
Remove `importedAt` and `importedFrom` from test `SCHEMA` to match the "real" `cozyMetadata` structure : https://github.com/cozy/cozy-doctypes/commit/1e60c8558b24be3ed3218d20c4414c1db81bd8b4