### PR TITLE
StackClient/Client: Add HasManyTriggers and update TriggerCollection

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -20,6 +20,9 @@ following the JSON API spec.</p>
 <dd><p>Used when related documents are stored directly under the attribute with
 only the ids.</p>
 </dd>
+<dt><a href="#HasManyTriggers">HasManyTriggers</a> ⇐ <code><a href="#HasMany">HasMany</a></code></dt>
+<dd><p>Association used for konnectors to retrieve all their related triggers.</p>
+</dd>
 <dt><a href="#CozyClient">CozyClient</a></dt>
 <dd><p>Responsible for</p>
 <ul>
@@ -52,6 +55,15 @@ from a Cozy. <code>QueryDefinition</code>s are sent to links.</p>
   }
 }, cozyStackClient)
 </code></pre>
+</dd>
+</dl>
+
+## Constants
+
+<dl>
+<dt><a href="#fetchKonnectorTriggers">fetchKonnectorTriggers</a></dt>
+<dd><p>Memoize the fetch promise. For now we are only fetching it once but it will
+evolve in the future.</p>
 </dd>
 </dl>
 
@@ -403,6 +415,41 @@ const todo = {
 }
 ```
 
+<a name="HasManyTriggers"></a>
+
+## HasManyTriggers ⇐ [<code>HasMany</code>](#HasMany)
+Association used for konnectors to retrieve all their related triggers.
+
+**Kind**: global class  
+**Extends**: [<code>HasMany</code>](#HasMany)  
+
+* [HasManyTriggers](#HasManyTriggers) ⇐ [<code>HasMany</code>](#HasMany)
+    * _instance_
+        * [.addById()](#HasMany+addById)
+    * _static_
+        * [.query()](#HasManyTriggers.query)
+
+<a name="HasMany+addById"></a>
+
+### hasManyTriggers.addById()
+Add a referenced document by id. You need to call save()
+in order to synchronize your document with the store.
+
+**Kind**: instance method of [<code>HasManyTriggers</code>](#HasManyTriggers)  
+**Todo**
+
+- [ ] We shouldn't create the array of relationship manually since
+it'll not be present in the store as well.
+We certainly should use something like `updateRelationship`
+
+<a name="HasManyTriggers.query"></a>
+
+### HasManyTriggers.query()
+In this association the query is special, we need to fetch all the triggers
+having for the 'konnector' worker, and then filter them based on their
+`message.konnector` attribute
+
+**Kind**: static method of [<code>HasManyTriggers</code>](#HasManyTriggers)  
 <a name="CozyClient"></a>
 
 ## CozyClient
@@ -749,6 +796,13 @@ Returns the relationship for a given doctype/name
 Validates a document considering the descriptions in schema.attributes.
 
 **Kind**: instance method of [<code>Schema</code>](#Schema)  
+<a name="fetchKonnectorTriggers"></a>
+
+## fetchKonnectorTriggers
+Memoize the fetch promise. For now we are only fetching it once but it will
+evolve in the future.
+
+**Kind**: global constant  
 <a name="withClient"></a>
 
 ## withClient(Component) ⇒ <code>function</code>

--- a/packages/cozy-client/src/associations/HasManyTriggers.js
+++ b/packages/cozy-client/src/associations/HasManyTriggers.js
@@ -1,0 +1,43 @@
+import get from 'lodash/get'
+import memoize from 'lodash/memoize'
+
+import HasMany from './HasMany'
+
+const TRIGGERS_DOCTYPE = 'io.cozy.triggers'
+
+/**
+ * Memoize the fetch promise. For now we are only fetching it once but it will
+ * evolve in the future.
+ */
+const fetchKonnectorTriggers = memoize(
+  client => client.all(TRIGGERS_DOCTYPE).where({ worker: 'konnector' }),
+  client => client.stackClient.uri
+)
+
+/**
+ * Association used for konnectors to retrieve all their related triggers.
+ * @extends HasMany
+ */
+class HasManyTriggers extends HasMany {
+  /**
+   * In this association the query is special, we need to fetch all the triggers
+   * having for the 'konnector' worker, and then filter them based on their
+   * `message.konnector` attribute
+   */
+  static async query(doc, client) {
+    // Check the memoized promise instead of the redux store to avoid executing
+    // the same query several times (one time per konnector)
+    await fetchKonnectorTriggers(client)
+
+    // Triggers are in store now !
+    const triggers = client.getCollectionFromState(TRIGGERS_DOCTYPE)
+
+    return triggers
+      ? triggers.filter(
+          trigger => get(trigger, 'message.konnector') === doc.slug
+        )
+      : []
+  }
+}
+
+export default HasManyTriggers

--- a/packages/cozy-client/src/associations/HasManyTriggers.spec.js
+++ b/packages/cozy-client/src/associations/HasManyTriggers.spec.js
@@ -1,0 +1,57 @@
+import HasManyTriggers from './HasManyTriggers'
+
+const ALL_TRIGGERS_FIXTURES = [
+  {
+    _id: '',
+    _type: 'io.cozy.triggers',
+    message: {
+      konnector: 'dummy'
+    }
+  },
+  {
+    _id: '',
+    _type: 'io.cozy.triggers',
+    message: {
+      konnector: 'dummy-test'
+    }
+  },
+  {
+    _id: '',
+    _type: 'io.cozy.triggers',
+    message: {
+      konnector: 'dummmy-fake'
+    }
+  }
+]
+
+describe('HasManyTriggers', () => {
+  describe('query', () => {
+    it('should return triggers', async () => {
+      const client = {
+        all: jest.fn().mockReturnValue({
+          where: jest.fn()
+        }),
+        query: jest.fn().mockResolvedValue(ALL_TRIGGERS_FIXTURES),
+        getCollectionFromState: jest
+          .fn()
+          .mockReturnValue(ALL_TRIGGERS_FIXTURES),
+        stackClient: {
+          uri: 'cozy.tools:8080'
+        }
+      }
+
+      const konnector = {
+        slug: 'dummy'
+      }
+
+      const triggers = await HasManyTriggers.query(konnector, client)
+      expect(triggers).toEqual([
+        {
+          _id: '',
+          _type: 'io.cozy.triggers',
+          message: { konnector: 'dummy' }
+        }
+      ])
+    })
+  })
+})

--- a/packages/cozy-client/src/associations/index.js
+++ b/packages/cozy-client/src/associations/index.js
@@ -3,6 +3,7 @@ import HasMany from './HasMany'
 import HasOne from './HasOne'
 import HasOneInPlace from './HasOneInPlace'
 import HasManyInPlace from './HasManyInPlace'
+import HasManyTriggers from './HasManyTriggers'
 import Association from './Association'
 
 export { resolveClass, create } from './helpers'
@@ -13,5 +14,6 @@ export {
   HasMany,
   HasOne,
   HasOneInPlace,
-  HasManyInPlace
+  HasManyInPlace,
+  HasManyTriggers
 }

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -18,7 +18,8 @@ export {
   HasMany,
   HasOne,
   HasOneInPlace,
-  HasManyInPlace
+  HasManyInPlace,
+  HasManyTriggers
 } from './associations'
 export { dehydrate } from './helpers'
 export { getQueryFromState } from './store'

--- a/packages/cozy-stack-client/src/TriggerCollection.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.js
@@ -45,7 +45,7 @@ class TriggerCollection {
       const resp = await this.stackClient.fetchJSON('GET', path)
 
       return {
-        data: resp.data.map(row => normalizeDoc(row, TRIGGERS_DOCTYPE)),
+        data: resp.data.map(row => normalizeTrigger(row, TRIGGERS_DOCTYPE)),
         meta: { count: resp.data.length },
         next: false,
         skip: 0

--- a/packages/cozy-stack-client/src/TriggerCollection.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.js
@@ -38,11 +38,8 @@ class TriggerCollection {
    * @throws {FetchError}
    */
   async all(options = {}) {
-    const url = uri`/jobs/triggers`
-    const path = querystring.buildURL(url, options)
-
     try {
-      const resp = await this.stackClient.fetchJSON('GET', path)
+      const resp = await this.stackClient.fetchJSON('GET', `/jobs/triggers`)
 
       return {
         data: resp.data.map(row => normalizeTrigger(row, TRIGGERS_DOCTYPE)),

--- a/packages/cozy-stack-client/src/TriggerCollection.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.js
@@ -74,8 +74,26 @@ class TriggerCollection {
     throw new Error('destroy() method is not available for triggers')
   }
 
-  async find() {
-    throw new Error('find() method is not yet implemented')
+  async find(selector = {}) {
+    if (!selector.worker) {
+      throw new Error('TriggerCollection can only find triggers with worker')
+    }
+
+    // @see https://github.com/cozy/cozy-stack/blob/master/docs/jobs.md#get-jobstriggers
+    const url = `/jobs/triggers?Worker=${selector.worker}`
+
+    try {
+      const resp = await this.stackClient.fetchJSON('GET', url)
+
+      return {
+        data: resp.data.map(row => normalizeTrigger(row, TRIGGERS_DOCTYPE)),
+        meta: { count: resp.data.length },
+        next: false,
+        skip: 0
+      }
+    } catch (error) {
+      return dontThrowNotFoundError(error)
+    }
   }
 
   async get() {

--- a/packages/cozy-stack-client/src/TriggerCollection.spec.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.spec.js
@@ -83,4 +83,18 @@ describe('TriggerCollection', () => {
       }
     })
   })
+
+  describe('find', () => {
+    it('should throw if no worker in selector', async () => {
+      await expect(collection.find()).rejects.toThrowError()
+    })
+
+    it('should call /jobs/triggers route', async () => {
+      await collection.find({ worker: 'thumbnail' })
+      expect(stackClient.fetchJSON).toHaveBeenLastCalledWith(
+        'GET',
+        '/jobs/triggers?Worker=thumbnail'
+      )
+    })
+  })
 })

--- a/packages/cozy-stack-client/src/TriggerCollection.spec.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.spec.js
@@ -7,10 +7,18 @@ const ALL_RESPONSE_FIXTURE = {
   data: [
     {
       type: 'io.cozy.triggers',
-      id: '123123',
+      id: 'f100f8d2d30449b98ff1f25437829b3e',
       attributes: {},
       links: {
-        self: '/jobs/triggers/123123'
+        self: '/jobs/triggers/f100f8d2d30449b98ff1f25437829b3e'
+      }
+    },
+    {
+      type: 'io.cozy.triggers',
+      id: '5d9b24acbb8e435c8543e5156d65501a',
+      attributes: {},
+      links: {
+        self: '/jobs/triggers/5d9b24acbb8e435c8543e5156d65501a'
       }
     }
   ]
@@ -18,31 +26,26 @@ const ALL_RESPONSE_FIXTURE = {
 
 describe('TriggerCollection', () => {
   const stackClient = new CozyStackClient()
+  const collection = new TriggerCollection(stackClient)
+
+  beforeEach(() => {
+    jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue(ALL_RESPONSE_FIXTURE)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
 
   describe('all', () => {
-    const collection = new TriggerCollection(stackClient)
-
-    beforeAll(() => {
-      stackClient.fetchJSON.mockReturnValue(
-        Promise.resolve(ALL_RESPONSE_FIXTURE)
-      )
-    })
-
-    afterAll(() => {
-      stackClient.fetchJSON.mockRestore()
-    })
-
-    it('should call the right route', async () => {
+    it('should call /jobs/triggers route', async () => {
       await collection.all()
       expect(stackClient.fetchJSON).toHaveBeenLastCalledWith(
         'GET',
         '/jobs/triggers'
-      )
-
-      await collection.all({ Worker: 'konnector' })
-      expect(stackClient.fetchJSON).toHaveBeenLastCalledWith(
-        'GET',
-        '/jobs/triggers?Worker=konnector'
       )
     })
 


### PR DESCRIPTION
This PR prepares need of retrieving all the triggers for a given konnector, with the goal to detect all errors related to it.

It fixes a few mistakes in TriggerCollection and implements the find() method, which will allow us to do:

```js
const triggers = client.query(client.all('io.cozy.triggers').where({worker: 'konnector'})
```

It also introduces the `HasManyTriggers` association, which fetch all triggers or get them in CozyClient redux store. It then filters them to only get triggers related to the konnector having the association.

It is more or less a hack to manage the way that we only have the endpoint `/jobs/triggers` to retrieve triggers.