### PR TITLE
Client: Better AppColleciton and KonnectorCollection

### DIFF
--- a/packages/cozy-stack-client/src/AppCollection.js
+++ b/packages/cozy-stack-client/src/AppCollection.js
@@ -10,10 +10,9 @@ export const normalizeApp = (app, doctype) => {
  * Extends `DocumentCollection` API along with specific methods for `io.cozy.apps`.
  */
 class AppCollection extends DocumentCollection {
-  endpoint = '/apps/'
-
   constructor(stackClient) {
     super(APPS_DOCTYPE, stackClient)
+    this.endpoint = '/apps/'
   }
 
   /**
@@ -34,6 +33,31 @@ class AppCollection extends DocumentCollection {
       skip: 0,
       next: false
     }
+  }
+
+  find(...args) {
+    console.warn(
+      `find() method for doctype '${
+        this.doctype
+      }' relies internally on DocumentCollection.find() and may not fetch all expected data.`
+    )
+    return super.find(...args)
+  }
+
+  async get() {
+    throw new Error('get() method is not yet implemented')
+  }
+
+  async create() {
+    throw new Error('create() method is not available for applications')
+  }
+
+  async update() {
+    throw new Error('update() method is not available for applications')
+  }
+
+  async destroy() {
+    throw new Error('destroy() method is not available for applications')
   }
 }
 

--- a/packages/cozy-stack-client/src/KonnectorCollection.js
+++ b/packages/cozy-stack-client/src/KonnectorCollection.js
@@ -3,11 +3,10 @@ import AppCollection from './AppCollection'
 export const KONNECTORS_DOCTYPE = 'io.cozy.konnectors'
 
 class KonnectorCollection extends AppCollection {
-  endpoint = '/konnectors/'
-
   constructor(stackClient) {
     super(stackClient)
     this.doctype = KONNECTORS_DOCTYPE
+    this.endpoint = '/konnectors/'
   }
 }
 

--- a/packages/cozy-stack-client/src/__tests__/AppCollection.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/AppCollection.spec.js
@@ -2,6 +2,7 @@ jest.mock('../CozyStackClient')
 
 import CozyStackClient from '../CozyStackClient'
 import AppCollection from '../AppCollection'
+import DocumentCollection from '../DocumentCollection'
 import ALL_APPS_RESPONSE from './fixtures/apps.json'
 
 const FIXTURES = {
@@ -32,6 +33,45 @@ describe(`AppCollection`, () => {
     it('should return normalized documents', async () => {
       const resp = await collection.all()
       expect(resp.data[0]).toHaveDocumentIdentity()
+    })
+  })
+
+  describe('get', () => {
+    it('should throw error', async () => {
+      const collection = new AppCollection(client)
+      expect(collection.get()).rejects.toThrowError(
+        'get() method is not yet implemented'
+      )
+    })
+  })
+
+  describe('create', () => {
+    const collection = new AppCollection(client)
+
+    it('should throw error', async () => {
+      expect(collection.create()).rejects.toThrowError(
+        'create() method is not available for applications'
+      )
+    })
+  })
+
+  describe('update', () => {
+    const collection = new AppCollection(client)
+
+    it('should throw error', async () => {
+      expect(collection.update()).rejects.toThrowError(
+        'update() method is not available for applications'
+      )
+    })
+  })
+
+  describe('destroy', () => {
+    const collection = new AppCollection(client)
+
+    it('should throw error', async () => {
+      expect(collection.destroy()).rejects.toThrowError(
+        'destroy() method is not available for applications'
+      )
     })
   })
 })

--- a/packages/cozy-stack-client/src/__tests__/KonnectorCollection.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/KonnectorCollection.spec.js
@@ -54,4 +54,43 @@ describe(`KonnectorCollection`, () => {
       })
     })
   })
+
+  describe('get', () => {
+    it('throw error', async () => {
+      const collection = new KonnectorCollection(client)
+      expect(collection.get()).rejects.toThrowError(
+        'get() method is not yet implemented'
+      )
+    })
+  })
+
+  describe('create', () => {
+    const collection = new KonnectorCollection(client)
+
+    it('should throw error', async () => {
+      expect(collection.create()).rejects.toThrowError(
+        'create() method is not available for konnectors'
+      )
+    })
+  })
+
+  describe('update', () => {
+    const collection = new KonnectorCollection(client)
+
+    it('should throw error', async () => {
+      expect(collection.update()).rejects.toThrowError(
+        'update() method is not available for konnectors'
+      )
+    })
+  })
+
+  describe('destroy', () => {
+    const collection = new KonnectorCollection(client)
+
+    it('should throw error', async () => {
+      expect(collection.destroy()).rejects.toThrowError(
+        'destroy() method is not available for konnectors'
+      )
+    })
+  })
 })


### PR DESCRIPTION
Get back to throwing method for not implemented endpoints for apps an konnectors.

Follows feedback from #406.