### PR TITLE
feat(cozy-stack-client): Download file version

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -328,6 +328,8 @@ files associated to a specific document
     * [.upload(data, dirPath)](#FileCollection+upload) ⇒ <code>object</code>
     * [.createFile(data, params)](#FileCollection+createFile)
     * [.updateFile(data, params)](#FileCollection+updateFile) ⇒ <code>object</code>
+    * [.download(file, versionId, filename)](#FileCollection+download)
+    * [.getBeautifulSize(file, decimal)](#FileCollection+getBeautifulSize)
     * [.isChildOf(child, parent)](#FileCollection+isChildOf) ⇒ <code>boolean</code>
     * [.createDirectoryByPath(path)](#FileCollection+createDirectoryByPath) ⇒ <code>object</code>
     * [.updateAttributes(id, attributes)](#FileCollection+updateAttributes) ⇒ <code>object</code>
@@ -512,6 +514,33 @@ updateFile - Updates a file's data
 | params.executable | <code>boolean</code> | Whether the file is executable or not |
 | params.metadata | <code>object</code> | Metadata to be attached to the File io.cozy.file |
 | params.options | <code>object</code> | Options to pass to doUpload method (additional headers) |
+
+<a name="FileCollection+download"></a>
+
+### fileCollection.download(file, versionId, filename)
+Download a file or a specific version of the file
+
+**Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| file | <code>object</code> |  | io.cozy.files object |
+| versionId | <code>string</code> | <code>null</code> | Id of the io.cozy.files.version |
+| filename | <code>string</code> |  | The name you want for the downloaded file                            (by default the same as the file) |
+
+<a name="FileCollection+getBeautifulSize"></a>
+
+### fileCollection.getBeautifulSize(file, decimal)
+Get a beautified size for a given file
+1024B => 1KB
+102404500404B => 95.37 GB
+
+**Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| file | <code>object</code> | io.cozy.files object |
+| decimal | <code>int</code> | number of decimal |
 
 <a name="FileCollection+isChildOf"></a>
 

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -480,7 +480,47 @@ describe('FileCollection', () => {
       })
     })
   })
+  describe('download', () => {
+    beforeEach(() => {
+      client.fetchJSON.mockResolvedValue({
+        data: {}
+      })
+    })
 
+    afterEach(() => {
+      client.fetchJSON.mockClear()
+    })
+
+    it('should work when not specifying a revision', async () => {
+      const file = {
+        _id: '42',
+        name: 'fileName'
+      }
+      collection.download(file)
+      const expectPath = `/files/downloads?Id=${file._id}&Filename=${file.name}`
+      expect(client.fetchJSON).toHaveBeenCalledWith('POST', expectPath)
+    })
+
+    it('should use download a specific version of a file', async () => {
+      const file = {
+        _id: '42',
+        name: 'fileName'
+      }
+      collection.download(file, '123')
+      const expectPath = `/files/downloads?VersionId=123&Filename=${file.name}`
+      expect(client.fetchJSON).toHaveBeenCalledWith('POST', expectPath)
+    })
+
+    it('should use download a specific version of a file with a specific name', async () => {
+      const file = {
+        _id: '42',
+        name: 'fileName'
+      }
+      collection.download(file, '123', 'myFileName')
+      const expectPath = `/files/downloads?VersionId=123&Filename=myFileName`
+      expect(client.fetchJSON).toHaveBeenCalledWith('POST', expectPath)
+    })
+  })
   describe('createFile', () => {
     const data = new File([''], 'mydoc.epub')
     const id = '59140416-b95f'

--- a/packages/cozy-stack-client/src/utils.js
+++ b/packages/cozy-stack-client/src/utils.js
@@ -67,3 +67,15 @@ export const forceFileDownload = (href, filename) => {
   element.click()
   document.body.removeChild(element)
 }
+
+export const formatBytes = (bytes, decimals = 2) => {
+  if (bytes === 0) return '0 Bytes'
+
+  const k = 1024
+  const dm = decimals < 0 ? 0 : decimals
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i]
+}

--- a/packages/cozy-stack-client/src/utils.spec.jsx
+++ b/packages/cozy-stack-client/src/utils.spec.jsx
@@ -1,0 +1,14 @@
+import { formatBytes } from './utils'
+
+describe('utils', () => {
+  it('should convert bytes to a better unit', () => {
+    expect(formatBytes('1024')).toEqual('1 KB')
+    expect(formatBytes('1026')).toEqual('1 KB')
+    expect(formatBytes('1024000')).toEqual('1000 KB')
+    expect(formatBytes('1024040')).toEqual('1000.04 KB')
+    expect(formatBytes('102404500404')).toEqual('95.37 GB')
+  })
+  it('should give the right decimal', () => {
+    expect(formatBytes('102404500404', 5)).toEqual('95.37162 GB')
+  })
+})


### PR DESCRIPTION
Cozy-stack now supports file versioning. This PR adds the ability to download a specific revision of the file. We use the stack's route: https://github.com/cozy/cozy-stack/blob/94e62d16054c0bec33d0f283a6fc49ed1f6c8300/docs/files.md#post-filesdownloadsversionidfile_idversion_id 


Added a few test for the `download` method. 

Also add a small utility : getBeautifulSize() that expose a new utility to beautify the size of a file