### PR TITLE
fix: Do not modify wrapped component PropTypes

### DIFF
--- a/packages/cozy-client/src/withMutations.jsx
+++ b/packages/cozy-client/src/withMutations.jsx
@@ -32,14 +32,6 @@ const withMutations = (...mutations) => WrappedComponent => {
   const wrappedDisplayName =
     WrappedComponent.displayName || WrappedComponent.name || 'Component'
 
-  WrappedComponent.propTypes = {
-    ...WrappedComponent.propTypes,
-    createDocument: PropTypes.func.isRequired,
-    saveDocument: PropTypes.func.isRequired,
-    deleteDocument: PropTypes.func.isRequired,
-    ...mutationsToPropTypes(mutations)
-  }
-
   class Wrapper extends Component {
     static contextTypes = {
       client: PropTypes.object

--- a/packages/cozy-client/src/withMutations.spec.jsx
+++ b/packages/cozy-client/src/withMutations.spec.jsx
@@ -37,23 +37,6 @@ describe('withMutations', () => {
     }).not.toThrowError()
   })
 
-  it('should expose all additional mutations provided proptypes', () => {
-    const Foo = () => <div />
-    const mutationsMock = client => ({
-      myMutation1: () => {},
-      myMutation2: () => {}
-    })
-
-    withMutations(mutationsMock)(Foo)
-    expect(Foo.propTypes).toEqual({
-      createDocument: PropTypes.func.isRequired,
-      deleteDocument: PropTypes.func.isRequired,
-      saveDocument: PropTypes.func.isRequired,
-      myMutation1: PropTypes.func.isRequired,
-      myMutation2: PropTypes.func.isRequired
-    })
-  })
-
   it('should inject base mutations props into wrapped component', async () => {
     const Foo = () => <div />
     const ConnectedFoo = withMutations()(Foo)


### PR DESCRIPTION
withMutations HOC was modifying the original component proptypes. This
would result in warning during tests in Banks. If the original component
needs some props, it should put them itself and not rely on the HOC
to put them.