### PR TITLE
feat: Add beforeLogin event

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -455,7 +455,8 @@ Responsible for
 
 * [CozyClient](#CozyClient)
     * [new CozyClient(options)](#new_CozyClient_new)
-    * [.login()](#CozyClient+login)
+    * [.login()](#CozyClient+login) ⇒ <code>Promise</code>
+    * [.logout()](#CozyClient+logout) ⇒ <code>Promise</code>
     * [.collection(doctype)](#CozyClient+collection) ⇒ <code>DocumentCollection</code>
     * [.getDocumentSavePlan(document, relationships)](#CozyClient+getDocumentSavePlan) ⇒ <code>Array.&lt;Mutation&gt;</code>
     * [.fetchRelationships()](#CozyClient+fetchRelationships)
@@ -485,19 +486,37 @@ Responsible for
 
 <a name="CozyClient+login"></a>
 
-### cozyClient.login()
+### cozyClient.login() ⇒ <code>Promise</code>
 Notify the links that they can start and set isLogged to true.
 
 On mobile, where url/token are set after instantiation, use this method
 to set the token and uri via options.
 
+Emits
+
+- "beforeLogin" at the beginning, before links have been set up
+- "login" when the client is fully logged in and links have been set up
+
 **Kind**: instance method of [<code>CozyClient</code>](#CozyClient)  
+**Returns**: <code>Promise</code> - - Resolves when all links have been setup and client is fully logged in  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | options.token | <code>options.token</code> | If passed, the token is set on the client |
 | options.uri | <code>options.uri</code> | If passed, the uri is set on the client |
 
+<a name="CozyClient+logout"></a>
+
+### cozyClient.logout() ⇒ <code>Promise</code>
+Logs out the client and reset all the links
+
+Emits
+
+- "beforeLogout" at the beginning, before links have been reset
+- "login" when the client is fully logged out and links have been reset
+
+**Kind**: instance method of [<code>CozyClient</code>](#CozyClient)  
+**Returns**: <code>Promise</code> - - Resolves when all links have been reset and client is fully logged out  
 <a name="CozyClient+collection"></a>
 
 ### cozyClient.collection(doctype) ⇒ <code>DocumentCollection</code>

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -119,6 +119,8 @@ class CozyClient {
       return
     }
 
+    this.emit('beforeLogin')
+
     this.isLogged = true
     this.isRevoked = false
     this.registerClientOnLinks()

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -110,8 +110,15 @@ class CozyClient {
    * On mobile, where url/token are set after instantiation, use this method
    * to set the token and uri via options.
    *
+   * Emits
+   *
+   * - "beforeLogin" at the beginning, before links have been set up
+   * - "login" when the client is fully logged in and links have been set up
+   *
    * @param  {options.token}   options.token  - If passed, the token is set on the client
    * @param  {options.uri}   options.uri  - If passed, the uri is set on the client
+   * @return {Promise} - Resolves when all links have been setup and client is fully logged in
+   *
    */
   async login(options) {
     if (this.isLogged && !this.isRevoked) {
@@ -147,6 +154,16 @@ class CozyClient {
     this.emit('login')
   }
 
+  /**
+   * Logs out the client and reset all the links
+   *
+   * Emits
+   *
+   * - "beforeLogout" at the beginning, before links have been reset
+   * - "login" when the client is fully logged out and links have been reset
+   *
+   * @return {Promise} - Resolves when all links have been reset and client is fully logged out
+   */
   async logout() {
     if (!this.isLogged) {
       console.warn(`CozyClient isn't logged.`)

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -178,13 +178,16 @@ describe('CozyClient logout', () => {
     links[0].reset = jest.fn()
     links[2].reset = jest.fn()
     jest.spyOn(client, 'logout').mockImplementation(async function() {
-      expect(client.emit).not.toHaveBeenCalled()
       await originalLogout.apply(this, arguments)
-      expect(client.emit).toHaveBeenCalledWith('beforeLogout')
-      expect(client.emit).toHaveBeenCalledWith('logout')
+      expect(client.emit.mock.calls.map(x => x[0])).toEqual([
+        'beforeLogin',
+        'login',
+        'beforeLogout',
+        'logout'
+      ])
     })
-    await client.login()
     jest.spyOn(client, 'emit')
+    await client.login()
     await client.logout()
   })
 })


### PR DESCRIPTION
Similarly to the beforeLogout event, the beforeLogin event
is sent when the login process has started and before the
links have been set up.