### PR TITLE
feat: Cozy-client will autologin if initialized with uri and token

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -482,7 +482,7 @@ Responsible for
 | options.link | <code>Link</code> | Backward compatibility |
 | options.links | <code>Array.Link</code> | List of links |
 | options.schema | <code>Object</code> | Schema description for each doctypes |
-| options.appMetadata | <code>Object</code> | Metadata about the application that will be used in ensureCozyMetadata |
+| options.appMetadata | <code>Object</code> | Metadata about the application that will be used in ensureCozyMetadata Cozy-Client will automatically call `this.login()` if provided with a token and an uri |
 
 <a name="CozyClient+login"></a>
 

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -60,6 +60,20 @@ describe('CozyClient initialization', () => {
     client = new CozyClient({ links, schema: SCHEMA })
   })
 
+  it('should autologin when provided token and uri', () => {
+    const token = 'fake_token'
+    const uri = 'https://example.mycozy.cloud'
+    client = new CozyClient({ token, uri })
+    expect(client.isLogged).toBeTruthy()
+  })
+
+  it('should not break explicit login when provided token and uri', () => {
+    const token = 'fake_token'
+    const uri = 'https://example.mycozy.cloud'
+    client = new CozyClient({ token, uri })
+    expect(client.login()).toBeInstanceOf(Promise)
+  })
+
   it('should have chained links', async () => {
     const res = await client.requestQuery({})
     expect(res).toBe('foobarbaz')


### PR DESCRIPTION
I was surprised by https://github.com/cozy/cozy-bar/pull/545#discussion-diff-282847190R209

Most apps initialize Cozy-Client by providing an uri and a token to the constructor, without any explicit call to `login()`. This PR allows compatibility with all events and state variables like `isLogged` by calling `login()`automatically in this case.

The promise returned by `login()`is kept in case one explicitly call `login()` anyways so there should be no compatibility break