### PR TITLE
WIP: Add selectFromState

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -21,7 +21,8 @@ import {
   receiveMutationResult,
   receiveMutationError,
   getQueryFromState,
-  getDocumentFromState
+  getDocumentFromState,
+  selectFromState
 } from './store'
 import Schema from './Schema'
 import { chain } from './CozyLink'
@@ -587,6 +588,15 @@ class CozyClient {
       return getDocumentFromState(this.store.getState(), type, id)
     } catch (e) {
       console.warn('Could not getDocumentFromState', type, id, e.message)
+      return null
+    }
+  }
+
+  selectFromState(selectorFn) {
+    try {
+      return selectFromState(this.store.getState(), selectorFn)
+    } catch (e) {
+      console.warn('Could not selectFromState')
       return null
     }
   }

--- a/packages/cozy-client/src/store/index.js
+++ b/packages/cozy-client/src/store/index.js
@@ -95,6 +95,14 @@ export const createStore = () =>
 
 export const getStateRoot = state => state.cozy || {}
 
+export const selectFromState = (state, selectorFn) => {
+  if (typeof selectorFn !== 'function') {
+    throw new Error('Selector must be a function')
+  }
+
+  return selectorFn(getStateRoot(state))
+}
+
 export const getDocumentFromState = (state, doctype, id) =>
   getDocumentFromSlice(getStateRoot(state).documents, doctype, id)
 


### PR DESCRIPTION
We are looking to be able to know the status of a given konnector. For that, we need to:
* Retrieve all triggers related with Worker=konnector (already available from TriggerCollection)
* Select the triggers related to one given konnector from the cozyClient redux store

For now, only `getDocumentFromState` is available, but we need something a little bit more powerful than just selecting a document from its doctype and its id.

I was thinking of a way to run a selector on cozyClient's state. This PR suggest something like:
```js
client.selectFromState(state => Object.keys(documents['io.cozy.triggers']).reduce(
// filter
))
```