### PR TITLE
feat: Add cancelable util

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -67,6 +67,10 @@ from a Cozy. <code>QueryDefinition</code>s are sent to links.</p>
 <dt><a href="#queryConnect">queryConnect(querySpecs)</a> ⇒ <code>function</code></dt>
 <dd><p>HOC creator to connect component to several queries in a declarative manner</p>
 </dd>
+<dt><a href="#cancelable">cancelable(promise)</a> ⇒ <code>AugmentedPromise</code></dt>
+<dd><p>Wraps a promise so that it can be canceled</p>
+<p>Rejects with canceled: true as soon as cancel is called</p>
+</dd>
 </dl>
 
 <a name="Association"></a>
@@ -871,4 +875,18 @@ HOC creator to connect component to several queries in a declarative manner
 | Param | Type | Description |
 | --- | --- | --- |
 | querySpecs | <code>object</code> | Definition of the queries |
+
+<a name="cancelable"></a>
+
+## cancelable(promise) ⇒ <code>AugmentedPromise</code>
+Wraps a promise so that it can be canceled
+
+Rejects with canceled: true as soon as cancel is called
+
+**Kind**: global function  
+**Returns**: <code>AugmentedPromise</code> - - Promise with .cancel method  
+
+| Param | Type |
+| --- | --- |
+| promise | <code>Promise</code> | 
 

--- a/packages/cozy-client/src/utils.js
+++ b/packages/cozy-client/src/utils.js
@@ -1,0 +1,24 @@
+/**
+ * Wraps a promise so that it can be canceled
+ *
+ * Rejects with canceled: true as soon as cancel is called
+ *
+ * @param  {Promise} promise
+ * @return {AugmentedPromise} - Promise with .cancel method
+ */
+const cancelable = promise => {
+  let _reject
+  const wrapped = new Promise((resolve, reject) => {
+    _reject = reject
+    promise.then(resolve)
+    promise.catch(reject)
+  })
+
+  wrapped.cancel = () => {
+    _reject({ canceled: true })
+  }
+
+  return wrapped
+}
+
+export { cancelable }

--- a/packages/cozy-client/src/utils.spec.js
+++ b/packages/cozy-client/src/utils.spec.js
@@ -1,0 +1,43 @@
+import { cancelable } from './utils'
+
+describe('cancelable', () => {
+  const setup = () => {
+    let original, resolve, reject
+    original = new Promise((_resolve, _reject) => {
+      resolve = _resolve
+      reject = _reject
+    })
+    const wrapped = cancelable(original)
+    return { resolve, reject, wrapped }
+  }
+
+  it('should resolve with the result of the promise', done => {
+    const { resolve, wrapped } = setup()
+    expect.assertions(1)
+    wrapped.then(res => {
+      expect(res).toBe(5)
+      done()
+    })
+    resolve(5)
+  })
+
+  it('should reject with the rejection of the promise', done => {
+    const { reject, wrapped } = setup()
+    expect.assertions(1)
+    wrapped.catch(res => {
+      expect(res).toBe(5)
+      done()
+    })
+    reject(5)
+  })
+
+  it('should reject with canceled: true if canceled', done => {
+    const { wrapped } = setup()
+    expect.assertions(1)
+    wrapped.catch(res => {
+      expect(res).toEqual({ canceled: true })
+      done()
+    })
+    wrapped.cancel()
+  })
+})


### PR DESCRIPTION
Wraps a promise and provides a `cancel` method.

.cancel() rejects the wrapped promise as soon as it is called.

`import { cancelable } from 'cozy-client/utils'`