### PR TITLE
Add restore method on FileCollection

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -228,6 +228,7 @@ files associated to a specific document
 * [FileCollection](#FileCollection)
     * [.find(selector, options)](#FileCollection+find) ⇒ <code>Object</code>
     * [.findReferencedBy(document, {, limit)](#FileCollection+findReferencedBy) ⇒ <code>object</code>
+    * [.restore(id)](#FileCollection+restore) ⇒ <code>Promise</code>
     * [.updateFile(data, params)](#FileCollection+updateFile) ⇒ <code>object</code>
     * [.createDirectoryByPath(path)](#FileCollection+createDirectoryByPath) ⇒ <code>object</code>
     * [.updateFileMetadata(id, attributes)](#FileCollection+updateFileMetadata) ⇒ <code>object</code>
@@ -264,6 +265,22 @@ async findReferencedBy - Returns the list of files referenced by a document — 
 | document | <code>object</code> | A JSON representing a document, with at least a `_type` and `_id` field. |
 | { | <code>number</code> | skip = 0   For pagination, the number of referenced files to skip |
 | limit | <code>number</code> | } For pagination, the number of results to return. |
+
+<a name="FileCollection+restore"></a>
+
+### fileCollection.restore(id) ⇒ <code>Promise</code>
+Restores a trashed file.
+
+**Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
+**Returns**: <code>Promise</code> - - A promise that returns the restored file if resolved.  
+**Throws**:
+
+- <code>FetchError</code> 
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| id | <code>string</code> | The file's id |
 
 <a name="FileCollection+updateFile"></a>
 

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -138,6 +138,18 @@ class FileCollection extends DocumentCollection {
     }
   }
 
+  /**
+   * Restores a trashed file.
+   *
+   * @param {string} id   - The file's id
+   * @returns {Promise}   - A promise that returns the restored file if resolved.
+   * @throws {FetchError}
+   *
+   */
+  restore(id) {
+    return this.stackClient.fetchJSON('POST', uri`/files/trash/${id}`)
+  }
+
   async upload(data, dirPath) {
     const dirId = await this.ensureDirectoryExists(dirPath)
     return this.createFile(data, { dirId })

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -312,4 +312,29 @@ describe('FileCollection', () => {
       })
     })
   })
+
+  describe('restore', () => {
+    it('should restore a trashed file', async () => {
+      const FILE_ID = 'd04ab491-2fc6'
+      client.fetchJSON.mockReturnValue({
+        data: {
+          id: FILE_ID,
+          type: 'io.cozy.files',
+          trashed: false
+        }
+      })
+      const result = await collection.restore(FILE_ID)
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        '/files/trash/d04ab491-2fc6'
+      )
+      expect(result).toEqual({
+        data: {
+          id: FILE_ID,
+          type: 'io.cozy.files',
+          trashed: false
+        }
+      })
+    })
+  })
 })


### PR DESCRIPTION
Add a method to restore a file from its id in `FileCollection` (the implementation is exactly the same as `cozy-client-js` `restoreById` : https://github.com/cozy/cozy-client-js/blob/master/src/files.js#L384-L386 )