### PR TITLE
Fix login

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -161,19 +161,7 @@ class CozyClient {
   async _login(options) {
     this.emit('beforeLogin')
 
-    this.isLogged = true
-    this.isRevoked = false
     this.registerClientOnLinks()
-
-    for (const link of this.links) {
-      if (link.onLogin) {
-        try {
-          await link.onLogin()
-        } catch (e) {
-          console.warn(e)
-        }
-      }
-    }
 
     if (options) {
       if (options.uri) {
@@ -183,6 +171,15 @@ class CozyClient {
         this.stackClient.setToken(options.token)
       }
     }
+
+    for (const link of this.links) {
+      if (link.onLogin) {
+        await link.onLogin()
+      }
+    }
+
+    this.isLogged = true
+    this.isRevoked = false
 
     this.emit('login')
   }

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -250,7 +250,7 @@ describe('CozyClient login', () => {
       }
     ]
     links.forEach(link => {
-      link.registerClient = jest.fn()
+      link.registerClient = jest.fn(client => (link.client = client))
     })
     client = new CozyClient({ links, schema: SCHEMA })
   })
@@ -263,10 +263,12 @@ describe('CozyClient login', () => {
   })
 
   it('Should call `onLogin` on every link that implements it', async () => {
-    links[0].onLogin = jest.fn()
+    links[0].onLogin = jest.fn(() =>
+      expect(links[0].client.stackClient.uri).toBe('http://cozy.tools')
+    )
     links[2].onLogin = jest.fn()
 
-    await client.login()
+    await client.login({ uri: 'http://cozy.tools' })
 
     expect(links[0].onLogin).toHaveBeenCalledTimes(1)
     expect(links[2].onLogin).toHaveBeenCalledTimes(1)

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -110,9 +110,14 @@ class PouchLink extends CozyLink {
       }
     }
 
+    if (!prefix) {
+      throw new Error('PouchLink: Prefix is required')
+    }
+
     if (process.env.NODE_ENV !== 'production') {
       logger.log('Create pouches with ' + prefix + ' prefix')
     }
+
     this.pouches = new PouchManager(this.doctypes, {
       pouch: this.options.pouch,
       getReplicationURL: this.getReplicationURL.bind(this),

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -263,4 +263,30 @@ describe('CozyPouchLink', () => {
       expect(link.pouches.syncImmediately).toHaveBeenCalled()
     })
   })
+
+  describe('login', () => {
+    it('should throw if the stack client uri is not initialized', () => {
+      const clientWithoutUri = {
+        stackClient: {
+          token: {
+            toBasicAuth: () => 'user:token@'
+          }
+        }
+      }
+
+      const link = new CozyPouchLink({ doctypes: [TODO_DOCTYPE] })
+      const client = new CozyClient({
+        ...clientWithoutUri,
+        links: [link],
+        warningForCustomHandlers: false,
+        schema: {
+          todos: omit(SCHEMA.todos, ['relationships'])
+        }
+      })
+
+      link.registerClient(client)
+
+      expect(link.onLogin()).rejects.toThrow()
+    })
+  })
 })

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -89,7 +89,7 @@ class PouchManager {
     this.pouches = fromPairs(
       doctypes.map(doctype => [
         doctype,
-        new PouchDB(this.getDatabaseName(doctype, options.prefix), pouchOptions)
+        new PouchDB(this.getDatabaseName(doctype), pouchOptions)
       ])
     )
     this.syncedDoctypes = this.getPersistedSyncedDoctypes()
@@ -310,12 +310,8 @@ class PouchManager {
     window.localStorage.removeItem(LOCALSTORAGE_SYNCED_KEY)
   }
 
-  getDatabaseName(doctype, prefix) {
-    if (!prefix) {
-      return doctype
-    }
-
-    return `${prefix}_${doctype}`
+  getDatabaseName(doctype) {
+    return `${this.options.prefix}_${doctype}`
   }
 }
 

--- a/packages/cozy-pouch-link/src/PouchManager.spec.js
+++ b/packages/cozy-pouch-link/src/PouchManager.spec.js
@@ -29,7 +29,8 @@ describe('PouchManager', () => {
     managerOptions = {
       replicationDelay: 16,
       getReplicationURL: () => getReplicationURL(),
-      onSync
+      onSync,
+      prefix: 'cozy.tools'
     }
     manager = new PouchManager(['io.cozy.todos'], managerOptions)
     const pouch = manager.getPouch('io.cozy.todos')
@@ -145,7 +146,10 @@ describe('PouchManager', () => {
     const pouchOptions = { adapter: 'cordova-sqlite', location: 'default' }
     const options = { ...managerOptions, pouch: { options: pouchOptions } }
     new PouchManager(['io.cozy.todos'], options)
-    expect(PouchDB).toHaveBeenCalledWith('io.cozy.todos', pouchOptions)
+    expect(PouchDB).toHaveBeenCalledWith(
+      'cozy.tools_io.cozy.todos',
+      pouchOptions
+    )
   })
 
   describe('getPersistedSyncedDoctypes', () => {


### PR DESCRIPTION
In login method, we were doing the links login before the stack client URI initialization. So links relying on this data (like pouch link) could have bug.

The solution we propose is to:

* Fail when a link's login method throws
* Call login on links after URI initialization