### PR TITLE
feat(stack): Expose JobCollection via client.collection('io.cozy.jobs')

### DIFF
--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -2,11 +2,11 @@ import AppCollection, { APPS_DOCTYPE } from './AppCollection'
 import AppToken from './AppToken'
 import DocumentCollection from './DocumentCollection'
 import FileCollection from './FileCollection'
+import JobCollection, { JOBS_DOCTYPE } from './JobCollection'
 import KonnectorCollection, { KONNECTORS_DOCTYPE } from './KonnectorCollection'
 import SharingCollection from './SharingCollection'
 import PermissionCollection from './PermissionCollection'
 import TriggerCollection, { TRIGGERS_DOCTYPE } from './TriggerCollection'
-import JobCollection from './JobCollection'
 import getIconURL from './getIconURL'
 import logDeprecate from './logDeprecate'
 import errors from './errors'
@@ -57,6 +57,8 @@ class CozyStackClient {
         return new PermissionCollection(doctype, this)
       case TRIGGERS_DOCTYPE:
         return new TriggerCollection(this)
+      case JOBS_DOCTYPE:
+        return new JobCollection(this)
       default:
         return new DocumentCollection(doctype, this)
     }

--- a/packages/cozy-stack-client/src/JobCollection.js
+++ b/packages/cozy-stack-client/src/JobCollection.js
@@ -1,4 +1,4 @@
-const JOB_DOCTYPE = 'io.cozy.jobs'
+export const JOBS_DOCTYPE = 'io.cozy.jobs'
 
 class JobCollection {
   constructor(stackClient) {
@@ -11,7 +11,7 @@ class JobCollection {
   create(workerType, args, options) {
     return this.stackClient.fetchJSON('POST', `/jobs/queue/${workerType}`, {
       data: {
-        type: JOB_DOCTYPE,
+        type: JOBS_DOCTYPE,
         attributes: {
           arguments: args || {},
           options: options || {}

--- a/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
@@ -3,6 +3,7 @@
 
 import CozyStackClient, { FetchError } from '../CozyStackClient'
 import DocumentCollection from '../DocumentCollection'
+import JobCollection from '../JobCollection'
 import KonnectorCollection from '../KonnectorCollection'
 import jestFetchMock from 'jest-fetch-mock'
 
@@ -58,6 +59,10 @@ describe('CozyStackClient', () => {
       expect(client.collection('io.cozy.todos')).toBeInstanceOf(
         DocumentCollection
       )
+    })
+
+    it('should return a JobCollection for io.cozy.jobs doctype', () => {
+      expect(client.collection('io.cozy.jobs')).toBeInstanceOf(JobCollection)
     })
 
     it('should throw if the doctype is undefined', () => {


### PR DESCRIPTION
We expect to get a `JobCollection` when we use `client.collection('io.cozy.jobs')`. This PR fixes this.
(context: we need `JobCollection` to be able to use the new zip worker for credit application)

PS: I'll create another PR to add `JobCollection` to the docs