### PR TITLE
feat: Expose Q helper to build query definitions

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -67,6 +67,10 @@ from a Cozy. <code>QueryDefinition</code>s are sent to links.</p>
 <dt><a href="#fetchPolicies">fetchPolicies</a></dt>
 <dd><p>Use those fetch policies with <code>&lt;Query /&gt;</code> to limit the number of re-fetch.</p>
 </dd>
+<dt><a href="#Q">Q</a></dt>
+<dd><p>Helper to create a QueryDefinition. Recommended way to create
+query definitions.</p>
+</dd>
 </dl>
 
 ## Functions
@@ -1219,6 +1223,19 @@ than `<delay>` ms.
 Fetch policy that deactivates any fetching.
 
 **Kind**: static method of [<code>fetchPolicies</code>](#fetchPolicies)  
+<a name="Q"></a>
+
+## Q
+Helper to create a QueryDefinition. Recommended way to create
+query definitions.
+
+**Kind**: global constant  
+**Example**  
+```
+import { Q } from 'cozy-client'
+
+const qDef = Q('io.cozy.todos').where({ _id: '1234' })
+```
 <a name="createClientInteractive"></a>
 
 ## createClientInteractive()

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -4,6 +4,7 @@ export { default as StackLink } from './StackLink'
 export { default as compose } from 'lodash/flow'
 export {
   QueryDefinition,
+  Q,
   Mutations,
   MutationTypes,
   getDoctypeFromOperation

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -197,6 +197,19 @@ class QueryDefinition {
   }
 }
 
+/**
+ * Helper to create a QueryDefinition. Recommended way to create
+ * query definitions.
+ *
+ * @example
+ * ```
+ * import { Q } from 'cozy-client'
+ *
+ * const qDef = Q('io.cozy.todos').where({ _id: '1234' })
+ * ```
+ */
+export const Q = doctype => new QueryDefinition({ doctype })
+
 // Mutations
 const CREATE_DOCUMENT = 'CREATE_DOCUMENT'
 const UPDATE_DOCUMENT = 'UPDATE_DOCUMENT'

--- a/packages/cozy-client/src/queries/dsl.spec.js
+++ b/packages/cozy-client/src/queries/dsl.spec.js
@@ -1,8 +1,8 @@
-import { QueryDefinition as Q } from '../queries/dsl'
+import { QueryDefinition, Q } from '../queries/dsl'
 
 describe('QueryDefinition', () => {
   it('should build query defs on selected fields', () => {
-    const q = new Q({ doctype: 'io.cozy.todos' })
+    const q = new QueryDefinition({ doctype: 'io.cozy.todos' })
     expect(q.select(['toto'])).toMatchObject({
       doctype: 'io.cozy.todos',
       fields: ['toto']
@@ -10,7 +10,7 @@ describe('QueryDefinition', () => {
   })
 
   it('should build query def on id', () => {
-    const q = new Q({ doctype: 'io.cozy.todos' })
+    const q = new QueryDefinition({ doctype: 'io.cozy.todos' })
     expect(q.getById('id1')).toMatchObject({
       id: 'id1',
       doctype: 'io.cozy.todos'
@@ -18,10 +18,18 @@ describe('QueryDefinition', () => {
   })
 
   it('should build query def on ids', () => {
-    const q = new Q({ doctype: 'io.cozy.todos' })
+    const q = new QueryDefinition({ doctype: 'io.cozy.todos' })
     expect(q.getByIds(['id1', 'ids2'])).toMatchObject({
       ids: ['id1', 'ids2'],
       doctype: 'io.cozy.todos'
+    })
+  })
+
+  it('should work with shorthand Q', () => {
+    const q = Q('io.cozy.files')
+    expect(q.getByIds(['id1', 'ids2'])).toMatchObject({
+      ids: ['id1', 'ids2'],
+      doctype: 'io.cozy.files'
     })
   })
 })


### PR DESCRIPTION
As discussed in https://github.com/cozy/cozy-client/issues/533, the Q helper
is here to simplify the creation of a query definition (no need for a client
to build a query definition). It will be used then to merge "read" query
definitions making and "write" (mutation) query definitions making.