### PR TITLE
[pouch-link] feat: Log via minilog

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - [How-to integrate with an existing store ?](docs/how-tos.md#how-to-integrate-with-an-existing-store-)
 - [How to connect to the documents store declaratively ?](docs/how-tos.md#how-to-connect-to-the-documents-store-declaratively-)
 - [How to provide a mutation to a component ?](docs/how-tos.md#how-to-provide-a-mutation-to-a-component-)
+- [How to activate logging ?](docs/how-tos.md#how-to-activate-logging-)
 
 ### Advanced
 

--- a/docs/how-tos.md
+++ b/docs/how-tos.md
@@ -4,6 +4,7 @@
 - [How to connect to the documents store declaratively ?](#how-to-connect-to-the-documents-store-declaratively-)
 - [How to provide a mutation to a component ?](#how-to-provide-a-mutation-to-a-component-)
 - [How to specify a schema ?](#how-to-specify-a-schema-)
+- [How to activate logging ?](#how-to-activate-logging-)
 
 <!-- /MarkdownTOC -->
 
@@ -244,3 +245,23 @@ const client = new CozyClient({
 ### Validation
 
 Validation is not yet implemented in cozy-client.
+
+## How to activate logging ?
+
+Cozy-client libs use [`minilog`](https://www.npmjs.com/package/minilog) for internal logging.
+If you need to see those logs, you need to tell minilog to show them, they are filtered by
+default. Each lib has a different namespace that can be enabled/disabled.
+
+For example if you want to allow `cozy-pouch-link` logs at `debug` level, you can do:
+
+```
+require('minilog').suggest.allow('cozy-pouch-link', 'debug')
+```
+
+If you want to see everything :
+
+```
+require('minilog').suggest.clear()
+```
+
+More info on [minilog docs](http://mixu.net/minilog/filter.html#filters).

--- a/packages/cozy-pouch-link/package.json
+++ b/packages/cozy-pouch-link/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "cozy-client": "^6.9.0",
     "cozy-device-helper": "1.4.8",
+    "minilog": "3.1.0",
     "pouchdb": "7.0.0",
     "pouchdb-find": "7.0.0"
   },

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -9,6 +9,8 @@ import { default as helpers } from './helpers'
 import { getIndexNameFromFields, getIndexFields } from './mango'
 import * as jsonapi from './jsonapi'
 import PouchManager from './PouchManager'
+import logger from './logger'
+
 PouchDB.plugin(PouchDBFind)
 
 const { find, allDocs, withoutDesignDocuments } = helpers
@@ -86,7 +88,7 @@ class PouchLink extends CozyLink {
 
   async onLogin() {
     if (!this.client) {
-      console.warn("PouchLink: no client registered, can't login")
+      logger.warn("PouchLink: no client registered, can't login")
       return
     }
 
@@ -99,17 +101,17 @@ class PouchLink extends CozyLink {
 
     if (shouldDestroyDatabases) {
       if (process.env.NODE_ENV !== 'production') {
-        console.info('PouchLink: URI changed, destroy pouches')
+        logger.info('PouchLink: URI changed, destroy pouches')
       }
       try {
         await this.pouches.destroy()
       } catch (e) {
-        console.warn('Error while destroying pouch DBs', e)
+        logger.warn('Error while destroying pouch DBs', e)
       }
     }
 
     if (process.env.NODE_ENV !== 'production') {
-      console.log('Create pouches with ' + prefix + ' prefix')
+      logger.log('Create pouches with ' + prefix + ' prefix')
     }
     this.pouches = new PouchManager(this.doctypes, {
       pouch: this.options.pouch,
@@ -147,7 +149,7 @@ class PouchLink extends CozyLink {
       this.options.onSync.call(this, normalizedData)
     }
     if (process.env.NODE_ENV !== 'production') {
-      console.info('Pouch synced')
+      logger.info('Pouch synced')
     }
   }
 
@@ -186,13 +188,13 @@ class PouchLink extends CozyLink {
         this.startReplication()
         return
       } catch (err) {
-        console.warn('Could not refresh token, replication has stopped', err)
+        logger.warn('Could not refresh token, replication has stopped', err)
         if (this.options.onSyncError) {
           this.options.onSyncError.call(this, err)
         }
       }
     } else {
-      console.warn('CozyPouchLink: Synchronization error', error)
+      logger.warn('CozyPouchLink: Synchronization error', error)
       if (this.options.onSyncError) {
         this.options.onSyncError.call(this, error)
       }
@@ -213,7 +215,7 @@ class PouchLink extends CozyLink {
 
     if (!this.pouches) {
       if (process.env.NODE_ENV !== 'production') {
-        console.info(
+        logger.info(
           `Tried to access local ${doctype} but Cozy Pouch is not initialized yet. Forwarding the operation to next link`
         )
       }
@@ -223,7 +225,7 @@ class PouchLink extends CozyLink {
 
     if (!this.pouches.isSynced(doctype)) {
       if (process.env.NODE_ENV !== 'production') {
-        console.info(
+        logger.info(
           `Tried to access local ${doctype} but Cozy Pouch is not synced yet. Forwarding the operation to next link`
         )
       }
@@ -233,7 +235,7 @@ class PouchLink extends CozyLink {
     // Forwards if doctype not supported
     if (!this.supportsOperation(operation)) {
       if (process.env.NODE_ENV !== 'production') {
-        console.info(
+        logger.info(
           `The doctype '${doctype}' is not supported. Forwarding the operation to next link`
         )
       }

--- a/packages/cozy-pouch-link/src/logger.js
+++ b/packages/cozy-pouch-link/src/logger.js
@@ -1,0 +1,6 @@
+import minilog from 'minilog'
+
+const logger = minilog('cozy-pouch-link')
+minilog.suggest.deny('cozy-pouch-link', 'info')
+
+export default logger

--- a/yarn.lock
+++ b/yarn.lock
@@ -7503,6 +7503,11 @@ merge@^1.2.0:
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
   integrity sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=
 
+microee@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/microee/-/microee-0.0.6.tgz#a12bdb0103681e8b126a9b071eba4c467c78fffe"
+  integrity sha1-oSvbAQNoHosSapsHHrpMRnx4//4=
+
 micromatch@^2.1.5, micromatch@^2.3.11:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
@@ -7587,6 +7592,13 @@ mimic-response@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
+
+minilog@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/minilog/-/minilog-3.1.0.tgz#d2d0f1887ca363d1acf0ea86d5c4df293b3fb675"
+  integrity sha1-0tDxiHyjY9Gs8OqG1cTfKTs/tnU=
+  dependencies:
+    microee "0.0.6"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
I propose that our libs use minilog for logging. It has namespaces and filtering abilities. This would allow us to view logs quickly without polluting the logs if we do care for them.

2.5kb minified/gzipped.

A package level logger is created. An application will be able to view logs via

```
require('minilog').enable()
```

Warn/errors logs are visible directly.

If an application wants to see the debug logs of cozy-pouch-link :

```
require('minilog').suggest.allow('cozy-pouch-link', 'debug')
```