### PR TITLE
Oauth client improv

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -455,6 +455,7 @@ Responsible for
 
 * [CozyClient](#CozyClient)
     * [new CozyClient(options)](#new_CozyClient_new)
+    * [.login()](#CozyClient+login)
     * [.collection(doctype)](#CozyClient+collection) ⇒ <code>DocumentCollection</code>
     * [.getDocumentSavePlan(document, relationships)](#CozyClient+getDocumentSavePlan) ⇒ <code>Array.&lt;Mutation&gt;</code>
     * [.fetchRelationships()](#CozyClient+fetchRelationships)
@@ -478,6 +479,21 @@ Responsible for
 | options.links | <code>Array.Link</code> | List of links |
 | options.schema | <code>Object</code> | Schema description for each doctypes |
 | options.appMetadata | <code>Object</code> | Metadata about the application that will be used in ensureCozyMetadata |
+
+<a name="CozyClient+login"></a>
+
+### cozyClient.login()
+Notify the links that they can start and set isLoggedIn to true.
+
+On mobile, where url/token are set after instantiation, use this method
+to set the token and uri via options.
+
+**Kind**: instance method of [<code>CozyClient</code>](#CozyClient)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options.token | <code>options.token</code> | If passed, the token is set on the client |
+| options.uri | <code>options.uri</code> | If passed, the uri is set on the client |
 
 <a name="CozyClient+collection"></a>
 

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -292,7 +292,7 @@ through OAuth.
     * [.generateStateCode()](#OAuthClient+generateStateCode) ⇒ <code>string</code>
     * [.getAuthCodeURL(stateCode, scopes)](#OAuthClient+getAuthCodeURL) ⇒ <code>string</code>
     * [.getAccessCodeFromURL(pageURL, stateCode)](#OAuthClient+getAccessCodeFromURL) ⇒ <code>string</code>
-    * [.fetchAccessToken(accessCode)](#OAuthClient+fetchAccessToken) ⇒ <code>Promise</code>
+    * [.fetchAccessToken(accessCode, oauthOptions, uri)](#OAuthClient+fetchAccessToken) ⇒ <code>Promise</code>
     * [.refreshToken()](#OAuthClient+refreshToken) ⇒ <code>Promise</code>
     * [.setToken(token)](#OAuthClient+setToken)
     * [.setOAuthOptions(options)](#OAuthClient+setOAuthOptions)
@@ -388,7 +388,7 @@ Retrieves the access code contained in the URL to which the user is redirected a
 
 <a name="OAuthClient+fetchAccessToken"></a>
 
-### oAuthClient.fetchAccessToken(accessCode) ⇒ <code>Promise</code>
+### oAuthClient.fetchAccessToken(accessCode, oauthOptions, uri) ⇒ <code>Promise</code>
 Exchanges an access code for an access token. This function does **not** update the client's token.
 
 **Kind**: instance method of [<code>OAuthClient</code>](#OAuthClient)  
@@ -400,7 +400,9 @@ Exchanges an access code for an access token. This function does **not** update 
 
 | Param | Type | Description |
 | --- | --- | --- |
-| accessCode | <code>string</code> | The access code contained in the redirection URL — sett `client.getAccessCodeFromURL()` |
+| accessCode | <code>string</code> | The access code contained in the redirection URL — see `client.getAccessCodeFromURL()` |
+| oauthOptions | <code>object</code> | — To use when OAuthClient is not yet registered (during login process) |
+| uri | <code>string</code> | — To use when OAuthClient is not yet registered (during login process) |
 
 <a name="OAuthClient+refreshToken"></a>
 

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -100,7 +100,7 @@ class CozyClient {
     }
   }
 
-  async login() {
+  async login(options) {
     if (this.isLogged) {
       console.warn(`CozyClient is already logged.`)
       return
@@ -116,6 +116,15 @@ class CozyClient {
         } catch (e) {
           console.warn(e)
         }
+      }
+    }
+
+    if (options) {
+      if (options.uri) {
+        this.stackClient.setUri(options.uri)
+      }
+      if (options.token) {
+        this.stackClient.setToken(options.token)
       }
     }
 

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -100,6 +100,15 @@ class CozyClient {
     }
   }
 
+  /**
+   * Notify the links that they can start and set isLoggedIn to true.
+   *
+   * On mobile, where url/token are set after instantiation, use this method
+   * to set the token and uri via options.
+   *
+   * @param  {options.token}   options.token  - If passed, the token is set on the client
+   * @param  {options.uri}   options.uri  - If passed, the uri is set on the client
+   */
   async login(options) {
     if (this.isLogged) {
       console.warn(`CozyClient is already logged.`)

--- a/packages/cozy-client/src/authentication/mobile.js
+++ b/packages/cozy-client/src/authentication/mobile.js
@@ -94,7 +94,7 @@ export const authenticateWithCordova = async url => {
       setTimeout(() => {
         const token = prompt('Paste the url here:')
         resolve(token)
-      }, 10000)
+      }, 5000)
     })
   }
 }

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -121,7 +121,11 @@ class CozyStackClient {
   }
 
   fullpath(path) {
-    return this.uri + path
+    if (path.startsWith('http')) {
+      return path
+    } else {
+      return this.uri + path
+    }
   }
 
   getAuthorizationHeader() {

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -309,7 +309,8 @@ class OAuthClient extends CozyStackClient {
    * @returns {Promise} A promise that resolves with an AccessToken object.
    */
   async fetchAccessToken(accessCode, oauthOptions, uri) {
-    if (!this.isRegistered() && !oauthOptions) throw new NotRegisteredException()
+    if (!this.isRegistered() && !oauthOptions)
+      throw new NotRegisteredException()
 
     oauthOptions = oauthOptions || this.oauthOptions
     const data = {
@@ -370,13 +371,9 @@ class OAuthClient extends CozyStackClient {
   }
 
   exchangeOAuthSecret(uri, secret) {
-    return this.fetchJSON(
-      'POST',
-      uri + '/auth/secret_exchange',
-      {
-        secret
-      }
-    )
+    return this.fetchJSON('POST', uri + '/auth/secret_exchange', {
+      secret
+    })
   }
 
   /**

--- a/packages/cozy-stack-client/src/TriggerCollection.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.js
@@ -1,6 +1,5 @@
 import { normalizeDoc, dontThrowNotFoundError } from './DocumentCollection'
 import { uri } from './utils'
-import * as querystring from './querystring'
 
 export const JOBS_DOCTYPE = 'io.cozy.jobs'
 export const TRIGGERS_DOCTYPE = 'io.cozy.triggers'

--- a/packages/cozy-stack-client/src/__tests__/AppCollection.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/AppCollection.spec.js
@@ -2,7 +2,6 @@ jest.mock('../CozyStackClient')
 
 import CozyStackClient from '../CozyStackClient'
 import AppCollection from '../AppCollection'
-import DocumentCollection from '../DocumentCollection'
 import ALL_APPS_RESPONSE from './fixtures/apps.json'
 
 const FIXTURES = {

--- a/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
@@ -23,6 +23,7 @@ describe('CozyStackClient', () => {
       token: ''
     })
     expect(client.fullpath('/foo')).toBe('http://cozy.tools:8080/foo')
+    expect(client.fullpath('http://customcozy.mycozy.cloud/foo')).toBe('http://customcozy.mycozy.cloud/foo')
   })
 
   it('should instanciate konnectors property', () => {

--- a/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
@@ -23,7 +23,9 @@ describe('CozyStackClient', () => {
       token: ''
     })
     expect(client.fullpath('/foo')).toBe('http://cozy.tools:8080/foo')
-    expect(client.fullpath('http://customcozy.mycozy.cloud/foo')).toBe('http://customcozy.mycozy.cloud/foo')
+    expect(client.fullpath('http://customcozy.mycozy.cloud/foo')).toBe(
+      'http://customcozy.mycozy.cloud/foo'
+    )
   })
 
   it('should instanciate konnectors property', () => {

--- a/packages/cozy-stack-client/src/__tests__/KonnectorCollection.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/KonnectorCollection.spec.js
@@ -2,7 +2,7 @@ jest.mock('../CozyStackClient')
 
 import CozyStackClient from '../CozyStackClient'
 import DocumentCollection from '../KonnectorCollection'
-import KonnectorCollection, { KONNECTORS_DOCTYPE } from '../KonnectorCollection'
+import KonnectorCollection from '../KonnectorCollection'
 import ALL_KONNECTORS_RESPONSE from './fixtures/konnectors.json'
 
 const FIXTURES = {


### PR DESCRIPTION
- Allowing to use stack client when not completely initialized enables to remove duplicated code from the authentication code. 
- Reduce timeout because who has 10s to lose ?
- When the login process has finished, it is ergonomic to do login(url, token) and have setURI and setToken done for you