### PR TITLE
chore: Use cozy-libs renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "extends": [
-    "cozy"
+    "cozy-libs"
   ]
 }


### PR DESCRIPTION
We now have a renovate config that does not pin dependencies.
See https://github.com/cozy/cozy-libs/blob/master/packages/renovate-config-cozy-libs/package.json

Related to https://github.com/cozy/cozy-client/pull/499