### PR TITLE
fix: Hydrate documents also for in-flight queries

### DIFF
--- a/packages/cozy-client/src/ObservableQuery.js
+++ b/packages/cozy-client/src/ObservableQuery.js
@@ -39,7 +39,7 @@ export default class ObservableQuery {
    */
   currentResult() {
     const result = getQueryFromState(this.getStore().getState(), this.queryId)
-    if (result.fetchStatus !== 'loaded') {
+    if (!result.lastFetch) {
       return result
     }
     const data = this.client.hydrateDocuments(

--- a/packages/cozy-client/src/__tests__/ObservableQuery.spec.js
+++ b/packages/cozy-client/src/__tests__/ObservableQuery.spec.js
@@ -110,7 +110,20 @@ describe('ObservableQuery', () => {
       await store.dispatch(
         receiveQueryResult('oneTodo', queryResultFromData([TODO_1]))
       )
-      expect(query.currentResult().data).toBe(TODO_1)
+      expect(query.currentResult().data).toEqual(TODO_1)
+    })
+
+    it('should return hydrated results even if fetch status != loaded', async () => {
+      jest.spyOn(client, 'hydrateDocuments')
+      const def = client.get('io.cozy.todos', TODO_1._id)
+      await store.dispatch(initQuery('oneTodo', def))
+      query = new ObservableQuery('oneTodo', def, client)
+      await store.dispatch(
+        receiveQueryResult('oneTodo', queryResultFromData([TODO_1]))
+      )
+      await store.dispatch(initQuery('oneTodo', def))
+      expect(query.currentResult().data).toEqual(TODO_1)
+      expect(client.hydrateDocuments).toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
When getting results from queries that were being refetched, the fetch
status was "loading" but there was data so the consumer received unhydrated
data