### PR TITLE
chore: Unpin dependencies

### DIFF
--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -12,15 +12,15 @@
     "url": "git+https://github.com/cozy/cozy-client.git"
   },
   "dependencies": {
-    "cozy-device-helper": "1.7.3",
+    "cozy-device-helper": "^1.7.3",
     "cozy-stack-client": "^6.58.1",
-    "lodash": "4.17.14",
-    "microee": "0.0.6",
-    "prop-types": "15.6.2",
-    "react-redux": "5.0.7",
-    "redux": "3.7.2",
-    "redux-thunk": "2.3.0",
-    "sift": "6.0.0",
+    "lodash": "^4.17.13",
+    "microee": "^0.0.6",
+    "prop-types": "^15.6.2",
+    "react-redux": "^5.0.7",
+    "redux": "^3.7.2",
+    "redux-thunk": "^2.3.0",
+    "sift": "^6.0.0",
     "url-search-params-polyfill": "^6.0.0"
   },
   "scripts": {

--- a/packages/cozy-pouch-link/package.json
+++ b/packages/cozy-pouch-link/package.json
@@ -12,10 +12,10 @@
   },
   "dependencies": {
     "cozy-client": "^6.58.1",
-    "cozy-device-helper": "1.7.3",
-    "minilog": "3.1.0",
-    "pouchdb-browser": "7.0.0",
-    "pouchdb-find": "7.0.0"
+    "cozy-device-helper": "^1.7.3",
+    "minilog": "^3.1.0",
+    "pouchdb-browser": "^7.0.0",
+    "pouchdb-find": "^7.0.0"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/packages/cozy-stack-client/package.json
+++ b/packages/cozy-stack-client/package.json
@@ -11,9 +11,9 @@
     "url": "git+https://github.com/cozy/cozy-client.git"
   },
   "dependencies": {
-    "detect-node": "2.0.4",
-    "mime": "2.4.0",
-    "qs": "6.7.0"
+    "detect-node": "^2.0.4",
+    "mime": "^2.4.0",
+    "qs": "^6.7.0"
   },
   "scripts": {
     "build": "../../bin/build",


### PR DESCRIPTION
Since the packages here are libraries, they need to more lenient on the
libs they accept from their host otherwise there can be duplicates in the
final bundle

https://renovatebot.com/docs/dependency-pinning/

This is helpful to remove duplicate package warnings that we see with DuplicatePackageCheckerPlugin:

```
    WARNING in lodash
      Multiple versions of lodash found:
        4.17.13 ./~/cozy-device-helper/~/lodash
        4.17.14 ./~/cozy-client/~/lodash
        4.17.15 ./~/lodash
    
    
    WARNING in prop-types
      Multiple versions of prop-types found:
        15.6.2 ./~/cozy-client/~/prop-types
        15.7.2 ./~/prop-types
    