### PR TITLE
feat(cozy-client): Add set and unset methods on HasOne

### DIFF
--- a/packages/cozy-client/src/associations/HasOne.js
+++ b/packages/cozy-client/src/associations/HasOne.js
@@ -1,4 +1,5 @@
 import get from 'lodash/get'
+import set from 'lodash/set'
 import Association from './Association'
 
 export default class HasOne extends Association {
@@ -17,5 +18,42 @@ export default class HasOne extends Association {
   static query(doc, client, assoc) {
     const relationship = get(doc, `relationships.${assoc.name}.data`, {})
     return client.get(assoc.doctype, relationship._id)
+  }
+
+  set(doc) {
+    if (doc && doc._type !== this.doctype) {
+      throw new Error(
+        `Tried to associate a ${
+          doc._type
+        } document to a HasOne relationship on ${this.doctype} document`
+      )
+    }
+
+    const path = `relationships[${this.name}].data`
+
+    if (doc) {
+      set(this.target, path, {
+        _id: doc._id,
+        _type: doc._type
+      })
+    } else {
+      set(this.target, path, undefined)
+    }
+  }
+
+  unset() {
+    this.set(undefined)
+  }
+
+  dehydrate(doc) {
+    return {
+      ...doc,
+      relationships: {
+        ...doc.relationships,
+        [this.name]: {
+          data: this.raw
+        }
+      }
+    }
   }
 }

--- a/packages/cozy-client/src/associations/HasOne.spec.js
+++ b/packages/cozy-client/src/associations/HasOne.spec.js
@@ -72,4 +72,27 @@ describe('HasOne', () => {
       expect(queryDef.id).toEqual(fixtures.apprentice._id)
     })
   })
+
+  describe('set', () => {
+    it("should throw if the document to be set's type is not the same as the association type", () => {
+      expect(() =>
+        hydratedMaster.padawan.set({ _id: '1', _type: 'io.cozy.stuff' })
+      ).toThrow()
+    })
+
+    it('should update the associated document', () => {
+      const newPadawan = {
+        _id: 'shameonmeidontknowstarwars',
+        _type: 'io.cozy.jedis',
+        name: 'Bernard Nobody'
+      }
+
+      hydratedMaster.padawan.set(newPadawan)
+
+      expect(hydratedMaster.padawan.raw).toEqual({
+        _id: newPadawan._id,
+        _type: newPadawan._type
+      })
+    })
+  })
 })


### PR DESCRIPTION
These methods can be used to update the document that is associated to another one when using a `HasOne` relationship.