### PR TITLE
Client: Add Schema.add() method

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -82,6 +82,10 @@ class CozyClient {
     this.schema = new Schema(schema, this.getStackClient())
   }
 
+  addSchema(schemaDefinition) {
+    this.schema.add(schemaDefinition)
+  }
+
   registerClientOnLinks() {
     for (const link of this.links) {
       if (link.registerClient) {

--- a/packages/cozy-client/src/Schema.js
+++ b/packages/cozy-client/src/Schema.js
@@ -1,5 +1,6 @@
 import keyBy from 'lodash/keyBy'
 import mapValues from 'lodash/mapValues'
+import merge from 'lodash/merge'
 import size from 'lodash/size'
 import { resolveClass as resolveAssociationClass } from './associations'
 
@@ -52,13 +53,18 @@ const normalizeDoctypeSchema = doctypeSchema => {
  */
 class Schema {
   constructor(schemaDefinition = {}, client = null) {
+    this.add(schemaDefinition)
+    this.client = client
+  }
+
+  add(schemaDefinition = {}) {
     const values = mapValues(schemaDefinition, (obj, name) => ({
       name,
       ...normalizeDoctypeSchema(obj)
     }))
-    this.client = client
-    this.byName = keyBy(values, x => x.name)
-    this.byDoctype = keyBy(values, x => x.doctype)
+
+    this.byName = merge(this.byName || {}, keyBy(values, x => x.name))
+    this.byDoctype = merge(this.byDoctype || {}, keyBy(values, x => x.doctype))
   }
 
   /**

--- a/packages/cozy-client/src/Schema.js
+++ b/packages/cozy-client/src/Schema.js
@@ -63,7 +63,6 @@ class Schema {
       ...normalizeDoctypeSchema(obj)
     }))
 
-    this.byName = merge(this.byName || {}, keyBy(values, x => x.name))
     this.byDoctype = merge(this.byDoctype || {}, keyBy(values, x => x.doctype))
   }
 

--- a/packages/cozy-client/src/Schema.spec.js
+++ b/packages/cozy-client/src/Schema.spec.js
@@ -1,5 +1,6 @@
 import Schema from './Schema'
 import HasOneInPlace from './associations/HasOneInPlace'
+import HasMany from './associations/HasMany'
 
 describe('Schema', () => {
   const schemaDef = {
@@ -51,6 +52,64 @@ describe('Schema', () => {
       doctype: 'io.cozy.bank.accounts',
       name: 'account',
       type: HasOneInPlace
+    })
+  })
+
+  describe('add', () => {
+    it('adds a schema definition', () => {
+      schema.add({
+        todos: {
+          doctype: 'io.cozy.todos',
+          attributes: {},
+          relationships: {
+            items: {
+              doctype: 'io.cozy.todo.items',
+              type: 'has-many'
+            }
+          }
+        }
+      })
+
+      expect(schema.getDoctypeSchema('io.cozy.todos')).toEqual({
+        doctype: 'io.cozy.todos',
+        name: 'todos',
+        attributes: {},
+        relationships: {
+          items: {
+            doctype: 'io.cozy.todo.items',
+            name: 'items',
+            type: HasMany
+          }
+        }
+      })
+
+      expect(schema.getRelationship('io.cozy.todos', 'items')).toEqual({
+        doctype: 'io.cozy.todo.items',
+        name: 'items',
+        type: HasMany
+      })
+    })
+
+    it('keeps the previous', () => {
+      expect(schema.getDoctypeSchema('io.cozy.bank.transactions')).toEqual({
+        doctype: 'io.cozy.bank.transactions',
+        name: 'transactions',
+        relationships: {
+          account: {
+            doctype: 'io.cozy.bank.accounts',
+            name: 'account',
+            type: HasOneInPlace
+          }
+        }
+      })
+
+      expect(
+        schema.getRelationship('io.cozy.bank.transactions', 'account')
+      ).toEqual({
+        doctype: 'io.cozy.bank.accounts',
+        name: 'account',
+        type: HasOneInPlace
+      })
     })
   })
 })

--- a/packages/cozy-client/src/Schema.spec.js
+++ b/packages/cozy-client/src/Schema.spec.js
@@ -56,7 +56,8 @@ describe('Schema', () => {
   })
 
   describe('add', () => {
-    it('adds a schema definition', () => {
+    beforeEach(() => {
+      schema = new Schema(schemaDef)
       schema.add({
         todos: {
           doctype: 'io.cozy.todos',
@@ -69,7 +70,9 @@ describe('Schema', () => {
           }
         }
       })
+    })
 
+    it('adds a schema definition', () => {
       expect(schema.getDoctypeSchema('io.cozy.todos')).toEqual({
         doctype: 'io.cozy.todos',
         name: 'todos',
@@ -90,7 +93,7 @@ describe('Schema', () => {
       })
     })
 
-    it('keeps the previous', () => {
+    it('keeps the previous schemas', () => {
       expect(schema.getDoctypeSchema('io.cozy.bank.transactions')).toEqual({
         doctype: 'io.cozy.bank.transactions',
         name: 'transactions',
@@ -109,6 +112,51 @@ describe('Schema', () => {
         doctype: 'io.cozy.bank.accounts',
         name: 'account',
         type: HasOneInPlace
+      })
+    })
+
+    it('throws if schema with same name exists', () => {
+      expect(() =>
+        schema.add({
+          todos: {
+            doctype: 'com.todocompany.todos',
+            attributes: {}
+          }
+        })
+      ).toThrow()
+    })
+
+    it('does not add schema if schema with same name exists', () => {
+      expect(schema.getDoctypeSchema('io.cozy.todos')).toEqual({
+        doctype: 'io.cozy.todos',
+        name: 'todos',
+        attributes: {},
+        relationships: {
+          items: {
+            doctype: 'io.cozy.todo.items',
+            name: 'items',
+            type: HasMany
+          }
+        }
+      })
+    })
+
+    it('throws if schema with same doctype exist', () => {
+      expect(() =>
+        schema.add({
+          foo: {
+            doctype: 'io.cozy.todos',
+            attributes: {}
+          }
+        })
+      ).toThrow()
+    })
+
+    it('does not add schema if schema with same doctype exists', () => {
+      expect(schema.getRelationship('io.cozy.todos', 'items')).toEqual({
+        doctype: 'io.cozy.todo.items',
+        name: 'items',
+        type: HasMany
       })
     })
   })


### PR DESCRIPTION
In the cozy-bar we will need to access konnectors, and we cannot be sure that CozyClient has been initialized with the expected schema.

This PR adds a method to dinamically add a schema.

```js
client.addSchema({
  todos: {
    doctype: 'io.cozy.todos'
  }
})
```