### PR TITLE
StackClient: Add Konnector Collection basis

### DIFF
--- a/packages/cozy-stack-client/src/AppCollection.js
+++ b/packages/cozy-stack-client/src/AppCollection.js
@@ -11,6 +11,8 @@ export const normalizeApp = app => {
  * Implements `DocumentCollection` API along with specific methods for `io.cozy.apps`.
  */
 class AppCollection {
+  endpoint = '/apps/'
+
   constructor(stackClient) {
     this.stackClient = stackClient
   }
@@ -24,8 +26,7 @@ class AppCollection {
    * @throws {FetchError}
    */
   async all() {
-    const path = uri`/apps/`
-    const resp = await this.stackClient.fetchJSON('GET', path)
+    const resp = await this.stackClient.fetchJSON('GET', this.endpoint)
     return {
       data: resp.data.map(app => normalizeApp(app)),
       meta: {

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -2,7 +2,7 @@ import AppCollection, { APPS_DOCTYPE } from './AppCollection'
 import AppToken from './AppToken'
 import DocumentCollection from './DocumentCollection'
 import FileCollection from './FileCollection'
-import KonnectorCollection from './KonnectorCollection'
+import KonnectorCollection, { KONNECTORS_DOCTYPE } from './KonnectorCollection'
 import SharingCollection from './SharingCollection'
 import PermissionCollection from './PermissionCollection'
 import TriggerCollection, { TRIGGERS_DOCTYPE } from './TriggerCollection'
@@ -41,6 +41,19 @@ class CozyStackClient {
     switch (doctype) {
       case APPS_DOCTYPE:
         return new AppCollection(this)
+      case KONNECTORS_DOCTYPE:
+        // For now we are still returning a DocumentCollection because
+        // Cozy-Banks is the only app which access konnectors with
+        // CozyStackClient, and it's using a `where()` query which is not yet
+        // implemented in KonnectorCollection.
+        //
+        // So we do not want to introduce a BREAKING CHANGE here by returning
+        // new KonnectorCollection(this).
+        // Next step to get rid of this : implement the `where()` query for
+        // KonnectorCollection.
+        //
+        // Until then, stackClient.konnectors can be used instead.
+        return new DocumentCollection(doctype, this)
       case 'io.cozy.files':
         return new FileCollection(doctype, this)
       case 'io.cozy.sharings':

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -2,6 +2,7 @@ import AppCollection, { APPS_DOCTYPE } from './AppCollection'
 import AppToken from './AppToken'
 import DocumentCollection from './DocumentCollection'
 import FileCollection from './FileCollection'
+import KonnectorCollection from './KonnectorCollection'
 import SharingCollection from './SharingCollection'
 import PermissionCollection from './PermissionCollection'
 import TriggerCollection, { TRIGGERS_DOCTYPE } from './TriggerCollection'
@@ -23,6 +24,8 @@ class CozyStackClient {
   constructor({ token, uri = '' }) {
     this.setUri(uri)
     this.setToken(token)
+
+    this.konnectors = new KonnectorCollection(this)
   }
 
   /**

--- a/packages/cozy-stack-client/src/KonnectorCollection.js
+++ b/packages/cozy-stack-client/src/KonnectorCollection.js
@@ -1,0 +1,7 @@
+import AppCollection from './AppCollection'
+
+class KonnectorCollection extends AppCollection {
+  endpoint = '/konnectors/'
+}
+
+export default KonnectorCollection

--- a/packages/cozy-stack-client/src/__tests__/AppCollection.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/AppCollection.spec.js
@@ -2,191 +2,21 @@ jest.mock('../CozyStackClient')
 
 import CozyStackClient from '../CozyStackClient'
 import AppCollection from '../AppCollection'
+import ALL_APPS_RESPONSE from './fixtures/apps.json'
 
-const ALL_RESPONSE_FIXTURE = {
-  data: [
-    {
-      type: 'io.cozy.apps',
-      id: 'io.cozy.apps/drive',
-      attributes: {
-        name: 'Drive',
-        editor: 'Cozy',
-        icon: 'public/app-icon.svg',
-        category: 'cozy',
-        vendor_link: '',
-        locales: {
-          fr: {
-            description: 'Gestionnaire de fichiers pour Cozy v3'
-          }
-        },
-        developer: {
-          name: 'Cozy',
-          url: 'https://cozy.io'
-        },
-        slug: 'drive',
-        state: 'ready',
-        source: 'git://github.com/cozy/cozy-drive.git#build',
-        version: '3.0.0-aa7af90c25ce4782b889c6e2845a62ba585ae633',
-        permissions: {
-          albums: {
-            type: 'io.cozy.photos.albums',
-            description: 'Required to manage photos albums'
-          },
-          apps: {
-            type: 'io.cozy.apps',
-            description:
-              'Required by the cozy-bar to display the icons of the apps',
-            verbs: ['GET']
-          },
-          files: {
-            type: 'io.cozy.files',
-            description: 'Required to access the files'
-          },
-          settings: {
-            type: 'io.cozy.settings',
-            description:
-              'Required by the cozy-bar to display Claudy and know which applications are coming soon',
-            verbs: ['GET']
-          }
-        },
-        intents: [
-          {
-            action: 'OPEN',
-            type: ['io.cozy.files'],
-            href: '/services'
-          },
-          {
-            action: 'GET_URL',
-            type: ['io.cozy.files'],
-            href: '/services'
-          }
-        ],
-        routes: {
-          '/': {
-            folder: '/',
-            index: 'index.html',
-            public: false
-          },
-          '/public': {
-            folder: '/public',
-            index: 'index.html',
-            public: true
-          },
-          '/services': {
-            folder: '/',
-            index: 'services.html',
-            public: false
-          }
-        },
-        services: null,
-        notifications: null,
-        created_at: '2018-07-06T00:59:36.319130083+02:00',
-        updated_at: '2018-08-06T15:35:01.62521429+02:00'
-      },
-      meta: {
-        rev: '2-b3f01490f0b443ad0cf642063b540921'
-      },
-      links: {
-        self: '/apps/drive',
-        related: 'http://drive.cozy.tools:8080/',
-        icon: '/apps/drive/icon'
-      }
-    },
-    {
-      type: 'io.cozy.apps',
-      id: 'io.cozy.apps/store',
-      attributes: {
-        name: 'Store',
-        name_prefix: 'Cozy',
-        editor: 'Cozy',
-        icon: 'icon-store.svg',
-        type: 'webapp',
-        vendor_link: '',
-        locales: {
-          de: {},
-          en: {},
-          fr: {},
-          nl_NL: {},
-          pl: {}
-        },
-        langs: ['de', 'en', 'fr', 'nl_NL', 'pl'],
-        categories: ['cozy'],
-        developer: {
-          name: 'Cozy Cloud',
-          url: 'https://cozy.io'
-        },
-        slug: 'store',
-        state: 'ready',
-        source: 'registry://store/dev',
-        version: '1.0.8-dev.cb61910db26290bf5be2c504e116b864587b8b42',
-        permissions: {
-          apps: {
-            type: 'io.cozy.apps',
-            description: 'Required to manage applications'
-          },
-          konnectors: {
-            type: 'io.cozy.konnectors',
-            description: 'Required to manage konnectors'
-          },
-          settings: {
-            type: 'io.cozy.settings',
-            description:
-              'Required by the cozy-bar to display Claudy and know which applications are coming soon',
-            verbs: ['GET']
-          }
-        },
-        intents: [
-          {
-            action: 'REDIRECT',
-            type: ['io.cozy.apps'],
-            href: '/#/redirect'
-          },
-          {
-            action: 'INSTALL',
-            type: ['io.cozy.apps'],
-            href: '/intents'
-          }
-        ],
-        routes: {
-          '/': {
-            folder: '/',
-            index: 'index.html',
-            public: false
-          },
-          '/intents': {
-            folder: '/intents',
-            index: 'index.html',
-            public: false
-          }
-        },
-        services: null,
-        notifications: null,
-        created_at: '2018-08-06T15:36:35.524158386+02:00',
-        updated_at: '2018-08-06T15:36:35.524158888+02:00'
-      },
-      meta: {
-        rev: '1-c83797d71661b24c262d1a5a223fc12c'
-      },
-      links: {
-        self: '/apps/store',
-        related: 'http://store.cozy.tools:8080/',
-        icon: '/apps/store/icon'
-      }
-    }
-  ],
-  meta: {
-    count: 2
-  }
+const FIXTURES = {
+  ALL_APPS_RESPONSE
 }
-
-describe('AppCollection', () => {
+describe(`AppCollection`, () => {
   const client = new CozyStackClient()
 
   describe('all', () => {
     const collection = new AppCollection(client)
 
     beforeAll(() => {
-      client.fetchJSON.mockReturnValue(Promise.resolve(ALL_RESPONSE_FIXTURE))
+      client.fetchJSON.mockReturnValue(
+        Promise.resolve(FIXTURES.ALL_APPS_RESPONSE)
+      )
     })
 
     it('should call the right route', async () => {

--- a/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
@@ -3,6 +3,7 @@
 
 import CozyStackClient, { FetchError } from '../CozyStackClient'
 import DocumentCollection from '../DocumentCollection'
+import KonnectorCollection from '../KonnectorCollection'
 
 const FAKE_RESPONSE = {
   offset: 0,
@@ -22,6 +23,14 @@ describe('CozyStackClient', () => {
       token: ''
     })
     expect(client.fullpath('/foo')).toBe('http://cozy.tools:8080/foo')
+  })
+
+  it('should instanciate konnectors property', () => {
+    const stackClient = new CozyStackClient({
+      FAKE_INIT_OPTIONS
+    })
+
+    expect(stackClient.konnectors instanceof KonnectorCollection).toBe(true)
   })
 
   describe('collection', () => {

--- a/packages/cozy-stack-client/src/__tests__/KonnectorCollection.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/KonnectorCollection.spec.js
@@ -1,0 +1,85 @@
+jest.mock('../CozyStackClient')
+
+import CozyStackClient from '../CozyStackClient'
+import KonnectorCollection from '../KonnectorCollection'
+import ALL_KONNECTORS_RESPONSE from './fixtures/konnectors.json'
+
+const FIXTURES = {
+  ALL_KONNECTORS_RESPONSE
+}
+describe(`KonnectorCollection`, () => {
+  const client = new CozyStackClient()
+
+  describe('all', () => {
+    const collection = new KonnectorCollection(client)
+
+    beforeAll(() => {
+      client.fetchJSON.mockReturnValue(
+        Promise.resolve(FIXTURES.ALL_KONNECTORS_RESPONSE)
+      )
+    })
+
+    it('should call the right route', async () => {
+      await collection.all()
+      expect(client.fetchJSON).toHaveBeenCalledWith('GET', '/konnectors/')
+    })
+
+    it('should return a correct JSON API response', async () => {
+      const resp = await collection.all()
+      expect(resp).toConformToJSONAPI()
+    })
+
+    it('should return normalized documents', async () => {
+      const resp = await collection.all()
+      expect(resp.data[0]).toHaveDocumentIdentity()
+    })
+  })
+
+  describe('find', () => {
+    it('throw error', async () => {
+      const collection = new KonnectorCollection(client)
+      expect(collection.find()).rejects.toThrowError(
+        'find() method is not yet implemented'
+      )
+    })
+  })
+
+  describe('get', () => {
+    it('throw error', async () => {
+      const collection = new KonnectorCollection(client)
+      expect(collection.get()).rejects.toThrowError(
+        'get() method is not yet implemented'
+      )
+    })
+  })
+
+  describe('create', () => {
+    const collection = new KonnectorCollection(client)
+
+    it('should throw error', async () => {
+      expect(collection.create()).rejects.toThrowError(
+        'create() method is not available for applications'
+      )
+    })
+  })
+
+  describe('update', () => {
+    const collection = new KonnectorCollection(client)
+
+    it('should throw error', async () => {
+      expect(collection.update()).rejects.toThrowError(
+        'update() method is not available for applications'
+      )
+    })
+  })
+
+  describe('destroy', () => {
+    const collection = new KonnectorCollection(client)
+
+    it('should throw error', async () => {
+      expect(collection.destroy()).rejects.toThrowError(
+        'destroy() method is not available for applications'
+      )
+    })
+  })
+})

--- a/packages/cozy-stack-client/src/__tests__/KonnectorCollection.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/KonnectorCollection.spec.js
@@ -58,7 +58,7 @@ describe(`KonnectorCollection`, () => {
 
     it('should throw error', async () => {
       expect(collection.create()).rejects.toThrowError(
-        'create() method is not available for applications'
+        'create() method is not available for konnectors'
       )
     })
   })
@@ -68,7 +68,7 @@ describe(`KonnectorCollection`, () => {
 
     it('should throw error', async () => {
       expect(collection.update()).rejects.toThrowError(
-        'update() method is not available for applications'
+        'update() method is not available for konnectors'
       )
     })
   })
@@ -78,7 +78,7 @@ describe(`KonnectorCollection`, () => {
 
     it('should throw error', async () => {
       expect(collection.destroy()).rejects.toThrowError(
-        'destroy() method is not available for applications'
+        'destroy() method is not available for konnectors'
       )
     })
   })

--- a/packages/cozy-stack-client/src/__tests__/fixtures/apps.json
+++ b/packages/cozy-stack-client/src/__tests__/fixtures/apps.json
@@ -1,0 +1,172 @@
+{
+  "data": [
+    {
+      "type": "io.cozy.apps",
+      "id": "io.cozy.apps/drive",
+      "attributes": {
+        "name": "Drive",
+        "editor": "Cozy",
+        "icon": "public/app-icon.svg",
+        "category": "cozy",
+        "vendor_link": "",
+        "locales": {
+          "fr": {
+            "description": "Gestionnaire de fichiers pour Cozy v3"
+          }
+        },
+        "developer": {
+          "name": "Cozy",
+          "url": "https://cozy.io"
+        },
+        "slug": "drive",
+        "state": "ready",
+        "source": "git://github.com/cozy/cozy-drive.git#build",
+        "version": "3.0.0-aa7af90c25ce4782b889c6e2845a62ba585ae633",
+        "permissions": {
+          "albums": {
+            "type": "io.cozy.photos.albums",
+            "description": "Required to manage photos albums"
+          },
+          "apps": {
+            "type": "io.cozy.apps",
+            "description": "Required by the cozy-bar to display the icons of the apps",
+            "verbs": ["GET"]
+          },
+          "files": {
+            "type": "io.cozy.files",
+            "description": "Required to access the files"
+          },
+          "settings": {
+            "type": "io.cozy.settings",
+            "description": "Required by the cozy-bar to display Claudy and know which applications are coming soon",
+            "verbs": ["GET"]
+          }
+        },
+        "intents": [
+          {
+            "action": "OPEN",
+            "type": ["io.cozy.files"],
+            "href": "/services"
+          },
+          {
+            "action": "GET_URL",
+            "type": ["io.cozy.files"],
+            "href": "/services"
+          }
+        ],
+        "routes": {
+          "/": {
+            "folder": "/",
+            "index": "index.html",
+            "public": false
+          },
+          "/public": {
+            "folder": "/public",
+            "index": "index.html",
+            "public": true
+          },
+          "/services": {
+            "folder": "/",
+            "index": "services.html",
+            "public": false
+          }
+        },
+        "services": null,
+        "notifications": null,
+        "created_at": "2018-07-06T00:59:36.319130083+02:00",
+        "updated_at": "2018-08-06T15:35:01.62521429+02:00"
+      },
+      "meta": {
+        "rev": "2-b3f01490f0b443ad0cf642063b540921"
+      },
+      "links": {
+        "self": "/apps/drive",
+        "related": "http://drive.cozy.tools:8080/",
+        "icon": "/apps/drive/icon"
+      }
+    },
+    {
+      "type": "io.cozy.apps",
+      "id": "io.cozy.apps/store",
+      "attributes": {
+        "name": "Store",
+        "name_prefix": "Cozy",
+        "editor": "Cozy",
+        "icon": "icon-store.svg",
+        "type": "webapp",
+        "vendor_link": "",
+        "locales": {
+          "de": {},
+          "en": {},
+          "fr": {},
+          "nl_NL": {},
+          "pl": {}
+        },
+        "langs": ["de", "en", "fr", "nl_NL", "pl"],
+        "categories": ["cozy"],
+        "developer": {
+          "name": "Cozy Cloud",
+          "url": "https://cozy.io"
+        },
+        "slug": "store",
+        "state": "ready",
+        "source": "registry://store/dev",
+        "version": "1.0.8-dev.cb61910db26290bf5be2c504e116b864587b8b42",
+        "permissions": {
+          "apps": {
+            "type": "io.cozy.apps",
+            "description": "Required to manage applications"
+          },
+          "konnectors": {
+            "type": "io.cozy.konnectors",
+            "description": "Required to manage konnectors"
+          },
+          "settings": {
+            "type": "io.cozy.settings",
+            "description": "Required by the cozy-bar to display Claudy and know which applications are coming soon",
+            "verbs": ["GET"]
+          }
+        },
+        "intents": [
+          {
+            "action": "REDIRECT",
+            "type": ["io.cozy.apps"],
+            "href": "/#/redirect"
+          },
+          {
+            "action": "INSTALL",
+            "type": ["io.cozy.apps"],
+            "href": "/intents"
+          }
+        ],
+        "routes": {
+          "/": {
+            "folder": "/",
+            "index": "index.html",
+            "public": false
+          },
+          "/intents": {
+            "folder": "/intents",
+            "index": "index.html",
+            "public": false
+          }
+        },
+        "services": null,
+        "notifications": null,
+        "created_at": "2018-08-06T15:36:35.524158386+02:00",
+        "updated_at": "2018-08-06T15:36:35.524158888+02:00"
+      },
+      "meta": {
+        "rev": "1-c83797d71661b24c262d1a5a223fc12c"
+      },
+      "links": {
+        "self": "/apps/store",
+        "related": "http://store.cozy.tools:8080/",
+        "icon": "/apps/store/icon"
+      }
+    }
+  ],
+  "meta": {
+    "count": 2
+  }
+}

--- a/packages/cozy-stack-client/src/__tests__/fixtures/konnectors.json
+++ b/packages/cozy-stack-client/src/__tests__/fixtures/konnectors.json
@@ -1,0 +1,310 @@
+{
+  "data": [
+    {
+      "type": "io.cozy.konnectors",
+      "id": "io.cozy.konnectors/bouibox",
+      "attributes": {
+        "name": "Boui Box",
+        "editor": "Cozy",
+        "icon": "bouibox.svg",
+        "type": "konnector",
+        "language": "node",
+        "vendor_link": "https://www.boui.fr/",
+        "locales": {
+          "fr": {
+            "short_description": "Récupère toutes vos factures Boui Box",
+            "long_description": "Récupère toutes vos factures Boui Box",
+            "permissions": {
+              "bank operations": {
+                "description": "Utilisé pour relier les factures à des operations bancaires"
+              },
+              "bills": {
+                "description": "Utilisé pour sauver les données des factures"
+              },
+              "files": {
+                "description": "Utilisé pour sauvegarder les factures"
+              },
+              "accounts": {
+                "description": "Utilisé pour obtenir les données du compte"
+              }
+            }
+          },
+          "en": {
+            "short_description": "Retrieves all your Boui Box invoices",
+            "long_description": "Retrieves all your Boui Box invoices",
+            "permissions": {
+              "bank operations": {
+                "description": "Required to link bank operations to bills"
+              },
+              "bills": { "description": "Required to save the bills data" },
+              "files": { "description": "Required to save the bills" },
+              "accounts": {
+                "description": "Required to get the account's data"
+              }
+            }
+          }
+        },
+        "langs": ["fr"],
+        "categories": ["isp"],
+        "developer": { "name": "Cozy Cloud", "url": "https://cozy.io" },
+        "screenshots": [],
+        "data_types": ["bill"],
+        "fields": {
+          "login": { "type": "text" },
+          "password": { "type": "password" },
+          "lastname": { "type": "text" },
+          "advancedFields": {
+            "folderPath": { "advanced": true, "isRequired": false }
+          }
+        },
+        "notifications": null,
+        "slug": "bouibox",
+        "state": "ready",
+        "source": "registry://bouibox/stable",
+        "version": "1.9.1",
+        "checksum": "",
+        "permissions": {
+          "accounts": { "type": "io.cozy.accounts", "verbs": ["GET", "PUT"] },
+          "bank operations": { "type": "io.cozy.bank.operations" },
+          "bills": { "type": "io.cozy.bills" },
+          "files": { "type": "io.cozy.files" }
+        },
+        "terms": { "url": "", "version": "" },
+        "created_at": "2019-01-21T18:37:55.65454+01:00",
+        "updated_at": "2019-01-21T18:37:55.654541+01:00"
+      },
+      "meta": { "rev": "1-264f83b3c71a2ce4c6bca3d1c281ba03" },
+      "links": {
+        "self": "/konnectors/bouibox",
+        "icon": "/konnectors/bouibox/icon/1.9.1",
+        "permissions": "/permissions/konnectors/bouibox"
+      }
+    },
+    {
+      "type": "io.cozy.konnectors",
+      "id": "io.cozy.konnectors/delivreousa",
+      "attributes": {
+        "name": "Delivreousa",
+        "editor": "Cozy",
+        "icon": "icon.svg",
+        "type": "konnector",
+        "language": "node",
+        "vendor_link": "https://delivreousa.fr/fr/login",
+        "locales": {
+          "fr": {
+            "short_description": "Connecteur delivreousa",
+            "long_description": "Ce connecteur récupère une liste de factures sur le site https://delivreousa.fr",
+            "permissions": {
+              "bank operations": {
+                "description": "Utilisé pour relier les factures à des operations bancaires"
+              },
+              "bills": {
+                "description": "Utilisé pour sauver les données des factures"
+              },
+              "files": {
+                "description": "Utilisé pour sauvegarder les factures"
+              },
+              "accounts": {
+                "description": "Utilisé pour obtenir les données du compte"
+              }
+            }
+          },
+          "en": {
+            "short_description": "Connector delivreousa",
+            "long_description": "This connector fetches a list of invoices from https://delivreousa.fr",
+            "permissions": {
+              "bank operations": {
+                "description": "Required to link bank operations to bills"
+              },
+              "bills": { "description": "Required to save the bills data" },
+              "files": { "description": "Required to save the bills" },
+              "accounts": {
+                "description": "Required to get the account's data"
+              }
+            }
+          }
+        },
+        "langs": ["fr", "en"],
+        "categories": ["online_services"],
+        "developer": { "name": "Cozy Cloud", "url": "https://cozy.io" },
+        "screenshots": [],
+        "data_types": ["bill"],
+        "fields": {
+          "login": { "type": "text" },
+          "password": { "type": "password" },
+          "advancedFields": {
+            "folderPath": { "advanced": true, "isRequired": false }
+          }
+        },
+        "notifications": null,
+        "slug": "delivreousa",
+        "state": "ready",
+        "source": "registry://delivreousa/stable",
+        "version": "1.1.1",
+        "checksum": "",
+        "permissions": {
+          "accounts": { "type": "io.cozy.accounts", "verbs": ["GET"] },
+          "bank operations": { "type": "io.cozy.bank.operations" },
+          "bills": { "type": "io.cozy.bills" },
+          "files": { "type": "io.cozy.files" }
+        },
+        "terms": { "url": "", "version": "" },
+        "created_at": "2019-01-21T18:28:18.009116+01:00",
+        "updated_at": "2019-01-21T18:28:18.009116+01:00"
+      },
+      "meta": { "rev": "1-0ad37818d94971da986d18f172fc5c87" },
+      "links": {
+        "self": "/konnectors/delivreousa",
+        "icon": "/konnectors/delivreousa/icon/1.1.1",
+        "permissions": "/permissions/konnectors/delivreousa"
+      }
+    },
+    {
+      "type": "io.cozy.konnectors",
+      "id": "io.cozy.konnectors/frit",
+      "attributes": {
+        "name": "Frit",
+        "editor": "Cozy",
+        "icon": "frit.svg",
+        "type": "konnector",
+        "language": "node",
+        "vendor_link": "https://www.frit.fr/",
+        "locales": {
+          "fr": {
+            "short_description": "Récupérer vos données Frit dans votre Cozy",
+            "long_description": "Ce fournisseur vous permettra de récupérer l'ensemble de vos facture Frit dans votre Cozy.",
+            "permissions": {
+              "bank operations": {
+                "description": "Utilisé pour relier les factures à des operations bancaires"
+              },
+              "bills": {
+                "description": "Utilisé pour sauver les données des factures"
+              },
+              "files": {
+                "description": "Utilisé pour sauvegarder les factures"
+              },
+              "accounts": {
+                "description": "Utilisé pour obtenir les données du compte"
+              }
+            }
+          },
+          "en": {
+            "short_description": "Fetch your Frit data in your Cozy",
+            "long_description": "This provider will allow you to fetch all your Frit bills in your Cozy.",
+            "permissions": {
+              "bank operations": {
+                "description": "Required to link bank operations to bills"
+              },
+              "bills": { "description": "Required to save the bills data" },
+              "files": { "description": "Required to save the bills" },
+              "accounts": {
+                "description": "Required to get the account's data"
+              }
+            }
+          }
+        },
+        "langs": ["fr", "en"],
+        "categories": ["isp"],
+        "developer": { "name": "Cozy Cloud", "url": "https://cozy.io" },
+        "screenshots": [],
+        "data_types": ["bill"],
+        "fields": {
+          "login": { "type": "text" },
+          "password": { "type": "password" },
+          "advancedFields": {
+            "folderPath": { "advanced": true, "isRequired": false }
+          }
+        },
+        "notifications": null,
+        "slug": "frit",
+        "state": "ready",
+        "source": "registry://frit/stable",
+        "version": "1.2.1",
+        "checksum": "",
+        "permissions": {
+          "accounts": { "type": "io.cozy.accounts", "verbs": ["GET"] },
+          "bank operations": { "type": "io.cozy.bank.operations" },
+          "bills": { "type": "io.cozy.bills" },
+          "files": { "type": "io.cozy.files" }
+        },
+        "terms": { "url": "", "version": "" },
+        "created_at": "2019-01-21T18:54:11.145111+01:00",
+        "updated_at": "2019-01-21T18:54:11.145111+01:00"
+      },
+      "meta": { "rev": "1-9b30fc9c3143a11c1df28ca09b1141cc" },
+      "links": {
+        "self": "/konnectors/frit",
+        "icon": "/konnectors/frit/icon/1.2.1",
+        "permissions": "/permissions/konnectors/frit"
+      }
+    },
+    {
+      "type": "io.cozy.konnectors",
+      "id": "io.cozy.konnectors/unpot",
+      "attributes": {
+        "name": "Unpot",
+        "editor": "Cozy",
+        "icon": "icon.svg",
+        "type": "konnector",
+        "language": "node",
+        "vendor_link": "https://unpot/LoginMDP",
+        "locales": {
+          "fr": {
+            "short_description": "Récupère vos déclarations de revenu et autres taxes",
+            "long_description": "Récupère vos déclarations de revenu et autres taxes",
+            "permissions": {
+              "files": {
+                "description": "Utilisé pour sauvegarder les documents fichiers"
+              },
+              "accounts": {
+                "description": "Utilisé pour obtenir les données du compte"
+              }
+            }
+          },
+          "en": {
+            "short_description": "Fetch your taxes declarations",
+            "long_description": "This connector fetches your taxes declarations",
+            "permissions": {
+              "files": { "description": "Required to save the file documents" },
+              "accounts": {
+                "description": "Required to get the account's data"
+              }
+            }
+          }
+        },
+        "langs": ["fr", "en"],
+        "categories": ["public_service"],
+        "developer": { "name": "Cozy", "url": "https://cozy.io" },
+        "data_types": ["documents"],
+        "fields": {
+          "login": { "type": "text", "min": 13, "max": 13 },
+          "password": { "type": "password" },
+          "advancedFields": {
+            "folderPath": { "advanced": true, "isRequired": false }
+          }
+        },
+        "notifications": null,
+        "slug": "unpot",
+        "state": "ready",
+        "source": "registry://unpot/stable",
+        "version": "1.0.0",
+        "checksum": "beb4523d1af9afb5cccac16670a53616cdb77f6fd2e66dbf1166541be3d6df3f",
+        "permissions": {
+          "accounts": { "type": "io.cozy.accounts", "verbs": ["GET"] },
+          "files": { "type": "io.cozy.files" }
+        },
+        "available_version": "1.3.0",
+        "terms": { "url": "", "version": "" },
+        "created_at": "2019-02-07T14:18:19.350339+01:00",
+        "updated_at": "2019-02-07T14:18:29.167049+01:00"
+      },
+      "meta": { "rev": "15-28e73174c7ef2703318c2489e7e4ec27" },
+      "links": {
+        "self": "/konnectors/unpot",
+        "icon": "/konnectors/unpot/icon/1.0.0",
+        "permissions": "/permissions/konnectors/unpot"
+      }
+    }
+  ],
+  "meta": { "count": 4 }
+}


### PR DESCRIPTION
Prepare the future implementation for konnector endpoints.

For now it allow developers to user `stackClient.konnectors.all()` to fetch all konnectors.

It keeps `stackClient.collection('io.cozy.konnetors').all()` plugged to regular `DocumentCollection` to not introduce regression in Cozy-Banks. See https://github.com/cozy/cozy-banks/commit/a7c8ac3823d18300bd3d2ef09c57795fc48d47f3#diff-872b51c7bdb364ada730166a867a9d38R90

Related to https://github.com/cozy/cozy-client/issues/374