### PR TITLE
feat: Added a simple settings collection

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -28,6 +28,9 @@ through OAuth.</p>
 <dt><a href="#PermissionCollection">PermissionCollection</a></dt>
 <dd><p>Implements <code>DocumentCollection</code> API along with specific methods for <code>io.cozy.permissions</code>.</p>
 </dd>
+<dt><a href="#SettingsCollection">SettingsCollection</a></dt>
+<dd><p>Implements <code>DocumentCollection</code> API to interact with the /settings endpoint of the stack</p>
+</dd>
 <dt><a href="#SharingCollection">SharingCollection</a></dt>
 <dd><p>Implements the <code>DocumentCollection</code> API along with specific methods for
 <code>io.cozy.sharings</code>.</p>
@@ -815,6 +818,24 @@ const permissions = await client
 async getOwnPermissions - Gets the permission for the current token
 
 **Kind**: instance method of [<code>PermissionCollection</code>](#PermissionCollection)  
+<a name="SettingsCollection"></a>
+
+## SettingsCollection
+Implements `DocumentCollection` API to interact with the /settings endpoint of the stack
+
+**Kind**: global class  
+<a name="SettingsCollection+get"></a>
+
+### settingsCollection.get(path) ⇒ <code>object</code>
+async get - Calls a route on the /settings API
+
+**Kind**: instance method of [<code>SettingsCollection</code>](#SettingsCollection)  
+**Returns**: <code>object</code> - The response from the route  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| path | <code>string</code> | The setting route to call, eg `instance` or `context` |
+
 <a name="SharingCollection"></a>
 
 ## SharingCollection

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -7,6 +7,7 @@ import KonnectorCollection, { KONNECTORS_DOCTYPE } from './KonnectorCollection'
 import SharingCollection from './SharingCollection'
 import PermissionCollection from './PermissionCollection'
 import TriggerCollection, { TRIGGERS_DOCTYPE } from './TriggerCollection'
+import SettingsCollection, { SETTINGS_DOCTYPE } from './SettingsCollection'
 import getIconURL from './getIconURL'
 import logDeprecate from './logDeprecate'
 import errors from './errors'
@@ -59,6 +60,8 @@ class CozyStackClient {
         return new TriggerCollection(this)
       case JOBS_DOCTYPE:
         return new JobCollection(this)
+      case SETTINGS_DOCTYPE:
+        return new SettingsCollection(this)
       default:
         return new DocumentCollection(doctype, this)
     }

--- a/packages/cozy-stack-client/src/SettingsCollection.js
+++ b/packages/cozy-stack-client/src/SettingsCollection.js
@@ -1,0 +1,31 @@
+import DocumentCollection from './DocumentCollection'
+
+export const SETTINGS_DOCTYPE = 'io.cozy.settings'
+
+/**
+ * Implements `DocumentCollection` API to interact with the /settings endpoint of the stack
+ */
+class SettingsCollection extends DocumentCollection {
+  constructor(stackClient) {
+    super(SETTINGS_DOCTYPE, stackClient)
+  }
+
+  /**
+   * async get - Calls a route on the /settings API
+   *
+   * @param  {string} path The setting route to call, eg `instance` or `context`
+   * @returns {object} The response from the route
+   */
+  async get(path) {
+    const resp = await this.stackClient.fetchJSON('GET', `/settings/${path}`)
+
+    return DocumentCollection.normalizeDoctypeJsonApi(SETTINGS_DOCTYPE)(
+      resp.data,
+      resp
+    )
+  }
+}
+
+SettingsCollection.normalizeDoctype = DocumentCollection.normalizeDoctypeJsonApi
+
+export default SettingsCollection

--- a/packages/cozy-stack-client/src/SettingsCollection.spec.js
+++ b/packages/cozy-stack-client/src/SettingsCollection.spec.js
@@ -1,0 +1,41 @@
+import SettingsCollection from './SettingsCollection'
+import CozyStackClient from './CozyStackClient'
+
+describe('SettingsCollection', () => {
+  const stackClient = new CozyStackClient()
+  const collection = new SettingsCollection(stackClient)
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should call the appropriate route', async () => {
+    jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue({
+      data: {}
+    })
+
+    await collection.get('instance')
+    expect(stackClient.fetchJSON).toHaveBeenCalledWith(
+      'GET',
+      '/settings/instance'
+    )
+
+    await collection.get('disk-usage')
+    expect(stackClient.fetchJSON).toHaveBeenCalledWith(
+      'GET',
+      '/settings/disk-usage'
+    )
+  })
+
+  it('should throw server error', async () => {
+    jest
+      .spyOn(stackClient, 'fetchJSON')
+      .mockRejectedValue(new Error('Some problem'))
+
+    await expect(collection.get('whatever')).rejects.toThrow()
+  })
+})


### PR DESCRIPTION
This PR adds a simple Settings collection that can be used to query routes on [`/settings`](https://docs.cozy.io/en/cozy-stack/settings/#get-settingsinstance)., as discussed [here](https://github.com/cozy/cozy-home/pull/1369#discussion_r340784655).