### PR TITLE
Client: Update fetchRelationships method

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -466,6 +466,19 @@ class CozyClient {
     // storing the document. This makes the data easier to manipulate for the front-end.
     const relationshipsByDocId = {}
 
+    for (const def of documents) {
+      const docIdAndRels = queryDefToDocIdAndRel.get(def)
+      for (const docIdAndRel of docIdAndRels) {
+        if (docIdAndRel) {
+          const [docId, relName] = docIdAndRel
+          relationshipsByDocId[docId] = relationshipsByDocId[docId] || {}
+          relationshipsByDocId[docId][relName] = responseToRelationship({
+            data: def
+          })
+        }
+      }
+    }
+
     for (const [def, resp] of zip(definitions, responses)) {
       const docIdAndRels = queryDefToDocIdAndRel.get(def)
       for (const docIdAndRel of docIdAndRels) {

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -430,7 +430,9 @@ class CozyClient {
 
         // Used to reattach responses into the relationships attribute of
         // each document
-        queryDefToDocIdAndRel.set(queryDef, [docId, relName])
+        const docIdAndRels = queryDefToDocIdAndRel.get(queryDef) || []
+        docIdAndRels.push([docId, relName])
+        queryDefToDocIdAndRel.set(queryDef, docIdAndRels)
 
         // Relationships can yield "queries" that are already resolved documents.
         // These do not need to go through the usual link request mechanism.
@@ -463,12 +465,15 @@ class CozyClient {
     // it so that we can fill the `relationships` attribute of each doc before
     // storing the document. This makes the data easier to manipulate for the front-end.
     const relationshipsByDocId = {}
-    for (const [def, resp] of zip(optimizedDefinitions, responses)) {
-      const docIdAndRel = queryDefToDocIdAndRel.get(def)
-      if (docIdAndRel) {
-        const [docId, relName] = docIdAndRel
-        relationshipsByDocId[docId] = relationshipsByDocId[docId] || {}
-        relationshipsByDocId[docId][relName] = responseToRelationship(resp)
+
+    for (const [def, resp] of zip(definitions, responses)) {
+      const docIdAndRels = queryDefToDocIdAndRel.get(def)
+      for (const docIdAndRel of docIdAndRels) {
+        if (docIdAndRel) {
+          const [docId, relName] = docIdAndRel
+          relationshipsByDocId[docId] = relationshipsByDocId[docId] || {}
+          relationshipsByDocId[docId][relName] = responseToRelationship(resp)
+        }
       }
     }
 

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -450,7 +450,9 @@ class CozyClient {
 
     // "Included" documents will be stored in the `documents` store
     const uniqueDocuments = uniqBy(flatten(documents), '_id')
-    const included = flatten(responses.map(r => r.included || r.data))
+    const included = uniqBy(
+      flatten(responses.map(r => r.included || r.data), '_id')
+    )
       .concat(uniqueDocuments)
       .filter(Boolean)
 

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -771,4 +771,75 @@ describe('CozyClient', () => {
       expect(doc).toBe(null)
     })
   })
+
+  describe('fetchRelationships', () => {
+    it('should handle async queries in Associations', async () => {
+      jest.spyOn(client.chain, 'request').mockResolvedValue({
+        data: {
+          _id: 'ab794478d016457e99bd6241ff6c0d32',
+          _type: 'io.cozy.fake'
+        },
+        meta: { count: 1 }
+      })
+
+      class FakeHasMany extends Association {
+        static async query() {
+          return Promise.resolve(new QueryDefinition())
+        }
+      }
+
+      const response = { data: [TODO_1, TODO_2] }
+
+      const relationshipsByName = {
+        fake: {
+          type: FakeHasMany
+        }
+      }
+
+      expect(
+        await client.fetchRelationships(response, relationshipsByName)
+      ).toEqual({
+        data: [
+          {
+            ...TODO_1,
+            relationships: {
+              fake: {
+                data: {
+                  _id: 'ab794478d016457e99bd6241ff6c0d32',
+                  _type: 'io.cozy.fake'
+                },
+                meta: {
+                  count: 1
+                }
+              }
+            }
+          },
+          {
+            ...TODO_2,
+            relationships: {
+              fake: {
+                data: {
+                  _id: 'ab794478d016457e99bd6241ff6c0d32',
+                  _type: 'io.cozy.fake'
+                },
+                meta: {
+                  count: 1
+                }
+              }
+            }
+          }
+        ],
+        included: [
+          {
+            _id: 'ab794478d016457e99bd6241ff6c0d32',
+            _type: 'io.cozy.fake'
+          },
+          {
+            _id: 'ab794478d016457e99bd6241ff6c0d32',
+            _type: 'io.cozy.fake'
+          }
+        ]
+      })
+    })
+  })
 })

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -773,13 +773,45 @@ describe('CozyClient', () => {
   })
 
   describe('fetchRelationships', () => {
+    const expectedRelationShipsData = {
+      data: [
+        {
+          ...TODO_1,
+          relationships: {
+            fake: {
+              data: {
+                _id: 'ab794478d016457e99bd6241ff6c0d32',
+                _type: 'io.cozy.fake'
+              }
+            }
+          }
+        },
+        {
+          ...TODO_2,
+          relationships: {
+            fake: {
+              data: {
+                _id: 'ab794478d016457e99bd6241ff6c0d32',
+                _type: 'io.cozy.fake'
+              }
+            }
+          }
+        }
+      ],
+      included: [
+        {
+          _id: 'ab794478d016457e99bd6241ff6c0d32',
+          _type: 'io.cozy.fake'
+        }
+      ]
+    }
+
     it('should handle async queries in Associations', async () => {
       jest.spyOn(client.chain, 'request').mockResolvedValue({
         data: {
           _id: 'ab794478d016457e99bd6241ff6c0d32',
           _type: 'io.cozy.fake'
-        },
-        meta: { count: 1 }
+        }
       })
 
       class FakeHasMany extends Association {
@@ -798,44 +830,7 @@ describe('CozyClient', () => {
 
       expect(
         await client.fetchRelationships(response, relationshipsByName)
-      ).toEqual({
-        data: [
-          {
-            ...TODO_1,
-            relationships: {
-              fake: {
-                data: {
-                  _id: 'ab794478d016457e99bd6241ff6c0d32',
-                  _type: 'io.cozy.fake'
-                },
-                meta: {
-                  count: 1
-                }
-              }
-            }
-          },
-          {
-            ...TODO_2,
-            relationships: {
-              fake: {
-                data: {
-                  _id: 'ab794478d016457e99bd6241ff6c0d32',
-                  _type: 'io.cozy.fake'
-                },
-                meta: {
-                  count: 1
-                }
-              }
-            }
-          }
-        ],
-        included: [
-          {
-            _id: 'ab794478d016457e99bd6241ff6c0d32',
-            _type: 'io.cozy.fake'
-          }
-        ]
-      })
+      ).toEqual(expectedRelationShipsData)
     })
 
     it('should use same QueryDefinition from Associations', async () => {
@@ -843,8 +838,7 @@ describe('CozyClient', () => {
         data: {
           _id: 'ab794478d016457e99bd6241ff6c0d32',
           _type: 'io.cozy.fake'
-        },
-        meta: { count: 1 }
+        }
       })
 
       const sameQueryDefinitionForEveryone = new QueryDefinition()
@@ -865,44 +859,30 @@ describe('CozyClient', () => {
 
       expect(
         await client.fetchRelationships(response, relationshipsByName)
-      ).toEqual({
-        data: [
-          {
-            ...TODO_1,
-            relationships: {
-              fake: {
-                data: {
-                  _id: 'ab794478d016457e99bd6241ff6c0d32',
-                  _type: 'io.cozy.fake'
-                },
-                meta: {
-                  count: 1
-                }
-              }
-            }
-          },
-          {
-            ...TODO_2,
-            relationships: {
-              fake: {
-                data: {
-                  _id: 'ab794478d016457e99bd6241ff6c0d32',
-                  _type: 'io.cozy.fake'
-                },
-                meta: {
-                  count: 1
-                }
-              }
-            }
-          }
-        ],
-        included: [
-          {
+      ).toEqual(expectedRelationShipsData)
+    })
+
+    it('should handle query returning documents', async () => {
+      class FakeHasMany extends Association {
+        static query() {
+          return {
             _id: 'ab794478d016457e99bd6241ff6c0d32',
             _type: 'io.cozy.fake'
           }
-        ]
-      })
+        }
+      }
+
+      const response = { data: [TODO_1, TODO_2] }
+
+      const relationshipsByName = {
+        fake: {
+          type: FakeHasMany
+        }
+      }
+
+      expect(
+        await client.fetchRelationships(response, relationshipsByName)
+      ).toEqual(expectedRelationShipsData)
     })
   })
 })

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -833,10 +833,6 @@ describe('CozyClient', () => {
           {
             _id: 'ab794478d016457e99bd6241ff6c0d32',
             _type: 'io.cozy.fake'
-          },
-          {
-            _id: 'ab794478d016457e99bd6241ff6c0d32',
-            _type: 'io.cozy.fake'
           }
         ]
       })

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -837,5 +837,72 @@ describe('CozyClient', () => {
         ]
       })
     })
+
+    it('should use same QueryDefinition from Associations', async () => {
+      jest.spyOn(client.chain, 'request').mockResolvedValue({
+        data: {
+          _id: 'ab794478d016457e99bd6241ff6c0d32',
+          _type: 'io.cozy.fake'
+        },
+        meta: { count: 1 }
+      })
+
+      const sameQueryDefinitionForEveryone = new QueryDefinition()
+
+      class FakeHasMany extends Association {
+        static query() {
+          return sameQueryDefinitionForEveryone
+        }
+      }
+
+      const response = { data: [TODO_1, TODO_2] }
+
+      const relationshipsByName = {
+        fake: {
+          type: FakeHasMany
+        }
+      }
+
+      expect(
+        await client.fetchRelationships(response, relationshipsByName)
+      ).toEqual({
+        data: [
+          {
+            ...TODO_1,
+            relationships: {
+              fake: {
+                data: {
+                  _id: 'ab794478d016457e99bd6241ff6c0d32',
+                  _type: 'io.cozy.fake'
+                },
+                meta: {
+                  count: 1
+                }
+              }
+            }
+          },
+          {
+            ...TODO_2,
+            relationships: {
+              fake: {
+                data: {
+                  _id: 'ab794478d016457e99bd6241ff6c0d32',
+                  _type: 'io.cozy.fake'
+                },
+                meta: {
+                  count: 1
+                }
+              }
+            }
+          }
+        ],
+        included: [
+          {
+            _id: 'ab794478d016457e99bd6241ff6c0d32',
+            _type: 'io.cozy.fake'
+          }
+        ]
+      })
+    })
   })
 })


### PR DESCRIPTION
We want to retrieve all the triggers for a given konnector to know which error they are containing.

For that, we will use a custom association in the konnector schema.

This association will have an async query method, which may return existing document.

The goal is to use an Association like this (naive implementation):
```js
class HasManyTriggers {
  static async query(){
    const triggers = await fethTriggers()
    return triggers.filter(isTriggerForKonnector(slug)
  }
}

```

This PR :
* Allows async query methods in Associations
* Allows a query method to return documents
* Fix a few things