### PR TITLE
feat: Fetch method on ObservableQuery

### DIFF
--- a/packages/cozy-client/src/ObservableQuery.js
+++ b/packages/cozy-client/src/ObservableQuery.js
@@ -47,6 +47,10 @@ export default class ObservableQuery {
     }
   }
 
+  fetch() {
+    return this.client.query(this.definition, { as: this.queryId })
+  }
+
   fetchMore() {
     return this.client.query(
       this.definition.offset(this.currentRawResult().data.length),

--- a/packages/cozy-client/src/Query.jsx
+++ b/packages/cozy-client/src/Query.jsx
@@ -34,14 +34,13 @@ export default class Query extends Component {
     this.deleteDocument = client.destroy.bind(client)
     this.getAssociation = client.getAssociation.bind(client)
     this.fetchMore = query.fetchMore.bind(query)
+    this.fetch = query.fetch.bind(query)
   }
 
   componentDidMount() {
     this.queryUnsubscribe = this.observableQuery.subscribe(this.onQueryChange)
     if (this.props.fetchPolicy !== 'cache-only') {
-      this.client.query(this.queryDefinition, {
-        as: this.observableQuery.queryId
-      })
+      this.observableQuery.fetch()
     }
   }
 
@@ -61,6 +60,7 @@ export default class Query extends Component {
     return children(
       {
         fetchMore: this.fetchMore,
+        fetch: this.fetch,
         ...query.currentResult()
       },
       {

--- a/packages/cozy-client/src/Query.spec.jsx
+++ b/packages/cozy-client/src/Query.spec.jsx
@@ -12,16 +12,19 @@ import {
 } from './store'
 import { TODOS, TODO_WITH_RELATION, FILE_1 } from './__tests__/fixtures'
 import * as mocks from './__tests__/mocks'
+
 describe('Query', () => {
   const queryDef = client => ({ doctype: 'io.cozy.todos' })
+  let observableQuery
   const client = mocks.client({
-    watchQuery: queryDef => mocks.observableQuery()
+    watchQuery: queryDef => observableQuery
   })
 
   const context = { client }
 
   beforeEach(() => {
     client.query.mockClear()
+    observableQuery = mocks.observableQuery()
   })
 
   describe('lifecycle', () => {
@@ -29,7 +32,7 @@ describe('Query', () => {
       mount(<Query query={queryDef}>{() => null}</Query>, {
         context
       })
-      expect(client.query).toHaveBeenCalled()
+      expect(observableQuery.fetch).toHaveBeenCalled()
     })
 
     it('should not fire a query fetch when mounted with initialFetch=false', () => {

--- a/packages/cozy-client/src/__tests__/ObservableQuery.spec.js
+++ b/packages/cozy-client/src/__tests__/ObservableQuery.spec.js
@@ -64,6 +64,32 @@ describe('ObservableQuery', () => {
     })
   })
 
+  describe('fetch', () => {
+    let query
+    const def = client.all('io.cozy.todos')
+    const observer = jest.fn()
+
+    beforeEach(async () => {
+      observer.mockReset()
+      query = new ObservableQuery('allTodos', def, client)
+      jest.spyOn(client, 'query').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should be able to tell the client to fetch', () => {
+      query.fetch()
+      expect(client.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          doctype: 'io.cozy.todos'
+        }),
+        { as: 'allTodos' }
+      )
+    })
+  })
+
   describe('current result', () => {
     let query
 

--- a/packages/cozy-client/src/__tests__/mocks.js
+++ b/packages/cozy-client/src/__tests__/mocks.js
@@ -25,7 +25,8 @@ export const observableQuery = implementations => {
   const base = {
     currentResult: jest.fn(),
     subscribe: jest.fn(),
-    fetchMore: jest.fn()
+    fetchMore: jest.fn(),
+    fetch: jest.fn()
   }
   mockImplementations(base, implementations)
   return base


### PR DESCRIPTION
Sometimes we want to refetch the query, for example in the Bar we want to refetch the konnectors when we go back online, or when the app resumes. We had already fetchMore, I just added fetch to the object received by the renderProps function in `<Query />`.