### PR TITLE
StackClient: Implement JobCollection.get() method

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -4,6 +4,10 @@
 <dt><a href="#AppCollection">AppCollection</a></dt>
 <dd><p>Extends <code>DocumentCollection</code> API along with specific methods for <code>io.cozy.apps</code>.</p>
 </dd>
+<dt><a href="#Collection">Collection</a></dt>
+<dd><p>Utility class to abstract an regroup identical methods and logics for
+specific collections.</p>
+</dd>
 <dt><a href="#CozyStackClient">CozyStackClient</a></dt>
 <dd><p>Main API against the <code>cozy-stack</code> server.</p>
 </dd>
@@ -30,6 +34,14 @@ through OAuth.</p>
 </dd>
 <dt><a href="#TriggerCollection">TriggerCollection</a></dt>
 <dd><p>Implements <code>DocumentCollection</code> API along with specific methods for <code>io.cozy.triggers</code>.</p>
+</dd>
+</dl>
+
+## Constants
+
+<dl>
+<dt><a href="#dontThrowNotFoundError">dontThrowNotFoundError</a> ⇒ <code>Object</code></dt>
+<dd><p>Handler for error response which return a empty value for &quot;not found&quot; error</p>
 </dd>
 </dl>
 
@@ -71,6 +83,30 @@ The returned documents are not paginated by the stack.
 **Throws**:
 
 - <code>FetchError</code> 
+
+<a name="Collection"></a>
+
+## Collection
+Utility class to abstract an regroup identical methods and logics for
+specific collections.
+
+**Kind**: global class  
+<a name="Collection.get"></a>
+
+### Collection.get(stackClient, endpoint, options) ⇒ <code>Object</code>
+Utility method aimed to return only one document.
+
+**Kind**: static method of [<code>Collection</code>](#Collection)  
+**Returns**: <code>Object</code> - JsonAPI response containing normalized
+document as data attribute  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| stackClient | <code>Object</code> |  |
+| endpoint | <code>String</code> | Stack endpoint |
+| options | <code>Object</code> |  |
+| options.normalize | <code>Func</code> | Callback to normalize response data (default `data => data`) |
+| options.method | <code>String</code> | HTTP method (default `GET`) |
 
 <a name="CozyStackClient"></a>
 
@@ -699,6 +735,20 @@ Force given trigger execution.
 | Param | Type | Description |
 | --- | --- | --- |
 | Trigger | <code>object</code> | to launch |
+
+<a name="dontThrowNotFoundError"></a>
+
+## dontThrowNotFoundError ⇒ <code>Object</code>
+Handler for error response which return a empty value for "not found" error
+
+**Kind**: global constant  
+**Returns**: <code>Object</code> - JsonAPI response with empty data in case of "not
+found" error.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| error | <code>Error</code> |  |
+| data | <code>Array</code> \| <code>Object</code> | Data to return in case of "not found" error |
 
 <a name="getAccessToken"></a>
 

--- a/packages/cozy-stack-client/src/Collection.js
+++ b/packages/cozy-stack-client/src/Collection.js
@@ -1,0 +1,54 @@
+/**
+ * Handler for error response which return a empty value for "not found" error
+ * @param  {Error}         error
+ * @param  {Array|Object}  data Data to return in case of "not found" error
+ * @return {Object}        JsonAPI response with empty data in case of "not
+ * found" error.
+ */
+export const dontThrowNotFoundError = (error, data = []) => {
+  if (error.message.match(/not_found/)) {
+    const expectsCollection = Array.isArray(data)
+    // Return expected JsonAPI attributes : collections are expecting
+    // meta, skip and next attribute
+    return expectsCollection
+      ? { data, meta: { count: 0 }, skip: 0, next: false }
+      : {
+          data
+        }
+  }
+  throw error
+}
+
+/**
+ * Utility class to abstract an regroup identical methods and logics for
+ * specific collections.
+ */
+export class Collection {
+  /**
+   * Utility method aimed to return only one document.
+   * @param  {Object}  stackClient
+   * @param  {String}  endpoint          Stack endpoint
+   * @param  {Object}  options
+   * @param  {Func}    options.normalize Callback to normalize response data
+   * (default `data => data`)
+   * @param  {String}  options.method    HTTP method (default `GET`)
+   * @return {Object}  JsonAPI response containing normalized
+   * document as data attribute
+   */
+  static async get(
+    stackClient,
+    endpoint,
+    { normalize = data => data, method = 'GET' }
+  ) {
+    try {
+      const resp = await stackClient.fetchJSON(method, endpoint)
+      return {
+        data: normalize(resp.data)
+      }
+    } catch (error) {
+      return dontThrowNotFoundError(error, null)
+    }
+  }
+}
+
+export default Collection

--- a/packages/cozy-stack-client/src/JobCollection.js
+++ b/packages/cozy-stack-client/src/JobCollection.js
@@ -1,4 +1,16 @@
+import Collection from './Collection'
+import { normalizeDoc } from './DocumentCollection'
+import { uri } from './utils'
+
 export const JOBS_DOCTYPE = 'io.cozy.jobs'
+
+export const normalizeJob = job => {
+  return {
+    ...job,
+    ...normalizeDoc(job, JOBS_DOCTYPE),
+    ...job.attributes
+  }
+}
 
 class JobCollection {
   constructor(stackClient) {
@@ -17,6 +29,12 @@ class JobCollection {
           options: options || {}
         }
       }
+    })
+  }
+
+  async get(id) {
+    return Collection.get(this.stackClient, uri`/jobs/${id}`, {
+      normalize: normalizeJob
     })
   }
 }

--- a/packages/cozy-stack-client/src/JobCollection.spec.js
+++ b/packages/cozy-stack-client/src/JobCollection.spec.js
@@ -4,8 +4,11 @@ import StackClient from './CozyStackClient'
 describe('job collection', () => {
   let stackClient, col
 
-  beforeEach(() => {
+  beforeAll(() => {
     stackClient = new StackClient()
+  })
+
+  beforeEach(() => {
     jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue({})
     col = new JobCollection(stackClient)
   })
@@ -38,5 +41,45 @@ describe('job collection', () => {
       'GET',
       '/jobs/queue/service'
     )
+  })
+
+  describe('get', () => {
+    beforeEach(() => {
+      jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue({
+        data: {
+          type: 'io.cozy.jobs',
+          id: '5396fc6299dd437d8d30fecd44745745',
+          attributes: {
+            domain: 'me.cozy.tools',
+            worker: 'sendmail',
+            options: {
+              priority: 3,
+              timeout: 60,
+              max_exec_count: 3
+            },
+            state: 'running',
+            queued_at: '2016-09-19T12:35:08Z',
+            started_at: '2016-09-19T12:35:08Z',
+            error: ''
+          },
+          links: {
+            self: '/jobs/5396fc6299dd437d8d30fecd44745745'
+          }
+        }
+      })
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should call the expected stack endpoint', async () => {
+      const jobId = '5396fc6299dd437d8d30fecd44745745'
+      await col.get(jobId)
+      expect(stackClient.fetchJSON).toHaveBeenCalledWith(
+        'GET',
+        '/jobs/5396fc6299dd437d8d30fecd44745745'
+      )
+    })
   })
 })

--- a/packages/cozy-stack-client/src/TriggerCollection.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.js
@@ -1,4 +1,5 @@
-import { normalizeDoc, dontThrowNotFoundError } from './DocumentCollection'
+import Collection, { dontThrowNotFoundError } from './Collection'
+import { normalizeDoc } from './DocumentCollection'
 import { uri } from './utils'
 
 export const JOBS_DOCTYPE = 'io.cozy.jobs'
@@ -109,18 +110,9 @@ class TriggerCollection {
   }
 
   async get(id) {
-    const path = uri`/jobs/triggers/${id}`
-    try {
-      const resp = await this.stackClient.fetchJSON('GET', path)
-      return {
-        data: normalizeTrigger(resp.data)
-      }
-    } catch (error) {
-      if (error.message.match(/not_found/)) {
-        return { data: null }
-      }
-      throw error
-    }
+    return Collection.get(this.stackClient, uri`/jobs/triggers/${id}`, {
+      normalize: normalizeTrigger
+    })
   }
 
   /**

--- a/packages/cozy-stack-client/src/TriggerCollection.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.js
@@ -1,17 +1,10 @@
 import Collection, { dontThrowNotFoundError } from './Collection'
 import { normalizeDoc } from './DocumentCollection'
+import { normalizeJob } from './JobCollection'
 import { uri } from './utils'
 
 export const JOBS_DOCTYPE = 'io.cozy.jobs'
 export const TRIGGERS_DOCTYPE = 'io.cozy.triggers'
-
-export const normalizeJob = job => {
-  return {
-    ...job,
-    ...normalizeDoc(job, JOBS_DOCTYPE),
-    ...job.attributes
-  }
-}
 
 export const normalizeTrigger = trigger => {
   return {


### PR DESCRIPTION
This method is actually used here https://github.com/cozy/cozy-libs/blob/master/packages/cozy-harvest-lib/src/models/konnector/KonnectorJobWatcher.js#L100, and throw an error.

This PR also suggest to abstract get methods pattern into an higher utility classed named Collection.