### PR TITLE
Add updateFile method to FileCollection

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -228,6 +228,7 @@ files associated to a specific document
 * [FileCollection](#FileCollection)
     * [.find(selector, options)](#FileCollection+find) ⇒ <code>Object</code>
     * [.findReferencedBy(document, {, limit)](#FileCollection+findReferencedBy) ⇒ <code>object</code>
+    * [.updateFile(data, params)](#FileCollection+updateFile) ⇒ <code>object</code>
     * [.createDirectoryByPath(path)](#FileCollection+createDirectoryByPath) ⇒ <code>object</code>
     * [.updateFileMetadata(id, attributes)](#FileCollection+updateFileMetadata) ⇒ <code>object</code>
 
@@ -263,6 +264,22 @@ async findReferencedBy - Returns the list of files referenced by a document — 
 | document | <code>object</code> | A JSON representing a document, with at least a `_type` and `_id` field. |
 | { | <code>number</code> | skip = 0   For pagination, the number of referenced files to skip |
 | limit | <code>number</code> | } For pagination, the number of results to return. |
+
+<a name="FileCollection+updateFile"></a>
+
+### fileCollection.updateFile(data, params) ⇒ <code>object</code>
+updateFile - Updates a file's data
+
+**Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
+**Returns**: <code>object</code> - Updated document  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| data | <code>object</code> | Javascript File object |
+| params | <code>object</code> | Additional parameters |
+| params.fileId | <code>string</code> | The id of the file to update (required) |
+| params.executable | <code>boolean</code> | Whether the file is executable or not |
+| params.options | <code>object</code> | Options to pass to doUpload method (additional headers) |
 
 <a name="FileCollection+createDirectoryByPath"></a>
 

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -265,4 +265,51 @@ describe('FileCollection', () => {
       ).toMatchSnapshot()
     })
   })
+
+  describe('updateFile', () => {
+    beforeEach(() => {
+      client.fetchJSON.mockReturnValue({
+        data: {
+          id: '59140416-b95f',
+          _id: '59140416-b95f',
+          dir_id: '41686c35-9d8e'
+        }
+      })
+    })
+
+    afterEach(() => {
+      client.fetchJSON.mockClear()
+    })
+
+    it('should update a file', async () => {
+      const data = new File([''], 'mydoc.odt')
+      const params = {
+        fileId: '59140416-b95f',
+        checksum: 'a6dabd99832b270468e254814df2ed20'
+      }
+      const result = await collection.updateFile(data, params)
+      const expectedPath =
+        '/files/59140416-b95f?Name=mydoc.odt&Type=file&Executable=false'
+      const expectedOptions = {
+        headers: {
+          'Content-MD5': 'a6dabd99832b270468e254814df2ed20',
+          'Content-Type': 'application/vnd.oasis.opendocument.text'
+        }
+      }
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'PUT',
+        expectedPath,
+        data,
+        expectedOptions
+      )
+      expect(result).toEqual({
+        data: {
+          id: '59140416-b95f',
+          _id: '59140416-b95f',
+          _type: 'io.cozy.files',
+          dir_id: '41686c35-9d8e'
+        }
+      })
+    })
+  })
 })


### PR DESCRIPTION
We need to be able to overwrite a file using `PUT` method for "Upload conflict management" card (more info here: https://trello.com/c/0cTBor9A/1761-%F0%9D%90%8B-upload-conflit-%C3%A9tape-1-%C3%A9craser-fichier-non-partag%C3%A9 )