### PR TITLE
feat: GetQueryFromState can hydrate documents directly

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -787,6 +787,7 @@ Get a query from the internal store.
 | Param | Type | Description |
 | --- | --- | --- |
 | id | <code>String</code> | Id of the query (set via Query.props.as) |
+| options.hydrated | <code>Boolean</code> | Whether documents should be returned already hydrated (default: false) |
 
 <a name="CozyClient+register"></a>
 

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -863,12 +863,18 @@ class CozyClient {
    * Get a query from the internal store.
    *
    * @param {String} id - Id of the query (set via Query.props.as)
+   * @param {Boolean} options.hydrated - Whether documents should be returned already hydrated (default: false)
    *
    * @return {QueryState} - Query state or null if it does not exist.
    */
-  getQueryFromState(id) {
+  getQueryFromState(id, options = {}) {
+    const hydrated = options.hydrated || false
     try {
-      return getQueryFromState(this.store.getState(), id)
+      const queryResults = getQueryFromState(this.store.getState(), id)
+      const data = hydrated
+        ? this.hydrateDocuments(queryResults.doctype, queryResults.data)
+        : queryResults.data
+      return { ...queryResults, data }
     } catch (e) {
       console.warn('Could not getQueryFromState', id, e.message)
       return null

--- a/packages/cozy-client/src/ObservableQuery.js
+++ b/packages/cozy-client/src/ObservableQuery.js
@@ -37,17 +37,17 @@ export default class ObservableQuery {
    * @return {HydratedQueryState}
    */
   currentResult() {
-    const result = getQueryFromState(this.getStore().getState(), this.queryId)
+    const result = this.client.getQueryFromState(this.queryId, {
+      hydrated: true
+    })
     if (!result.lastFetch) {
       return result
     }
-    const data = this.client.hydrateDocuments(
-      this.definition.doctype,
-      result.data
-    )
     return {
       ...result,
-      data: this.definition.id ? data[0] : data
+      // Weird to have this.definition.id here, maybe it could be getQueryFromState
+      // that should do that
+      data: this.definition.id ? result.data[0] : result.data
     }
   }
 


### PR DESCRIPTION
/!\ : Should change base branch to master when docstrings is merged

Since selectors can be a way for an app to get documents from client, it
is useful to be able to select already hydrated documents. It also enables to remove hydratation logic from the Query.

This is useful to fix a bug in Banks that was introduced when we changed to use selectors on the store : since we previously received the documents from `queryConnect`, they were already hydrated. After changing to use selectors, they
were not hydrated. 