### PR TITLE
Fix unhandled rejections

### DIFF
--- a/packages/cozy-stack-client/src/KonnectorCollection.js
+++ b/packages/cozy-stack-client/src/KonnectorCollection.js
@@ -8,6 +8,22 @@ class KonnectorCollection extends AppCollection {
     this.doctype = KONNECTORS_DOCTYPE
     this.endpoint = '/konnectors/'
   }
+
+  async create() {
+    throw new Error('create() method is not available for konnectors')
+  }
+
+  async find() {
+    throw new Error('find() method is not available for konnectors')
+  }
+
+  async destroy() {
+    throw new Error('destroy() method is not available for konnectors')
+  }
+
+  async update() {
+    throw new Error('update() method is not available for konnectors')
+  }
 }
 
 export default KonnectorCollection

--- a/packages/cozy-stack-client/src/__tests__/AppCollection.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/AppCollection.spec.js
@@ -48,7 +48,7 @@ describe(`AppCollection`, () => {
     const collection = new AppCollection(client)
 
     it('should throw error', async () => {
-      expect(collection.create()).rejects.toThrowError(
+      await expect(collection.create()).rejects.toThrowError(
         'create() method is not available for applications'
       )
     })
@@ -58,7 +58,7 @@ describe(`AppCollection`, () => {
     const collection = new AppCollection(client)
 
     it('should throw error', async () => {
-      expect(collection.update()).rejects.toThrowError(
+      await expect(collection.update()).rejects.toThrowError(
         'update() method is not available for applications'
       )
     })
@@ -68,7 +68,7 @@ describe(`AppCollection`, () => {
     const collection = new AppCollection(client)
 
     it('should throw error', async () => {
-      expect(collection.destroy()).rejects.toThrowError(
+      await expect(collection.destroy()).rejects.toThrowError(
         'destroy() method is not available for applications'
       )
     })

--- a/packages/cozy-stack-client/src/__tests__/KonnectorCollection.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/KonnectorCollection.spec.js
@@ -58,7 +58,7 @@ describe(`KonnectorCollection`, () => {
   describe('get', () => {
     it('throw error', async () => {
       const collection = new KonnectorCollection(client)
-      expect(collection.get()).rejects.toThrowError(
+      await expect(collection.get()).rejects.toThrowError(
         'get() method is not yet implemented'
       )
     })
@@ -68,7 +68,7 @@ describe(`KonnectorCollection`, () => {
     const collection = new KonnectorCollection(client)
 
     it('should throw error', async () => {
-      expect(collection.create()).rejects.toThrowError(
+      await expect(collection.create()).rejects.toThrowError(
         'create() method is not available for konnectors'
       )
     })
@@ -78,7 +78,7 @@ describe(`KonnectorCollection`, () => {
     const collection = new KonnectorCollection(client)
 
     it('should throw error', async () => {
-      expect(collection.update()).rejects.toThrowError(
+      await expect(collection.update()).rejects.toThrowError(
         'update() method is not available for konnectors'
       )
     })
@@ -88,7 +88,7 @@ describe(`KonnectorCollection`, () => {
     const collection = new KonnectorCollection(client)
 
     it('should throw error', async () => {
-      expect(collection.destroy()).rejects.toThrowError(
+      await expect(collection.destroy()).rejects.toThrowError(
         'destroy() method is not available for konnectors'
       )
     })


### PR DESCRIPTION
expect().rejects.toBe()  returns a promise, it's necessary to await it otherwise if it fails, it is an unhandledRejections that does not make the test fail.