### PR TITLE
fix(withMutations): Expose all withMutations provided props types

### DIFF
--- a/packages/cozy-client/src/withMutations.jsx
+++ b/packages/cozy-client/src/withMutations.jsx
@@ -49,6 +49,12 @@ const withMutations = (...mutations) => WrappedComponent => {
       return <WrappedComponent {...this.mutations} {...this.props} />
     }
   }
+  Wrapper.propTypes = {
+    ...WrappedComponent.propTypes,
+    createDocument: PropTypes.func,
+    saveDocument: PropTypes.func,
+    deleteDocument: PropTypes.func
+  }
 
   Wrapper.displayName = `WithMutations(${wrappedDisplayName})`
   return Wrapper

--- a/packages/cozy-client/src/withMutations.spec.jsx
+++ b/packages/cozy-client/src/withMutations.spec.jsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
+import omit from 'lodash/omit'
+import PropTypes from 'prop-types'
 
 import withMutations from './withMutations'
 
@@ -14,6 +16,35 @@ describe('withMutations', () => {
 
   afterEach(() => {
     jest.resetAllMocks()
+    jest.restoreAllMocks()
+  })
+
+  it('should expose all additional mutations provided proptypes', () => {
+    // mock for proptypes
+    jest.spyOn(console, 'error').mockImplementation(message => {
+      throw new Error(message)
+    })
+    const mutationsMock = client => ({
+      myMutation1: () => {},
+      myMutation2: () => {}
+    })
+
+    let wrapper
+    expect(() => {
+      const ConnectedFoo = withMutations(mutationsMock)(() => <div />)
+      wrapper = shallow(<ConnectedFoo />, {
+        context: { client: clientMock }
+      })
+    }).not.toThrowError()
+
+    const componentProps = wrapper.props()
+    for (const mutation of [
+      'createDocument',
+      'deleteDocument',
+      'saveDocument'
+    ]) {
+      expect(typeof componentProps[mutation]).toBe('function')
+    }
   })
 
   it('should inject base mutations props into wrapped component', async () => {


### PR DESCRIPTION
Get exposed prop-types is useful when you want to check or get an exhaustive list of provided props and the related types for developing or for testing