### PR TITLE
[client] feat: Add beforeLogout event

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "scripts": {
     "lint": "eslint 'packages/*/src/**/*.{js,jsx}' 'packages/*/examples/**/*.{js,jsx}'",
-    "test": "jest --verbose --coverage",
+    "test": "jest --verbose",
     "watch": "lerna run watch --parallel",
     "build": "lerna run build",
     "commitmsg": "commitlint -e $GIT_PARAMS",

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -151,6 +151,7 @@ class CozyClient {
       return
     }
 
+    this.emit('beforeLogout')
     this.isLogged = false
 
     try {

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -172,6 +172,21 @@ describe('CozyClient logout', () => {
     expect(links[2].reset).toHaveBeenCalledTimes(1)
     spy.mockRestore()
   })
+
+  it('should emit events', async () => {
+    const originalLogout = client.logout
+    links[0].reset = jest.fn()
+    links[2].reset = jest.fn()
+    jest.spyOn(client, 'logout').mockImplementation(async function() {
+      expect(client.emit).not.toHaveBeenCalled()
+      await originalLogout.apply(this, arguments)
+      expect(client.emit).toHaveBeenCalledWith('beforeLogout')
+      expect(client.emit).toHaveBeenCalledWith('logout')
+    })
+    await client.login()
+    jest.spyOn(client, 'emit')
+    await client.logout()
+  })
 })
 
 describe('CozyClient login', () => {


### PR DESCRIPTION
Emit a beforeLogout when starting the logout process.
It lets us know when logout process has started so we can
display a message to the user in cozy-authentication:MobileRouter.