### PR TITLE
Helper method on triggers

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -58,6 +58,14 @@ from a Cozy. <code>QueryDefinition</code>s are sent to links.</p>
 </dd>
 </dl>
 
+## Constants
+
+<dl>
+<dt><a href="#triggerStates">triggerStates</a></dt>
+<dd><p>Trigger states come from /jobs/triggers</p>
+</dd>
+</dl>
+
 ## Functions
 
 <dl>
@@ -1103,6 +1111,29 @@ Returns the relationship for a given doctype/name
 Validates a document considering the descriptions in schema.attributes.
 
 **Kind**: instance method of [<code>Schema</code>](#Schema)  
+<a name="triggerStates"></a>
+
+## triggerStates
+Trigger states come from /jobs/triggers
+
+**Kind**: global constant  
+
+* [triggerStates](#triggerStates)
+    * [.getLastExecution()](#triggerStates.getLastExecution)
+    * [.isErrored()](#triggerStates.isErrored)
+
+<a name="triggerStates.getLastExecution"></a>
+
+### triggerStates.getLastExecution()
+Returns when the trigger was last executed. Need a trigger
+
+**Kind**: static method of [<code>triggerStates</code>](#triggerStates)  
+<a name="triggerStates.isErrored"></a>
+
+### triggerStates.isErrored()
+Returns whether last job failed
+
+**Kind**: static method of [<code>triggerStates</code>](#triggerStates)  
 <a name="withClient"></a>
 
 ## withClient(Component) ⇒ <code>function</code>

--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -478,6 +478,7 @@ Responsible for
         * [.logout()](#CozyClient+logout) ⇒ <code>Promise</code>
         * [.collection(doctype)](#CozyClient+collection) ⇒ <code>DocumentCollection</code>
         * [.getDocumentSavePlan(document, relationships)](#CozyClient+getDocumentSavePlan) ⇒ <code>Array.&lt;Mutation&gt;</code>
+        * [.query(queryDefinition)](#CozyClient+query) ⇒ <code>QueryResult</code>
         * [.fetchRelationships()](#CozyClient+fetchRelationships)
         * [.hydrateDocument()](#CozyClient+hydrateDocument)
         * [.makeNewDocument()](#CozyClient+makeNewDocument)
@@ -629,6 +630,22 @@ client.getDocumentSavePlan(baseDoc, relationships)
 | --- | --- | --- |
 | document | <code>object</code> | The base document to create |
 | relationships | <code>object</code> | The list of relationships to add, as a dictionnary. Keys should be relationship names and values the documents to link. |
+
+<a name="CozyClient+query"></a>
+
+### cozyClient.query(queryDefinition) ⇒ <code>QueryResult</code>
+Executes a query and returns its results.
+
+Results from the query will be saved internally and can be retrieved via
+`getQueryFromState` or directly using `<Query />`. `<Query />` automatically
+executes its query when mounted if no fetch policy has been indicated.
+
+**Kind**: instance method of [<code>CozyClient</code>](#CozyClient)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| queryDefinition | [<code>QueryDefinition</code>](#QueryDefinition) |  |
+| options.as | <code>String</code> | Names the query so it can be reused (by multiple components for example) |
 
 <a name="CozyClient+fetchRelationships"></a>
 

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -502,6 +502,17 @@ class CozyClient {
     }
   }
 
+  /**
+   * Executes a query and returns its results.
+   *
+   * Results from the query will be saved internally and can be retrieved via
+   * `getQueryFromState` or directly using `<Query />`. `<Query />` automatically
+   * executes its query when mounted if no fetch policy has been indicated.
+   *
+   * @param  {QueryDefinition} queryDefinition
+   * @param  {String} options.as - Names the query so it can be reused (by multiple components for example)
+   * @return {QueryResult}
+   */
   async query(queryDefinition, { update, ...options } = {}) {
     this.ensureStore()
     const queryId = options.as || this.generateId()

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -30,3 +30,6 @@ export { default as withMutation } from './withMutation'
 export { default as withMutations } from './withMutations'
 export { default as Query } from './Query'
 export { queryConnect, withClient } from './hoc'
+
+import * as models from './models'
+export { models }

--- a/packages/cozy-client/src/models/index.js
+++ b/packages/cozy-client/src/models/index.js
@@ -1,0 +1,1 @@
+export { triggerResults } from './triggers'

--- a/packages/cozy-client/src/models/triggers.js
+++ b/packages/cozy-client/src/models/triggers.js
@@ -1,0 +1,25 @@
+/** Trigger states come from /jobs/triggers */
+const triggerStates = {
+  /** Returns when the trigger was last executed. Need a trigger */
+  getLastExecution: triggerState => triggerState.last_execution,
+  /** Returns whether last job failed */
+  isErrored: triggerState => triggerState.current_state.status === 'errored'
+}
+
+const triggers = {
+  isKonnectorWorker: trigger => trigger.worker === 'konnector',
+  getKonnector: trigger => {
+    if (!triggers.isKonnectorWorker(trigger)) {
+      return
+    }
+    if (trigger.message && trigger.message.konnector) {
+      return trigger.message.konnector
+    } else if (trigger.message && trigger.message.Data) {
+      // Legacy triggers
+      const message = JSON.parse(atob(trigger.message.Data))
+      return message.konnector
+    }
+  }
+}
+
+export { triggerStates, triggers }

--- a/packages/cozy-client/src/models/triggers.spec.js
+++ b/packages/cozy-client/src/models/triggers.spec.js
@@ -1,0 +1,50 @@
+import { triggerStates, triggers } from './triggers'
+
+describe('trigger states', () => {
+  it('should get execution date', () => {
+    expect(
+      triggerStates.getLastExecution({
+        last_execution: '2010-09-10T00:00'
+      })
+    ).toBe('2010-09-10T00:00')
+  })
+})
+
+describe('getKonnectorFromTrigger', () => {
+  it('should work with normal triggers', () => {
+    const normalTrigger = {
+      _rev: '1-31eb8f0da1db0f3196ccf0d4329ea554',
+      prefix: 'toto.mycozy.cloud',
+      arguments: '0 35 0 * * 3',
+      message: {
+        account: '4cbfe8f3d89edf60542d5fe9cdcac7b1',
+        konnector: 'orangemobile'
+      },
+      _id: 'fa4c076914ce46a92fa3e7e5f0672ca5',
+      domain: 'claire.mycozy.cloud',
+      worker: 'konnector',
+      debounce: '',
+      options: null,
+      type: '@cron'
+    }
+    expect(triggers.getKonnector(normalTrigger)).toBe('orangemobile')
+  })
+
+  it('should work with legacy triggers', () => {
+    const legacyTrigger = {
+      arguments: '37 42 0 * * 3',
+      domain: 'claire.mycozy.cloud',
+      _rev: '2-a9f7f0eb5ccc0871e10721797ef5dcf0',
+      worker: 'konnector',
+      _id: '3a7c363eea2ddb4d73bd11afa9bb4691',
+      type: '@cron',
+      options: null,
+      message: {
+        Data:
+          'eyJrb25uZWN0b3IiOiJhbWVsaSIsImFjY291bnQiOiIzYTdjMzYzZWVhMmRkYjRkNzNiZDExYWZhOWJiM2ViNiJ9',
+        Type: 'json'
+      }
+    }
+    expect(triggers.getKonnector(legacyTrigger)).toBe('ameli')
+  })
+})


### PR DESCRIPTION
Need helpers on triggers in Banks and finally took the leap and moved methods from Banks related to triggers in cozy-client 🎉 

## Future

This folder will serve to put all helpers on documents.
Bring helper methods from apps here.
Also bring non-network methods from cozy-doctypes here.
Network methods involving the stack must be put inside cozy-stack-client.