### PR TITLE
feat: Add an unified way to get the access token

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -36,6 +36,12 @@ through OAuth.</p>
 ## Functions
 
 <dl>
+<dt><a href="#getAccessToken">getAccessToken()</a> ⇒ <code>string</code></dt>
+<dd><p>Get the access token string</p>
+</dd>
+<dt><a href="#getAccessToken">getAccessToken()</a> ⇒ <code>string</code></dt>
+<dd><p>Get the app token string</p>
+</dd>
 <dt><a href="#garbageCollect">garbageCollect()</a></dt>
 <dd><p>Delete outdated results from cache</p>
 </dd>
@@ -78,6 +84,7 @@ Main API against the `cozy-stack` server.
     * [.fetch(method, path, body, options)](#CozyStackClient+fetch) ⇒ <code>Object</code>
     * [.refreshToken()](#CozyStackClient+refreshToken) ⇒ <code>Promise</code>
     * [.fetchJSON(method, path, body, options)](#CozyStackClient+fetchJSON) ⇒ <code>Object</code>
+    * [.getAccessToken()](#CozyStackClient+getAccessToken) ⇒ <code>string</code>
 
 <a name="CozyStackClient+collection"></a>
 
@@ -138,6 +145,13 @@ Fetches JSON in an authorized way.
 | body | <code>Object</code> | The payload. |
 | options | <code>Object</code> |  |
 
+<a name="CozyStackClient+getAccessToken"></a>
+
+### cozyStackClient.getAccessToken() ⇒ <code>string</code>
+Get the access token string, being an oauth token or an app token
+
+**Kind**: instance method of [<code>CozyStackClient</code>](#CozyStackClient)  
+**Returns**: <code>string</code> - token  
 <a name="DocumentCollection"></a>
 
 ## DocumentCollection
@@ -641,6 +655,22 @@ Force given trigger execution.
 | --- | --- | --- |
 | Trigger | <code>object</code> | to launch |
 
+<a name="getAccessToken"></a>
+
+## getAccessToken() ⇒ <code>string</code>
+Get the access token string
+
+**Kind**: global function  
+**Returns**: <code>string</code> - token  
+**See**: CozyStackClient.getAccessToken  
+<a name="getAccessToken"></a>
+
+## getAccessToken() ⇒ <code>string</code>
+Get the app token string
+
+**Kind**: global function  
+**Returns**: <code>string</code> - token  
+**See**: CozyStackClient.getAccessToken  
 <a name="garbageCollect"></a>
 
 ## garbageCollect()

--- a/packages/cozy-stack-client/src/AccessToken.js
+++ b/packages/cozy-stack-client/src/AccessToken.js
@@ -28,4 +28,13 @@ export default class AccessToken {
   toString() {
     return JSON.stringify(this.toJSON())
   }
+
+  /**
+   * Get the access token string
+   * @see CozyStackClient.getAccessToken
+   * @return {string} token
+   */
+  getAccessToken() {
+    return this.accessToken
+  }
 }

--- a/packages/cozy-stack-client/src/AppToken.js
+++ b/packages/cozy-stack-client/src/AppToken.js
@@ -10,4 +10,13 @@ export default class AppToken {
   toBasicAuth() {
     return `user:${this.token}@`
   }
+
+  /**
+   * Get the app token string
+   * @see CozyStackClient.getAccessToken
+   * @return {string} token
+   */
+  getAccessToken() {
+    return this.token
+  }
 }

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -229,6 +229,14 @@ class CozyStackClient {
     }
   }
 
+  /**
+   * Get the access token string, being an oauth token or an app token
+   * @return {string} token
+   */
+  getAccessToken() {
+    return this.token && this.token.getAccessToken()
+  }
+
   setUri(uri) {
     this.uri = normalizeUri(uri)
   }

--- a/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
@@ -339,6 +339,13 @@ describe('CozyStackClient', () => {
       await expect(newToken).rejects.toThrow()
     })
   })
+
+  describe('getAccessToken', () => {
+    it('should return the current app token', () => {
+      const client = new CozyStackClient(FAKE_INIT_OPTIONS)
+      expect(client.getAccessToken()).toBe(FAKE_INIT_OPTIONS.token)
+    })
+  })
 })
 
 describe('FetchError', () => {

--- a/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/OAuthClient.spec.js
@@ -189,4 +189,17 @@ describe('OAuthClient', () => {
       expect(client.token).toBeNull()
     })
   })
+
+  describe('getAccessToken', () => {
+    it('should return the current access token', () => {
+      client = new OAuthClient(REGISTERED_CLIENT_INIT_OPTIONS)
+      client.setToken({
+        tokenType: 'type',
+        accessToken: 'accessToken-abcd',
+        refreshToken: 'refresh-789',
+        scope: 'io.cozy.todos'
+      })
+      expect(client.getAccessToken()).toBe('accessToken-abcd')
+    })
+  })
 })


### PR DESCRIPTION
`client.getStackClient().getAccessToken()`

I was sick of looking for
```
  cozyClient.stackClient.token.accessToken
  ||
  cozyClient.stackClient.token.token
```