### PR TITLE
Client: Add getCollectionFromState()

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -21,6 +21,7 @@ import {
   receiveMutationResult,
   receiveMutationError,
   getQueryFromState,
+  getCollectionFromState,
   getDocumentFromState
 } from './store'
 import Schema from './Schema'
@@ -580,6 +581,15 @@ class CozyClient {
       }
     }
     return this.storeAccessors
+  }
+
+  getCollectionFromState(type) {
+    try {
+      return getCollectionFromState(this.store.getState(), type)
+    } catch (e) {
+      console.warn('Could not getCollectionFromState', type, e.message)
+      return null
+    }
   }
 
   getDocumentFromState(type, id) {

--- a/packages/cozy-client/src/__tests__/store.spec.js
+++ b/packages/cozy-client/src/__tests__/store.spec.js
@@ -3,6 +3,7 @@ import sortBy from 'lodash/sortBy'
 
 import reducer, {
   initQuery,
+  getCollectionFromState,
   getDocumentFromState,
   getQueryFromStore,
   receiveQueryResult,
@@ -175,6 +176,30 @@ describe('Store', () => {
         getDocumentFromState(store.getState(), 'io.cozy.files', FILE_1._id)
           .label
       ).toBe(FILE_1.label)
+    })
+  })
+
+  describe('getCollectionFromState', () => {
+    it('should return null when the store is empty', () => {
+      const spy = jest.spyOn(global.console, 'warn').mockReturnValue(jest.fn())
+      expect(getCollectionFromState(store.getState(), 'io.cozy.todos')).toBe(
+        null
+      )
+      spy.mockRestore()
+    })
+
+    it('should return all documents for the given doctype', () => {
+      store.dispatch(
+        receiveQueryResult('allTodos', {
+          data: [TODO_1, TODO_2],
+          meta: { count: 2 },
+          skip: 0,
+          next: false
+        })
+      )
+      expect(getCollectionFromState(store.getState(), 'io.cozy.todos')).toEqual(
+        [TODO_1, TODO_2]
+      )
     })
   })
 

--- a/packages/cozy-client/src/store/documents.js
+++ b/packages/cozy-client/src/store/documents.js
@@ -105,6 +105,24 @@ export const getDocumentFromSlice = (state = {}, doctype, id) => {
   return state[doctype][id]
 }
 
+export const getCollectionFromSlice = (state = {}, doctype) => {
+  if (!doctype) {
+    throw new Error(
+      'getDocumentFromSlice: Cannot retrieve document with undefined doctype'
+    )
+  }
+  if (!state[doctype]) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        `getDocumentFromSlice: ${doctype} is absent from the store documents`
+      )
+    }
+    return null
+  }
+
+  return Object.values(state[doctype])
+}
+
 /*
   This method has been created in order to get a returned object 
   in `data` with the full set on information coming potentielly from 

--- a/packages/cozy-client/src/store/index.js
+++ b/packages/cozy-client/src/store/index.js
@@ -5,7 +5,10 @@ import {
 } from 'redux'
 import thunk from 'redux-thunk'
 
-import documents, { getDocumentFromSlice } from './documents'
+import documents, {
+  getCollectionFromSlice,
+  getDocumentFromSlice
+} from './documents'
 import queries, { getQueryFromSlice, isQueryAction } from './queries'
 import { isMutationAction } from './mutations'
 
@@ -94,6 +97,9 @@ export const createStore = () =>
   )
 
 export const getStateRoot = state => state.cozy || {}
+
+export const getCollectionFromState = (state, doctype) =>
+  getCollectionFromSlice(getStateRoot(state).documents, doctype)
 
 export const getDocumentFromState = (state, doctype, id) =>
   getDocumentFromSlice(getStateRoot(state).documents, doctype, id)


### PR DESCRIPTION
Goal: easily get all the fetched triggers.

`AddCollectionFromState()` allows to retrieve all document for a given doctype existing in CozyClient redux state.

Example:
```
await client.query(client.all('io.cozy.accounts').where(auth: '$exists'))

const accounts = client.getCollectionFromState('io.cozy.accounts')
```

It's the "get list" alternative of existing method `getDocumentFromState()`.