### PR TITLE
Add support for referenced-by

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -242,6 +242,10 @@ files associated to a specific document
 * [FileCollection](#FileCollection)
     * [.find(selector, options)](#FileCollection+find) ⇒ <code>Object</code>
     * [.findReferencedBy(document, options)](#FileCollection+findReferencedBy) ⇒ <code>object</code>
+    * [.addReferencedBy(document, documents)](#FileCollection+addReferencedBy) ⇒ <code>object</code>
+    * [.removeReferencedBy(document, documents)](#FileCollection+removeReferencedBy) ⇒ <code>object</code>
+    * [.addReferencesTo(document, documents)](#FileCollection+addReferencesTo) ⇒ <code>object</code>
+    * [.removeReferencesTo(document, documents)](#FileCollection+removeReferencesTo) ⇒ <code>object</code>
     * [.restore(id)](#FileCollection+restore) ⇒ <code>Promise</code>
     * [.updateFile(data, params)](#FileCollection+updateFile) ⇒ <code>object</code>
     * [.isChildOf(child, parent)](#FileCollection+isChildOf) ⇒ <code>boolean</code>
@@ -283,6 +287,58 @@ async findReferencedBy - Returns the list of files referenced by a document — 
 | options.skip | <code>number</code> | For skip-based pagination, the number of referenced files to skip. |
 | options.limit | <code>number</code> | For pagination, the number of results to return. |
 | options.cursor | <code>object</code> | For cursor-based pagination, the index cursor. |
+
+<a name="FileCollection+addReferencedBy"></a>
+
+### fileCollection.addReferencedBy(document, documents) ⇒ <code>object</code>
+Add referenced_by documents to a file — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#post-filesfile-idrelationshipsreferenced_by
+
+**Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
+**Returns**: <code>object</code> - The JSON API conformant response.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | <code>object</code> | A JSON representing the file |
+| documents | <code>Array</code> | An array of JSON documents having a `_type` and `_id` field. |
+
+<a name="FileCollection+removeReferencedBy"></a>
+
+### fileCollection.removeReferencedBy(document, documents) ⇒ <code>object</code>
+Remove referenced_by documents from a file — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#delete-filesfile-idrelationshipsreferenced_by
+
+**Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
+**Returns**: <code>object</code> - The JSON API conformant response.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | <code>object</code> | A JSON representing the file |
+| documents | <code>Array</code> | An array of JSON documents having a `_type` and `_id` field. |
+
+<a name="FileCollection+addReferencesTo"></a>
+
+### fileCollection.addReferencesTo(document, documents) ⇒ <code>object</code>
+Add files references to a document — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#post-datatypedoc-idrelationshipsreferences
+
+**Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
+**Returns**: <code>object</code> - The JSON API conformant response.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | <code>object</code> | A JSON representing a document, with at least a `_type` and `_id` field. |
+| documents | <code>Array</code> | An array of JSON files having an `_id` field. |
+
+<a name="FileCollection+removeReferencesTo"></a>
+
+### fileCollection.removeReferencesTo(document, documents) ⇒ <code>object</code>
+Remove files references to a document — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#delete-datatypedoc-idrelationshipsreferences
+
+**Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
+**Returns**: <code>object</code> - The JSON API conformant response.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | <code>object</code> | A JSON representing a document, with at least a `_type` and `_id` field. |
+| documents | <code>Array</code> | An array of JSON files having an `_id` field. |
 
 <a name="FileCollection+restore"></a>
 

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -293,6 +293,11 @@ async findReferencedBy - Returns the list of files referenced by a document — 
 ### fileCollection.addReferencedBy(document, documents) ⇒ <code>object</code>
 Add referenced_by documents to a file — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#post-filesfile-idrelationshipsreferenced_by
 
+ For example, to have an album referenced by a file:
+ ```
+addReferencedBy({_id: 123, _type: "io.cozy.files", name: "cozy.jpg"}, [{_id: 456, _type: "io.cozy.photos.albums", name: "Happy Cloud"}])
+```
+
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
 **Returns**: <code>object</code> - The JSON API conformant response.  
 
@@ -305,6 +310,11 @@ Add referenced_by documents to a file — see https://docs.cozy.io/en/cozy-stack
 
 ### fileCollection.removeReferencedBy(document, documents) ⇒ <code>object</code>
 Remove referenced_by documents from a file — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#delete-filesfile-idrelationshipsreferenced_by
+
+ For example, to remove an album reference from a file:
+ ```
+ removeReferencedBy({_id: 123, _type: "io.cozy.files", name: "cozy.jpg"}, [{_id: 456, _type: "io.cozy.photos.albums", name: "Happy Cloud"}])
+```
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
 **Returns**: <code>object</code> - The JSON API conformant response.  
@@ -319,6 +329,11 @@ Remove referenced_by documents from a file — see https://docs.cozy.io/en/cozy-
 ### fileCollection.addReferencesTo(document, documents) ⇒ <code>object</code>
 Add files references to a document — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#post-datatypedoc-idrelationshipsreferences
 
+ For example, to add a photo to an album:
+ ```
+ addReferencesTo({_id: 456, _type: "io.cozy.photos.albums", name: "Happy Cloud"}, [{_id: 123, _type: "io.cozy.files", name: "cozy.jpg"}])
+```
+
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
 **Returns**: <code>object</code> - The JSON API conformant response.  
 
@@ -331,6 +346,11 @@ Add files references to a document — see https://docs.cozy.io/en/cozy-stack/re
 
 ### fileCollection.removeReferencesTo(document, documents) ⇒ <code>object</code>
 Remove files references to a document — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#delete-datatypedoc-idrelationshipsreferences
+
+ For example, to remove a photo from an album:
+ ```
+ removeReferencesTo({_id: 456, _type: "io.cozy.photos.albums", name: "Happy Cloud"}, [{_id: 123, _type: "io.cozy.files", name: "cozy.jpg"}])
+```
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
 **Returns**: <code>object</code> - The JSON API conformant response.  

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -528,6 +528,7 @@ describe('CozyClient', () => {
     })
 
     it('should handle associations for a new file with relationship', () => {
+      // icons is a has-many relationship defined in __tests__/fixtures for files
       const NEW_FILE = {
         _type: 'io.cozy.files',
         icons: [

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -527,6 +527,34 @@ describe('CozyClient', () => {
       ])
     })
 
+    it('should handle associations for a new file with relationship', () => {
+      const NEW_FILE = {
+        _type: 'io.cozy.files',
+        icons: [
+          {
+            id: 67890,
+            type: 'io.cozy.files'
+          }
+        ]
+      }
+      const EXPECTED_CREATED_FILE = { _id: 12345, _type: 'io.cozy.files' }
+      const mutation = client.getDocumentSavePlan(NEW_FILE, {
+        icons: [
+          {
+            id: 67890,
+            type: 'io.cozy.files'
+          }
+        ]
+      })
+      expect(Array.isArray(mutation)).toBe(true)
+      expect(typeof mutation[1] === 'function').toBe(true)
+      expect(mutation[1]({ data: EXPECTED_CREATED_FILE })).toEqual([
+        Mutations.addReferencedBy(EXPECTED_CREATED_FILE, [
+          { id: 67890, type: 'io.cozy.files' }
+        ])
+      ])
+    })
+
     it('should handle empty associations', () => {
       const NEW_TODO = {
         _type: 'io.cozy.todos',

--- a/packages/cozy-client/src/StackLink.js
+++ b/packages/cozy-client/src/StackLink.js
@@ -64,24 +64,28 @@ export default class StackLink extends CozyLink {
           .collection(props.document._type)
           .destroy(props.document)
       case MutationTypes.ADD_REFERENCES_TO:
-        if (props.referencedDocuments[0]._type === 'io.cozy.files') {
-          return this.stackClient
-            .collection('io.cozy.files')
-            .addReferencesTo(props.document, props.referencedDocuments)
-        } else {
+        return this.stackClient
+          .collection(props.referencedDocuments[0]._type)
+          .addReferencesTo(props.document, props.referencedDocuments)
+      case MutationTypes.REMOVE_REFERENCES_TO:
+        return this.stackClient
+          .collection(props.referencedDocuments[0]._type)
+          .removeReferencesTo(props.document, props.referencedDocuments)
+      case MutationTypes.ADD_REFERENCED_BY:
+        if (props.document._type === 'io.cozy.files') {
           return this.stackClient
             .collection('io.cozy.files')
             .addReferencedBy(props.document, props.referencedDocuments)
-        }
-      case MutationTypes.REMOVE_REFERENCES_TO:
-        if (props.referencedDocuments[0]._type === 'io.cozy.files') {
-          return this.stackClient
-            .collection('io.cozy.files')
-            .removeReferencesTo(props.document, props.referencedDocuments)
         } else {
+          throw new Error('The document type should be io.cozy.files')
+        }
+      case MutationTypes.REMOVE_REFERENCED_BY:
+        if (props.document._type === 'io.cozy.files') {
           return this.stackClient
             .collection('io.cozy.files')
             .removeReferencedBy(props.document, props.referencedDocuments)
+        } else {
+          throw new Error('The document type should be io.cozy.files')
         }
       case MutationTypes.UPLOAD_FILE:
         return this.stackClient

--- a/packages/cozy-client/src/StackLink.js
+++ b/packages/cozy-client/src/StackLink.js
@@ -64,13 +64,25 @@ export default class StackLink extends CozyLink {
           .collection(props.document._type)
           .destroy(props.document)
       case MutationTypes.ADD_REFERENCES_TO:
-        return this.stackClient
-          .collection(props.referencedDocuments[0]._type)
-          .addReferencesTo(props.document, props.referencedDocuments)
+        if (props.referencedDocuments[0]._type === 'io.cozy.files') {
+          return this.stackClient
+            .collection('io.cozy.files')
+            .addReferencesTo(props.document, props.referencedDocuments)
+        } else {
+          return this.stackClient
+            .collection('io.cozy.files')
+            .addReferencedBy(props.document, props.referencedDocuments)
+        }
       case MutationTypes.REMOVE_REFERENCES_TO:
-        return this.stackClient
-          .collection(props.referencedDocuments[0]._type)
-          .removeReferencesTo(props.document, props.referencedDocuments)
+        if (props.referencedDocuments[0]._type === 'io.cozy.files') {
+          return this.stackClient
+            .collection('io.cozy.files')
+            .removeReferencesTo(props.document, props.referencedDocuments)
+        } else {
+          return this.stackClient
+            .collection('io.cozy.files')
+            .removeReferencedBy(props.document, props.referencedDocuments)
+        }
       case MutationTypes.UPLOAD_FILE:
         return this.stackClient
           .collection('io.cozy.files')

--- a/packages/cozy-client/src/__tests__/fixtures.js
+++ b/packages/cozy-client/src/__tests__/fixtures.js
@@ -84,5 +84,14 @@ export const SCHEMA = {
         doctype: 'io.cozy.persons'
       }
     }
+  },
+  files: {
+    doctype: 'io.cozy.files',
+    relationships: {
+      icons: {
+        type: 'has-many',
+        doctype: 'io.cozy.files'
+      }
+    }
   }
 }

--- a/packages/cozy-client/src/associations/HasManyFiles.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.js
@@ -64,11 +64,27 @@ export default class HasManyFiles extends HasMany {
   }
 
   insertDocuments(referencedDocs) {
-    return Mutations.addReferencesTo(this.target, referencedDocs)
+    if (this.target._type === 'io.cozy.files') {
+      return Mutations.addReferencedBy(this.target, referencedDocs)
+    } else if (referencedDocs[0]._type === 'io.cozy.files') {
+      return Mutations.addReferencesTo(this.target, referencedDocs)
+    } else {
+      throw new Error(
+        'Either the document or the references should be io.cozy.files'
+      )
+    }
   }
 
   removeDocuments(referencedDocs) {
-    return Mutations.removeReferencesTo(this.target, referencedDocs)
+    if (this.target._type === 'io.cozy.files') {
+      return Mutations.removeReferencedBy(this.target, referencedDocs)
+    } else if (referencedDocs[0]._type === 'io.cozy.files') {
+      return Mutations.removeReferencesTo(this.target, referencedDocs)
+    } else {
+      throw new Error(
+        'Either the document or the references should be io.cozy.files'
+      )
+    }
   }
 
   dehydrate(doc) {

--- a/packages/cozy-client/src/associations/HasManyFiles.spec.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.spec.js
@@ -92,4 +92,12 @@ describe('HasManyFiles', () => {
     })
     expect(save).toHaveBeenCalled()
   })
+
+  it('add wrong file relations', () => {
+    const refTodo = {
+      _id: 456,
+      _type: 'io.cozy.todos'
+    }
+    expect(() => hydrated.files.insertDocuments([refTodo])).toThrow(Error)
+  })
 })

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -9,6 +9,7 @@ export { default as Query } from './Query'
 export { default as compose } from 'lodash/flow'
 export {
   QueryDefinition,
+  Mutations,
   MutationTypes,
   getDoctypeFromOperation
 } from './queries/dsl'

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -201,6 +201,8 @@ const UPDATE_DOCUMENT = 'UPDATE_DOCUMENT'
 const DELETE_DOCUMENT = 'DELETE_DOCUMENT'
 const ADD_REFERENCES_TO = 'ADD_REFERENCES_TO'
 const REMOVE_REFERENCES_TO = 'REMOVE_REFERENCES_TO'
+const ADD_REFERENCED_BY = 'ADD_REFERENCED_BY'
+const REMOVE_REFERENCED_BY = 'REMOVE_REFERENCED_BY'
 const UPLOAD_FILE = 'UPLOAD_FILE'
 
 export const createDocument = document => ({
@@ -226,6 +228,18 @@ export const addReferencesTo = (document, referencedDocuments) => ({
 
 export const removeReferencesTo = (document, referencedDocuments) => ({
   mutationType: MutationTypes.REMOVE_REFERENCES_TO,
+  referencedDocuments,
+  document
+})
+
+export const addReferencedBy = (document, referencedDocuments) => ({
+  mutationType: MutationTypes.ADD_REFERENCED_BY,
+  referencedDocuments,
+  document
+})
+
+export const removeReferencedBy = (document, referencedDocuments) => ({
+  mutationType: MutationTypes.REMOVE_REFERENCED_BY,
   referencedDocuments,
   document
 })
@@ -264,6 +278,8 @@ export const Mutations = {
   deleteDocument,
   addReferencesTo,
   removeReferencesTo,
+  addReferencedBy,
+  removeReferencedBy,
   uploadFile
 }
 
@@ -273,6 +289,8 @@ export const MutationTypes = {
   DELETE_DOCUMENT,
   ADD_REFERENCES_TO,
   REMOVE_REFERENCES_TO,
+  ADD_REFERENCED_BY,
+  REMOVE_REFERENCED_BY,
   UPLOAD_FILE
 }
 

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -113,6 +113,45 @@ class FileCollection extends DocumentCollection {
     }
   }
 
+  /**
+   *  Add referenced_by documents to a file — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#post-filesfile-idrelationshipsreferenced_by
+   *
+   * @param  {object} document        A JSON representing the file
+   * @param  {Array}  documents       An array of JSON documents having a `_type` and `_id` field.
+   * @returns {object}                The JSON API conformant response.
+   */
+  addReferencedBy(document, documents) {
+    const refs = documents.map(d => ({ id: d._id, type: d._type }))
+    return this.stackClient.fetchJSON(
+      'POST',
+      uri`/files/${document._id}/relationships/referenced_by`,
+      { data: refs }
+    )
+  }
+
+  /**
+   *  Remove referenced_by documents from a file — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#delete-filesfile-idrelationshipsreferenced_by
+   *
+   * @param  {object} document        A JSON representing the file
+   * @param  {Array}  documents       An array of JSON documents having a `_type` and `_id` field.
+   * @returns {object}                The JSON API conformant response.
+   */
+  removeReferencedBy(document, documents) {
+    const refs = documents.map(d => ({ id: d._id, type: d._type }))
+    return this.stackClient.fetchJSON(
+      'DELETE',
+      uri`/files/${document._id}/relationships/referenced_by`,
+      { data: refs }
+    )
+  }
+
+  /**
+   *  Add files references to a document — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#post-datatypedoc-idrelationshipsreferences
+   *
+   * @param  {object} document        A JSON representing a document, with at least a `_type` and `_id` field.
+   * @param  {Array}  documents       An array of JSON files having an `_id` field.
+   * @returns {object}                The JSON API conformant response.
+   */
   addReferencesTo(document, documents) {
     const refs = documents.map(d => ({ id: d._id, type: 'io.cozy.files' }))
     return this.stackClient.fetchJSON(
@@ -122,6 +161,13 @@ class FileCollection extends DocumentCollection {
     )
   }
 
+  /**
+   *  Remove files references to a document — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#delete-datatypedoc-idrelationshipsreferences
+   *
+   * @param  {object} document        A JSON representing a document, with at least a `_type` and `_id` field.
+   * @param  {Array}  documents       An array of JSON files having an `_id` field.
+   * @returns {object}                The JSON API conformant response.
+   */
   removeReferencesTo(document, documents) {
     const refs = documents.map(d => ({ id: d._id, type: 'io.cozy.files' }))
     return this.stackClient.fetchJSON(

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -116,6 +116,11 @@ class FileCollection extends DocumentCollection {
   /**
    *  Add referenced_by documents to a file — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#post-filesfile-idrelationshipsreferenced_by
    *
+   *  For example, to have an album referenced by a file:
+   *  ```
+   * addReferencedBy({_id: 123, _type: "io.cozy.files", name: "cozy.jpg"}, [{_id: 456, _type: "io.cozy.photos.albums", name: "Happy Cloud"}])
+   * ```
+   *
    * @param  {object} document        A JSON representing the file
    * @param  {Array}  documents       An array of JSON documents having a `_type` and `_id` field.
    * @returns {object}                The JSON API conformant response.
@@ -131,6 +136,11 @@ class FileCollection extends DocumentCollection {
 
   /**
    *  Remove referenced_by documents from a file — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#delete-filesfile-idrelationshipsreferenced_by
+   *
+   *  For example, to remove an album reference from a file:
+   *  ```
+   *  removeReferencedBy({_id: 123, _type: "io.cozy.files", name: "cozy.jpg"}, [{_id: 456, _type: "io.cozy.photos.albums", name: "Happy Cloud"}])
+   * ```
    *
    * @param  {object} document        A JSON representing the file
    * @param  {Array}  documents       An array of JSON documents having a `_type` and `_id` field.
@@ -148,6 +158,11 @@ class FileCollection extends DocumentCollection {
   /**
    *  Add files references to a document — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#post-datatypedoc-idrelationshipsreferences
    *
+   *  For example, to add a photo to an album:
+   *  ```
+   *  addReferencesTo({_id: 456, _type: "io.cozy.photos.albums", name: "Happy Cloud"}, [{_id: 123, _type: "io.cozy.files", name: "cozy.jpg"}])
+   * ```
+   *
    * @param  {object} document        A JSON representing a document, with at least a `_type` and `_id` field.
    * @param  {Array}  documents       An array of JSON files having an `_id` field.
    * @returns {object}                The JSON API conformant response.
@@ -163,6 +178,11 @@ class FileCollection extends DocumentCollection {
 
   /**
    *  Remove files references to a document — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#delete-datatypedoc-idrelationshipsreferences
+   *
+   *  For example, to remove a photo from an album:
+   *  ```
+   *  removeReferencesTo({_id: 456, _type: "io.cozy.photos.albums", name: "Happy Cloud"}, [{_id: 123, _type: "io.cozy.files", name: "cozy.jpg"}])
+   * ```
    *
    * @param  {object} document        A JSON representing a document, with at least a `_type` and `_id` field.
    * @param  {Array}  documents       An array of JSON files having an `_id` field.

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -246,6 +246,43 @@ describe('FileCollection', () => {
     })
   })
 
+  describe('referencedBy', () => {
+    const client = new CozyStackClient()
+    const collection = new FileCollection('io.cozy.files', client)
+
+    const spy = jest.spyOn(client, 'fetchJSON')
+
+    beforeEach(() => {
+      spy.mockClear()
+    })
+
+    const file = {
+      _type: 'io.cozy.files',
+      _id: '123'
+    }
+
+    it('should add a reference', async () => {
+      const refs = [
+        {
+          _id: '456',
+          _type: 'io.cozy.photos.albums'
+        }
+      ]
+      await collection.addReferencedBy(file, refs)
+      expect(spy).toMatchSnapshot()
+    })
+    it('should remove a reference', async () => {
+      const refs = [
+        {
+          _id: '456',
+          _type: 'io.cozy.photos.albums'
+        }
+      ]
+      await collection.removeReferencedBy(file, refs)
+      expect(spy).toMatchSnapshot()
+    })
+  })
+
   describe('updateFileMetadata', () => {
     beforeEach(() => {
       client.fetchJSON.mockReturnValue({ data: [] })

--- a/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
+++ b/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
@@ -35,6 +35,56 @@ exports[`FileCollection findReferencedBy should pass all the filters 1`] = `
 }
 `;
 
+exports[`FileCollection referencedBy should add a reference 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "POST",
+      "/files/123/relationships/referenced_by",
+      Object {
+        "data": Array [
+          Object {
+            "id": "456",
+            "type": "io.cozy.photos.albums",
+          },
+        ],
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`FileCollection referencedBy should remove a reference 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "DELETE",
+      "/files/123/relationships/referenced_by",
+      Object {
+        "data": Array [
+          Object {
+            "id": "456",
+            "type": "io.cozy.photos.albums",
+          },
+        ],
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": undefined,
+    },
+  ],
+}
+`;
+
 exports[`FileCollection updateFileMetadata should call the right route 1`] = `
 Array [
   "PATCH",


### PR DESCRIPTION
This allows to add / remove referenced_by documents, from files. It implements the following routes: 
* https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#post-filesfile-idrelationshipsreferenced_by
* https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#delete-filesfile-idrelationshipsreferenced_by

For example, one can add / remove albums directly from a file.