### PR TITLE
feat: Don't use client.schema to add/update cozyMetadata, 

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -439,6 +439,7 @@ Responsible for
 | options.link | <code>Link</code> | Backward compatibility |
 | options.links | <code>Array.Link</code> | List of links |
 | options.schema | <code>Object</code> | Schema description for each doctypes |
+| options.appMetadata | <code>Object</code> | Metadata about the application that will be used in ensureCozyMetadata |
 
 <a name="CozyClient+collection"></a>
 

--- a/docs/how-tos.md
+++ b/docs/how-tos.md
@@ -210,13 +210,36 @@ Custom relationships are useful if the relationship data is not stored in a buil
 
 ### Metadata
 
-cozy-client will also automatically insert and update the standard document metadata if you provide a `cozyMetadata` object to the schema.
+cozy-client will also automatically insert and update the standard document metadata. You may provide some info when you initialize the client:
 
-Each metadata field can be configured with the following options:
+- in the `appMetadata` parameter:
+  - `slug`: the app's slug
+  - `sourceAccount`: in case of the app is a connector, the `io.cozy.accounts` (defaults to `null`)
+  - `version`: the app's version
+- in the `schema`, for each doctype:
+  - `doctypeVersion`: the version of the doctype
 
-- `trigger`: Can be `creation` or `update`, and determines whether to update this value every time the document changes, or only on creation.
-- `value`: The value to use when setting the metadata field. If `value` is an array, the values will be appended to the array on each update.
-- `useCurrentDate`: Instead of a fixed value, use the current execution date for this field.
+For example, to initialize the client for google connector that deals with `io.cozy.contacts` and `io.cozy.contacts.accounts`:
+
+```javascript
+const client = new CozyClient({
+  schema: {
+    contacts: {
+      doctype: 'io.cozy.contacts',
+      doctypeVersion: 2
+    },
+    contactsAccounts: {
+      doctype: 'io.cozy.contacts.accounts',
+      doctypeVersion: 1
+    }
+  },
+  appMetadata: {
+    slug: 'konnector-google',
+    sourceAccount: 'xxx', // id of the io.cozy.accounts object
+    version: 3
+  }
+})
+```
 
 ### Validation
 

--- a/packages/cozy-client/src/__tests__/fixtures.js
+++ b/packages/cozy-client/src/__tests__/fixtures.js
@@ -69,9 +69,11 @@ export const APP_NAME = 'cozy-client-test'
 export const APP_VERSION = 2
 export const DOCTYPE_VERSION = 1
 export const SOURCE_ACCOUNT_ID = '123-456-abc'
+
 export const SCHEMA = {
   todos: {
     doctype: 'io.cozy.todos',
+    doctypeVersion: DOCTYPE_VERSION,
     relationships: {
       attachments: {
         type: 'has-many',
@@ -80,36 +82,6 @@ export const SCHEMA = {
       authors: {
         type: 'has-many',
         doctype: 'io.cozy.persons'
-      }
-    },
-    cozyMetadata: {
-      doctypeVersion: {
-        trigger: 'creation',
-        value: DOCTYPE_VERSION
-      },
-      createdByApp: {
-        trigger: 'creation',
-        value: APP_NAME
-      },
-      createdByAppVersion: {
-        trigger: 'creation',
-        value: APP_VERSION
-      },
-      updatedByApps: {
-        trigger: 'update',
-        value: [APP_NAME]
-      },
-      createdAt: {
-        trigger: 'creation',
-        useCurrentDate: true
-      },
-      updatedAt: {
-        trigger: 'update',
-        useCurrentDate: true
-      },
-      sourceAccount: {
-        trigger: 'creation',
-        value: SOURCE_ACCOUNT_ID
       }
     }
   }


### PR DESCRIPTION
- don't use client.schema to add/update cozyMetadata. Metadata are updated directly in `ensureCozyMetadata` using `client.metadata` for data that have to be passed by the app
- new format for updatedByApps (see https://github.com/cozy/cozy-libs/pull/302 )

I still need to update the docs.