### PR TITLE
feat: Add Registry API

### DIFF
--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -20,7 +20,8 @@
     "react-redux": "5.0.7",
     "redux": "3.7.2",
     "redux-thunk": "2.3.0",
-    "sift": "6.0.0"
+    "sift": "6.0.0",
+    "url-search-params-polyfill": "^6.0.0"
   },
   "scripts": {
     "build": "../../bin/build",

--- a/packages/cozy-client/src/constants.js
+++ b/packages/cozy-client/src/constants.js
@@ -1,0 +1,4 @@
+export const APP_TYPE = {
+  KONNECTOR: 'konnector',
+  WEBAPP: 'webapp'
+}

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -23,3 +23,4 @@ export {
 } from './associations'
 export { dehydrate } from './helpers'
 export { getQueryFromState } from './store'
+export { default as Registry } from './registry'

--- a/packages/cozy-client/src/registry.js
+++ b/packages/cozy-client/src/registry.js
@@ -1,0 +1,63 @@
+import 'url-search-params-polyfill'
+import termUtils from './terms'
+import { APP_TYPE } from './constants'
+
+const queryPartFromOptions = options => {
+  const query = new URLSearchParams(options).toString()
+  return query ? `?${query}` : ''
+}
+
+const getBaseRoute = app => {
+  const { type } = app
+  // TODO node is an historic type, it should be `konnector`, check with the back
+  const route =
+    type === APP_TYPE.KONNECTOR || type === 'node' ? 'konnectors' : 'apps'
+  return `/${route}`
+}
+
+class Registry {
+  constructor(options) {
+    if (!options.client) {
+      throw new Error('Need to pass a client to instantiate a Registry API.')
+    }
+    this.client = options.client
+  }
+
+  /**
+   * Installs or updates an app from a source.
+   *
+   * Accepts the terms if the app has them.
+
+   * @param  {RegistryApp} app - App to be installed 
+   * @param  {string} source - String (ex: registry://drive/stable)
+   * @return {Promise}
+   */
+  async installApp(app, source) {
+    const { slug, type, terms } = app
+    const searchParams = {}
+    const isUpdate = app.installed
+    if (isUpdate) searchParams.PermissionsAcked = isUpdate
+    if (source) searchParams.Source = source
+    const querypart = queryPartFromOptions(searchParams)
+    if (terms) {
+      await termUtils.save(this.client, terms)
+    }
+    const verb = app.installed ? 'PUT' : 'POST'
+    const baseRoute = getBaseRoute(app)
+    return this.client.stackClient.fetchJSON(
+      verb,
+      `${baseRoute}/${slug}${querypart}`
+    )
+  }
+
+  /**
+   * Uninstalls an app.
+   */
+  async uninstallApp(app) {
+    const { slug } = app
+    const baseRoute = getBaseRoute(app)
+    return this.client.stackClient.fetchJSON('DELETE', `${baseRoute}/${slug}`)
+  }
+}
+
+export default Registry

--- a/packages/cozy-client/src/registry.spec.js
+++ b/packages/cozy-client/src/registry.spec.js
@@ -1,0 +1,94 @@
+import CozyClient from 'cozy-client'
+import termUtils from './terms'
+import Registry from './registry'
+
+jest.mock('./terms', () => ({
+  save: jest.fn()
+}))
+
+describe('registry api', () => {
+  let fetchJSON, client, api
+
+  beforeEach(() => {
+    fetchJSON = jest.fn()
+    client = new CozyClient({
+      stackClient: {
+        fetchJSON
+      }
+    })
+    api = new Registry({ client })
+    termUtils.save.mockReset()
+  })
+
+  const testApp = {
+    slug: 'test-app',
+    type: 'webapp'
+  }
+
+  const testKonn = {
+    slug: 'test-konn',
+    type: 'konnector'
+  }
+
+  describe('installation', () => {
+    it('should call the right routes', async () => {
+      await api.installApp(testApp)
+      expect(termUtils.save).not.toHaveBeenCalled()
+      expect(fetchJSON).toHaveBeenCalledWith('POST', '/apps/test-app')
+    })
+
+    it('should call the right routes (app with terms)', async () => {
+      const app = {
+        ...testApp,
+        terms: {
+          name: 'hello'
+        }
+      }
+      await api.installApp(app)
+      expect(termUtils.save).toHaveBeenCalledWith(client, app.terms)
+      expect(fetchJSON).toHaveBeenCalledWith('POST', '/apps/test-app')
+    })
+
+    it('should call the right routes (app already installed)', async () => {
+      const app = {
+        ...testApp,
+        installed: true
+      }
+      await api.installApp(app)
+      expect(fetchJSON).toHaveBeenCalledWith(
+        'PUT',
+        '/apps/test-app?PermissionsAcked=true'
+      )
+    })
+
+    it('should call the right routes (konnector)', async () => {
+      await api.installApp(testKonn)
+      expect(fetchJSON).toHaveBeenCalledWith('POST', '/konnectors/test-konn')
+    })
+
+    it('should call the right routes (custom source)', async () => {
+      await api.installApp(testKonn, 'registry://test-konn/beta')
+      expect(fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        '/konnectors/test-konn?Source=registry%3A%2F%2Ftest-konn%2Fbeta'
+      )
+    })
+  })
+
+  describe('app uninstallation', () => {
+    it('should call the correct routes (app)', async () => {
+      await api.uninstallApp(testApp)
+      expect(fetchJSON).toHaveBeenCalledWith('DELETE', '/apps/test-app')
+    })
+
+    it('should call the correct routes (konn)', async () => {
+      await api.uninstallApp(testKonn)
+      expect(fetchJSON).toHaveBeenCalledWith('DELETE', '/konnectors/test-konn')
+    })
+
+    it('should call the correct routes (node)', async () => {
+      await api.uninstallApp({ ...testKonn, type: 'node' })
+      expect(fetchJSON).toHaveBeenCalledWith('DELETE', '/konnectors/test-konn')
+    })
+  })
+})

--- a/packages/cozy-client/src/terms.js
+++ b/packages/cozy-client/src/terms.js
@@ -1,0 +1,45 @@
+const TERMS_DOCTYPE = 'io.cozy.terms'
+
+/* TODO Use collection terms */
+async function save(client, terms) {
+  const { id, ...termsAttributes } = terms
+  const { data: savedTermsDocs } = await client.query({
+    doctype: TERMS_DOCTYPE,
+    selector: {
+      termsId: id,
+      version: termsAttributes.version
+    },
+    limit: 1
+  })
+
+  if (savedTermsDocs && savedTermsDocs.length) {
+    // we just update the url if this is the same id and same version
+    // but the url changed
+    const savedTerms = savedTermsDocs[0]
+    if (
+      savedTerms.termsId == id &&
+      savedTerms.version == termsAttributes.version &&
+      savedTerms.url != termsAttributes.url
+    ) {
+      const termsToSave = {
+        _type: TERMS_DOCTYPE,
+        ...savedTerms,
+        url: termsAttributes.url
+      }
+      await client.save(termsToSave)
+    }
+  } else {
+    const termsToSave = {
+      _type: TERMS_DOCTYPE,
+      ...termsAttributes,
+      termsId: id,
+      accepted: true,
+      acceptedAt: new Date()
+    }
+    await client.save(termsToSave)
+  }
+}
+
+export default {
+  save
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11681,6 +11681,11 @@ url-parse-lax@^1.0.0:
   dependencies:
     prepend-http "^1.0.1"
 
+url-search-params-polyfill@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-6.0.0.tgz#f5e5fc230d56125f5b0ba67d9cbcd6555fa347e3"
+  integrity sha512-69Bl5s3SiEgcHe8SMpzLGOyag27BQeTeSaP/CfVHkKc/VdUHtNjaP2PnhshFVC021221ItueOzuMMGofZ/HDmQ==
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"


### PR DESCRIPTION
Ability to install/uninstall an app.

```js
import { Registry } from 'cozy-client'
const registryAPI = Registry({ client })
await registryAPI.installApp(app, source) 
```

Functions taken from the store.