### PR TITLE
Unregister and revocation

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -486,7 +486,7 @@ Responsible for
 <a name="CozyClient+login"></a>
 
 ### cozyClient.login()
-Notify the links that they can start and set isLoggedIn to true.
+Notify the links that they can start and set isLogged to true.
 
 On mobile, where url/token are set after instantiation, use this method
 to set the token and uri via options.

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -114,12 +114,13 @@ class CozyClient {
    * @param  {options.uri}   options.uri  - If passed, the uri is set on the client
    */
   async login(options) {
-    if (this.isLogged) {
+    if (this.isLogged && !this.isRevoked) {
       console.warn(`CozyClient is already logged.`)
       return
     }
 
     this.isLogged = true
+    this.isRevoked = false
     this.registerClientOnLinks()
 
     for (const link of this.links) {

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -105,7 +105,7 @@ class CozyClient {
   }
 
   /**
-   * Notify the links that they can start and set isLoggedIn to true.
+   * Notify the links that they can start and set isLogged to true.
    *
    * On mobile, where url/token are set after instantiation, use this method
    * to set the token and uri via options.

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -217,6 +217,21 @@ describe('CozyClient login', () => {
     expect(links[0].onLogin).toHaveBeenCalledTimes(1)
     expect(links[2].onLogin).toHaveBeenCalledTimes(1)
   })
+
+  it('should emit login', async () => {
+    client.emit = jest.fn()
+    client.registerClientOnLinks = jest.fn()
+    await client.login()
+    expect(client.emit).toHaveBeenCalledWith('login')
+  })
+
+  it('should set isRevoked to false', async () => {
+    client.emit = jest.fn()
+    client.registerClientOnLinks = jest.fn()
+    client.isRevoked = true
+    await client.login()
+    expect(client.isRevoked).toBe(false)
+  })
 })
 
 describe('CozyClient', () => {

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -115,7 +115,7 @@ describe('CozyClient handlers', () => {
 
   it('should warn when overriding default handlers', () => {
     jest.spyOn(console, 'warn').mockImplementation(() => {})
-    let client2 = new CozyClient({
+    new CozyClient({
       stackClient: new CozyStackClient({
         onRevocationChange: () => {}
       })

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -167,7 +167,9 @@ class OAuthClient extends CozyStackClient {
     this.oauthOptions.clientID = ''
 
     return this.fetchJSON('DELETE', `/auth/register/${clientID}`, null, {
-      credentials: this.registrationAccessTokenToAuthHeader()
+      headers: {
+        Authorization: this.registrationAccessTokenToAuthHeader()
+      }
     })
   }
 
@@ -184,7 +186,9 @@ class OAuthClient extends CozyStackClient {
       `/auth/register/${this.oauthOptions.clientID}`,
       null,
       {
-        credentials: this.registrationAccessTokenToAuthHeader()
+        headers: {
+          Authorization: this.registrationAccessTokenToAuthHeader()
+        }
       }
     )
   }
@@ -217,7 +221,9 @@ class OAuthClient extends CozyStackClient {
       `/auth/register/${this.oauthOptions.clientID}`,
       data,
       {
-        credentials: this.registrationAccessTokenToAuthHeader()
+        headers: {
+          Authorization: this.registrationAccessTokenToAuthHeader()
+        }
       }
     )
 

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -435,6 +435,9 @@ class OAuthClient extends CozyStackClient {
    * @private
    */
   registrationAccessTokenToAuthHeader() {
+    if (!this.oauthOptions.registrationAccessToken) {
+      throw new Error('No registration access token')
+    }
     return 'Bearer ' + this.oauthOptions.registrationAccessToken
   }
 }

--- a/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
@@ -16,7 +16,7 @@ const REGISTERED_CLIENT_INIT_OPTIONS = {
     ...CLIENT_INIT_OPTIONS.oauth,
     clientID: '1',
     clientsecret: '1',
-    registrationAccessToken: '1234'
+    registrationAccessToken: 'registrationAccessToken-1234'
   }
 }
 
@@ -62,7 +62,7 @@ describe('OAuthClient', () => {
       client = new OAuthClient(REGISTERED_CLIENT_INIT_OPTIONS)
       client.setToken({
         tokenType: 'type',
-        accessToken: 'abcd',
+        accessToken: 'accessToken-abcd',
         refreshToken: 'refresh-789',
         scope: 'io.cozy.todos'
       })

--- a/packages/cozy-stack-client/src/__tests__/__snapshots__/OAuthClient.spec.js.snap
+++ b/packages/cozy-stack-client/src/__tests__/__snapshots__/OAuthClient.spec.js.snap
@@ -8,7 +8,7 @@ Array [
     "credentials": "include",
     "headers": Object {
       "Accept": "application/json",
-      "Authorization": "Bearer abcd",
+      "Authorization": "Bearer accessToken-abcd",
       "Content-Type": "application/x-www-form-urlencoded",
     },
     "method": "POST",
@@ -23,7 +23,7 @@ Array [
     "credentials": "include",
     "headers": Object {
       "Accept": "application/json",
-      "Authorization": "Bearer abcd",
+      "Authorization": "Bearer registrationAccessToken-1234",
     },
     "method": "GET",
   },
@@ -38,7 +38,7 @@ Array [
     "credentials": "include",
     "headers": Object {
       "Accept": "application/json",
-      "Authorization": "Bearer abcd",
+      "Authorization": "Bearer accessToken-abcd",
       "Content-Type": "application/x-www-form-urlencoded",
     },
     "method": "POST",
@@ -62,7 +62,7 @@ Array [
     "credentials": "include",
     "headers": Object {
       "Accept": "application/json",
-      "Authorization": "Bearer abcd",
+      "Authorization": "Bearer registrationAccessToken-1234",
       "Content-Type": "application/json",
     },
     "method": "DELETE",
@@ -78,7 +78,7 @@ Array [
     "credentials": "include",
     "headers": Object {
       "Accept": "application/json",
-      "Authorization": "Bearer abcd",
+      "Authorization": "Bearer registrationAccessToken-1234",
       "Content-Type": "application/json",
     },
     "method": "PUT",


### PR DESCRIPTION
While finishing https://github.com/cozy/cozy-libs/pull/401, I stumbled upon
bugs in revocation and unregister.

- unregister used a deprecated way to set headers which resulted in the
accessToken being used instead of the registrationAccessToken. Unregister
did not work with the accessToken

- When logging back in, we have to check if the client is revoked. After
revocation, the client is logged in (isLogged = true) and isRevoked = true.
This is a bit surprising (I thought at first to set isLogged to false in
handleRevocationChange when revocation is true) but in cozy-authentication we have to differentiate between never having logged (isLogged = false, show login form), and having logged but being revoked (isLogged = true, isRevoked = true, show
revocation modal). This is why I bypass the early return of login().