### PR TITLE
chore: Remove log when query re-renders

### DIFF
--- a/packages/cozy-client/src/Query.jsx
+++ b/packages/cozy-client/src/Query.jsx
@@ -52,9 +52,6 @@ export default class Query extends Component {
   }
 
   onQueryChange = () => {
-    console.log(
-      `query ${this.observableQuery.queryId} changed, forcing rerender`
-    )
     this.setState(dummyState)
   }
 


### PR DESCRIPTION
Remove logs since too much logs distracts and hides important logs

In my mind, we should be able to selectively view logs from a
part of the app. Every library should namespace its logs and we
should be able to say "I want to see logs from cozy-client".