### PR TITLE
StackClient/Client: Add HasManyTriggers association and update TriggerCollection

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -418,12 +418,17 @@ class CozyClient {
     const responseDocs = isSingleDoc ? [response.data] : response.data
 
     const queryDefToDocIdAndRel = new Map()
+
     const documents = []
     const definitions = []
 
-    responseDocs.forEach(doc => {
-      return forEach(relationshipsByName, (relationship, relName) => {
-        const queryDef = relationship.type.query(doc, this, relationship)
+    for (const doc of responseDocs) {
+      for (const relName in relationshipsByName) {
+        const relationship = relationshipsByName[relName]
+        const queryResponse = relationship.type.query(doc, this, relationship)
+        const queryDef =
+          queryResponse instanceof Promise ? await queryResponse : queryResponse
+
         const docId = doc._id
 
         // Used to reattach responses into the relationships attribute of
@@ -437,8 +442,8 @@ class CozyClient {
         } else {
           documents.push(queryDef)
         }
-      })
-    })
+      }
+    }
 
     // Definitions can be in optimized/regrouped in case of HasMany relationships.
     const optimizedDefinitions = optimizeQueryDefinitions(definitions)

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -453,7 +453,9 @@ class CozyClient {
 
     // "Included" documents will be stored in the `documents` store
     const uniqueDocuments = uniqBy(flatten(documents), '_id')
-    const included = flatten(responses.map(r => r.included || r.data))
+    const included = uniqBy(
+      flatten(responses.map(r => r.included || r.data), '_id')
+    )
       .concat(uniqueDocuments)
       .filter(Boolean)
 

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -433,7 +433,9 @@ class CozyClient {
 
         // Used to reattach responses into the relationships attribute of
         // each document
-        queryDefToDocIdAndRel.set(queryDef, [docId, relName])
+        const docIdAndRels = queryDefToDocIdAndRel.get(queryDef) || []
+        docIdAndRels.push([docId, relName])
+        queryDefToDocIdAndRel.set(queryDef, docIdAndRels)
 
         // Relationships can yield "queries" that are already resolved documents.
         // These do not need to go through the usual link request mechanism.
@@ -466,12 +468,15 @@ class CozyClient {
     // it so that we can fill the `relationships` attribute of each doc before
     // storing the document. This makes the data easier to manipulate for the front-end.
     const relationshipsByDocId = {}
-    for (const [def, resp] of zip(optimizedDefinitions, responses)) {
-      const docIdAndRel = queryDefToDocIdAndRel.get(def)
-      if (docIdAndRel) {
-        const [docId, relName] = docIdAndRel
-        relationshipsByDocId[docId] = relationshipsByDocId[docId] || {}
-        relationshipsByDocId[docId][relName] = responseToRelationship(resp)
+
+    for (const [def, resp] of zip(definitions, responses)) {
+      const docIdAndRels = queryDefToDocIdAndRel.get(def)
+      for (const docIdAndRel of docIdAndRels) {
+        if (docIdAndRel) {
+          const [docId, relName] = docIdAndRel
+          relationshipsByDocId[docId] = relationshipsByDocId[docId] || {}
+          relationshipsByDocId[docId][relName] = responseToRelationship(resp)
+        }
       }
     }
 

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -21,6 +21,7 @@ import {
   receiveMutationResult,
   receiveMutationError,
   getQueryFromState,
+  getCollectionFromState,
   getDocumentFromState
 } from './store'
 import Schema from './Schema'
@@ -580,6 +581,15 @@ class CozyClient {
       }
     }
     return this.storeAccessors
+  }
+
+  getCollectionFromState(type) {
+    try {
+      return getCollectionFromState(this.store.getState(), type)
+    } catch (e) {
+      console.warn('Could not getCollectionFromState', type, e.message)
+      return null
+    }
   }
 
   getDocumentFromState(type, id) {

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -469,6 +469,19 @@ class CozyClient {
     // storing the document. This makes the data easier to manipulate for the front-end.
     const relationshipsByDocId = {}
 
+    for (const def of documents) {
+      const docIdAndRels = queryDefToDocIdAndRel.get(def)
+      for (const docIdAndRel of docIdAndRels) {
+        if (docIdAndRel) {
+          const [docId, relName] = docIdAndRel
+          relationshipsByDocId[docId] = relationshipsByDocId[docId] || {}
+          relationshipsByDocId[docId][relName] = responseToRelationship({
+            data: def
+          })
+        }
+      }
+    }
+
     for (const [def, resp] of zip(definitions, responses)) {
       const docIdAndRels = queryDefToDocIdAndRel.get(def)
       for (const docIdAndRel of docIdAndRels) {

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -771,4 +771,75 @@ describe('CozyClient', () => {
       expect(doc).toBe(null)
     })
   })
+
+  describe('fetchRelationships', () => {
+    it('should handle async queries in Associations', async () => {
+      jest.spyOn(client.chain, 'request').mockResolvedValue({
+        data: {
+          _id: 'ab794478d016457e99bd6241ff6c0d32',
+          _type: 'io.cozy.fake'
+        },
+        meta: { count: 1 }
+      })
+
+      class FakeHasMany extends Association {
+        static async query() {
+          return Promise.resolve(new QueryDefinition())
+        }
+      }
+
+      const response = { data: [TODO_1, TODO_2] }
+
+      const relationshipsByName = {
+        fake: {
+          type: FakeHasMany
+        }
+      }
+
+      expect(
+        await client.fetchRelationships(response, relationshipsByName)
+      ).toEqual({
+        data: [
+          {
+            ...TODO_1,
+            relationships: {
+              fake: {
+                data: {
+                  _id: 'ab794478d016457e99bd6241ff6c0d32',
+                  _type: 'io.cozy.fake'
+                },
+                meta: {
+                  count: 1
+                }
+              }
+            }
+          },
+          {
+            ...TODO_2,
+            relationships: {
+              fake: {
+                data: {
+                  _id: 'ab794478d016457e99bd6241ff6c0d32',
+                  _type: 'io.cozy.fake'
+                },
+                meta: {
+                  count: 1
+                }
+              }
+            }
+          }
+        ],
+        included: [
+          {
+            _id: 'ab794478d016457e99bd6241ff6c0d32',
+            _type: 'io.cozy.fake'
+          },
+          {
+            _id: 'ab794478d016457e99bd6241ff6c0d32',
+            _type: 'io.cozy.fake'
+          }
+        ]
+      })
+    })
+  })
 })

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -773,13 +773,45 @@ describe('CozyClient', () => {
   })
 
   describe('fetchRelationships', () => {
+    const expectedRelationShipsData = {
+      data: [
+        {
+          ...TODO_1,
+          relationships: {
+            fake: {
+              data: {
+                _id: 'ab794478d016457e99bd6241ff6c0d32',
+                _type: 'io.cozy.fake'
+              }
+            }
+          }
+        },
+        {
+          ...TODO_2,
+          relationships: {
+            fake: {
+              data: {
+                _id: 'ab794478d016457e99bd6241ff6c0d32',
+                _type: 'io.cozy.fake'
+              }
+            }
+          }
+        }
+      ],
+      included: [
+        {
+          _id: 'ab794478d016457e99bd6241ff6c0d32',
+          _type: 'io.cozy.fake'
+        }
+      ]
+    }
+
     it('should handle async queries in Associations', async () => {
       jest.spyOn(client.chain, 'request').mockResolvedValue({
         data: {
           _id: 'ab794478d016457e99bd6241ff6c0d32',
           _type: 'io.cozy.fake'
-        },
-        meta: { count: 1 }
+        }
       })
 
       class FakeHasMany extends Association {
@@ -798,44 +830,7 @@ describe('CozyClient', () => {
 
       expect(
         await client.fetchRelationships(response, relationshipsByName)
-      ).toEqual({
-        data: [
-          {
-            ...TODO_1,
-            relationships: {
-              fake: {
-                data: {
-                  _id: 'ab794478d016457e99bd6241ff6c0d32',
-                  _type: 'io.cozy.fake'
-                },
-                meta: {
-                  count: 1
-                }
-              }
-            }
-          },
-          {
-            ...TODO_2,
-            relationships: {
-              fake: {
-                data: {
-                  _id: 'ab794478d016457e99bd6241ff6c0d32',
-                  _type: 'io.cozy.fake'
-                },
-                meta: {
-                  count: 1
-                }
-              }
-            }
-          }
-        ],
-        included: [
-          {
-            _id: 'ab794478d016457e99bd6241ff6c0d32',
-            _type: 'io.cozy.fake'
-          }
-        ]
-      })
+      ).toEqual(expectedRelationShipsData)
     })
 
     it('should use same QueryDefinition from Associations', async () => {
@@ -843,8 +838,7 @@ describe('CozyClient', () => {
         data: {
           _id: 'ab794478d016457e99bd6241ff6c0d32',
           _type: 'io.cozy.fake'
-        },
-        meta: { count: 1 }
+        }
       })
 
       const sameQueryDefinitionForEveryone = new QueryDefinition()
@@ -865,44 +859,30 @@ describe('CozyClient', () => {
 
       expect(
         await client.fetchRelationships(response, relationshipsByName)
-      ).toEqual({
-        data: [
-          {
-            ...TODO_1,
-            relationships: {
-              fake: {
-                data: {
-                  _id: 'ab794478d016457e99bd6241ff6c0d32',
-                  _type: 'io.cozy.fake'
-                },
-                meta: {
-                  count: 1
-                }
-              }
-            }
-          },
-          {
-            ...TODO_2,
-            relationships: {
-              fake: {
-                data: {
-                  _id: 'ab794478d016457e99bd6241ff6c0d32',
-                  _type: 'io.cozy.fake'
-                },
-                meta: {
-                  count: 1
-                }
-              }
-            }
-          }
-        ],
-        included: [
-          {
+      ).toEqual(expectedRelationShipsData)
+    })
+
+    it('should handle query returning documents', async () => {
+      class FakeHasMany extends Association {
+        static query() {
+          return {
             _id: 'ab794478d016457e99bd6241ff6c0d32',
             _type: 'io.cozy.fake'
           }
-        ]
-      })
+        }
+      }
+
+      const response = { data: [TODO_1, TODO_2] }
+
+      const relationshipsByName = {
+        fake: {
+          type: FakeHasMany
+        }
+      }
+
+      expect(
+        await client.fetchRelationships(response, relationshipsByName)
+      ).toEqual(expectedRelationShipsData)
     })
   })
 })

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -833,10 +833,6 @@ describe('CozyClient', () => {
           {
             _id: 'ab794478d016457e99bd6241ff6c0d32',
             _type: 'io.cozy.fake'
-          },
-          {
-            _id: 'ab794478d016457e99bd6241ff6c0d32',
-            _type: 'io.cozy.fake'
           }
         ]
       })

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -837,5 +837,72 @@ describe('CozyClient', () => {
         ]
       })
     })
+
+    it('should use same QueryDefinition from Associations', async () => {
+      jest.spyOn(client.chain, 'request').mockResolvedValue({
+        data: {
+          _id: 'ab794478d016457e99bd6241ff6c0d32',
+          _type: 'io.cozy.fake'
+        },
+        meta: { count: 1 }
+      })
+
+      const sameQueryDefinitionForEveryone = new QueryDefinition()
+
+      class FakeHasMany extends Association {
+        static query() {
+          return sameQueryDefinitionForEveryone
+        }
+      }
+
+      const response = { data: [TODO_1, TODO_2] }
+
+      const relationshipsByName = {
+        fake: {
+          type: FakeHasMany
+        }
+      }
+
+      expect(
+        await client.fetchRelationships(response, relationshipsByName)
+      ).toEqual({
+        data: [
+          {
+            ...TODO_1,
+            relationships: {
+              fake: {
+                data: {
+                  _id: 'ab794478d016457e99bd6241ff6c0d32',
+                  _type: 'io.cozy.fake'
+                },
+                meta: {
+                  count: 1
+                }
+              }
+            }
+          },
+          {
+            ...TODO_2,
+            relationships: {
+              fake: {
+                data: {
+                  _id: 'ab794478d016457e99bd6241ff6c0d32',
+                  _type: 'io.cozy.fake'
+                },
+                meta: {
+                  count: 1
+                }
+              }
+            }
+          }
+        ],
+        included: [
+          {
+            _id: 'ab794478d016457e99bd6241ff6c0d32',
+            _type: 'io.cozy.fake'
+          }
+        ]
+      })
+    })
   })
 })

--- a/packages/cozy-client/src/associations/HasManyTriggers.js
+++ b/packages/cozy-client/src/associations/HasManyTriggers.js
@@ -1,0 +1,43 @@
+import get from 'lodash/get'
+
+import HasMany from './HasMany'
+
+const TRIGGERS_DOCTYPE = 'io.cozy.triggers'
+
+/**
+ * Memoize the fetch promise. For now we are only fetching it once but it will
+ * evolve in the future.
+ */
+let memoizedFetchPromise = null
+
+/**
+ * Association used for konnectors to retrieve all their related triggers.
+ * @extends HasMany
+ */
+class HasManyTriggers extends HasMany {
+  /**
+   * In this association the query is special, we need to fetch all the triggers
+   * having for the 'konnector' worker, and then filter them based on their
+   * `message.konnector` attribute
+   */
+  static async query(doc, client) {
+    // Check the memoized promise instead of the redux store to avoid executing
+    // the same query several times (one time per konnector)
+    if (!memoizedFetchPromise) {
+      memoizedFetchPromise = client.query(
+        client.all(TRIGGERS_DOCTYPE).where({ worker: 'konnector' })
+      )
+    }
+
+    await memoizedFetchPromise
+
+    // Triggers are in store now !
+    const triggers = client.getCollectionFromState(TRIGGERS_DOCTYPE)
+
+    return triggers.filter(
+      trigger => get(trigger, 'message.konnector') === doc.slug
+    )
+  }
+}
+
+export default HasManyTriggers

--- a/packages/cozy-client/src/associations/HasManyTriggers.spec.js
+++ b/packages/cozy-client/src/associations/HasManyTriggers.spec.js
@@ -1,0 +1,52 @@
+import HasManyTriggers from './HasManyTriggers'
+
+const ALL_TRIGGERS_FIXTURES = [
+  {
+    _id: '',
+    _type: 'io.cozy.triggers',
+    message: {
+      konnector: 'dummy'
+    }
+  },
+  {
+    _id: '',
+    _type: 'io.cozy.triggers',
+    message: {
+      konnector: 'dummy-test'
+    }
+  },
+  {
+    _id: '',
+    _type: 'io.cozy.triggers',
+    message: {
+      konnector: 'dummmy-fake'
+    }
+  }
+]
+
+describe('HasManyTriggers', () => {
+  describe('query', () => {
+    it('should return triggers', async () => {
+      const client = {
+        all: jest.fn().mockReturnValue({
+          where: jest.fn()
+        }),
+        query: jest.fn().mockResolvedValue(ALL_TRIGGERS_FIXTURES),
+        getCollectionFromState: jest.fn().mockReturnValue(ALL_TRIGGERS_FIXTURES)
+      }
+
+      const konnector = {
+        slug: 'dummy'
+      }
+
+      const triggers = await HasManyTriggers.query(konnector, client)
+      expect(triggers).toEqual([
+        {
+          _id: '',
+          _type: 'io.cozy.triggers',
+          message: { konnector: 'dummy' }
+        }
+      ])
+    })
+  })
+})

--- a/packages/cozy-client/src/associations/index.js
+++ b/packages/cozy-client/src/associations/index.js
@@ -3,6 +3,7 @@ import HasMany from './HasMany'
 import HasOne from './HasOne'
 import HasOneInPlace from './HasOneInPlace'
 import HasManyInPlace from './HasManyInPlace'
+import HasManyTriggers from './HasManyTriggers'
 import Association from './Association'
 
 export { resolveClass, create } from './helpers'
@@ -13,5 +14,6 @@ export {
   HasMany,
   HasOne,
   HasOneInPlace,
-  HasManyInPlace
+  HasManyInPlace,
+  HasManyTriggers
 }

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -18,7 +18,8 @@ export {
   HasMany,
   HasOne,
   HasOneInPlace,
-  HasManyInPlace
+  HasManyInPlace,
+  HasManyTriggers
 } from './associations'
 export { dehydrate } from './helpers'
 export { getQueryFromState } from './store'

--- a/packages/cozy-client/src/store/documents.js
+++ b/packages/cozy-client/src/store/documents.js
@@ -105,6 +105,24 @@ export const getDocumentFromSlice = (state = {}, doctype, id) => {
   return state[doctype][id]
 }
 
+export const getCollectionFromSlice = (state = {}, doctype) => {
+  if (!doctype) {
+    throw new Error(
+      'getDocumentFromSlice: Cannot retrieve document with undefined doctype'
+    )
+  }
+  if (!state[doctype]) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        `getDocumentFromSlice: ${doctype} is absent from the store documents`
+      )
+    }
+    return null
+  }
+
+  return Object.values(state[doctype])
+}
+
 /*
   This method has been created in order to get a returned object 
   in `data` with the full set on information coming potentielly from 

--- a/packages/cozy-client/src/store/index.js
+++ b/packages/cozy-client/src/store/index.js
@@ -5,7 +5,10 @@ import {
 } from 'redux'
 import thunk from 'redux-thunk'
 
-import documents, { getDocumentFromSlice } from './documents'
+import documents, {
+  getCollectionFromSlice,
+  getDocumentFromSlice
+} from './documents'
 import queries, { getQueryFromSlice, isQueryAction } from './queries'
 import { isMutationAction } from './mutations'
 
@@ -94,6 +97,9 @@ export const createStore = () =>
   )
 
 export const getStateRoot = state => state.cozy || {}
+
+export const getCollectionFromState = (state, doctype) =>
+  getCollectionFromSlice(getStateRoot(state).documents, doctype)
 
 export const getDocumentFromState = (state, doctype, id) =>
   getDocumentFromSlice(getStateRoot(state).documents, doctype, id)

--- a/packages/cozy-stack-client/src/TriggerCollection.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.js
@@ -45,7 +45,7 @@ class TriggerCollection {
       const resp = await this.stackClient.fetchJSON('GET', path)
 
       return {
-        data: resp.data.map(row => normalizeDoc(row, TRIGGERS_DOCTYPE)),
+        data: resp.data.map(row => normalizeTrigger(row, TRIGGERS_DOCTYPE)),
         meta: { count: resp.data.length },
         next: false,
         skip: 0

--- a/packages/cozy-stack-client/src/TriggerCollection.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.js
@@ -38,11 +38,8 @@ class TriggerCollection {
    * @throws {FetchError}
    */
   async all(options = {}) {
-    const url = uri`/jobs/triggers`
-    const path = querystring.buildURL(url, options)
-
     try {
-      const resp = await this.stackClient.fetchJSON('GET', path)
+      const resp = await this.stackClient.fetchJSON('GET', `/jobs/triggers`)
 
       return {
         data: resp.data.map(row => normalizeTrigger(row, TRIGGERS_DOCTYPE)),

--- a/packages/cozy-stack-client/src/TriggerCollection.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.js
@@ -74,8 +74,26 @@ class TriggerCollection {
     throw new Error('destroy() method is not available for triggers')
   }
 
-  async find() {
-    throw new Error('find() method is not yet implemented')
+  async find(selector = {}) {
+    if (!selector.worker) {
+      throw new Error('TriggerCollection can only find triggers with worker')
+    }
+
+    // @see https://github.com/cozy/cozy-stack/blob/master/docs/jobs.md#get-jobstriggers
+    const url = `/jobs/triggers?Worker=${selector.worker}`
+
+    try {
+      const resp = await this.stackClient.fetchJSON('GET', url)
+
+      return {
+        data: resp.data.map(row => normalizeTrigger(row, TRIGGERS_DOCTYPE)),
+        meta: { count: resp.data.length },
+        next: false,
+        skip: 0
+      }
+    } catch (error) {
+      return dontThrowNotFoundError(error)
+    }
   }
 
   async get() {

--- a/packages/cozy-stack-client/src/TriggerCollection.spec.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.spec.js
@@ -83,4 +83,18 @@ describe('TriggerCollection', () => {
       }
     })
   })
+
+  describe('find', () => {
+    it('should throw if no worker in selector', async () => {
+      await expect(collection.find()).rejects.toThrowError()
+    })
+
+    it('should call /jobs/triggers route', async () => {
+      await collection.find({ worker: 'thumbnail' })
+      expect(stackClient.fetchJSON).toHaveBeenLastCalledWith(
+        'GET',
+        '/jobs/triggers?Worker=thumbnail'
+      )
+    })
+  })
 })

--- a/packages/cozy-stack-client/src/TriggerCollection.spec.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.spec.js
@@ -7,10 +7,18 @@ const ALL_RESPONSE_FIXTURE = {
   data: [
     {
       type: 'io.cozy.triggers',
-      id: '123123',
+      id: 'f100f8d2d30449b98ff1f25437829b3e',
       attributes: {},
       links: {
-        self: '/jobs/triggers/123123'
+        self: '/jobs/triggers/f100f8d2d30449b98ff1f25437829b3e'
+      }
+    },
+    {
+      type: 'io.cozy.triggers',
+      id: '5d9b24acbb8e435c8543e5156d65501a',
+      attributes: {},
+      links: {
+        self: '/jobs/triggers/5d9b24acbb8e435c8543e5156d65501a'
       }
     }
   ]
@@ -18,31 +26,26 @@ const ALL_RESPONSE_FIXTURE = {
 
 describe('TriggerCollection', () => {
   const stackClient = new CozyStackClient()
+  const collection = new TriggerCollection(stackClient)
+
+  beforeEach(() => {
+    jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue(ALL_RESPONSE_FIXTURE)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
 
   describe('all', () => {
-    const collection = new TriggerCollection(stackClient)
-
-    beforeAll(() => {
-      stackClient.fetchJSON.mockReturnValue(
-        Promise.resolve(ALL_RESPONSE_FIXTURE)
-      )
-    })
-
-    afterAll(() => {
-      stackClient.fetchJSON.mockRestore()
-    })
-
-    it('should call the right route', async () => {
+    it('should call /jobs/triggers route', async () => {
       await collection.all()
       expect(stackClient.fetchJSON).toHaveBeenLastCalledWith(
         'GET',
         '/jobs/triggers'
-      )
-
-      await collection.all({ Worker: 'konnector' })
-      expect(stackClient.fetchJSON).toHaveBeenLastCalledWith(
-        'GET',
-        '/jobs/triggers?Worker=konnector'
       )
     })
 


### PR DESCRIPTION
This PR prepares need of retrieving all the triggers for a given konnector, with the goal to detect all errors related to it.

It fixes a few mistakes in TriggerCollection and implements the find() method, which will allow us to do:

```js
const triggers = client.query(client.all('io.cozy.triggers').where({worker: 'konnector'})
```

It also introduces the `HasManyTriggers` association, which fetch all triggers or get them in CozyClient redux store. It then filters them to only get triggers related to the konnector having the association.

It is more or less a hack to manage the way that we only have the endpoint `/jobs/triggers` to retrieve triggers.