### PR TITLE
StackClient: Update KonnectorCollection

### DIFF
--- a/packages/cozy-stack-client/src/AppCollection.js
+++ b/packages/cozy-stack-client/src/AppCollection.js
@@ -3,8 +3,8 @@ import { uri } from './utils'
 
 export const APPS_DOCTYPE = 'io.cozy.apps'
 
-export const normalizeApp = app => {
-  return { ...app, ...normalizeDoc(app, APPS_DOCTYPE), ...app.attributes }
+export const normalizeApp = (app, doctype) => {
+  return { ...app, ...normalizeDoc(app, doctype), ...app.attributes }
 }
 
 /**
@@ -12,6 +12,7 @@ export const normalizeApp = app => {
  */
 class AppCollection {
   endpoint = '/apps/'
+  doctype = APPS_DOCTYPE
 
   constructor(stackClient) {
     this.stackClient = stackClient
@@ -28,7 +29,7 @@ class AppCollection {
   async all() {
     const resp = await this.stackClient.fetchJSON('GET', this.endpoint)
     return {
-      data: resp.data.map(app => normalizeApp(app)),
+      data: resp.data.map(app => normalizeApp(app, this.doctype)),
       meta: {
         count: resp.meta.count
       },

--- a/packages/cozy-stack-client/src/AppCollection.js
+++ b/packages/cozy-stack-client/src/AppCollection.js
@@ -1,4 +1,4 @@
-import { normalizeDoc } from './DocumentCollection'
+import DocumentCollection, { normalizeDoc } from './DocumentCollection'
 import { uri } from './utils'
 
 export const APPS_DOCTYPE = 'io.cozy.apps'
@@ -38,8 +38,8 @@ class AppCollection {
     }
   }
 
-  async find() {
-    throw new Error('find() method is not yet implemented')
+  find(...args) {
+    return DocumentCollection.prototype.find.call(this, ...args)
   }
 
   async get() {

--- a/packages/cozy-stack-client/src/AppCollection.js
+++ b/packages/cozy-stack-client/src/AppCollection.js
@@ -39,6 +39,11 @@ class AppCollection {
   }
 
   find(...args) {
+    console.warn(
+      `find() method for doctype '${
+        this.doctype
+      }' relies internally on DocumentCollection.find() and may not fetch all expected data.`
+    )
     return DocumentCollection.prototype.find.call(this, ...args)
   }
 

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -42,18 +42,7 @@ class CozyStackClient {
       case APPS_DOCTYPE:
         return new AppCollection(this)
       case KONNECTORS_DOCTYPE:
-        // For now we are still returning a DocumentCollection because
-        // Cozy-Banks is the only app which access konnectors with
-        // CozyStackClient, and it's using a `where()` query which is not yet
-        // implemented in KonnectorCollection.
-        //
-        // So we do not want to introduce a BREAKING CHANGE here by returning
-        // new KonnectorCollection(this).
-        // Next step to get rid of this : implement the `where()` query for
-        // KonnectorCollection.
-        //
-        // Until then, stackClient.konnectors can be used instead.
-        return new DocumentCollection(doctype, this)
+        return new KonnectorCollection(this)
       case 'io.cozy.files':
         return new FileCollection(doctype, this)
       case 'io.cozy.sharings':

--- a/packages/cozy-stack-client/src/KonnectorCollection.js
+++ b/packages/cozy-stack-client/src/KonnectorCollection.js
@@ -3,6 +3,7 @@ import AppCollection from './AppCollection'
 export const KONNECTORS_DOCTYPE = 'io.cozy.konnectors'
 
 class KonnectorCollection extends AppCollection {
+  doctype = KONNECTORS_DOCTYPE
   endpoint = '/konnectors/'
 }
 

--- a/packages/cozy-stack-client/src/KonnectorCollection.js
+++ b/packages/cozy-stack-client/src/KonnectorCollection.js
@@ -1,5 +1,7 @@
 import AppCollection from './AppCollection'
 
+export const KONNECTORS_DOCTYPE = 'io.cozy.konnectors'
+
 class KonnectorCollection extends AppCollection {
   endpoint = '/konnectors/'
 }

--- a/packages/cozy-stack-client/src/__tests__/KonnectorCollection.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/KonnectorCollection.spec.js
@@ -1,7 +1,8 @@
 jest.mock('../CozyStackClient')
 
 import CozyStackClient from '../CozyStackClient'
-import KonnectorCollection from '../KonnectorCollection'
+import DocumentCollection from '../KonnectorCollection'
+import KonnectorCollection, { KONNECTORS_DOCTYPE } from '../KonnectorCollection'
 import ALL_KONNECTORS_RESPONSE from './fixtures/konnectors.json'
 
 const FIXTURES = {
@@ -17,6 +18,10 @@ describe(`KonnectorCollection`, () => {
       client.fetchJSON.mockReturnValue(
         Promise.resolve(FIXTURES.ALL_KONNECTORS_RESPONSE)
       )
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
     })
 
     it('should call the right route', async () => {
@@ -36,11 +41,17 @@ describe(`KonnectorCollection`, () => {
   })
 
   describe('find', () => {
-    it('throw error', async () => {
+    it('should rely internally on DocumentCollection.find()', async () => {
+      jest
+        .spyOn(DocumentCollection.prototype, 'find')
+        .mockImplementation(() => {})
+
       const collection = new KonnectorCollection(client)
-      expect(collection.find()).rejects.toThrowError(
-        'find() method is not yet implemented'
-      )
+      await collection.find({ slug: 'test' })
+
+      expect(DocumentCollection.prototype.find).toHaveBeenLastCalledWith({
+        slug: 'test'
+      })
     })
   })
 


### PR DESCRIPTION
Last step for us to be able to get installed konnectors and
their triggers as HasManyTriggers relationship.

Unfortunately we would like to do:

```
const konnectors = client.query(client.all('io.cozy.konnectors').include('triggers)
```

But [remember](https://github.com/cozy/cozy-client/pull/393), we have a blocking change in Cozy-Banks that forbid us to respond to client.all('io.cozy.konnectors') with a KonnectorCollection.

Here the good news, as `client.all('io.cozy.konnectors').where({ something })` rely internally on `KonnectorCollection.find()`, this PR made `AppCollection.find()` encapsulate a call to `DocumentCollection.find()`, which make everything works well (As `KonnectorCollection` extends `AppCollection`.