### PR TITLE
WIP: refactor(cozy-client): Put react exports in a react entry point

### DIFF
--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -15,7 +15,8 @@ The following procedure requires you to already know how to initialize a CozyCli
 Import `CozyClient` and `CozyProvider`
 
 ```javascript
-import CozyClient, { CozyProvider } from 'cozy-client'
+import CozyClient from 'cozy-client'
+import { CozyProvider } from 'cozy-client/react'
 ```
 
 Initialize a CozyClient instance (see the `CozyClient()` documentation for additional parameters, for example to provide a schema)
@@ -46,7 +47,8 @@ The CozyClient will be available for consumption to all components inside your w
 `cozy-client` uses redux internally to centralize the statuses of the various fetches and replications triggered by the library, and to store locally the data in a normalized way. If you already have a redux store in your app, you can configure `cozy-client` to use this existing store:
 
 ```jsx
-import CozyClient, { CozyProvider } from 'cozy-client'
+import CozyClient from 'cozy-client'
+import { CozyProvider } from 'cozy-client/react'
 import { combineReducers, createStore, applyMiddleware } from 'redux'
 
 const client = new CozyClient({
@@ -76,7 +78,7 @@ To make it easy to fetch data and make it available to your component, we provid
 
 
 ```jsx
-import { Query } from 'cozy-client'
+import { Query } from 'cozy-client/react'
 
 const todos = 'io.cozy.todos'
 const checked = { checked: false }
@@ -110,7 +112,7 @@ The following props will be given to your wrapped component:
 You can also pass a function intead of a direct query. Your function will be given the props of the component and should return the requested query:
 
 ```jsx
-import { Query } from 'cozy-client'
+import { Query } from 'cozy-client/react'
 
 const query = function (props) {
   const todos = 'io.cozy.todos'
@@ -139,7 +141,7 @@ Note: Your query will be bound when the `<Query/>` component mounts. Future chan
 At your preference, you can use an higher-order component. `queryConnect` will take the name of the props field where it should send the result of the query and the actual query:
 
 ```jsx
-import { queryConnect } from 'cozy-client'
+import { queryConnect } from 'cozy-client/react'
 
 function TodoList(props) {
   const { data, fetchStatus } = props.result
@@ -166,7 +168,7 @@ const ConnectedTodoList = queryConnect(queryOpts)(TodoList)
 With the same syntax, you may register multiple queries to run:
 
 ```jsx
-import { queryConnect } from 'cozy-client'
+import { queryConnect } from 'cozy-client/react'
 
 function TodoList(props) {
   const { data, fetchStatus } = props.checked
@@ -191,7 +193,7 @@ const ConnectedTodoList = queryConnect(queries)(TodoList)
 The simplest way is to use the `withClient` high order component. It will inject a `client` in your props with the CozyClient instance you gave to the `<CozyProvider />` upper.
 
 ```jsx
-import { withClient } from 'cozy-client'
+import { withClient } from 'cozy-client/react'
 
 function TodoList(props) {
   const { client } = props
@@ -217,7 +219,7 @@ const ConnectedTodoList = withClient(TodoList)
 Alternatively, you have `withMutation()` which returns an HOC. This HOC forwards you a `createDocument`, a `saveDocument` and a `deleteDocument` in your props. They are the `create()`, `save()`and `delete()` functions from CozyClient, bound to the instance you gave to the `<CozyProvider />`.
 
 ```jsx
-import { withMutations } from 'cozy-client'
+import { withMutations } from 'cozy-client/react'
 
 function TodoList(props) {
   const { createDocument } = props
@@ -243,7 +245,7 @@ const ConnectedTodoList = withMutations()(TodoList)
 Finally, `<Query />` also takes a `mutations` optional props. It should have a function that will receive the CozyClient instance, the query requested and the rest of props given to the component, and should return a keyed object which will be added to the props of your wrapped component.
 
 ```jsx
-import { Query } from 'cozy-client'
+import { Query } from 'cozy-client/react'
 
 const todos = 'io.cozy.todos'
 const checked = { checked: false }

--- a/packages/cozy-client/codemods/split-react-exports.js
+++ b/packages/cozy-client/codemods/split-react-exports.js
@@ -1,0 +1,60 @@
+const groupBy = (arr, fn) => {
+  const res = {}
+  for (let item of arr) {
+    const groupKey = fn(item)
+    res[groupKey] = res[groupKey] || []
+    res[groupKey].push(item)
+  }
+  return res
+}
+
+const reactSpecificIdentifiers = [
+  'CozyProvider',
+  'Query',
+  'withClient',
+  'withMutation',
+  'withMutations',
+  'queryConnect',
+  'withClient',
+  'connect'
+]
+
+const isReactSpecifier = spec => {
+  if (!spec.imported) {
+    return false
+  }
+  return reactSpecificIdentifiers.includes(spec.imported.name)
+}
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift
+  const root = j(file.source)
+
+  const importDeclarations = root.find(j.ImportDeclaration, {
+    source: {
+      value: 'cozy-client'
+    }
+  })
+
+  importDeclarations.forEach(path => {
+    const node = path.node
+
+    const {
+      true: reactSpecifiers = [],
+      false: nonReactSpecifiers = []
+    } = groupBy(node.specifiers, isReactSpecifier)
+
+    if (reactSpecifiers.length) {
+      path.insertAfter(
+        j.importDeclaration(reactSpecifiers, j.literal('cozy-client/react'))
+      )
+    }
+
+    node.specifiers = nonReactSpecifiers
+    if (node.specifiers.length === 0) {
+      path.prune()
+    }
+  })
+
+  return root.toSource()
+}

--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "main": "dist/index.js",
   "files": [
-    "dist"
+    "dist",
+    "codemods"
   ],
   "repository": {
     "type": "git",

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -1,11 +1,6 @@
 export { default } from './CozyClient'
-export { default as CozyProvider } from './Provider'
 export { default as CozyLink } from './CozyLink'
 export { default as StackLink } from './StackLink'
-export { default as connect } from './connect'
-export { default as withMutation } from './withMutation'
-export { default as withMutations } from './withMutations'
-export { default as Query } from './Query'
 export { default as compose } from 'lodash/flow'
 export {
   QueryDefinition,
@@ -13,7 +8,6 @@ export {
   MutationTypes,
   getDoctypeFromOperation
 } from './queries/dsl'
-export { queryConnect, withClient } from './hoc'
 export {
   Association,
   HasMany,

--- a/packages/cozy-client/src/react.js
+++ b/packages/cozy-client/src/react.js
@@ -1,0 +1,6 @@
+export { default as CozyProvider } from './Provider'
+export { default as connect } from './connect'
+export { default as withMutation } from './withMutation'
+export { default as withMutations } from './withMutations'
+export { default as Query } from './Query'
+export { queryConnect, withClient } from './hoc'


### PR DESCRIPTION
The following exports are now located in a react specific entry point:

* `Provider`
* `Query`
* `withMutation`
* `withMutations`
* `queryConnect`
* `withClient`
* `connect`

You should import these modules from `cozy-client/react`. To achieve
this automatically, we ship a codemod that you can run on your codebase
using the following command:

```
npx jscodeshift --parser babel -t ./node_modules/cozy-client/codemods/split-react-exports.js --extensions js,jsx src/
```

This is a WIP because in the current form, `import ... from 'cozy-client/react'` doesn't work, the real import is `import ... from 'cozy-client/dist/react`, which is not ideal. I will search if this is possible to do this but I am not that optimist about that. Anyway, if this is not possible, I think this would still be a good way to avoid problems like https://github.com/cozy/cozy-client/issues/489.