### PR TITLE
Perf: Return the same args for Query.Children()

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -530,7 +530,14 @@ class CozyClient {
     return documents
   }
 
-  watchQuery(queryDefinition, options = {}) {
+  watchQuery(...args) {
+    console.warn(
+      'client.watchQuery is deprecated, please use client.makeObservableQuery.'
+    )
+    return this.makeObservableQuery(...args)
+  }
+
+  makeObservableQuery(queryDefinition, options = {}) {
     this.ensureStore()
     const queryId = options.as || this.generateId()
     this.ensureQueryExists(queryId, queryDefinition)

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -164,8 +164,8 @@ describe('CozyClient initialization', () => {
     }
   })
 
-  it('should create a store when calling watch query', () => {
-    client.watchQuery(new QueryDefinition({ doctype: 'io.cozy.todos' }))
+  it('should create a store when calling makeObservableQuery', () => {
+    client.makeObservableQuery(new QueryDefinition({ doctype: 'io.cozy.todos' }))
     expect(client.store).not.toBe(undefined)
   })
 })

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -67,11 +67,20 @@ describe('CozyClient initialization', () => {
     expect(client.isLogged).toBeTruthy()
   })
 
-  it('should not break explicit login when provided token and uri', () => {
-    const token = 'fake_token'
-    const uri = 'https://example.mycozy.cloud'
-    client = new CozyClient({ token, uri })
-    expect(client.login()).toBeInstanceOf(Promise)
+  describe('explicit login', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+    afterEach(() => {
+      console.warn.mockRestore()
+    })
+
+    it('should not break explicit login when provided token and uri', () => {
+      const token = 'fake_token'
+      const uri = 'https://example.mycozy.cloud'
+      client = new CozyClient({ token, uri })
+      expect(client.login()).toBeInstanceOf(Promise)
+    })
   })
 
   it('can be instantiated from environment with string token', () => {
@@ -165,14 +174,25 @@ describe('CozyClient initialization', () => {
   })
 
   it('should create a store when calling makeObservableQuery', () => {
-    client.makeObservableQuery(new QueryDefinition({ doctype: 'io.cozy.todos' }))
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    client.makeObservableQuery(
+      new QueryDefinition({ doctype: 'io.cozy.todos' })
+    )
+    console.warn.mockRestore()
     expect(client.store).not.toBe(undefined)
   })
 })
 
 describe('Stack client initialization', () => {
-  it('should add default callbacks', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    console.warn.mockRestore()
+  })
+  it('should add default callbacks', async () => {
     const client = new CozyClient({})
+    await client.login()
     expect(client.stackClient.options.onRevocationChange).toBe(
       client.handleRevocationChange
     )
@@ -249,7 +269,9 @@ describe('CozyClient logout', () => {
     expect(links[2].reset).toHaveBeenCalledTimes(1)
 
     // test if we launch twice logout, it doesn't launch twice reset.
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
     await client.logout()
+    console.warn.mockRestore()
 
     expect(links[0].reset).toHaveBeenCalledTimes(1)
     expect(links[2].reset).toHaveBeenCalledTimes(1)

--- a/packages/cozy-client/src/Query.jsx
+++ b/packages/cozy-client/src/Query.jsx
@@ -47,6 +47,8 @@ export default class Query extends Component {
     if (query.fetch) {
       this.fetch = query.fetch.bind(query)
     }
+
+    this.recomputeChildrenArgs()
   }
 
   componentDidMount() {
@@ -70,27 +72,30 @@ export default class Query extends Component {
     }
   }
 
+  recomputeChildrenArgs() {
+    const query = this.observableQuery
+    this.data = {
+      fetchMore: this.fetchMore,
+      fetch: this.fetch,
+      ...query.currentResult()
+    }
+    this.methods = {
+      createDocument: this.createDocument,
+      saveDocument: this.saveDocument,
+      deleteDocument: this.deleteDocument,
+      getAssociation: this.getAssociation,
+      ...this.mutations
+    }
+  }
+
   onQueryChange = () => {
+    this.recomputeChildrenArgs()
     this.setState(dummyState)
   }
 
   render() {
     const { children } = this.props
-    const query = this.observableQuery
-    return children(
-      {
-        fetchMore: this.fetchMore,
-        fetch: this.fetch,
-        ...query.currentResult()
-      },
-      {
-        createDocument: this.createDocument,
-        saveDocument: this.saveDocument,
-        deleteDocument: this.deleteDocument,
-        getAssociation: this.getAssociation,
-        ...this.mutations
-      }
-    )
+    return children(this.data, this.methods)
   }
 }
 

--- a/packages/cozy-client/src/Query.spec.jsx
+++ b/packages/cozy-client/src/Query.spec.jsx
@@ -178,7 +178,7 @@ describe('Query', () => {
       })
       expect(children).toHaveBeenCalledWith(
         {
-          fetch: undefined,
+          fetch: null,
           fetchMore: expect.any(Function)
         },
         expect.any(Object)

--- a/packages/cozy-client/src/Query.spec.jsx
+++ b/packages/cozy-client/src/Query.spec.jsx
@@ -3,7 +3,6 @@ import { mount } from 'enzyme'
 import CozyProvider from './Provider'
 
 import Query from './Query'
-import { createTestAssets, queryResultFromData } from './__tests__/utils'
 import {
   initQuery,
   receiveQueryResult,
@@ -11,13 +10,19 @@ import {
   getQueryFromState
 } from './store'
 import { TODOS, TODO_WITH_RELATION, FILE_1 } from './__tests__/fixtures'
+
+// TODO we should have only one way of testing with the client
+import { createTestAssets, queryResultFromData } from './__tests__/utils'
 import * as mocks from './__tests__/mocks'
 
 describe('Query', () => {
   const queryDef = client => ({ doctype: 'io.cozy.todos' })
   let observableQuery
   const client = mocks.client({
-    makeObservableQuery: queryDef => observableQuery
+    makeObservableQuery: queryDef => observableQuery,
+    requestQuery: async () => {
+      return { data: [] }
+    }
   })
 
   const context = { client }

--- a/packages/cozy-client/src/Query.spec.jsx
+++ b/packages/cozy-client/src/Query.spec.jsx
@@ -17,7 +17,7 @@ describe('Query', () => {
   const queryDef = client => ({ doctype: 'io.cozy.todos' })
   let observableQuery
   const client = mocks.client({
-    watchQuery: queryDef => observableQuery
+    makeObservableQuery: queryDef => observableQuery
   })
 
   const context = { client }
@@ -167,7 +167,7 @@ describe('Query', () => {
     })
 
     it('should work with a client not providing fetch', () => {
-      client.watchQuery = () => ({
+      client.makeObservableQuery = () => ({
         subscribe: () => {},
         fetchMore: () => {},
         currentResult: () => {}

--- a/packages/cozy-client/src/__tests__/connect.spec.jsx
+++ b/packages/cozy-client/src/__tests__/connect.spec.jsx
@@ -10,6 +10,14 @@ import { getQueryFromState, initQuery } from '../store'
 
 import { TODO_1, TODO_2, TODO_3 } from './fixtures'
 
+beforeEach(() => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  console.warn.mockRestore()
+})
+
 describe('connect', () => {
   const requestHandler = jest.fn()
   const link = new CozyLink(requestHandler)

--- a/packages/cozy-client/src/__tests__/mocks.js
+++ b/packages/cozy-client/src/__tests__/mocks.js
@@ -14,7 +14,7 @@ export const client = implementations => {
     save: jest.fn(),
     destroy: jest.fn(),
     getAssociation: jest.fn(),
-    watchQuery: jest.fn(),
+    makeObservableQuery: jest.fn(),
     all: jest.fn()
   }
   mockImplementations(base, implementations)

--- a/packages/cozy-client/src/__tests__/mocks.js
+++ b/packages/cozy-client/src/__tests__/mocks.js
@@ -3,7 +3,12 @@ const mockImplementations = (base, implementations) => {
     return
   }
   Object.entries(implementations).map(([name, implementation]) => {
-    base[name].mockImplementation(implementation)
+    try {
+      base[name].mockImplementation(implementation)
+    } catch (e) {
+      console.error(e)
+      throw new Error(`Could not mock '${name}. Original error above.`)
+    }
   })
 }
 
@@ -15,6 +20,7 @@ export const client = implementations => {
     destroy: jest.fn(),
     getAssociation: jest.fn(),
     makeObservableQuery: jest.fn(),
+    requestQuery: jest.fn(),
     all: jest.fn()
   }
   mockImplementations(base, implementations)

--- a/packages/cozy-client/src/__tests__/utils.js
+++ b/packages/cozy-client/src/__tests__/utils.js
@@ -1,3 +1,7 @@
+// TODO
+// Provide a better means to test with the client
+// See also ./mocks.js
+
 import { createStore, combineReducers } from 'redux'
 import CozyLink from '../CozyLink'
 import CozyClient from '../CozyClient'
@@ -11,7 +15,10 @@ export const queryResultFromData = (data, opts = {}) => ({
 })
 
 export const createTestAssets = () => {
-  const requestHandler = jest.fn()
+  // TODO this requestHandler should be improved upon
+  const requestHandler = () => {
+    return { data: [] }
+  }
   const link = new CozyLink(requestHandler)
   const client = new CozyClient({ links: [link] })
   const store = createStore(combineReducers({ cozy: client.reducer() }))

--- a/packages/cozy-client/src/hoc.spec.js
+++ b/packages/cozy-client/src/hoc.spec.js
@@ -3,6 +3,14 @@ import { mount } from 'enzyme'
 import { withClient, queryConnect } from './hoc'
 import * as mocks from './__tests__/mocks'
 
+beforeEach(() => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  console.warn.mockRestore()
+})
+
 class Component extends React.Component {
   render() {
     return <div />

--- a/packages/cozy-client/src/hoc.spec.js
+++ b/packages/cozy-client/src/hoc.spec.js
@@ -41,7 +41,7 @@ describe('queryConnect', () => {
 
     const client = mocks.client({
       all: doctype => queryDefinitionFromDoctype(doctype),
-      watchQuery: queryDef => observableQueryFromDefinition(queryDef)
+      makeObservableQuery: queryDef => observableQueryFromDefinition(queryDef)
     })
 
     const WithQueries = queryConnect({

--- a/packages/cozy-client/src/utils.spec.js
+++ b/packages/cozy-client/src/utils.spec.js
@@ -22,13 +22,14 @@ describe('cancelable', () => {
   })
 
   it('should reject with the rejection of the promise', done => {
+    const error = 'normal-rejection-from-cancelable-test'
     const { reject, wrapped } = setup()
     expect.assertions(1)
     wrapped.catch(res => {
-      expect(res).toBe(5)
+      expect(res).toBe(error)
       done()
     })
-    reject(5)
+    reject(error)
   })
 
   it('should reject with canceled: true if canceled', done => {

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -352,7 +352,7 @@ class DocumentCollection {
     if (typeof couchOptions !== 'object') {
       urlParams = `?include_docs=true&since=${couchOptions}`
       console.warn(
-        'fetchChanges use couchOptions as Object not a string, since is deprecated, please use fetchChanges({include_docs: true, since: 0}).'
+        `fetchChanges use couchOptions as Object not a string, since is deprecated, please use fetchChanges({include_docs: true, since: "${couchOptions}"}).`
       )
     } else if (Object.keys(couchOptions).length > 0) {
       urlParams = `?${[

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -548,7 +548,9 @@ describe('DocumentCollection', () => {
     })
 
     it('should call the right route with deprecated parameter', async () => {
+      jest.spyOn(console, 'warn').mockImplementation(() => {})
       await collection.fetchChanges('my-seq')
+      console.warn.mockRestore()
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'GET',
         '/data/io.cozy.todos/_changes?include_docs=true&since=my-seq',

--- a/packages/cozy-stack-client/src/__tests__/setup.js
+++ b/packages/cozy-stack-client/src/__tests__/setup.js
@@ -35,14 +35,8 @@ expect.extend({
   }
 })
 
-beforeEach(() => {
-  jest.spyOn(global.console, 'log').mockImplementation(() => {})
-  jest.spyOn(global.console, 'info').mockImplementation(() => {})
-})
-
-afterEach(() => {
-  global.console.log.mockRestore && global.console.log.mockRestore()
-  global.console.info.mockRestore && global.console.info.mockRestore()
+jest.spyOn(console, 'warn').mockImplementation(msg => {
+  throw new Error(msg)
 })
 
 // In Node v7 unhandled promise rejections will terminate the process

--- a/packages/cozy-stack-client/src/getIconURL.spec.js
+++ b/packages/cozy-stack-client/src/getIconURL.spec.js
@@ -100,7 +100,9 @@ describe('get icon', () => {
     responses['/registry/caissedepargne1'] = {
       data: { name: 'caissedepargne1', icon: 'icon.mp4' }
     }
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
     const url = await getIconURL(stackClient, defaultOpts)
+    console.warn.mockRestore()
     expect(url).toEqual('')
   })
 


### PR DESCRIPTION
Previous PR was merged in the wrong branch. As soon as this is green, I merge since the previous PR #519 was approved.