### PR TITLE
Stack: Improve Not Found Error handling in Document Collection

### DIFF
--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -12,9 +12,9 @@ export const normalizeDoc = (doc, doctype) => {
   return { id, _id: id, _type: doctype, ...doc }
 }
 
-export const dontThrowNotFoundError = error => {
+export const dontThrowNotFoundError = (error, dataValue = []) => {
   if (error.message.match(/not_found/)) {
-    return { data: [], meta: { count: 0 }, skip: 0, next: false }
+    return { data: dataValue, meta: { count: 0 }, skip: 0, next: false }
   }
 
   throw error
@@ -136,10 +136,7 @@ class DocumentCollection {
         uri`/data/${this.doctype}/${id}`
       )
     } catch (error) {
-      if (error.message.match(/not_found/)) {
-        return { data: null }
-      }
-      throw error
+      dontThrowNotFoundError(error, null)
     }
     return {
       data: normalizeDoc(resp, this.doctype)

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -139,6 +139,7 @@ class DocumentCollection {
       if (error.message.match(/not_found/)) {
         return { data: null }
       }
+      throw error
     }
     return {
       data: normalizeDoc(resp, this.doctype)

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -468,6 +468,22 @@ describe('DocumentCollection', () => {
     })
   })
 
+  describe('get', () => {
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    it('should throw', async () => {
+      jest.spyOn(client, 'fetchJSON').mockImplementation(() => {
+        throw new Error('Not a 404 error')
+      })
+      const collection = new DocumentCollection('io.cozy.todos', client)
+      await expect(collection.get('whatever_id')).rejects.toEqual(
+        new Error('Not a 404 error')
+      )
+    })
+  })
+
   describe('update', () => {
     const collection = new DocumentCollection('io.cozy.todos', client)
 


### PR DESCRIPTION
This PR: 
* Make `DocumentCollection.get()` throw error if it's not a "Not Found" error. Could be a **BREAKING CHANGE**.
* Update the function `dontThrowNotFoundError` to make it able to return a specific value, for example `null` for method fetching only one document and not a list. Use this update for `DocumentCollection.get()`