### PR TITLE
docs: Remove how to links from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,6 @@
 - [Getting started](docs/getting-started.md)
 - [Mobile guide](docs/mobile-guide.md)
 
-### How to
-
-- [How-to integrate with an existing store ?](docs/how-tos.md#how-to-integrate-with-an-existing-store-)
-- [How to connect to the documents store declaratively ?](docs/how-tos.md#how-to-connect-to-the-documents-store-declaratively-)
-- [How to provide a mutation to a component ?](docs/how-tos.md#how-to-provide-a-mutation-to-a-component-)
-- [How to activate logging ?](docs/how-tos.md#how-to-activate-logging-)
-
 ### Advanced
 
 - API docs


### PR DESCRIPTION
The how-to.md file has been removed since
https://github.com/cozy/cozy-client/pull/490 so these links are not
needed anymore.