### PR TITLE
fix(cozy-client): Association HasOne don't fail if there is no data

### DIFF
--- a/packages/cozy-client/src/associations/HasOne.js
+++ b/packages/cozy-client/src/associations/HasOne.js
@@ -3,10 +3,14 @@ import Association from './Association'
 
 export default class HasOne extends Association {
   get raw() {
-    return this.target.relationships[this.name].data
+    return get(this.target, `relationships[${this.name}].data`, null)
   }
 
   get data() {
+    if (!this.raw) {
+      return null
+    }
+
     return this.get(this.doctype, this.raw._id)
   }
 

--- a/packages/cozy-client/src/associations/HasOne.spec.js
+++ b/packages/cozy-client/src/associations/HasOne.spec.js
@@ -23,27 +23,38 @@ const fixtures = {
   }
 }
 
-const get = jest.fn().mockReturnValue(fixtures.apprentice)
-
-const hydrated = {
+const hydratedMaster = {
   ...fixtures.jediMaster,
-  padawan: new HasOne(fixtures.jediMaster, 'padawan', 'io.cozy.jedis', { get })
+  padawan: new HasOne(fixtures.jediMaster, 'padawan', 'io.cozy.jedis', {
+    get: jest.fn().mockReturnValue(fixtures.apprentice)
+  })
+}
+
+const hydratedApprentice = {
+  ...fixtures.apprentice,
+  padawan: new HasOne(fixtures.apprentice, 'padawan', 'io.cozy.jedis', {
+    get: jest.fn().mockReturnValue(undefined)
+  })
 }
 
 describe('HasOne', () => {
   describe('raw', () => {
     it('returns relationship raw data', () => {
-      expect(hydrated.padawan.raw).toEqual({
+      expect(hydratedMaster.padawan.raw).toEqual({
         _id: 'anakin',
         _type: 'io.cozy.jedis'
       })
+    })
+
+    it('returns null if the relationship has no data', () => {
+      expect(hydratedApprentice.padawan.raw).toEqual(null)
     })
   })
 
   describe('data', () => {
     it('calls get method', () => {
-      const jedi = hydrated.padawan.data
-      expect(hydrated.padawan.get).toHaveBeenCalledWith(
+      const jedi = hydratedMaster.padawan.data
+      expect(hydratedMaster.padawan.get).toHaveBeenCalledWith(
         'io.cozy.jedis',
         'anakin'
       )


### PR DESCRIPTION
When trying to add a `HasOne` relationship on `io.cozy.bank.accounts` like this:

```js
const schema = {
  bankAccounts: {
    doctype: ACCOUNT_DOCTYPE,
    attributes: {},
    relationships: {
      masterAccount: {
        type: 'has-one',
        doctype: ACCOUNT_DOCTYPE
      }
    }
  },
}
```

Then access the `masterAccount.data` property on an account, I got an error:

```
Cannot read property 'masterAccount' of undefined
```

This was because in `HasOne.raw` getter `this.target.relationships` was undefined.

I handled it by using lodash's `get` to access `this.target.relationships[this.name].data` and fallback on null.