### PR TITLE
feat(cozy-stack-client): Filecollection update file metadata

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -325,9 +325,9 @@ files associated to a specific document
     * [.updateFile(data, params)](#FileCollection+updateFile) ⇒ <code>object</code>
     * [.isChildOf(child, parent)](#FileCollection+isChildOf) ⇒ <code>boolean</code>
     * [.createDirectoryByPath(path)](#FileCollection+createDirectoryByPath) ⇒ <code>object</code>
-    * [.updateFileMetadata(id, attributes)](#FileCollection+updateFileMetadata) ⇒ <code>object</code>
+    * [.updateAttributes(id, attributes)](#FileCollection+updateAttributes) ⇒ <code>object</code>
     * [.createFileMetadata(attributes)](#FileCollection+createFileMetadata) ⇒ <code>object</code>
-    * [.updateFileMetadataAttribute(id, attributes)](#FileCollection+updateFileMetadataAttribute) ⇒ <code>object</code>
+    * [.updateMetadataAttribute(id, metadata)](#FileCollection+updateMetadataAttribute) ⇒ <code>object</code>
 
 <a name="FileCollection+find"></a>
 
@@ -506,12 +506,20 @@ async createDirectoryByPath - Creates one or more folders until the given path e
 | --- | --- |
 | path | <code>string</code> | 
 
-<a name="FileCollection+updateFileMetadata"></a>
+<a name="FileCollection+updateAttributes"></a>
 
-### fileCollection.updateFileMetadata(id, attributes) ⇒ <code>object</code>
-async updateFileMetadata - Updates a file / folder's attributes except
-the metadata attribute. To update its metadata use `updateFileMetadataAttribute`
-see https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.files/#folder
+### fileCollection.updateAttributes(id, attributes) ⇒ <code>object</code>
+async updateAttributes - Updates a file / folder's attributes except
+the metadata attribute. If you want to update its metadata attribute,
+then use `updateFileMetadataAttribute` since `metadata` is a specific
+doctype.
+
+For instance, if you want to update the name of a file, you can pass
+attributes = { name: 'newName'}
+
+You can see the attributes for both Folder and File (as they share the
+same doctype they have a few in common) here :
+https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.files/#iocozyfiles
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
 **Returns**: <code>object</code> - Updated document  
@@ -519,7 +527,7 @@ see https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.files/#folder
 | Param | Type | Description |
 | --- | --- | --- |
 | id | <code>string</code> | File id |
-| attributes | <code>object</code> | New file meta data |
+| attributes | <code>object</code> | New file attributes |
 
 <a name="FileCollection+createFileMetadata"></a>
 
@@ -535,11 +543,15 @@ See https://github.com/cozy/cozy-stack/blob/master/docs/files.md#post-filesuploa
 | --- | --- | --- |
 | attributes | <code>object</code> | The file's metadata |
 
-<a name="FileCollection+updateFileMetadataAttribute"></a>
+<a name="FileCollection+updateMetadataAttribute"></a>
 
-### fileCollection.updateFileMetadataAttribute(id, attributes) ⇒ <code>object</code>
-This method allows you to update the metadata attribute of a io.cozy.files
-It will result in a creation of a new version of the file
+### fileCollection.updateMetadataAttribute(id, metadata) ⇒ <code>object</code>
+Updates the metadata attribute of a io.cozy.files
+Creates a new version of the file without having
+to upload again the file's content
+
+To see available content of the metadata attribute
+see : https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.files_metadata/
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
 **Returns**: <code>object</code> - io.cozy.files updated  
@@ -547,7 +559,7 @@ It will result in a creation of a new version of the file
 | Param | Type | Description |
 | --- | --- | --- |
 | id | <code>string</code> | File id |
-| attributes | <code>object</code> | io.cozy.files.metadata attributes |
+| metadata | <code>object</code> | io.cozy.files.metadata attributes |
 
 <a name="OAuthClient"></a>
 

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -327,6 +327,7 @@ files associated to a specific document
     * [.createDirectoryByPath(path)](#FileCollection+createDirectoryByPath) ⇒ <code>object</code>
     * [.updateFileMetadata(id, attributes)](#FileCollection+updateFileMetadata) ⇒ <code>object</code>
     * [.createFileMetadata(attributes)](#FileCollection+createFileMetadata) ⇒ <code>object</code>
+    * [.updateFileMetadataAttribute(id, attributes)](#FileCollection+updateFileMetadataAttribute) ⇒ <code>object</code>
 
 <a name="FileCollection+find"></a>
 
@@ -508,7 +509,9 @@ async createDirectoryByPath - Creates one or more folders until the given path e
 <a name="FileCollection+updateFileMetadata"></a>
 
 ### fileCollection.updateFileMetadata(id, attributes) ⇒ <code>object</code>
-async updateFileMetadata - Updates a file's metadata
+async updateFileMetadata - Updates a file / folder's attributes except
+the metadata attribute. To update its metadata use `updateFileMetadataAttribute`
+see https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.files/#folder
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
 **Returns**: <code>object</code> - Updated document  
@@ -531,6 +534,20 @@ See https://github.com/cozy/cozy-stack/blob/master/docs/files.md#post-filesuploa
 | Param | Type | Description |
 | --- | --- | --- |
 | attributes | <code>object</code> | The file's metadata |
+
+<a name="FileCollection+updateFileMetadataAttribute"></a>
+
+### fileCollection.updateFileMetadataAttribute(id, attributes) ⇒ <code>object</code>
+This method allows you to update the metadata attribute of a io.cozy.files
+It will result in a creation of a new version of the file
+
+**Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
+**Returns**: <code>object</code> - io.cozy.files updated  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| id | <code>string</code> | File id |
+| attributes | <code>object</code> | io.cozy.files.metadata attributes |
 
 <a name="OAuthClient"></a>
 

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -518,15 +518,23 @@ class FileCollection extends DocumentCollection {
   }
 
   /**
-   * async updateFileMetadata - Updates a file / folder's attributes except
-   * the metadata attribute. To update its metadata use `updateFileMetadataAttribute`
-   * see https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.files/#folder
+   * async updateAttributes - Updates a file / folder's attributes except
+   * the metadata attribute. If you want to update its metadata attribute,
+   * then use `updateFileMetadataAttribute` since `metadata` is a specific
+   * doctype.
+   *
+   * For instance, if you want to update the name of a file, you can pass
+   * attributes = { name: 'newName'}
+   *
+   * You can see the attributes for both Folder and File (as they share the
+   * same doctype they have a few in common) here :
+   * https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.files/#iocozyfiles
    *
    * @param  {string} id         File id
-   * @param  {object} attributes New file meta data
+   * @param  {object} attributes New file attributes
    * @returns {object}            Updated document
    */
-  async updateFileMetadata(id, attributes) {
+  async updateAttributes(id, attributes) {
     const resp = await this.stackClient.fetchJSON('PATCH', uri`/files/${id}`, {
       data: {
         type: 'io.cozy.files',
@@ -537,6 +545,13 @@ class FileCollection extends DocumentCollection {
     return {
       data: normalizeFile(resp.data)
     }
+  }
+
+  async updateFileMetadata(id, attributes) {
+    console.warn(
+      'CozyClient FileCollection updateFileMetadata method is deprecated. Use updateAttributes instead'
+    )
+    return this.updateAttributes(id, attributes)
   }
 
   /**
@@ -565,21 +580,24 @@ class FileCollection extends DocumentCollection {
 
   /**
    *
-   * This method allows you to update the metadata attribute of a io.cozy.files
-   * It will result in a creation of a new version of the file
+   * Updates the metadata attribute of a io.cozy.files
+   * Creates a new version of the file without having
+   * to upload again the file's content
    *
+   * To see available content of the metadata attribute
+   * see : https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.files_metadata/
    * @param {string} id File id
-   * @param {object} attributes io.cozy.files.metadata attributes
+   * @param {object} metadata io.cozy.files.metadata attributes
    * @return {object} io.cozy.files updated
    */
-  async updateFileMetadataAttribute(id, attributes) {
+  async updateMetadataAttribute(id, metadata) {
     const resp = await this.stackClient.fetchJSON(
       'POST',
       uri`/files/${id}/versions`,
       {
         data: {
           type: 'io.cozy.files.metadata',
-          attributes
+          attributes: metadata
         }
       }
     )

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -518,7 +518,9 @@ class FileCollection extends DocumentCollection {
   }
 
   /**
-   * async updateFileMetadata - Updates a file's metadata
+   * async updateFileMetadata - Updates a file / folder's attributes except
+   * the metadata attribute. To update its metadata use `updateFileMetadataAttribute`
+   * see https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.files/#folder
    *
    * @param  {string} id         File id
    * @param  {object} attributes New file meta data
@@ -549,6 +551,31 @@ class FileCollection extends DocumentCollection {
     const resp = await this.stackClient.fetchJSON(
       'POST',
       uri`/files/upload/metadata`,
+      {
+        data: {
+          type: 'io.cozy.files.metadata',
+          attributes
+        }
+      }
+    )
+    return {
+      data: resp.data
+    }
+  }
+
+  /**
+   *
+   * This method allows you to update the metadata attribute of a io.cozy.files
+   * It will result in a creation of a new version of the file
+   *
+   * @param {string} id File id
+   * @param {object} attributes io.cozy.files.metadata attributes
+   * @return {object} io.cozy.files updated
+   */
+  async updateFileMetadataAttribute(id, attributes) {
+    const resp = await this.stackClient.fetchJSON(
+      'POST',
+      uri`/files/${id}/versions`,
       {
         data: {
           type: 'io.cozy.files.metadata',

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -302,6 +302,26 @@ describe('FileCollection', () => {
     })
   })
 
+  describe('updateFileMetadataAttribute', () => {
+    beforeEach(() => {
+      client.fetchJSON.mockReturnValue({ data: [] })
+    })
+
+    afterEach(() => {
+      client.fetchJSON.mockClear()
+    })
+
+    it('should call the right route', async () => {
+      await collection.updateFileMetadataAttribute('42', {
+        classification: 'tax_notice'
+      })
+      expect(client.fetchJSON.mock.calls.length).toBeGreaterThan(0)
+      expect(
+        client.fetchJSON.mock.calls[client.fetchJSON.mock.calls.length - 1]
+      ).toMatchSnapshot()
+    })
+  })
+
   describe('createFileMetadata', () => {
     beforeEach(() => {
       client.fetchJSON.mockReturnValue({ data: [] })

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -282,7 +282,7 @@ describe('FileCollection', () => {
     })
   })
 
-  describe('updateFileMetadata', () => {
+  describe('updateAttributes', () => {
     beforeEach(() => {
       client.fetchJSON.mockReturnValue({ data: [] })
     })
@@ -292,7 +292,7 @@ describe('FileCollection', () => {
     })
 
     it('should call the right route', async () => {
-      await collection.updateFileMetadata('42', {
+      await collection.updateAttributes('42', {
         dir_id: '123'
       })
       expect(client.fetchJSON.mock.calls.length).toBeGreaterThan(0)
@@ -302,7 +302,7 @@ describe('FileCollection', () => {
     })
   })
 
-  describe('updateFileMetadataAttribute', () => {
+  describe('updateMetadataAttribute', () => {
     beforeEach(() => {
       client.fetchJSON.mockReturnValue({ data: [] })
     })
@@ -312,7 +312,7 @@ describe('FileCollection', () => {
     })
 
     it('should call the right route', async () => {
-      await collection.updateFileMetadataAttribute('42', {
+      await collection.updateMetadataAttribute('42', {
         classification: 'tax_notice'
       })
       expect(client.fetchJSON.mock.calls.length).toBeGreaterThan(0)

--- a/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
+++ b/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
@@ -85,7 +85,7 @@ exports[`FileCollection referencedBy should remove a reference 1`] = `
 }
 `;
 
-exports[`FileCollection updateFileMetadata should call the right route 1`] = `
+exports[`FileCollection updateAttributes should call the right route 1`] = `
 Array [
   "PATCH",
   "/files/42",
@@ -101,7 +101,7 @@ Array [
 ]
 `;
 
-exports[`FileCollection updateFileMetadataAttribute should call the right route 1`] = `
+exports[`FileCollection updateMetadataAttribute should call the right route 1`] = `
 Array [
   "POST",
   "/files/42/versions",

--- a/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
+++ b/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
@@ -100,3 +100,18 @@ Array [
   },
 ]
 `;
+
+exports[`FileCollection updateFileMetadataAttribute should call the right route 1`] = `
+Array [
+  "POST",
+  "/files/42/versions",
+  Object {
+    "data": Object {
+      "attributes": Object {
+        "classification": "tax_notice",
+      },
+      "type": "io.cozy.files.metadata",
+    },
+  },
+]
+`;


### PR DESCRIPTION
Use the new route to update file's metadata by creating a new
version of the file without having to upload it again.

See: https://github.com/cozy/cozy-stack/pull/2119/files