### PR TITLE
feat: Sync pouch immediately

### DIFF
--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -343,6 +343,15 @@ class PouchLink extends CozyLink {
       throw new Error('Coud not apply mutation')
     }
   }
+
+  async syncImmediately() {
+    if (!this.pouches) {
+      logger.warn('Cannot sync immediately, no PouchManager')
+      return
+    }
+    this.pouches.stopReplicationLoop()
+    await this.pouches.startReplicationLoop()
+  }
 }
 
 export default PouchLink

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -36,7 +36,7 @@ async function clean() {
   await link.reset()
 }
 
-fdescribe('CozyPouchLink', () => {
+describe('CozyPouchLink', () => {
   afterEach(clean)
 
   it('should generate replication url', async () => {
@@ -238,6 +238,23 @@ fdescribe('CozyPouchLink', () => {
       await setup({ initialSync: false })
 
       expect(link.startReplication).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('immediate sync', () => {
+    it('should start/stop replication loop', async () => {
+      await setup()
+      const order = []
+      link.pouches.startReplicationLoop = jest
+        .fn()
+        .mockImplementation(() => order.push('start'))
+      link.pouches.stopReplicationLoop = jest
+        .fn()
+        .mockImplementation(() => order.push('stop'))
+      await link.syncImmediately()
+      expect(link.pouches.stopReplicationLoop).toHaveBeenCalled()
+      expect(link.pouches.startReplicationLoop).toHaveBeenCalled()
+      expect(order).toEqual(['stop', 'start'])
     })
   })
 })


### PR DESCRIPTION
It can be useful to trigger a sync for Pouch. We do this by restarting the
synchronization loop.