### PR TITLE
Client: Pass the expected Map of QueryDefinition

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -465,7 +465,7 @@ class CozyClient {
     const relationshipsByDocId = reconstructRelationships(
       queryDefToDocIdAndRel,
       documents,
-      definitions,
+      optimizedDefinitions,
       responses
     )
 

--- a/packages/cozy-client/src/associations/helpers.js
+++ b/packages/cozy-client/src/associations/helpers.js
@@ -77,11 +77,13 @@ export const reconstructRelationships = (
 
   for (const [def, resp] of zip(definitions, responses)) {
     const docIdAndRels = queryDefToDocIdAndRel.get(def)
-    for (const docIdAndRel of docIdAndRels) {
-      if (docIdAndRel) {
-        const [docId, relName] = docIdAndRel
-        relationshipsByDocId[docId] = relationshipsByDocId[docId] || {}
-        relationshipsByDocId[docId][relName] = responseToRelationship(resp)
+    if(docIdAndRels) {
+      for (const docIdAndRel of docIdAndRels) {
+        if (docIdAndRel) {
+          const [docId, relName] = docIdAndRel
+          relationshipsByDocId[docId] = relationshipsByDocId[docId] || {}
+          relationshipsByDocId[docId][relName] = responseToRelationship(resp)
+        }
       }
     }
   }


### PR DESCRIPTION
This PR fixes #404.

The wrong Map of QueryDefinition was passed to reconstructRelationShips.

I fixed but in reconstructRelationShips docIdAndRel can now be `undefined`, which is espacially weird. Testing it before reconstructing relationShip seems to do the job,
but I cannot be 100% sure that id does not introduce another issue. By the way, Banks seems to work again.

I am thinking of a whole refactoring of fetchRelationShips, this method is pretty huge and complex.