### PR TITLE
feat(cozy-stack-client): Files get binary of a file

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -329,6 +329,7 @@ files associated to a specific document
     * [.createFile(data, params)](#FileCollection+createFile)
     * [.updateFile(data, params)](#FileCollection+updateFile) ⇒ <code>object</code>
     * [.download(file, versionId, filename)](#FileCollection+download)
+    * [.fetchFileContent(id)](#FileCollection+fetchFileContent)
     * [.getBeautifulSize(file, decimal)](#FileCollection+getBeautifulSize)
     * [.isChildOf(child, parent)](#FileCollection+isChildOf) ⇒ <code>boolean</code>
     * [.createDirectoryByPath(path)](#FileCollection+createDirectoryByPath) ⇒ <code>object</code>
@@ -527,6 +528,20 @@ Download a file or a specific version of the file
 | file | <code>object</code> |  | io.cozy.files object |
 | versionId | <code>string</code> | <code>null</code> | Id of the io.cozy.files.version |
 | filename | <code>string</code> |  | The name you want for the downloaded file                            (by default the same as the file) |
+
+<a name="FileCollection+fetchFileContent"></a>
+
+### fileCollection.fetchFileContent(id)
+Fetch the binary of a file or a specific version of a file
+Useful for instance when you can't download the file directly
+(via a content-disposition attachement header) and need to store
+it before doing an operation.
+
+**Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| id | <code>string</code> | Id of the io.cozy.files or io.cozy.files.version |
 
 <a name="FileCollection+getBeautifulSize"></a>
 

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -400,6 +400,18 @@ class FileCollection extends DocumentCollection {
   }
 
   /**
+   * Fetch the binary of a file or a specific version of a file
+   * Useful for instance when you can't download the file directly
+   * (via a content-disposition attachement header) and need to store
+   * it before doing an operation.
+   *
+   * @param {string} id Id of the io.cozy.files or io.cozy.files.version
+   *
+   */
+  async fetchFileContent(id) {
+    return this.stackClient.fetch('GET', `/files/download/${id}`)
+  }
+  /**
    * Get a beautified size for a given file
    * 1024B => 1KB
    * 102404500404B => 95.37 GB

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -664,4 +664,16 @@ describe('FileCollection', () => {
       expect(res).toEqual(false)
     })
   })
+
+  describe('fetchFileContent', () => {
+    it('should fetch the content of a file', async () => {
+      const FILE_ID = 'd04ab491-2fc6'
+
+      await collection.fetchFileContent(FILE_ID)
+      expect(client.fetch).toHaveBeenCalledWith(
+        'GET',
+        '/files/download/d04ab491-2fc6'
+      )
+    })
+  })
 })


### PR DESCRIPTION
In a mobile env, we need to get the content of a file (or a version) in order to write it on the local FS. 

This is an equivalent cozy-client-js' `downloadById` 