### PR TITLE
feat: Add display name for HOC

### DIFF
--- a/packages/cozy-client/src/hoc.js
+++ b/packages/cozy-client/src/hoc.js
@@ -14,6 +14,7 @@ export const withClient = Component => {
   const Wrapped = (props, context) => (
     <Component {...props} client={context.client} />
   )
+  Wrapped.displayName = `withClient(${Component.displayName || Component.name})`
   Wrapped.contextTypes = {
     client: PropTypes.object
   }
@@ -48,6 +49,8 @@ const withQuery = (dest, queryOpts, Original) => {
     Wrapped.contextTypes = {
       client: PropTypes.object
     }
+    Wrapped.displayName = `withQuery(${Component.displayName ||
+      Component.name})`
     return Wrapped
   }
 }

--- a/packages/cozy-client/src/hoc.spec.js
+++ b/packages/cozy-client/src/hoc.spec.js
@@ -20,32 +20,33 @@ describe('with client', () => {
 })
 
 describe('queryConnect', () => {
-  it('should pass result of query definitions as props', () => {
-    const fakeData = {
-      'io.cozy.toto': 'hello',
-      'io.cozy.tata': 'hello2'
-    }
-    const queryDefinitionFromDoctype = doctype => ({ doctype })
-    const observableQueryFromDefinition = definition => {
-      return mocks.observableQuery({
-        currentResult: () => ({
-          data: fakeData[definition.doctype]
-        })
+  const fakeData = {
+    'io.cozy.toto': 'hello',
+    'io.cozy.tata': 'hello2'
+  }
+  const queryDefinitionFromDoctype = doctype => ({ doctype })
+  const observableQueryFromDefinition = definition => {
+    return mocks.observableQuery({
+      currentResult: () => ({
+        data: fakeData[definition.doctype]
       })
-    }
-
-    const client = mocks.client({
-      all: doctype => queryDefinitionFromDoctype(doctype),
-      watchQuery: queryDef => observableQueryFromDefinition(queryDef)
     })
+  }
 
+  const client = mocks.client({
+    all: doctype => queryDefinitionFromDoctype(doctype),
+    watchQuery: queryDef => observableQueryFromDefinition(queryDef)
+  })
+
+  const WithQueries = queryConnect({
+    toto: { query: client => client.all('io.cozy.toto') },
+    tata: { query: client => client.all('io.cozy.tata') }
+  })(Component)
+
+  it('should pass result of query definitions as props', () => {
     const context = {
       client
     }
-    const WithQueries = queryConnect({
-      toto: { query: client => client.all('io.cozy.toto') },
-      tata: { query: client => client.all('io.cozy.tata') }
-    })(Component)
     const uut = mount(<WithQueries />, { context })
     expect(uut.find(Component).prop('toto').data).toBe('hello')
     expect(uut.find(Component).prop('tata').data).toBe('hello2')

--- a/packages/cozy-client/src/hoc.spec.js
+++ b/packages/cozy-client/src/hoc.spec.js
@@ -17,6 +17,11 @@ describe('with client', () => {
     const uut = mount(<WithClientComponent />, { context })
     expect(uut.find(Component).prop('client')).toBe(fakeClient)
   })
+
+  it('should give a display name', () => {
+    const WithClientComponent = withClient(Component)
+    expect(WithClientComponent.displayName).toBe('withClient(Component)')
+  })
 })
 
 describe('queryConnect', () => {
@@ -42,6 +47,10 @@ describe('queryConnect', () => {
     toto: { query: client => client.all('io.cozy.toto') },
     tata: { query: client => client.all('io.cozy.tata') }
   })(Component)
+
+  it('should give a display name', () => {
+    expect(WithQueries.displayName).toBe('withQuery(withQuery(Component))')
+  })
 
   it('should pass result of query definitions as props', () => {
     const context = {

--- a/packages/cozy-client/src/hoc.spec.js
+++ b/packages/cozy-client/src/hoc.spec.js
@@ -3,15 +3,16 @@ import { mount } from 'enzyme'
 import { withClient, queryConnect } from './hoc'
 import * as mocks from './__tests__/mocks'
 
+class Component extends React.Component {
+  render() {
+    return <div />
+  }
+}
+
 describe('with client', () => {
   it('should pass the client to its children', () => {
     const fakeClient = mocks.client()
     const context = { client: fakeClient }
-    class Component extends React.Component {
-      render() {
-        return <div />
-      }
-    }
     const WithClientComponent = withClient(Component)
     const uut = mount(<WithClientComponent />, { context })
     expect(uut.find(Component).prop('client')).toBe(fakeClient)
@@ -40,11 +41,6 @@ describe('queryConnect', () => {
 
     const context = {
       client
-    }
-    class Component extends React.Component {
-      render() {
-        return <div />
-      }
     }
     const WithQueries = queryConnect({
       toto: { query: client => client.all('io.cozy.toto') },


### PR DESCRIPTION
It is useful in snapshots and in inspector to see the display names
of the components. queryConnect and withClient previously would lose
the displayName. Now they wrap the  display name of the wrapped component into "withName()".

⚠️ You might see changes in your snapshots if you use `withClient`.
