### PR TITLE
Improvements

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -54,9 +54,6 @@ through OAuth.</p>
 <dt><a href="#getAccessToken">getAccessToken()</a> ⇒ <code>string</code></dt>
 <dd><p>Get the app token string</p>
 </dd>
-<dt><a href="#normalizeDoc">normalizeDoc(doc, doctype)</a> ⇒ <code>object</code></dt>
-<dd><p>Normalize a document, adding its doctype if needed</p>
-</dd>
 <dt><a href="#garbageCollect">garbageCollect()</a></dt>
 <dd><p>Delete outdated results from cache</p>
 </dd>
@@ -199,15 +196,15 @@ Abstracts a collection of documents of the same doctype, providing CRUD methods 
 **Kind**: global class  
 
 * [DocumentCollection](#DocumentCollection)
-    * _instance_
-        * [.all(options)](#DocumentCollection+all) ⇒ <code>Object</code>
-        * [.find(selector, options)](#DocumentCollection+find) ⇒ <code>Object</code>
-        * [.getIndexFields(options)](#DocumentCollection+getIndexFields) ⇒ <code>Array</code>
-        * [.fetchChanges(couchOptions, options)](#DocumentCollection+fetchChanges)
-    * _static_
-        * [.normalizeDoctype(doctype)](#DocumentCollection.normalizeDoctype) ⇒ <code>function</code>
-        * [.normalizeDoctypeJsonApi(doctype)](#DocumentCollection.normalizeDoctypeJsonApi) ⇒ <code>function</code>
-        * [.normalizeDoctypeRawApi(doctype)](#DocumentCollection.normalizeDoctypeRawApi) ⇒ <code>function</code>
+    * [.all(options)](#DocumentCollection+all) ⇒ <code>Object</code>
+    * [.find(selector, options)](#DocumentCollection+find) ⇒ <code>Object</code>
+    * [.get()](#DocumentCollection+get)
+    * [.getAll()](#DocumentCollection+getAll)
+    * [.update()](#DocumentCollection+update)
+    * [.destroy()](#DocumentCollection+destroy)
+    * [.updateAll(docs)](#DocumentCollection+updateAll)
+    * [.destroyAll(docs)](#DocumentCollection+destroyAll)
+    * [.fetchChanges(couchOptions, options)](#DocumentCollection+fetchChanges)
 
 <a name="DocumentCollection+all"></a>
 
@@ -246,18 +243,51 @@ The returned documents are paginated by the stack.
 | selector | <code>Object</code> | The Mango selector. |
 | options | <code>Object</code> | The query options. |
 
-<a name="DocumentCollection+getIndexFields"></a>
+<a name="DocumentCollection+get"></a>
 
-### documentCollection.getIndexFields(options) ⇒ <code>Array</code>
-Compute fields that should be indexed for a mango
-query to work
+### documentCollection.get()
+Get a document by id
 
 **Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
-**Returns**: <code>Array</code> - - Fields to index  
+<a name="DocumentCollection+getAll"></a>
+
+### documentCollection.getAll()
+Get many documents by id
+
+**Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
+<a name="DocumentCollection+update"></a>
+
+### documentCollection.update()
+Updates a document
+
+**Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
+<a name="DocumentCollection+destroy"></a>
+
+### documentCollection.destroy()
+Destroys a document
+
+**Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
+<a name="DocumentCollection+updateAll"></a>
+
+### documentCollection.updateAll(docs)
+Updates several documents in one batch
+
+**Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
+
+| Param | Type |
+| --- | --- |
+| docs | <code>Array.&lt;Document&gt;</code> | 
+
+<a name="DocumentCollection+destroyAll"></a>
+
+### documentCollection.destroyAll(docs)
+Deletes several documents in one batch
+
+**Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| options | <code>Object</code> | Mango query options |
+| docs | <code>Array.&lt;Document&gt;</code> | Documents to delete |
 
 <a name="DocumentCollection+fetchChanges"></a>
 
@@ -270,45 +300,6 @@ Use Couch _changes API
 | --- | --- | --- |
 | couchOptions | <code>Object</code> | Couch options for changes https://kutt.it/5r7MNQ |
 | options | <code>Object</code> | { includeDesign: false, includeDeleted: false } |
-
-<a name="DocumentCollection.normalizeDoctype"></a>
-
-### DocumentCollection.normalizeDoctype(doctype) ⇒ <code>function</code>
-Provides a callback for `Collection.get`
-
-**Kind**: static method of [<code>DocumentCollection</code>](#DocumentCollection)  
-**Returns**: <code>function</code> - (data, response) => normalizedDocument
-                                       using `normalizeDoc`  
-
-| Param | Type |
-| --- | --- |
-| doctype | <code>string</code> | 
-
-<a name="DocumentCollection.normalizeDoctypeJsonApi"></a>
-
-### DocumentCollection.normalizeDoctypeJsonApi(doctype) ⇒ <code>function</code>
-`normalizeDoctype` for api end points returning json api responses
-
-**Kind**: static method of [<code>DocumentCollection</code>](#DocumentCollection)  
-**Returns**: <code>function</code> - (data, response) => normalizedDocument
-                                       using `normalizeDoc`  
-
-| Param | Type |
-| --- | --- |
-| doctype | <code>string</code> | 
-
-<a name="DocumentCollection.normalizeDoctypeRawApi"></a>
-
-### DocumentCollection.normalizeDoctypeRawApi(doctype) ⇒ <code>function</code>
-`normalizeDoctype` for api end points returning raw documents
-
-**Kind**: static method of [<code>DocumentCollection</code>](#DocumentCollection)  
-**Returns**: <code>function</code> - (data, response) => normalizedDocument
-                                       using `normalizeDoc`  
-
-| Param | Type |
-| --- | --- |
-| doctype | <code>string</code> | 
 
 <a name="FileCollection"></a>
 
@@ -910,19 +901,6 @@ Get the app token string
 **Kind**: global function  
 **Returns**: <code>string</code> - token  
 **See**: CozyStackClient.getAccessToken  
-<a name="normalizeDoc"></a>
-
-## normalizeDoc(doc, doctype) ⇒ <code>object</code>
-Normalize a document, adding its doctype if needed
-
-**Kind**: global function  
-**Returns**: <code>object</code> - normalized document  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| doc | <code>object</code> | Document to normalize |
-| doctype | <code>string</code> |  |
-
 <a name="garbageCollect"></a>
 
 ## garbageCollect()

--- a/packages/cozy-client/src/Query.jsx
+++ b/packages/cozy-client/src/Query.jsx
@@ -1,6 +1,5 @@
 import { Component } from 'react'
 import PropTypes from 'prop-types'
-import { getQueryFromState } from './store'
 
 const dummyState = {}
 

--- a/packages/cozy-client/src/__tests__/ObservableQuery.spec.js
+++ b/packages/cozy-client/src/__tests__/ObservableQuery.spec.js
@@ -53,7 +53,7 @@ describe('ObservableQuery', () => {
     })
 
     it('should not notify observers when other queries changed', async () => {
-      const { observer, query } = await setup()
+      const { observer } = await setup()
       await store.dispatch(
         receiveQueryResult('allTodos', queryResultFromData([TODO_1, TODO_2]))
       )

--- a/packages/cozy-client/src/withMutations.spec.jsx
+++ b/packages/cozy-client/src/withMutations.spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import omit from 'lodash/omit'
 import PropTypes from 'prop-types'
 
 import withMutations from './withMutations'

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -124,6 +124,11 @@ class CozyStackClient {
       method: 'GET',
       credentials: 'include'
     }
+
+    if (!global.document) {
+      throw new Error('Not in a web context, cannot refresh token')
+    }
+
     const response = await fetch('/', options)
 
     if (!response.ok) {
@@ -169,7 +174,12 @@ class CozyStackClient {
       return await this.fetchJSONWithCurrentToken(method, path, body, options)
     } catch (e) {
       if (errors.EXPIRED_TOKEN.test(e.message)) {
-        const token = await this.refreshToken()
+        let token
+        try {
+          token = await this.refreshToken()
+        } catch (refreshError) {
+          throw e
+        }
         this.setToken(token)
         return await this.fetchJSONWithCurrentToken(method, path, body, options)
       } else {

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -171,12 +171,18 @@ class DocumentCollection {
     }
   }
 
+  /**
+   * Get a document by id
+   */
   async get(id) {
     return Collection.get(this.stackClient, uri`/data/${this.doctype}/${id}`, {
       normalize: this.constructor.normalizeDoctype(this.doctype)
     })
   }
 
+  /**
+   * Get many documents by id
+   */
   async getAll(ids) {
     let resp
     try {
@@ -206,12 +212,14 @@ class DocumentCollection {
     const method = hasFixedId ? 'PUT' : 'POST'
     const endpoint = uri`/data/${this.doctype}/${hasFixedId ? _id : ''}`
     const resp = await this.stackClient.fetchJSON(method, endpoint, document)
-
     return {
       data: normalizeDoc(resp.data, this.doctype)
     }
   }
 
+  /**
+   * Updates a document
+   */
   async update(document) {
     const resp = await this.stackClient.fetchJSON(
       'PUT',
@@ -223,6 +231,9 @@ class DocumentCollection {
     }
   }
 
+  /**
+   * Destroys a document
+   */
   async destroy({ _id, _rev, ...document }) {
     const resp = await this.stackClient.fetchJSON(
       'DELETE',

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -274,7 +274,7 @@ class DocumentCollection {
       if (
         e.reason &&
         e.reason.reason &&
-        e.reason.reason == DATABASE_DOES_NOT_EXIST
+        e.reason.reason === DATABASE_DOES_NOT_EXIST
       ) {
         const firstDoc = await this.create(docs[0])
         const resp = await this.updateAll(docs.slice(1))

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -14,6 +14,7 @@ import * as querystring from './querystring'
  * @param {object} doc - Document to normalize
  * @param {string} doctype
  * @return {object} normalized document
+ * @private
  */
 export function normalizeDoc(doc = {}, doctype) {
   const id = doc._id || doc.id
@@ -32,6 +33,8 @@ class DocumentCollection {
 
   /**
    * Provides a callback for `Collection.get`
+   *
+   * @private
    * @param {string} doctype
    * @return {function} (data, response) => normalizedDocument
    *                                        using `normalizeDoc`
@@ -42,6 +45,8 @@ class DocumentCollection {
 
   /**
    * `normalizeDoctype` for api end points returning json api responses
+   *
+   * @private
    * @param {string} doctype
    * @return {function} (data, response) => normalizedDocument
    *                                        using `normalizeDoc`
@@ -55,6 +60,8 @@ class DocumentCollection {
 
   /**
    * `normalizeDoctype` for api end points returning raw documents
+   *
+   * @private
    * @param {string} doctype
    * @return {function} (data, response) => normalizedDocument
    *                                        using `normalizeDoc`
@@ -328,6 +335,7 @@ class DocumentCollection {
    * Compute fields that should be indexed for a mango
    * query to work
    *
+   * @private
    * @param  {Object} options - Mango query options
    * @return {Array} - Fields to index
    */


### PR DESCRIPTION
- Throw when refreshToken is used in a context where the token cannot be refreshed

I saw this error when developing for a service. The original error was "Need absolute URIs" since fetch("/") would fetch a URL that was not absolute (since it did not have the URL of the Cozy). Anyway, this method of refreshing the token by asking the server an HTML page cannot work in services, this is why I prefer a hard throw.

- Privatized methods from DocumentCollection as they were cluttering the docs
- Added updateAll and deleteAll in DocumentCollection. Originally from Document. 