### PR TITLE
feat(cozy-stack-client): Updatefile can create metadata

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -313,6 +313,7 @@ updateFile - Updates a file's data
 | params | <code>object</code> | Additional parameters |
 | params.fileId | <code>string</code> | The id of the file to update (required) |
 | params.executable | <code>boolean</code> | Whether the file is executable or not |
+| params.metadata | <code>object</code> | Metadata to be attached to the File io.cozy.file |
 | params.options | <code>object</code> | Options to pass to doUpload method (additional headers) |
 
 <a name="FileCollection+createDirectoryByPath"></a>

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -301,7 +301,7 @@ describe('FileCollection', () => {
       client.fetchJSON.mockClear()
     })
 
-    it('should update a file', async () => {
+    it('should update a file without metadata', async () => {
       const data = new File([''], 'mydoc.odt')
       const params = {
         fileId: '59140416-b95f',
@@ -310,6 +310,43 @@ describe('FileCollection', () => {
       const result = await collection.updateFile(data, params)
       const expectedPath =
         '/files/59140416-b95f?Name=mydoc.odt&Type=file&Executable=false'
+      const expectedOptions = {
+        headers: {
+          'Content-MD5': 'a6dabd99832b270468e254814df2ed20',
+          'Content-Type': 'application/vnd.oasis.opendocument.text'
+        }
+      }
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'PUT',
+        expectedPath,
+        data,
+        expectedOptions
+      )
+      expect(result).toEqual({
+        data: {
+          id: '59140416-b95f',
+          _id: '59140416-b95f',
+          _type: 'io.cozy.files',
+          dir_id: '41686c35-9d8e'
+        }
+      })
+    })
+
+    it('should update a file with metadata', async () => {
+      const metadataId = '2460a631-ae55'
+      client.fetchJSON.mockReturnValueOnce({
+        data: {
+          id: metadataId
+        }
+      })
+      const data = new File([''], 'mydoc.odt')
+      const params = {
+        fileId: '59140416-b95f',
+        checksum: 'a6dabd99832b270468e254814df2ed20',
+        metadata: { type: 'bill' }
+      }
+      const result = await collection.updateFile(data, params)
+      const expectedPath = `/files/59140416-b95f?Name=mydoc.odt&Type=file&Executable=false&MetadataID=${metadataId}`
       const expectedOptions = {
         headers: {
           'Content-MD5': 'a6dabd99832b270468e254814df2ed20',


### PR DESCRIPTION
Same as https://github.com/cozy/cozy-client/commit/c9dbb6f50fe14e9084f8af62d955602b7203e537 but for updateFile. 

We can now attach a metadata to the updatedFile. 