### PR TITLE
fix(schema): Map on names to show duplicate error

### DIFF
--- a/packages/cozy-client/src/Schema.js
+++ b/packages/cozy-client/src/Schema.js
@@ -39,7 +39,9 @@ const ensureCanBeAdded = (newSchemas, existingSchemas) => {
   const sameNames = intersectionBy(newSchemas, existingSchemas, x => x.name)
   assert(
     sameNames.length === 0,
-    `Duplicated names in schemas being added: ${sameNames.join(', ')}`
+    `Duplicated names in schemas being added: ${sameNames
+      .map(x => x.name)
+      .join(', ')}`
   )
 
   const sameDoctypes = intersectionBy(
@@ -49,7 +51,9 @@ const ensureCanBeAdded = (newSchemas, existingSchemas) => {
   )
   assert(
     sameDoctypes.length === 0,
-    `Duplicated doctypes in schemas being added: ${sameDoctypes.join(', ')}`
+    `Duplicated doctypes in schemas being added: ${sameDoctypes
+      .map(x => x.name)
+      .join(', ')}`
   )
 }
 


### PR DESCRIPTION
"[Object object]" was showing in the console since we were not logging
the `.name` of the schemas.