### PR TITLE
Allows to refresh app tokens

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -76,6 +76,7 @@ Main API against the `cozy-stack` server.
 * [CozyStackClient](#CozyStackClient)
     * [.collection(doctype)](#CozyStackClient+collection) ⇒ [<code>DocumentCollection</code>](#DocumentCollection)
     * [.fetch(method, path, body, options)](#CozyStackClient+fetch) ⇒ <code>Object</code>
+    * [.refreshToken()](#CozyStackClient+refreshToken) ⇒ <code>Promise</code>
     * [.fetchJSON(method, path, body, options)](#CozyStackClient+fetchJSON) ⇒ <code>Object</code>
 
 <a name="CozyStackClient+collection"></a>
@@ -106,6 +107,18 @@ Fetches an endpoint in an authorized way.
 | path | <code>String</code> | The URI. |
 | body | <code>Object</code> | The payload. |
 | options | <code>Object</code> |  |
+
+<a name="CozyStackClient+refreshToken"></a>
+
+### cozyStackClient.refreshToken() ⇒ <code>Promise</code>
+Retrieves a new app token by refreshing the currently used token.
+
+**Kind**: instance method of [<code>CozyStackClient</code>](#CozyStackClient)  
+**Returns**: <code>Promise</code> - A promise that resolves with a new AccessToken object  
+**Throws**:
+
+- <code>Error</code> The client should already have an access token to use this function
+- <code>Error</code> The client couldn't fetch a new token
 
 <a name="CozyStackClient+fetchJSON"></a>
 

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -1,7 +1,6 @@
 import CozyStackClient from './CozyStackClient'
 import AccessToken from './AccessToken'
 import logDeprecate from './logDeprecate'
-import errors from './errors'
 
 const defaultoauthOptions = {
   clientID: '',
@@ -419,20 +418,6 @@ class OAuthClient extends CozyStackClient {
     this.resetClientId()
     this.setUri(null)
     this.setToken(null)
-  }
-
-  async fetchJSON(method, path, body, options) {
-    try {
-      return await super.fetchJSON(method, path, body, options)
-    } catch (e) {
-      if (errors.EXPIRED_TOKEN.test(e.message)) {
-        const token = await this.refreshToken()
-        this.setToken(token)
-        return await super.fetchJSON(method, path, body, options)
-      } else {
-        throw e
-      }
-    }
   }
 
   /**

--- a/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
@@ -17,6 +17,20 @@ const FAKE_INIT_OPTIONS = {
   token: 'aAbBcCdDeEfFgGhH'
 }
 
+const FAKE_APP_TOKEN =
+  'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhcHAiLCJpYXQiOjE1NTYxMTIwOTQsImlzcyI6ImVkYXMubXljb3p5LmNsb3VkIiwic3ViIjoiaG9tZSIsInNlc3Npb25faWQiOiI4YjI1ZTgzNTkwYTg5MDg0MDUzNDIxZGE0ZmZlOTMwNiJ9.gA3Xnoliu43gwpuO88O6G59rVP_HClZ_vBp96pEjVNnZDpxU4ZnQoWmICoLXih4PvFZRj2eHjnG-eqnJx6XM2A'
+
+const FAKE_APP_HTML = `<!DOCTYPE html><html lang="fr"><head><meta charset="utf-8"><title>Cozy Home</title>
+  <link rel="icon" href="//test.mycozy.cloud/assets/favicon.f56cf1d03b.ico">
+  <link rel="icon" type="image/png" href="//test.mycozy.cloud/assets/favicon-16x16.192a16308f.png" sizes="16x16">
+  <link rel="icon" type="image/png" href="//test.mycozy.cloud/assets/favicon-32x32.9f958fa2c7.png" sizes="32x32">
+  <link rel="apple-touch-icon" sizes="180x180" href="//test.mycozy.cloud/assets/apple-touch-icon.a0e0ae4102.png"/>
+    <link rel="manifest" href="/manifest.json" crossorigin="use-credentials"><meta name="msapplication-TileColor" content="#2b5797"><meta name="theme-color" content="#ffffff"><meta name="viewport" content="width=device-width,height=device-height,initial-scale=1,viewport-fit=cover"><link rel="stylesheet" href="vendors/home.c451e5ac76c8377b20c5.0.min.css"><link rel="stylesheet" href="app/home.cbb1b1050b936df11fbd.min.css"><link rel="stylesheet" type="text/css" href="//test.mycozy.cloud/assets/styles/theme.faa4e12bdc.css"> <script src="//test.mycozy.cloud/assets/js/cozy-client.605c649bc3.min.js"></script> 
+<link rel="stylesheet" type="text/css" href="//test.mycozy.cloud/assets/fonts/fonts.33109548ca.css">
+<link rel="stylesheet" type="text/css" href="//test.mycozy.cloud/assets/css/cozy-bar.6effa2d88c.min.css">
+<script src="//test.mycozy.cloud/assets/js/cozy-bar.f99c08ee53.min.js"></script></head><body><div role="application" data-cozy-token="${FAKE_APP_TOKEN}" data-cozy-domain="test.mycozy.cloud" data-cozy-locale="fr" data-cozy-app-editor="Cozy" data-cozy-app-name="Accueil" data-cozy-app-name-prefix="Cozy" data-cozy-app-slug="home" data-cozy-tracking="false" data-cozy-icon-path="icon.svg"><script src="vendors/home.a664629f1a5622ccb459.js"></script><script src="app/home.455bbc269323b2c64382.js"></script><script src="//test.mycozy.cloud/assets/js/piwik.js" async></script></div></body></html>
+`
+
 describe('CozyStackClient', () => {
   it('should normalize the provided uri', () => {
     const client = new CozyStackClient({
@@ -268,6 +282,60 @@ describe('CozyStackClient', () => {
         // expect(e.name).toBe('FetchError')
         expect(e.message).toMatch(/Not/)
       }
+    })
+  })
+
+  describe('refreshToken', () => {
+    beforeAll(() => {
+      global.fetch = require('jest-fetch-mock')
+    })
+
+    beforeEach(() => {
+      fetch.resetMocks()
+      fetch.mockResponse(FAKE_APP_HTML)
+    })
+
+    const getClient = () =>
+      new CozyStackClient({
+        uri: 'http://cozy.tools:8080/',
+        token: 'azertyuio'
+      })
+
+    it('should return a new token', async () => {
+      const client = getClient()
+      const newToken = await client.refreshToken()
+      expect(newToken.token).toEqual(FAKE_APP_TOKEN)
+    })
+
+    it('should have called onRefreshToken`', async () => {
+      const client = getClient()
+      const promise = new Promise(function(res, rej) {
+        client.onTokenRefresh = tok => res(tok)
+      })
+      client.refreshToken()
+      const newToken = await promise
+      expect(newToken.token).toEqual(FAKE_APP_TOKEN)
+    })
+
+    it('should fail without repeat on server error', async () => {
+      const client = getClient()
+      fetch.mockReject(new Error('server error'))
+      const newToken = client.refreshToken()
+      await expect(newToken).rejects.toThrow()
+    })
+
+    it('should fail on server error', async () => {
+      const client = getClient()
+      fetch.mockReject(new Error('server error'))
+      const newToken = client.refreshToken()
+      await expect(newToken).rejects.toThrow()
+    })
+
+    it('should fail on server error', async () => {
+      const client = getClient()
+      fetch.mockReject(new Error('server error'))
+      const newToken = client.refreshToken()
+      await expect(newToken).rejects.toThrow()
     })
   })
 })


### PR DESCRIPTION
If an app is opened too long, the stack token could expire. This PR allows the stack client to fetch a new token when needed. This is probably a rare case but the code should have no compatibility break.