### PR TITLE
fix: Don't memoize if the result is an error

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -60,13 +60,6 @@ through OAuth.</p>
 <dt><a href="#getAccessToken">getAccessToken()</a> ⇒ <code>string</code></dt>
 <dd><p>Get the app token string</p>
 </dd>
-<dt><a href="#normalizeDoc">normalizeDoc(doc, doctype)</a> ⇒ <code>object</code></dt>
-<dd><p>Normalize a document, adding its doctype if needed</p>
-</dd>
-<dt><a href="#getIconURL">getIconURL()</a></dt>
-<dd><p>We need to catch the error and return a special object in
-order to be able to delete the memoization if needed</p>
-</dd>
 <dt><a href="#garbageCollect">garbageCollect()</a></dt>
 <dd><p>Delete outdated results from cache</p>
 </dd>

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -60,6 +60,13 @@ through OAuth.</p>
 <dt><a href="#getAccessToken">getAccessToken()</a> ⇒ <code>string</code></dt>
 <dd><p>Get the app token string</p>
 </dd>
+<dt><a href="#normalizeDoc">normalizeDoc(doc, doctype)</a> ⇒ <code>object</code></dt>
+<dd><p>Normalize a document, adding its doctype if needed</p>
+</dd>
+<dt><a href="#getIconURL">getIconURL()</a></dt>
+<dd><p>We need to catch the error and return a special object in
+order to be able to delete the memoization if needed</p>
+</dd>
 <dt><a href="#garbageCollect">garbageCollect()</a></dt>
 <dd><p>Delete outdated results from cache</p>
 </dd>

--- a/packages/cozy-stack-client/src/getIconURL.js
+++ b/packages/cozy-stack-client/src/getIconURL.js
@@ -1,5 +1,4 @@
-import memoize from './memoize'
-
+import memoize, { ErrorReturned } from './memoize'
 const mimeTypes = {
   gif: 'image/gif',
   ico: 'image/vnd.microsoft.icon',
@@ -101,14 +100,9 @@ const _getIconURL = async (stackClient, opts) => {
   return URL.createObjectURL(icon)
 }
 
-/**
- * We need to catch the error and return a special object in
- * order to be able to delete the memoization if needed
- */
-
 const getIconURL = function() {
   return _getIconURL.apply(this, arguments).catch(e => {
-    return ''
+    return new ErrorReturned()
   })
 }
 

--- a/packages/cozy-stack-client/src/getIconURL.js
+++ b/packages/cozy-stack-client/src/getIconURL.js
@@ -114,7 +114,17 @@ export default memoize(getIconURL, {
   maxDuration: 300 * 1000,
   key: (stackClient, opts) => {
     const { type, slug, priority } = opts
-    return stackClient.uri + +':' + type + ':' + slug + ':' + priority
+    return (
+      stackClient.uri +
+      +':' +
+      type +
+      ':' +
+      slug +
+      ':' +
+      priority +
+      ':' +
+      window.navigator.onLine
+    )
   }
 })
 

--- a/packages/cozy-stack-client/src/getIconURL.js
+++ b/packages/cozy-stack-client/src/getIconURL.js
@@ -73,7 +73,6 @@ const _getIconURL = async (stackClient, opts) => {
       throw new Error(`Error while fetching icon ${resp.statusText}`)
     }
   })
-
   let icon = await resp.blob()
   let app
   if (!icon.type) {
@@ -99,13 +98,16 @@ const _getIconURL = async (stackClient, opts) => {
     }
     icon = new Blob([icon], { type: mimeTypes[ext] })
   }
-
   return URL.createObjectURL(icon)
 }
 
+/**
+ * We need to catch the error and return a special object in
+ * order to be able to delete the memoization if needed
+ */
+
 const getIconURL = function() {
   return _getIconURL.apply(this, arguments).catch(e => {
-    console.warn(e)
     return ''
   })
 }
@@ -114,17 +116,7 @@ export default memoize(getIconURL, {
   maxDuration: 300 * 1000,
   key: (stackClient, opts) => {
     const { type, slug, priority } = opts
-    return (
-      stackClient.uri +
-      +':' +
-      type +
-      ':' +
-      slug +
-      ':' +
-      priority +
-      ':' +
-      window.navigator.onLine
-    )
+    return stackClient.uri + +':' + type + ':' + slug + ':' + priority
   }
 })
 

--- a/packages/cozy-stack-client/src/getIconURL.spec.js
+++ b/packages/cozy-stack-client/src/getIconURL.spec.js
@@ -6,7 +6,6 @@ const FakeBlob = (data, options) => {
 }
 
 const resetcreateObjectURL = () => {
-  global.URL.createObjectURL = undefined
   global.URL.createObjectURL = jest.fn(blob => {
     return blob
   })

--- a/packages/cozy-stack-client/src/memoize.js
+++ b/packages/cozy-stack-client/src/memoize.js
@@ -17,6 +17,12 @@ const garbageCollect = (cache, maxDuration) => {
   }
 }
 
+const isPromise = maybePromise => {
+  return (
+    typeof maybePromise === 'object' && typeof maybePromise.then === 'function'
+  )
+}
+
 /**
  * Memoize with maxDuration and custom key
  */
@@ -35,25 +41,23 @@ const memoize = (fn, options) => {
         result,
         date: Date.now()
       }
+
       /**
        * If the result is a promise and this promise
        * failed or resolved with a specific error (aka ErrorReturned),
        * let's remove the result from the cache since we don't want to
        * memoize error
        */
-
-      if (typeof result === 'object') {
-        if (typeof result.then === 'function') {
-          result
-            .then(v => {
-              if (v instanceof ErrorReturned) {
-                delete cache[key]
-              }
-            })
-            .catch(e => {
+      if (isPromise(result)) {
+        result
+          .then(v => {
+            if (v instanceof ErrorReturned) {
               delete cache[key]
-            })
-        }
+            }
+          })
+          .catch(e => {
+            delete cache[key]
+          })
       }
       return result
     }

--- a/packages/cozy-stack-client/src/memoize.js
+++ b/packages/cozy-stack-client/src/memoize.js
@@ -29,6 +29,26 @@ const memoize = (fn, options) => {
         result,
         date: Date.now()
       }
+      /**
+       * If the result is a promise and that this promise
+       * failed or resolved with a specific key (aka ''), let's remove
+       * the result from the cache since we don't want to
+       * memoize error
+       */
+
+      if (typeof result === 'object') {
+        if (typeof result.then === 'function') {
+          result
+            .then(v => {
+              if (v === '') {
+                delete cache[key]
+              }
+            })
+            .catch(() => {
+              delete cache[key]
+            })
+        }
+      }
       return result
     }
   }

--- a/packages/cozy-stack-client/src/memoize.js
+++ b/packages/cozy-stack-client/src/memoize.js
@@ -1,3 +1,9 @@
+class ErrorReturned extends String {
+  /**
+   * We need to catch the error and return a special object in
+   * order to be able to delete the memoization if needed
+   */
+}
 /**
  * Delete outdated results from cache
  */
@@ -30,9 +36,9 @@ const memoize = (fn, options) => {
         date: Date.now()
       }
       /**
-       * If the result is a promise and that this promise
-       * failed or resolved with a specific key (aka ''), let's remove
-       * the result from the cache since we don't want to
+       * If the result is a promise and this promise
+       * failed or resolved with a specific error (aka ErrorReturned),
+       * let's remove the result from the cache since we don't want to
        * memoize error
        */
 
@@ -40,11 +46,11 @@ const memoize = (fn, options) => {
         if (typeof result.then === 'function') {
           result
             .then(v => {
-              if (v === '') {
+              if (v instanceof ErrorReturned) {
                 delete cache[key]
               }
             })
-            .catch(() => {
+            .catch(e => {
               delete cache[key]
             })
         }
@@ -55,3 +61,4 @@ const memoize = (fn, options) => {
 }
 
 export default memoize
+export { ErrorReturned }

--- a/packages/cozy-stack-client/src/memoize.spec.js
+++ b/packages/cozy-stack-client/src/memoize.spec.js
@@ -1,7 +1,8 @@
-import memoize from './memoize'
+import memoize, { ErrorReturned } from './memoize'
 
 describe('memoize', () => {
   let now
+  let c
   beforeEach(() => {
     jest.spyOn(Date, 'now').mockImplementation(() => now)
   })
@@ -10,7 +11,7 @@ describe('memoize', () => {
   })
   it('should remember results ', () => {
     now = 0
-    let c = 0
+    c = 0
     const counter = () => c++
     const mcounter = memoize(counter, { key: () => 'A', maxDuration: 5 })
     expect(mcounter()).toBe(0)
@@ -18,5 +19,24 @@ describe('memoize', () => {
     now = 6
     expect(mcounter()).toBe(1)
     expect(mcounter()).toBe(1)
+  })
+
+  it('should not memoize the result if an error occurs', async () => {
+    now = 0
+    c = 0
+    const counter = async () => {
+      c++
+      return new Promise(function(resolve, reject) {
+        resolve(new ErrorReturned())
+      })
+    }
+    const mcounter = memoize(counter, { key: () => 'A', maxDuration: 5 })
+    mcounter()
+    expect(c).toEqual(1)
+    mcounter()
+    //Let's wait the promise resolution
+    setTimeout(() => {
+      expect(c).toEqual(2)
+    }, 10)
   })
 })

--- a/packages/cozy-stack-client/src/memoize.spec.js
+++ b/packages/cozy-stack-client/src/memoize.spec.js
@@ -6,9 +6,11 @@ describe('memoize', () => {
   beforeEach(() => {
     jest.spyOn(Date, 'now').mockImplementation(() => now)
   })
+
   afterEach(() => {
     jest.resetAllMocks()
   })
+
   it('should remember results ', () => {
     now = 0
     c = 0
@@ -23,20 +25,17 @@ describe('memoize', () => {
 
   it('should not memoize the result if an error occurs', async () => {
     now = 0
-    c = 0
+    let callCounter = 0
+
+    // This counter always returns an error, so it will never be memoized
     const counter = async () => {
-      c++
-      return new Promise(function(resolve, reject) {
-        resolve(new ErrorReturned())
-      })
+      callCounter++
+      return new ErrorReturned()
     }
     const mcounter = memoize(counter, { key: () => 'A', maxDuration: 5 })
-    mcounter()
-    expect(c).toEqual(1)
-    mcounter()
-    //Let's wait the promise resolution
-    setTimeout(() => {
-      expect(c).toEqual(2)
-    }, 10)
+    await mcounter()
+    expect(callCounter).toEqual(1)
+    await mcounter()
+    expect(callCounter).toEqual(2)
   })
 })


### PR DESCRIPTION
Currently, if we render an `AppIcon` component with a `fetchIcon` props calling  :
```jsx
client.getStackClient().getIconURL({
        type: 'konnector',
        slug: konnector.slug
      })
```

When first call this getIconURL being offline, it'll memoize the return of this function aka an error. If we're now online and then call this same method again, we'll not have the icon since we've memoized the first response. 

This fix was my first idea to quickly see if this was really the issue. And it seems that yes. I'm not sure this is the best way to fix it thought since if we go then offline, we will request the icon and since the `onLine` has changed, we will not hit the cache and try to really fetch the icon. 

So maybe the best solution is to not memoize when we're get an error ?


(I think it can fix the issue, when we launch a mobile app when having no network and then having network but we still see the fallback icons) 

