### PR TITLE
Add deleteFilePermanently method

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -243,6 +243,7 @@ files associated to a specific document
     * [.find(selector, options)](#FileCollection+find) ⇒ <code>Object</code>
     * [.findReferencedBy(document, {, limit)](#FileCollection+findReferencedBy) ⇒ <code>object</code>
     * [.restore(id)](#FileCollection+restore) ⇒ <code>Promise</code>
+    * [.deleteFilePermanently(id)](#FileCollection+deleteFilePermanently) ⇒ <code>object</code>
     * [.updateFile(data, params)](#FileCollection+updateFile) ⇒ <code>object</code>
     * [.createDirectoryByPath(path)](#FileCollection+createDirectoryByPath) ⇒ <code>object</code>
     * [.updateFileMetadata(id, attributes)](#FileCollection+updateFileMetadata) ⇒ <code>object</code>
@@ -296,6 +297,18 @@ Restores a trashed file.
 | Param | Type | Description |
 | --- | --- | --- |
 | id | <code>string</code> | The file's id |
+
+<a name="FileCollection+deleteFilePermanently"></a>
+
+### fileCollection.deleteFilePermanently(id) ⇒ <code>object</code>
+async deleteFilePermanently - Definitely delete a file
+
+**Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
+**Returns**: <code>object</code> - The deleted file object  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| id | <code>string</code> | The id of the file to delete |
 
 <a name="FileCollection+updateFile"></a>
 

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -150,6 +150,26 @@ class FileCollection extends DocumentCollection {
     return this.stackClient.fetchJSON('POST', uri`/files/trash/${id}`)
   }
 
+  /**
+   * async deleteFilePermanently - Definitely delete a file
+   *
+   * @param  {string} id - The id of the file to delete
+   * @returns {object} The deleted file object
+   */
+  async deleteFilePermanently(id) {
+    const resp = await this.stackClient.fetchJSON('PATCH', uri`/files/${id}`, {
+      data: {
+        type: 'io.cozy.files',
+        id,
+        attributes: {
+          permanent_delete: true
+        }
+      }
+    })
+
+    return resp.data
+  }
+
   async upload(data, dirPath) {
     const dirId = await this.ensureDirectoryExists(dirPath)
     return this.createFile(data, { dirId })

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -358,6 +358,36 @@ describe('FileCollection', () => {
     })
   })
 
+  describe('deleteFilePermanently', () => {
+    it('should definitely delete a file', async () => {
+      const FILE_ID = 'd04ab491-2fc6'
+      client.fetchJSON.mockReturnValue({
+        data: {
+          id: FILE_ID,
+          type: 'io.cozy.files'
+        }
+      })
+      const result = await collection.deleteFilePermanently(FILE_ID)
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'PATCH',
+        '/files/d04ab491-2fc6',
+        {
+          data: {
+            type: 'io.cozy.files',
+            id: 'd04ab491-2fc6',
+            attributes: {
+              permanent_delete: true
+            }
+          }
+        }
+      )
+      expect(result).toEqual({
+        id: FILE_ID,
+        type: 'io.cozy.files'
+      })
+    })
+  })
+
   describe('createFile', () => {
     const data = new File([''], 'mydoc.odt')
     const id = '59140416-b95f'


### PR DESCRIPTION
Discussed on the mattermost channel a few days ago. Uses the route from the stack : https://docs.cozy.io/en/cozy-stack/files/#patch-filesfile-id-and-patch-filesmetadata

(well, maybe we could name it `permanentDelete` here too)