### PR TITLE
feat: Fetch policy

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -494,6 +494,9 @@ Responsible for
         * [.createClient()](#CozyClient+createClient)
         * [.setData(data)](#CozyClient+setData)
     * _static_
+        * [.fetchPolicies](#CozyClient.fetchPolicies)
+            * [.olderThan(delay)](#CozyClient.fetchPolicies.olderThan) ⇒ <code>function</code>
+            * [.noFetch()](#CozyClient.fetchPolicies.noFetch)
         * [.fromOldClient()](#CozyClient.fromOldClient)
         * [.fromEnv()](#CozyClient.fromEnv)
 
@@ -772,6 +775,41 @@ set some data in the store.
 | --- | --- | --- |
 | data | <code>Object</code> | { doctype: [data] } |
 
+<a name="CozyClient.fetchPolicies"></a>
+
+### CozyClient.fetchPolicies
+Use those fetch policies with <Query /> to limit the number of re-fetch.
+
+**Kind**: static property of [<code>CozyClient</code>](#CozyClient)  
+**Example**  
+```
+const olderThan30s = CozyClient.fetchPolicies.olderThan(30 * 1000)
+<Query fetchPolicy={olderThan30s} />
+```
+
+* [.fetchPolicies](#CozyClient.fetchPolicies)
+    * [.olderThan(delay)](#CozyClient.fetchPolicies.olderThan) ⇒ <code>function</code>
+    * [.noFetch()](#CozyClient.fetchPolicies.noFetch)
+
+<a name="CozyClient.fetchPolicies.olderThan"></a>
+
+#### fetchPolicies.olderThan(delay) ⇒ <code>function</code>
+Returns a fetchPolicy that will only re-fetch queries that are older
+than <delay> ms.
+
+**Kind**: static method of [<code>fetchPolicies</code>](#CozyClient.fetchPolicies)  
+**Returns**: <code>function</code> - Fetch policy to be used with <Query />  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| delay | <code>Number</code> | Milliseconds since the query has been fetched |
+
+<a name="CozyClient.fetchPolicies.noFetch"></a>
+
+#### fetchPolicies.noFetch()
+Fetch policy that deactivates any fetching.
+
+**Kind**: static method of [<code>fetchPolicies</code>](#CozyClient.fetchPolicies)  
 <a name="CozyClient.fromOldClient"></a>
 
 ### CozyClient.fromOldClient()

--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -483,6 +483,9 @@ Responsible for
         * [.makeNewDocument()](#CozyClient+makeNewDocument)
         * [.getAssociation()](#CozyClient+getAssociation)
         * [.getRelationshipStoreAccessors()](#CozyClient+getRelationshipStoreAccessors)
+        * [.getCollectionFromState(type)](#CozyClient+getCollectionFromState) ⇒ <code>Array.&lt;Document&gt;</code>
+        * [.getDocumentFromState(type, id)](#CozyClient+getDocumentFromState) ⇒ <code>Document</code>
+        * [.getQueryFromState(id)](#CozyClient+getQueryFromState) ⇒ <code>QueryState</code>
         * [.register(cozyURL)](#CozyClient+register) ⇒ <code>object</code>
         * [.startOAuthFlow(openURLCallback)](#CozyClient+startOAuthFlow) ⇒ <code>object</code>
         * [.renewAuthorization()](#CozyClient+renewAuthorization) ⇒ <code>object</code>
@@ -663,6 +666,43 @@ a modification (addById/removeById etc...) has been done. This wakes
 the store up, which in turn will update the `<Query>`s and re-render the data.
 
 **Kind**: instance method of [<code>CozyClient</code>](#CozyClient)  
+<a name="CozyClient+getCollectionFromState"></a>
+
+### cozyClient.getCollectionFromState(type) ⇒ <code>Array.&lt;Document&gt;</code>
+Get a collection of documents from the internal store.
+
+**Kind**: instance method of [<code>CozyClient</code>](#CozyClient)  
+**Returns**: <code>Array.&lt;Document&gt;</code> - Array of documents or null if the collection does not exist.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| type | <code>String</code> | Doctype of the collection |
+
+<a name="CozyClient+getDocumentFromState"></a>
+
+### cozyClient.getDocumentFromState(type, id) ⇒ <code>Document</code>
+Get a document from the internal store.
+
+**Kind**: instance method of [<code>CozyClient</code>](#CozyClient)  
+**Returns**: <code>Document</code> - Document or null if the object does not exist.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| type | <code>String</code> | Doctype of the document |
+| id | <code>String</code> | Id of the document |
+
+<a name="CozyClient+getQueryFromState"></a>
+
+### cozyClient.getQueryFromState(id) ⇒ <code>QueryState</code>
+Get a query from the internal store.
+
+**Kind**: instance method of [<code>CozyClient</code>](#CozyClient)  
+**Returns**: <code>QueryState</code> - - Query state or null if it does not exist.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| id | <code>String</code> | Id of the query (set via Query.props.as) |
+
 <a name="CozyClient+register"></a>
 
 ### cozyClient.register(cozyURL) ⇒ <code>object</code>

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -1008,6 +1008,38 @@ class CozyClient {
   }
 }
 
+/**
+ * Use those fetch policies with <Query /> to limit the number of re-fetch.
+ *
+ * @example
+ * ```
+ * const olderThan30s = CozyClient.fetchPolicies.olderThan(30 * 1000)
+ * <Query fetchPolicy={olderThan30s} />
+ * ```
+ */
+CozyClient.fetchPolicies = {
+  /**
+   * Returns a fetchPolicy that will only re-fetch queries that are older
+   * than <delay> ms.
+   *
+   * @param  {Number} delay - Milliseconds since the query has been fetched
+   * @return {Function} Fetch policy to be used with <Query />
+   */
+  olderThan: delay => queryState => {
+    if (!queryState || !queryState.lastUpdate) {
+      return true
+    } else {
+      const elapsed = Date.now() - queryState.lastUpdate
+      return elapsed > delay
+    }
+  },
+
+  /**
+   * Fetch policy that deactivates any fetching.
+   */
+  noFetch: () => false
+}
+
 MicroEE.mixin(CozyClient)
 
 export default CozyClient

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -760,6 +760,13 @@ class CozyClient {
     return this.storeAccessors
   }
 
+  /**
+   * Get a collection of documents from the internal store.
+   *
+   * @param {String} type - Doctype of the collection
+   *
+   * @return {Document[]} Array of documents or null if the collection does not exist.
+   */
   getCollectionFromState(type) {
     try {
       return getCollectionFromState(this.store.getState(), type)
@@ -769,11 +776,35 @@ class CozyClient {
     }
   }
 
+  /**
+   * Get a document from the internal store.
+   *
+   * @param {String} type - Doctype of the document
+   * @param {String} id   - Id of the document
+   *
+   * @return {Document} Document or null if the object does not exist.
+   */
   getDocumentFromState(type, id) {
     try {
       return getDocumentFromState(this.store.getState(), type, id)
     } catch (e) {
       console.warn('Could not getDocumentFromState', type, id, e.message)
+      return null
+    }
+  }
+
+  /**
+   * Get a query from the internal store.
+   *
+   * @param {String} id - Id of the query (set via Query.props.as)
+   *
+   * @return {QueryState} - Query state or null if it does not exist.
+   */
+  getQueryFromState(id) {
+    try {
+      return getQueryFromState(this.store.getState(), id)
+    } catch (e) {
+      console.warn('Could not getQueryFromState', id, e.message)
       return null
     }
   }

--- a/packages/cozy-client/src/Query.jsx
+++ b/packages/cozy-client/src/Query.jsx
@@ -1,5 +1,6 @@
 import { Component } from 'react'
 import PropTypes from 'prop-types'
+import { getQueryFromState } from './store'
 
 const dummyState = {}
 
@@ -103,7 +104,16 @@ export default class Query extends Component {
 
   componentDidMount() {
     this.queryUnsubscribe = this.observableQuery.subscribe(this.onQueryChange)
-    if (this.props.fetchPolicy !== 'cache-only') {
+    if (this.props.fetchPolicy) {
+      const queryState = this.client.getQueryFromState(this.props.as)
+      if (
+        this.props.fetchPolicy &&
+        typeof this.props.fetchPolicy === 'function' &&
+        this.props.fetchPolicy(queryState)
+      ) {
+        fetchQuery(this.client, this.observableQuery)
+      }
+    } else {
       fetchQuery(this.client, this.observableQuery)
     }
   }
@@ -141,8 +151,23 @@ Query.propTypes = {
   as: PropTypes.string,
   /** Function called with the data from the query */
   children: PropTypes.func.isRequired,
-  /** How data is fetched */
-  fetchPolicy: PropTypes.oneOf(['cache-only'])
+  /**
+   * Decides if the query is fetched at mount time. If not present
+   * the query is always fetched at mount time. Receives the current
+   * state of the query from the store as 1st argument.
+   *
+   *
+   * @example
+   * If you want to only fetch queries that are older than 30 seconds:
+
+   * ```js
+   * const cache30s = ({ lastUpdate }) => {
+   *   return !lastUpdate || (Date.now() - 30 * 1000 > lastUpdate)
+   * }
+   * <Query fetchPolicy={cache30s} ... />
+   * ```
+   */
+  fetchPolicy: PropTypes.func
 }
 
 export { getQueryAttributes, computeChildrenArgs }

--- a/packages/cozy-client/src/Query.jsx
+++ b/packages/cozy-client/src/Query.jsx
@@ -156,7 +156,6 @@ Query.propTypes = {
    * the query is always fetched at mount time. Receives the current
    * state of the query from the store as 1st argument.
    *
-   *
    * @example
    * If you want to only fetch queries that are older than 30 seconds:
 

--- a/packages/cozy-client/src/Query.spec.jsx
+++ b/packages/cozy-client/src/Query.spec.jsx
@@ -40,13 +40,18 @@ describe('Query', () => {
       expect(observableQuery.fetch).toHaveBeenCalled()
     })
 
-    it('should not fire a query fetch when mounted with fetchPolicy=cache-only', () => {
+    it('should not fire a query fetch when mounted when fetchPolicy returns false', () => {
+      const queryState = { lastUpdate: Date.now() }
+      client.getQueryFromState = jest.fn().mockReturnValue(queryState)
+      const fetchPolicy = jest.fn().mockReturnValue(false)
       mount(
-        <Query query={queryDef} as="allTodos" fetchPolicy="cache-only">
+        <Query query={queryDef} as="allTodos" fetchPolicy={fetchPolicy}>
           {() => null}
         </Query>,
         { context }
       )
+      expect(client.getQueryFromState).toHaveBeenCalledWith('allTodos')
+      expect(fetchPolicy).toHaveBeenCalledWith(queryState)
       expect(client.query).not.toHaveBeenCalled()
     })
 
@@ -77,10 +82,11 @@ describe('Query', () => {
       const assets = createTestAssets()
       store = assets.store
       client = assets.client
+      const noFetch = () => false
       await store.dispatch(initQuery('allTodos', queryDef(client)))
       uut = mount(
         <CozyProvider client={client}>
-          <Query fetchPolicy="cache-only" query={queryDef}>
+          <Query fetchPolicy={noFetch} query={queryDef}>
             {({ data }) => (
               <ul>
                 {data.map(x => (
@@ -139,9 +145,10 @@ describe('Query', () => {
     })
 
     const setup = ({ children }) => {
+      const noFetch = () => false
       mount(
         <CozyProvider client={client}>
-          <Query fetchPolicy="cache-only" query={queryDef}>
+          <Query fetchPolicy={noFetch} query={queryDef}>
             {children}
           </Query>
         </CozyProvider>
@@ -205,13 +212,11 @@ describe('Query', () => {
         update: jest.fn()
       })
 
+      const noFetch = () => false
+
       mount(
         <CozyProvider client={client}>
-          <Query
-            fetchPolicy="cache-only"
-            query={queryDef}
-            mutations={mutations}
-          >
+          <Query fetchPolicy={noFetch} query={queryDef} mutations={mutations}>
             {(result, mutations) => {
               mutationsArgument = mutations
               return null
@@ -237,13 +242,11 @@ describe('Query', () => {
         update: jest.fn()
       }
 
+      const noFetch = () => false
+
       mount(
         <CozyProvider client={client}>
-          <Query
-            fetchPolicy="cache-only"
-            query={queryDef}
-            mutations={mutations}
-          >
+          <Query fetchPolicy={noFetch} query={queryDef} mutations={mutations}>
             {(result, mutations) => {
               mutationsArgument = mutations
               return null

--- a/packages/cozy-client/src/Query.spec.jsx
+++ b/packages/cozy-client/src/Query.spec.jsx
@@ -40,7 +40,7 @@ describe('Query', () => {
       expect(observableQuery.fetch).toHaveBeenCalled()
     })
 
-    it('should not fire a query fetch when mounted with initialFetch=false', () => {
+    it('should not fire a query fetch when mounted with fetchPolicy=cache-only', () => {
       mount(
         <Query query={queryDef} as="allTodos" fetchPolicy="cache-only">
           {() => null}


### PR DESCRIPTION
`fetchPolicy` gives the ability to decide if the query should be
refetched at mount time. See query prop documentation for more
information ;).

Note: The `cache-only` value did not work and was never used, this is why I went with a breaking change here. 