### PR TITLE
feat: Client emits events for log{in,out}

### DIFF
--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -14,6 +14,7 @@
     "cozy-device-helper": "1.6.3",
     "cozy-stack-client": "^6.12.0",
     "lodash": "4.17.11",
+    "microee": "0.0.6",
     "prop-types": "15.6.2",
     "react": "16.7.0",
     "react-redux": "5.0.7",

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -690,9 +690,21 @@ class CozyClient {
     if (stackClient) {
       this.stackClient = stackClient
     } else {
+      const options = {
+        ...this.options,
+        onTokenRefresh: token => {
+          this.emit('tokenRefreshed')
+          if (this.options.onTokenRefresh) {
+            deprecatedHandler(
+              `Using onTokenRefresh is deprecated, please use events like this: cozyClient.on('tokenUpdated', token => console.log('Token is updated', token)). https://git.io/fj3M3`
+            )
+            this.options.onTokenRefresh(token)
+          }
+        }
+      }
       this.stackClient = this.options.oauth
-        ? new OAuthClient(this.options)
-        : new CozyStackClient(this.options)
+        ? new OAuthClient(options)
+        : new CozyStackClient(options)
     }
 
     this.client = new Proxy(

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -32,6 +32,7 @@ import fromPairs from 'lodash/fromPairs'
 import flatten from 'lodash/flatten'
 import uniqBy from 'lodash/uniqBy'
 import get from 'lodash/get'
+import MicroEE from 'microee'
 
 const ensureArray = arr => (Array.isArray(arr) ? arr : [arr])
 
@@ -115,6 +116,8 @@ class CozyClient {
         }
       }
     }
+
+    this.emit('login')
   }
 
   async logout() {
@@ -147,6 +150,8 @@ class CozyClient {
         }
       }
     }
+
+    this.emit('logout')
   }
 
   /**
@@ -740,5 +745,7 @@ class CozyClient {
     })
   }
 }
+
+MicroEE.mixin(CozyClient)
 
 export default CozyClient


### PR DESCRIPTION
Emitting events during login/logout provides a flexible way
for components/objects using CozyClient to setup/destroy
themselves. It lets the setup to be decoupled from where
the login/logout happens.

I think it can be a good way for example to init the bar.

```
cozyClient.on('login', setupBar)
cozyClient.on('logout', destroyBar)
```

I would like to have your views on this.