### PR TITLE
feat(cozy-client): Expose main and browsers entry points

### DIFF
--- a/docs/details.md
+++ b/docs/details.md
@@ -19,6 +19,10 @@ global.fetch = fetch
 
 Then you will be able to use all the client methods and fetch data correctly.
 
+When using cozy-client on Node environment, you don't have access to all React
+specific APIs. If, for any reason, you want to access these APIs, you can still
+import them from `cozy-client/dist/react`.
+
 
 ## How to activate logging ?
 

--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -2,7 +2,8 @@
   "name": "cozy-client",
   "version": "6.57.0",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/node.js",
+  "browser": "dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/cozy-client/src/node.js
+++ b/packages/cozy-client/src/node.js
@@ -23,10 +23,3 @@ export { default as Registry } from './registry'
 
 import * as manifest from './manifest'
 export { manifest }
-
-export { default as CozyProvider } from './Provider'
-export { default as connect } from './connect'
-export { default as withMutation } from './withMutation'
-export { default as withMutations } from './withMutations'
-export { default as Query } from './Query'
-export { queryConnect, withClient } from './hoc'

--- a/packages/cozy-client/src/react.js
+++ b/packages/cozy-client/src/react.js
@@ -1,0 +1,6 @@
+export { default as CozyProvider } from './Provider'
+export { default as connect } from './connect'
+export { default as withMutation } from './withMutation'
+export { default as withMutations } from './withMutations'
+export { default as Query } from './Query'
+export { queryConnect, withClient } from './hoc'


### PR DESCRIPTION
Following discussions on https://github.com/cozy/cozy-client/pull/494, I decided to open another PR.

The main entry point is exposing the API without react bindings. This
allows a node application to use cozy-client without having to import
modules from the `dist` directory and without having to install react as
a dependency.

The browsers entry point is exposing the entire API (with react
bindings). This changes nothing for web apps.

There is also the possibility to import react specific stuff from
`cozy-client/dist/react` in rare cases in which this could be useful.
This is just an escape hatch.

There is some duplication in `index.js`, `node.js` and `react.js` that I tried to avoid by doing the following in `index.js`:

```js
export * from './node.js'
export * from './react.js'
```

But when testing it in banks, I got a `ReferenceError: exports is not defined` error in my browser. Actually babel transformed the exports into

```js
'use strict';

import _Object$defineProperty from 'babel-runtime/core-js/object/define-property';
import _Object$keys from 'babel-runtime/core-js/object/keys';
Object.defineProperty(exports, "__esModule", {
  value: true
});

var _node = require('./node');

_Object$keys(_node).forEach(function (key) {
  if (key === "default" || key === "__esModule") return;

  _Object$defineProperty(exports, key, {
    enumerable: true,
    get: function get() {
      return _node[key];
    }
  });
});

var _react = require('./react');

_Object$keys(_react).forEach(function (key) {
  if (key === "default" || key === "__esModule") return;

  _Object$defineProperty(exports, key, {
    enumerable: true,
    get: function get() {
      return _react[key];
    }
  });
});
```

Which references the `exports` variable and webpack doesn't seem to handle it.