### PR TITLE
fix: Find method was used for KonnectorCollection

### DIFF
--- a/packages/cozy-stack-client/src/KonnectorCollection.js
+++ b/packages/cozy-stack-client/src/KonnectorCollection.js
@@ -13,10 +13,6 @@ class KonnectorCollection extends AppCollection {
     throw new Error('create() method is not available for konnectors')
   }
 
-  async find() {
-    throw new Error('find() method is not available for konnectors')
-  }
-
   async destroy() {
     throw new Error('destroy() method is not available for konnectors')
   }


### PR DESCRIPTION
find() is used on KonnectorCollection. Removing it was a mistake :/