### PR TITLE
feat: Make mime-types package optional

### DIFF
--- a/packages/cozy-stack-client/package.json
+++ b/packages/cozy-stack-client/package.json
@@ -12,8 +12,10 @@
   },
   "dependencies": {
     "detect-node": "2.0.4",
-    "mime-types": "2.1.20",
     "qs": "6.6.0"
+  },
+  "optionalDependencies": {
+    "mime-types": "2.1.20"
   },
   "scripts": {
     "build": "../../bin/build",

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -1,8 +1,9 @@
-import mime from 'mime-types'
 import has from 'lodash/has'
 import DocumentCollection, { normalizeDoc } from './DocumentCollection'
 import { uri, slugify, forceFileDownload } from './utils'
 import * as querystring from './querystring'
+import mime from './mime-types'
+
 const ROOT_DIR_ID = 'io.cozy.files.root-dir'
 const CONTENT_TYPE_OCTET_STREAM = 'application/octet-stream'
 

--- a/packages/cozy-stack-client/src/mime-types.js
+++ b/packages/cozy-stack-client/src/mime-types.js
@@ -1,0 +1,14 @@
+let mimeTypes
+try {
+  mimeTypes = require('mime-types')
+} catch (e) {
+  mimeTypes = {
+    lookup: () => {
+      console.warn(
+        'Package mime-types is not installed, cannot guess file type. Please add mime-types to your project via npm/yarn if you want this functionality'
+      )
+    }
+  }
+}
+
+module.exports = mimeTypes


### PR DESCRIPTION
mime-db (on which mime-types rely) is very big (see https://github.com/cozy/cozy-banks/issues/926) and not all apps rely on automatic
file type from extension.

Related : https://github.com/cozy/cozy-client/pull/373



In this PR, mime-types is made optional, if an app wants to
use automatic file type detection from extension, it can
add manually the mime-types package (Drive :) ).