### PR TITLE
Add cursor-based pagination

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -710,6 +710,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
     * [.include(includes)](#QueryDefinition+include) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
     * [.limitBy(limit)](#QueryDefinition+limitBy) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
     * [.offset(skip)](#QueryDefinition+offset) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
+    * [.offsetCursor(cursor)](#QueryDefinition+offsetCursor) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
     * [.referencedBy(document)](#QueryDefinition+referencedBy) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
 
 <a name="new_QueryDefinition_new"></a>
@@ -833,12 +834,31 @@ Maximum number of documents returned, useful for pagination. Default is 100.
 ### queryDefinition.offset(skip) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
 Skip the first ‘n’ documents, where ‘n’ is the value specified.
 
+Beware, this [performs badly](http://docs.couchdb.org/en/stable/ddocs/views/pagination.html#paging-alternate-method) on view's index.
+ Prefer cursor-based pagination in such situation.
+
 **Kind**: instance method of [<code>QueryDefinition</code>](#QueryDefinition)  
 **Returns**: [<code>QueryDefinition</code>](#QueryDefinition) - The QueryDefinition object.  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | skip | <code>number</code> | The number of documents to skip. |
+
+<a name="QueryDefinition+offsetCursor"></a>
+
+### queryDefinition.offsetCursor(cursor) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
+Use [cursor-based](https://docs.cozy.io/en/cozy-stack/jsonapi/#pagination) pagination.
+The cursor is a [startkey, startkey_docid] array, where startkey is the view's key,
+e.g. ["io.cozy.photos.albums", "album-id"] and startkey_docid is the id of
+the starting document of the query, e.g. "file-id".
+Use the last docid of each query as startkey_docid to paginate or leave blank for the first query.
+
+**Kind**: instance method of [<code>QueryDefinition</code>](#QueryDefinition)  
+**Returns**: [<code>QueryDefinition</code>](#QueryDefinition) - The QueryDefinition object.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| cursor | <code>Array</code> | The cursor for pagination. |
 
 <a name="QueryDefinition+referencedBy"></a>
 

--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -848,6 +848,7 @@ Beware, this [performs badly](http://docs.couchdb.org/en/stable/ddocs/views/pagi
 
 ### queryDefinition.offsetCursor(cursor) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
 Use [cursor-based](https://docs.cozy.io/en/cozy-stack/jsonapi/#pagination) pagination.
+*Warning*: this is only useful for views.
 The cursor is a [startkey, startkey_docid] array, where startkey is the view's key,
 e.g. ["io.cozy.photos.albums", "album-id"] and startkey_docid is the id of
 the starting document of the query, e.g. "file-id".

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -241,7 +241,7 @@ files associated to a specific document
 
 * [FileCollection](#FileCollection)
     * [.find(selector, options)](#FileCollection+find) ⇒ <code>Object</code>
-    * [.findReferencedBy(document, {, limit)](#FileCollection+findReferencedBy) ⇒ <code>object</code>
+    * [.findReferencedBy(document, skip, limit, cursor)](#FileCollection+findReferencedBy) ⇒ <code>object</code>
     * [.restore(id)](#FileCollection+restore) ⇒ <code>Promise</code>
     * [.updateFile(data, params)](#FileCollection+updateFile) ⇒ <code>object</code>
     * [.createDirectoryByPath(path)](#FileCollection+createDirectoryByPath) ⇒ <code>object</code>
@@ -269,7 +269,7 @@ The returned documents are paginated by the stack.
 
 <a name="FileCollection+findReferencedBy"></a>
 
-### fileCollection.findReferencedBy(document, {, limit) ⇒ <code>object</code>
+### fileCollection.findReferencedBy(document, skip, limit, cursor) ⇒ <code>object</code>
 async findReferencedBy - Returns the list of files referenced by a document — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
@@ -278,8 +278,9 @@ async findReferencedBy - Returns the list of files referenced by a document — 
 | Param | Type | Description |
 | --- | --- | --- |
 | document | <code>object</code> | A JSON representing a document, with at least a `_type` and `_id` field. |
-| { | <code>number</code> | skip = 0   For pagination, the number of referenced files to skip |
-| limit | <code>number</code> | } For pagination, the number of results to return. |
+| skip | <code>number</code> | For skip-based pagination, the number of referenced files to skip. |
+| limit | <code>number</code> | For pagination, the number of results to return. |
+| cursor | <code>object</code> | For cursor-based pagination, the index cursor. |
 
 <a name="FileCollection+restore"></a>
 

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -241,7 +241,7 @@ files associated to a specific document
 
 * [FileCollection](#FileCollection)
     * [.find(selector, options)](#FileCollection+find) ⇒ <code>Object</code>
-    * [.findReferencedBy(document, skip, limit, cursor)](#FileCollection+findReferencedBy) ⇒ <code>object</code>
+    * [.findReferencedBy(document, options)](#FileCollection+findReferencedBy) ⇒ <code>object</code>
     * [.restore(id)](#FileCollection+restore) ⇒ <code>Promise</code>
     * [.updateFile(data, params)](#FileCollection+updateFile) ⇒ <code>object</code>
     * [.createDirectoryByPath(path)](#FileCollection+createDirectoryByPath) ⇒ <code>object</code>
@@ -269,7 +269,7 @@ The returned documents are paginated by the stack.
 
 <a name="FileCollection+findReferencedBy"></a>
 
-### fileCollection.findReferencedBy(document, skip, limit, cursor) ⇒ <code>object</code>
+### fileCollection.findReferencedBy(document, options) ⇒ <code>object</code>
 async findReferencedBy - Returns the list of files referenced by a document — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
@@ -278,9 +278,10 @@ async findReferencedBy - Returns the list of files referenced by a document — 
 | Param | Type | Description |
 | --- | --- | --- |
 | document | <code>object</code> | A JSON representing a document, with at least a `_type` and `_id` field. |
-| skip | <code>number</code> | For skip-based pagination, the number of referenced files to skip. |
-| limit | <code>number</code> | For pagination, the number of results to return. |
-| cursor | <code>object</code> | For cursor-based pagination, the index cursor. |
+| options | <code>object</code> | Additional options |
+| options.skip | <code>number</code> | For skip-based pagination, the number of referenced files to skip. |
+| options.limit | <code>number</code> | For pagination, the number of results to return. |
+| options.cursor | <code>object</code> | For cursor-based pagination, the index cursor. |
 
 <a name="FileCollection+restore"></a>
 

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -480,7 +480,8 @@ class CozyClient {
     }
     const withIncluded = await this.fetchRelationships(
       mainResponse,
-      this.getIncludesRelationships(definition)
+      this.getIncludesRelationships(definition),
+      definition.cursor
     )
     return withIncluded
   }
@@ -492,7 +493,7 @@ class CozyClient {
    * Can potentially result in several fetch requests.
    * Queries are optimized before being sent.
    */
-  async fetchRelationships(response, relationshipsByName) {
+  async fetchRelationships(response, relationshipsByName, cursor) {
     const isSingleDoc = !Array.isArray(response.data)
     if (!isSingleDoc && response.data.length === 0) {
       return response
@@ -505,7 +506,12 @@ class CozyClient {
 
     responseDocs.forEach(doc => {
       return forEach(relationshipsByName, (relationship, relName) => {
-        const queryDef = relationship.type.query(doc, this, relationship)
+        const queryDef = relationship.type.query(
+          doc,
+          this,
+          relationship,
+          cursor
+        )
         const docId = doc._id
 
         // Used to reattach responses into the relationships attribute of

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -505,11 +505,7 @@ class CozyClient {
 
     responseDocs.forEach(doc => {
       return forEach(relationshipsByName, (relationship, relName) => {
-        const queryDef = relationship.type.query(
-          doc,
-          this,
-          relationship
-        )
+        const queryDef = relationship.type.query(doc, this, relationship)
         const docId = doc._id
 
         // Used to reattach responses into the relationships attribute of

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -480,8 +480,7 @@ class CozyClient {
     }
     const withIncluded = await this.fetchRelationships(
       mainResponse,
-      this.getIncludesRelationships(definition),
-      definition.cursor
+      this.getIncludesRelationships(definition)
     )
     return withIncluded
   }
@@ -493,7 +492,7 @@ class CozyClient {
    * Can potentially result in several fetch requests.
    * Queries are optimized before being sent.
    */
-  async fetchRelationships(response, relationshipsByName, cursor) {
+  async fetchRelationships(response, relationshipsByName) {
     const isSingleDoc = !Array.isArray(response.data)
     if (!isSingleDoc && response.data.length === 0) {
       return response
@@ -509,8 +508,7 @@ class CozyClient {
         const queryDef = relationship.type.query(
           doc,
           this,
-          relationship,
-          cursor
+          relationship
         )
         const docId = doc._id
 

--- a/packages/cozy-client/src/__tests__/associations.spec.js
+++ b/packages/cozy-client/src/__tests__/associations.spec.js
@@ -42,8 +42,26 @@ describe('Associations', () => {
           TODO_2
         ],
         included: [
-          { _id: 'abc', _type: 'io.cozy.files', name: 'abc.pdf' },
-          { _id: 'def', _type: 'io.cozy.files', name: 'def.png' }
+          {
+            _id: 'abc',
+            _type: 'io.cozy.files',
+            name: 'abc.jpg',
+            attributes: {
+              metadata: {
+                datetime: '2019-01-01'
+              }
+            }
+          },
+          {
+            _id: 'def',
+            _type: 'io.cozy.files',
+            name: 'def.png',
+            attributes: {
+              metadata: {
+                datetime: '2019-01-02'
+              }
+            }
+          }
         ]
       })
     )
@@ -52,8 +70,26 @@ describe('Associations', () => {
   describe('HasMany', () => {
     it('should return data', () => {
       expect(getTodo(TODO_1._id).attachments.data).toEqual([
-        { _id: 'abc', _type: 'io.cozy.files', name: 'abc.pdf' },
-        { _id: 'def', _type: 'io.cozy.files', name: 'def.png' }
+        {
+          _id: 'abc',
+          _type: 'io.cozy.files',
+          name: 'abc.jpg',
+          attributes: {
+            metadata: {
+              datetime: '2019-01-01'
+            }
+          }
+        },
+        {
+          _id: 'def',
+          _type: 'io.cozy.files',
+          name: 'def.png',
+          attributes: {
+            metadata: {
+              datetime: '2019-01-02'
+            }
+          }
+        }
       ])
     })
 
@@ -64,11 +100,21 @@ describe('Associations', () => {
     it('should be able to fetchMore data', async () => {
       const FAKE_RESPONSE = {
         data: [
+          {
+            _id: 'def',
+            _type: 'io.cozy.files',
+            name: 'def.png',
+            attributes: {
+              metadata: {
+                datetime: '2019-01-02'
+              }
+            }
+          },
           { _id: 'ghi', _type: 'io.cozy.files' },
           { _id: 'jkl', _type: 'io.cozy.files' }
         ],
         included: [
-          { _id: 'ghi', _type: 'io.cozy.files', name: 'ghi.pdf' },
+          { _id: 'ghi', _type: 'io.cozy.files', name: 'ghi.jpg' },
           { _id: 'jkl', _type: 'io.cozy.files', name: 'jkl.png' }
         ],
         next: false
@@ -78,9 +124,27 @@ describe('Associations', () => {
       const queryBefore = getQueryFromStore(client.store, 'allTodos')
       await getTodo(TODO_1._id).attachments.fetchMore()
       expect(getTodo(TODO_1._id).attachments.data).toEqual([
-        { _id: 'abc', _type: 'io.cozy.files', name: 'abc.pdf' },
-        { _id: 'def', _type: 'io.cozy.files', name: 'def.png' },
-        { _id: 'ghi', _type: 'io.cozy.files', name: 'ghi.pdf' },
+        {
+          _id: 'abc',
+          _type: 'io.cozy.files',
+          name: 'abc.jpg',
+          attributes: {
+            metadata: {
+              datetime: '2019-01-01'
+            }
+          }
+        },
+        {
+          _id: 'def',
+          _type: 'io.cozy.files',
+          name: 'def.png',
+          attributes: {
+            metadata: {
+              datetime: '2019-01-02'
+            }
+          }
+        },
+        { _id: 'ghi', _type: 'io.cozy.files', name: 'ghi.jpg' },
         { _id: 'jkl', _type: 'io.cozy.files', name: 'jkl.png' }
       ])
       const queryAfter = getQueryFromStore(client.store, 'allTodos')

--- a/packages/cozy-client/src/associations/HasManyFiles.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.js
@@ -1,36 +1,43 @@
 import omit from 'lodash/omit'
 import HasMany from './HasMany'
 import { QueryDefinition, Mutations } from '../queries/dsl'
+import { getDocumentFromState } from '../store'
 
+/**
+ *  This class is only used for photos albums relationships.
+ *  Behind the hood, the queries uses a view returning the files sorted
+ *  by datetime, with a cursor-based pagination.
+ */
 export default class HasManyFiles extends HasMany {
-  async fetchMore(withCursor) {
+  async fetchMore() {
     const queryDef = new QueryDefinition({ doctype: 'io.cozy.files' })
     const relationships = this.getRelationship().data
-    let response
-    if (withCursor) {
+    // Get last datetime for cursor
+    const lastRelationship = relationships[relationships.length - 1]
+    await this.dispatch(async (dispatch, getState) => {
+      const lastRelDoc = getDocumentFromState(
+        getState(),
+        lastRelationship._type,
+        lastRelationship._id
+      )
+      const lastDatetime = lastRelDoc.attributes.metadata.datetime
       // cursor-based pagination
-      const cursorKey = [this.target._type, this.target._id]
+      const cursorKey = [this.target._type, this.target._id, lastDatetime]
       const startDocId = relationships[relationships.length - 1]._id
-      const cursor = [cursorKey, startDocId]
-      response = await this.query(
-        queryDef.referencedBy(this.target).offsetCursor(cursor)
+      const cursorView = [cursorKey, startDocId]
+      const response = await this.query(
+        queryDef.referencedBy(this.target).offsetCursor(cursorView)
       )
       // Remove first returned element, used as starting point for the query
       response.data.shift()
-    } else {
-      // skip-based pagination
-      const skip = relationships.length
-      response = await this.query(
-        queryDef.referencedBy(this.target).offset(skip)
+      await this.dispatch(
+        this.updateRelationshipData(previousRelationshipData => ({
+          ...previousRelationshipData,
+          data: [...previousRelationshipData.data, ...response.data],
+          next: response.next
+        }))
       )
-    }
-    await this.dispatch(
-      this.updateRelationshipData(previousRelationshipData => ({
-        ...previousRelationshipData,
-        data: [...previousRelationshipData.data, ...response.data],
-        next: response.next
-      }))
-    )
+    })
   }
 
   async addById(ids) {
@@ -68,10 +75,10 @@ export default class HasManyFiles extends HasMany {
     return omit(doc, [this.name, `relationships.${this.name}`])
   }
 
-  static query(document, client, assoc, cursor) {
+  static query(document, client, assoc) {
+    const key = [document._type, document._id]
+    const cursor = [key, '']
     const queryAll = client.find(assoc.doctype)
-    return cursor
-      ? queryAll.referencedBy(document).offsetCursor(cursor)
-      : queryAll.referencedBy(document)
+    return queryAll.referencedBy(document).offsetCursor(cursor)
   }
 }

--- a/packages/cozy-client/src/associations/HasManyFiles.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.js
@@ -20,6 +20,7 @@ export default class HasManyFiles extends HasMany {
         lastRelationship._type,
         lastRelationship._id
       )
+      // Photos always have a datetime field in metadata
       const lastDatetime = lastRelDoc.attributes.metadata.datetime
       // cursor-based pagination
       const cursorKey = [this.target._type, this.target._id, lastDatetime]

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -155,6 +155,7 @@ class QueryDefinition {
 
   /**
    * Use [cursor-based](https://docs.cozy.io/en/cozy-stack/jsonapi/#pagination) pagination.
+   * *Warning*: this is only useful for views.
    * The cursor is a [startkey, startkey_docid] array, where startkey is the view's key,
    * e.g. ["io.cozy.photos.albums", "album-id"] and startkey_docid is the id of
    * the starting document of the query, e.g. "file-id".

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -30,7 +30,8 @@ class QueryDefinition {
     includes,
     referenced,
     limit,
-    skip
+    skip,
+    cursor
   } = {}) {
     this.doctype = doctype
     this.id = id
@@ -43,6 +44,7 @@ class QueryDefinition {
     this.referenced = referenced
     this.limit = limit
     this.skip = skip
+    this.cursor = cursor
   }
 
   /**
@@ -142,6 +144,8 @@ class QueryDefinition {
   /**
    * Skip the first ‘n’ documents, where ‘n’ is the value specified.
    *
+   * Beware, this [performs badly](http://docs.couchdb.org/en/stable/ddocs/views/pagination.html#paging-alternate-method) on view's index.
+   *  Prefer cursor-based pagination in such situation.
    * @param {number} skip The number of documents to skip.
    * @return {QueryDefinition}  The QueryDefinition object.
    */
@@ -150,8 +154,21 @@ class QueryDefinition {
   }
 
   /**
-   * Use the [file reference system](https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/)
+   * Use [cursor-based](https://docs.cozy.io/en/cozy-stack/jsonapi/#pagination) pagination.
+   * The cursor is a [startkey, startkey_docid] array, where startkey is the view's key,
+   * e.g. ["io.cozy.photos.albums", "album-id"] and startkey_docid is the id of
+   * the starting document of the query, e.g. "file-id".
+   * Use the last docid of each query as startkey_docid to paginate or leave blank for the first query.
    *
+   * @param {Array} cursor The cursor for pagination.
+   * @return {QueryDefinition}  The QueryDefinition object.
+   */
+  offsetCursor(cursor) {
+    return new QueryDefinition({ ...this.toDefinition(), cursor })
+  }
+
+  /**
+   * Use the [file reference system](https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/)
    * @param {Object} document The reference document
    * @return {QueryDefinition}  The QueryDefinition object.
    */
@@ -171,7 +188,8 @@ class QueryDefinition {
       includes: this.includes,
       referenced: this.referenced,
       limit: this.limit,
-      skip: this.skip
+      skip: this.skip,
+      cursor: this.cursor
     }
   }
 }

--- a/packages/cozy-client/src/store/__snapshots__/queries.spec.js.snap
+++ b/packages/cozy-client/src/store/__snapshots__/queries.spec.js.snap
@@ -6,6 +6,7 @@ Object {
     "count": 0,
     "data": Array [],
     "definition": QueryDefinition {
+      "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
       "id": undefined,
@@ -37,6 +38,7 @@ Object {
       "67890",
     ],
     "definition": QueryDefinition {
+      "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
       "id": undefined,
@@ -67,6 +69,7 @@ Object {
       "54321",
     ],
     "definition": QueryDefinition {
+      "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
       "id": undefined,
@@ -92,6 +95,7 @@ Object {
       "54321",
     ],
     "definition": QueryDefinition {
+      "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
       "id": undefined,
@@ -127,6 +131,7 @@ Object {
       "54321",
     ],
     "definition": QueryDefinition {
+      "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
       "id": undefined,
@@ -152,6 +157,7 @@ Object {
       "54321",
     ],
     "definition": QueryDefinition {
+      "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
       "id": undefined,
@@ -185,6 +191,7 @@ Object {
       "67890",
     ],
     "definition": QueryDefinition {
+      "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
       "id": undefined,
@@ -211,6 +218,7 @@ Object {
       "67890",
     ],
     "definition": QueryDefinition {
+      "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
       "id": undefined,
@@ -239,6 +247,7 @@ Object {
     "count": 0,
     "data": Array [],
     "definition": QueryDefinition {
+      "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
       "id": undefined,
@@ -262,6 +271,7 @@ Object {
     "count": 0,
     "data": Array [],
     "definition": QueryDefinition {
+      "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
       "id": "not-existing-doc",
@@ -292,6 +302,7 @@ Object {
       "54321",
     ],
     "definition": QueryDefinition {
+      "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
       "id": undefined,
@@ -315,6 +326,7 @@ Object {
     "count": 0,
     "data": Array [],
     "definition": QueryDefinition {
+      "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
       "id": undefined,

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -149,7 +149,7 @@ describe('DocumentCollection', () => {
       await collection.all({ keys: ['abc', 'def'] })
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'GET',
-        '/data/io.cozy.todos/_all_docs?include_docs=true&keys=[%22abc%22%2C%22def%22]'
+        '/data/io.cozy.todos/_all_docs?include_docs=true&keys=[%22abc%22,%22def%22]'
       )
     })
 

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -68,16 +68,22 @@ class FileCollection extends DocumentCollection {
    * async findReferencedBy - Returns the list of files referenced by a document — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/
    *
    * @param  {object} document     A JSON representing a document, with at least a `_type` and `_id` field.
-   * @param  {number} { skip = 0   For pagination, the number of referenced files to skip
-   * @param  {number} limit } For pagination, the number of results to return.
+   * @param  {number} skip    For skip-based pagination, the number of referenced files to skip.
+   * @param  {number} limit For pagination, the number of results to return.
+   * @param  {object} cursor   For cursor-based pagination, the index cursor.
    * @returns {object}         The JSON API conformant response.
    */
-  async findReferencedBy(document, { skip = 0, limit } = {}) {
+  async findReferencedBy(document, { skip = 0, limit, cursor } = {}) {
     const params = {
       include: 'files',
-      sort: 'datetime',
-      'page[limit]': limit,
-      'page[skip]': skip
+      'page[limit]': limit
+    }
+    if (cursor) {
+      params['page[cursor]'] = cursor
+      params['sort'] = 'id'
+    } else {
+      params['page[skip]'] = skip
+      params['sort'] = 'datetime'
     }
     const url = uri`/data/${document._type}/${
       document._id

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -67,23 +67,19 @@ class FileCollection extends DocumentCollection {
   /**
    * async findReferencedBy - Returns the list of files referenced by a document — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/
    *
-   * @param  {object} document     A JSON representing a document, with at least a `_type` and `_id` field.
-   * @param  {number} skip    For skip-based pagination, the number of referenced files to skip.
-   * @param  {number} limit For pagination, the number of results to return.
-   * @param  {object} cursor   For cursor-based pagination, the index cursor.
-   * @returns {object}         The JSON API conformant response.
+   * @param  {object} document        A JSON representing a document, with at least a `_type` and `_id` field.
+   * @param  {object} options         Additional options
+   * @param  {number} options.skip    For skip-based pagination, the number of referenced files to skip.
+   * @param  {number} options.limit   For pagination, the number of results to return.
+   * @param  {object} options.cursor  For cursor-based pagination, the index cursor.
+   * @returns {object}                The JSON API conformant response.
    */
   async findReferencedBy(document, { skip = 0, limit, cursor } = {}) {
     const params = {
       include: 'files',
-      'page[limit]': limit
-    }
-    if (cursor) {
-      params['page[cursor]'] = cursor
-      params['sort'] = 'id'
-    } else {
-      params['page[skip]'] = skip
-      params['sort'] = 'datetime'
+      'page[limit]': limit,
+      'page[cursor]': cursor,
+      sort: 'datetime'
     }
     const url = uri`/data/${document._type}/${
       document._id

--- a/packages/cozy-stack-client/src/querystring.js
+++ b/packages/cozy-stack-client/src/querystring.js
@@ -1,19 +1,12 @@
 import pickBy from 'lodash/pickBy'
 
-const encodeValues = values => {
-  const encoded =
-    '[' +
-    encodeURIComponent(
-      values
-        .map(value => {
-          return Array.isArray(value)
-            ? '[' + value.map(arrayVal => `"${arrayVal}"`).join(',') + ']'
-            : `"${value}"`
-        })
-        .join(',')
-    ) +
-    ']'
-  return encoded
+const encodeValues = (values, fromArray = false) => {
+  if (Array.isArray(values)) {
+    return '[' + values.map(v => encodeValues(v, true)).join(',') + ']'
+  }
+  return fromArray
+    ? encodeURIComponent(`"${values}"`)
+    : encodeURIComponent(values)
 }
 
 /**
@@ -26,9 +19,7 @@ const encodeValues = values => {
 export const encode = data => {
   return Object.entries(data)
     .map(([k, v]) => {
-      const encodedValue = Array.isArray(v)
-        ? encodeValues(v)
-        : encodeURIComponent(v)
+      const encodedValue = encodeValues(v)
       return `${k}=${encodedValue}`
     })
     .join('&')

--- a/packages/cozy-stack-client/src/querystring.js
+++ b/packages/cozy-stack-client/src/querystring.js
@@ -1,5 +1,21 @@
 import pickBy from 'lodash/pickBy'
 
+const encodeValues = values => {
+  const encoded =
+    '[' +
+    encodeURIComponent(
+      values
+        .map(value => {
+          return Array.isArray(value)
+            ? '[' + value.map(arrayVal => `"${arrayVal}"`).join(',') + ']'
+            : `"${value}"`
+        })
+        .join(',')
+    ) +
+    ']'
+  return encoded
+}
+
 /**
  * Encode an object as querystring, values are encoded as
  * URI components, keys are not.
@@ -11,9 +27,7 @@ export const encode = data => {
   return Object.entries(data)
     .map(([k, v]) => {
       const encodedValue = Array.isArray(v)
-        ? '[' +
-          encodeURIComponent(v.map(arrayVal => `"${arrayVal}"`).join(',')) +
-          ']'
+        ? encodeValues(v)
         : encodeURIComponent(v)
       return `${k}=${encodedValue}`
     })


### PR DESCRIPTION
This adds the possibility to use cursor-based pagination, just like [this](https://github.com/cozy/cozy-client-js/pull/288).
For a query on 2185 files referenced by a single album, it takes 14.1s with skip-based pagination and 7.6s with cursor-based pagination.
Note the Couch query itself is greatly sped up, especially with large skip, e.g. 343ms for a `skip=2000` vs 20ms with cursor.