### PR TITLE
feat(cozy-client): Add queryAll method

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -442,6 +442,18 @@ class CozyClient {
     }
   }
 
+  async queryAll(queryDefinition, options) {
+    const documents = []
+    let resp = { next: true }
+
+    while (resp && resp.next) {
+      resp = await this.query(queryDefinition.offset(documents.length), options)
+      documents.push(...resp.data)
+    }
+
+    return documents
+  }
+
   watchQuery(queryDefinition, options = {}) {
     this.ensureStore()
     const queryId = options.as || this.generateId()

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -801,6 +801,50 @@ describe('CozyClient', () => {
     })
   })
 
+  describe('queryAll', () => {
+    let query
+
+    beforeEach(() => {
+      query = client.all('io.cozy.todos')
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should call `query` until there is no more document to query', async () => {
+      let i = 0
+      jest.spyOn(client, 'query').mockImplementation(() => {
+        let resp
+
+        if (i === 0) {
+          resp = { data: [{ _id: '0', label: 'Shopping' }], next: true }
+        }
+
+        if (i === 1) {
+          resp = { data: [{ _id: '1', label: 'Laundry' }], next: true }
+        }
+
+        if (i === 2) {
+          resp = { data: [{ _id: '2', label: 'Cook' }], next: true }
+        }
+
+        if (i === 3) {
+          resp = { data: [{ _id: '3', label: 'Rest' }], next: false }
+        }
+
+        ++i
+
+        return resp
+      })
+
+      const documents = await client.queryAll(query)
+
+      expect(client.query).toHaveBeenCalledTimes(4)
+      expect(documents).toMatchSnapshot()
+    })
+  })
+
   describe('mutate', () => {
     const mutation = { mutationType: 'FAKE' }
     const fakeResponse = {

--- a/packages/cozy-client/src/__snapshots__/CozyClient.spec.js.snap
+++ b/packages/cozy-client/src/__snapshots__/CozyClient.spec.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CozyClient queryAll should call \`query\` until there is no more document to query 1`] = `
+Array [
+  Object {
+    "_id": "0",
+    "label": "Shopping",
+  },
+  Object {
+    "_id": "1",
+    "label": "Laundry",
+  },
+  Object {
+    "_id": "2",
+    "label": "Cook",
+  },
+  Object {
+    "_id": "3",
+    "label": "Rest",
+  },
+]
+`;


### PR DESCRIPTION
Today, we have to manually do the query loop everytime we need to query all documents with a given selector. Until now, we had [`Document::queryAll`](https://github.com/cozy/cozy-libs/blob/master/packages/cozy-doctypes/src/Document.js#L459) to achieve the same goal, but this logic can be implemented directly inside cozy-client.

We also have a [`UNSAFE_noLimit`](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L140-L142) method, but this can't be used with a selector (see https://github.com/cozy/cozy-client/blob/master/packages/cozy-stack-client/src/DocumentCollection.js#L45-L48)

It will be useful in [cozy-procedures](https://github.com/cozy/cozy-libs/pull/682#discussion_r306162578), where we precisely want to query all documents with a selector.