### PR TITLE
Export cancelable util

### DIFF
--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -22,6 +22,7 @@ export {
   HasManyTriggers
 } from './associations'
 export { dehydrate } from './helpers'
+export { cancelable } from './utils'
 export { getQueryFromState } from './store'
 export { default as Registry } from './registry'
 


### PR DESCRIPTION
Export `cancelable` util directly to be able to do `import { cancelable } from 'cozy-client'`
I had issues trying to import it from `cozy-client/utils` (see #443 ) but it's maybe related to path resolution in drive