### PR TITLE
feat(OAuthClient): Add resetClient

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -296,6 +296,7 @@ through OAuth.
     * [.refreshToken()](#OAuthClient+refreshToken) ⇒ <code>Promise</code>
     * [.setCredentials(token)](#OAuthClient+setCredentials)
     * [.setOAuthOptions(options)](#OAuthClient+setOAuthOptions)
+    * [.resetClient()](#OAuthClient+resetClient)
 
 <a name="OAuthClient+register"></a>
 
@@ -435,6 +436,12 @@ Updates the OAuth informations
 | --- | --- | --- |
 | options | <code>object</code> | Map of OAuth options |
 
+<a name="OAuthClient+resetClient"></a>
+
+### oAuthClient.resetClient()
+Reset the current OAuth client
+
+**Kind**: instance method of [<code>OAuthClient</code>](#OAuthClient)  
 <a name="PermissionCollection"></a>
 
 ## PermissionCollection

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -8,6 +8,7 @@ import TriggerCollection, { TRIGGERS_DOCTYPE } from './TriggerCollection'
 import getIconURL from './getIconURL'
 
 const normalizeUri = uri => {
+  if (uri === null) return null
   while (uri[uri.length - 1] === '/') {
     uri = uri.slice(0, -1)
   }

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -389,6 +389,15 @@ class OAuthClient extends CozyStackClient {
     this.oauthOptions.clientID = ''
   }
 
+  /**
+   * Reset the current OAuth client
+   */
+  resetClient() {
+    this.resetClientId()
+    this.setUri(null)
+    this.setCredentials(null)
+  }
+
   async fetchJSON(method, path, body, options) {
     try {
       return await super.fetchJSON(method, path, body, options)

--- a/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
@@ -185,5 +185,14 @@ describe('OAuthClient', () => {
       client.fetchJSON('GET', 'http://example.com')
       expect(spy).toHaveBeenCalled()
     })
+
+    it('should reset the client', () => {
+      client.setUri('test')
+      expect(client.uri).toEqual('test')
+      client.resetClient()
+      expect(client.uri).toBeNull()
+      expect(client.oauthOptions.clientID).toEqual('')
+      expect(client.token).toBeNull()
+    })
   })
 })


### PR DESCRIPTION
With the new onboarding process (with deeplink, access_code and state), we're not using "standard OAuth" since the client (aka our app) is not registering the OAuth Client anymore. This work is done by the stack. 

In order to manage the logout process correctly with this new onboarding, we have to reset manually the OAuth Client. 

We can do that manually in each app, or we can provide a small method in CozyClient. 
