### PR TITLE
feat: Implicitly create unknown schema

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -854,6 +854,8 @@ const schema = new Schema({
 ### schema.getDoctypeSchema()
 Returns the schema for a doctype
 
+Creates an empty schema implicitly if it does not exist
+
 **Kind**: instance method of [<code>Schema</code>](#Schema)  
 <a name="Schema+getRelationship"></a>
 

--- a/packages/cozy-client/src/Schema.js
+++ b/packages/cozy-client/src/Schema.js
@@ -100,11 +100,17 @@ class Schema {
 
   /**
    * Returns the schema for a doctype
+   *
+   * Creates an empty schema implicitly if it does not exist
    */
   getDoctypeSchema(doctype) {
-    const schema = this.byDoctype[doctype]
+    let schema = this.byDoctype[doctype]
     if (!schema) {
-      throw new Error(`No schema found for '${doctype}' doctype`)
+      schema = normalizeDoctypeSchema({
+        name: doctype,
+        doctype
+      })
+      this.byDoctype[doctype] = schema
     }
     return schema
   }

--- a/packages/cozy-client/src/Schema.spec.js
+++ b/packages/cozy-client/src/Schema.spec.js
@@ -115,6 +115,14 @@ describe('Schema', () => {
       })
     })
 
+    it('gets schema even they have not been explicitly added', () => {
+      expect(schema.getDoctypeSchema('io.cozy.terms')).toEqual({
+        doctype: 'io.cozy.terms',
+        name: 'io.cozy.terms',
+        relationships: null
+      })
+    })
+
     it('throws if schema with same name exists', () => {
       expect(() =>
         schema.add({


### PR DESCRIPTION
Schemas are necessary for relationships but are not really necessary for
simple doctypes. If a schema has not been added to the client, for now
we throw. I think it would be more ergonomic either to 

- return an empty object if we do not know the doctype.
- have a list of known doctypes that can be used without declaring them.

Here I added the `io.cozy.terms` doctype (the second solution). WDYT ? 

cc @edas ?