### PR TITLE
fix: Allow fromEnv instantiation from oauth client

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -103,9 +103,19 @@ class CozyClient {
         'Env used to instantiate CozyClient must have COZY_URL and COZY_CREDENTIALS'
       )
     }
+    let oauth
+    let token
+    try {
+      oauth = JSON.parse(COZY_CREDENTIALS)
+      token = JSON.parse(COZY_CREDENTIALS)
+    } catch (e) {
+      token = COZY_CREDENTIALS.trim()
+    }
+
     return new CozyClient({
+      oauth: oauth,
       uri: COZY_URL.trim(),
-      token: COZY_CREDENTIALS.trim(),
+      token: token,
       ...options
     })
   }

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -95,27 +95,22 @@ class CozyClient {
   }
 
   /** In konnector/service context, CozyClient can be instantiated from environment variables */
-  static fromEnv(env, options) {
+  static fromEnv(env, options = {}) {
     env = env || (typeof process !== 'undefined' ? process.env : {})
-    const { COZY_URL, COZY_CREDENTIALS } = env
+    const { COZY_URL, COZY_CREDENTIALS, NODE_ENV } = env
     if (!COZY_URL || !COZY_CREDENTIALS) {
       throw new Error(
         'Env used to instantiate CozyClient must have COZY_URL and COZY_CREDENTIALS'
       )
     }
-    let oauth
-    let token
-    try {
-      oauth = JSON.parse(COZY_CREDENTIALS)
-      token = JSON.parse(COZY_CREDENTIALS)
-    } catch (e) {
-      token = COZY_CREDENTIALS.trim()
+    if (NODE_ENV === 'development') {
+      options.oauth = JSON.parse(COZY_CREDENTIALS)
+    } else {
+      options.token = COZY_CREDENTIALS.trim()
     }
+    options.uri = COZY_URL.trim()
 
     return new CozyClient({
-      oauth: oauth,
-      uri: COZY_URL.trim(),
-      token: token,
       ...options
     })
   }

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -74,7 +74,7 @@ describe('CozyClient initialization', () => {
     expect(client.login()).toBeInstanceOf(Promise)
   })
 
-  it('can be instantiated from environment', () => {
+  it('can be instantiated from environment with string token', () => {
     const url = 'https://testcozy.mycozy.cloud'
     const token = 'test-token'
     global.process.env.COZY_URL = url
@@ -82,6 +82,23 @@ describe('CozyClient initialization', () => {
     client = CozyClient.fromEnv()
     expect(client.stackClient.uri).toBe(url)
     expect(client.stackClient.token.token).toBe(token)
+  })
+
+  it('can be instantiated from environment with OAuth token', () => {
+    const url = 'https://testcozy.mycozy.cloud'
+    const token = 'test-token'
+    const creds = {
+      token: {
+        accessToken: token
+      }
+    }
+    global.process.env.COZY_URL = url
+    global.process.env.COZY_CREDENTIALS = JSON.stringify(creds)
+    global.process.env.NODE_ENV = 'development'
+    client = CozyClient.fromEnv()
+    expect(client.stackClient.uri).toBe(url)
+    expect(client.stackClient.token.accessToken).toBe(token)
+    global.process.env.NODE_ENV = 'test'
   })
 
   it('should have chained links', async () => {

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -77,9 +77,10 @@ describe('CozyClient initialization', () => {
   it('can be instantiated from environment with string token', () => {
     const url = 'https://testcozy.mycozy.cloud'
     const token = 'test-token'
-    global.process.env.COZY_URL = url
-    global.process.env.COZY_CREDENTIALS = token
-    client = CozyClient.fromEnv()
+    client = CozyClient.fromEnv({
+      COZY_URL: url,
+      COZY_CREDENTIALS: token
+    })
     expect(client.stackClient.uri).toBe(url)
     expect(client.stackClient.token.token).toBe(token)
   })
@@ -92,13 +93,13 @@ describe('CozyClient initialization', () => {
         accessToken: token
       }
     }
-    global.process.env.COZY_URL = url
-    global.process.env.COZY_CREDENTIALS = JSON.stringify(creds)
-    global.process.env.NODE_ENV = 'development'
-    client = CozyClient.fromEnv()
+    client = CozyClient.fromEnv({
+      COZY_URL: url,
+      COZY_CREDENTIALS: JSON.stringify(creds),
+      NODE_ENV: 'development'
+    })
     expect(client.stackClient.uri).toBe(url)
     expect(client.stackClient.token.accessToken).toBe(token)
-    global.process.env.NODE_ENV = 'test'
   })
 
   it('should have chained links', async () => {

--- a/packages/cozy-client/src/__mocks__/cozy-stack-client.js
+++ b/packages/cozy-client/src/__mocks__/cozy-stack-client.js
@@ -1,4 +1,4 @@
-const StackClient = jest.requireActual('cozy-stack-client').default
+const StackClient = jest.requireActual('cozy-stack-client')
 
 const collectionMock = {
   all: jest.fn(() => Promise.resolve()),
@@ -9,11 +9,17 @@ const collectionMock = {
   findReferencedBy: jest.fn(() => Promise.resolve())
 }
 
-class MockedStackClient extends StackClient {
+class MockedStackClient extends StackClient.default {
   constructor(opts) {
     super(opts)
     this.collection = jest.fn(() => collectionMock)
   }
 }
 
+export class OAuthClient extends StackClient.OAuthClient {
+  constructor(opts) {
+    super(opts)
+    this.collection = jest.fn(() => collectionMock)
+  }
+}
 export default MockedStackClient

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -26,8 +26,8 @@ class OAuthClient extends CozyStackClient {
   constructor({ oauth, scope = [], onTokenRefresh, ...options }) {
     super(options)
     this.setOAuthOptions({ ...defaultoauthOptions, ...oauth })
-    if (options.token) {
-      this.setToken(options.token.token)
+    if (oauth.token) {
+      this.setToken(oauth.token)
     }
     this.scope = scope
     this.onTokenRefresh = onTokenRefresh

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -26,6 +26,9 @@ class OAuthClient extends CozyStackClient {
   constructor({ oauth, scope = [], onTokenRefresh, ...options }) {
     super(options)
     this.setOAuthOptions({ ...defaultoauthOptions, ...oauth })
+    if (options.token) {
+      this.setToken(options.token.token)
+    }
     this.scope = scope
     this.onTokenRefresh = onTokenRefresh
   }


### PR DESCRIPTION
#447 could not work with the [cozy-konnector-dev](https://github.com/konnectors/libs/tree/master/packages/cozy-jobs-cli) script because it uses an OAuth authentication and `fromEnv` was expecting a string from `COZY_CREDENTIALS`
This PR fixes this behaviour. 