### PR TITLE
feat: Remove warning

### DIFF
--- a/packages/cozy-stack-client/src/AppCollection.js
+++ b/packages/cozy-stack-client/src/AppCollection.js
@@ -35,15 +35,6 @@ class AppCollection extends DocumentCollection {
     }
   }
 
-  find(...args) {
-    console.warn(
-      `find() method for doctype '${
-        this.doctype
-      }' relies internally on DocumentCollection.find() and may not fetch all expected data.`
-    )
-    return super.find(...args)
-  }
-
   async get() {
     throw new Error('get() method is not yet implemented')
   }


### PR DESCRIPTION
Since the route currently works, and the user does not have to do anything, I think we can remove the warning. 