### PR TITLE
feat: Expose instance options

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -520,6 +520,8 @@ Responsible for
         * [.handleRevocationChange()](#CozyClient+handleRevocationChange)
         * [.handleTokenRefresh()](#CozyClient+handleTokenRefresh)
         * [.createClient()](#CozyClient+createClient)
+        * [.getInstanceOptions()](#CozyClient+getInstanceOptions) ⇒ <code>object</code>
+        * [.loadInstanceOptionsFromDOM([selector])](#CozyClient+loadInstanceOptionsFromDOM) ⇒ <code>void</code>
         * [.setData(data)](#CozyClient+setData)
     * _static_
         * [.fromOldClient()](#CozyClient.fromOldClient)
@@ -883,6 +885,23 @@ revocation and token refresh.
 If `oauth` options are passed, stackClient is an OAuthStackClient.
 
 **Kind**: instance method of [<code>CozyClient</code>](#CozyClient)  
+<a name="CozyClient+getInstanceOptions"></a>
+
+### cozyClient.getInstanceOptions() ⇒ <code>object</code>
+getInstanceOptions - Returns current instance options, such as domain or app slug
+
+**Kind**: instance method of [<code>CozyClient</code>](#CozyClient)  
+<a name="CozyClient+loadInstanceOptionsFromDOM"></a>
+
+### cozyClient.loadInstanceOptionsFromDOM([selector]) ⇒ <code>void</code>
+loadInstanceOptionsFromDOM - Loads the dataset injected by the Stack in web pages and exposes it through getInstanceOptions
+
+**Kind**: instance method of [<code>CozyClient</code>](#CozyClient)  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [selector] | <code>string</code> | <code>&quot;[role&#x3D;application]&quot;</code> | A selector for the node that holds the dataset to load |
+
 <a name="CozyClient+setData"></a>
 
 ### cozyClient.setData(data)

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -94,6 +94,12 @@ class CozyClient {
     // Instances of plugins registered with registerPlugin
     this.plugins = {}
 
+    try {
+      this.loadInstanceOptionsFromDOM()
+    } catch (err) {
+      // not a critical error, we may be in node or the instance options are not on the default HTML element
+    }
+
     if (options.uri && options.token) {
       this.login()
     }

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -76,6 +76,7 @@ class CozyClient {
     this.options = options
     this.idCounter = 1
     this.isLogged = false
+    this.instanceOptions = {}
 
     // Bind handlers
     this.handleRevocationChange = this.handleRevocationChange.bind(this)
@@ -1100,6 +1101,27 @@ class CozyClient {
     const id = this.idCounter
     this.idCounter++
     return id
+  }
+
+  /**
+   * getInstanceOptions - Returns current instance options, such as domain or app slug
+   *
+   * @returns {object}
+   */
+  getInstanceOptions() {
+    return this.instanceOptions
+  }
+
+  /**
+   * loadInstanceOptionsFromDOM - Loads the dataset injected by the Stack in web pages and exposes it through getInstanceOptions
+   *
+   * @param {string} [selector=[role=application]] A selector for the node that holds the dataset to load
+   *
+   * @returns {void}
+   */
+  loadInstanceOptionsFromDOM(selector = '[role=application]') {
+    const root = document.querySelector(selector)
+    this.instanceOptions = { ...root.dataset } // convert from DOMStringMap to plain object
   }
 
   /**

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -1119,4 +1119,19 @@ describe('CozyClient', () => {
       expect(doc).toBe(null)
     })
   })
+
+  describe('Instance options', () => {
+    it('should expose options loaded via the DOM', () => {
+      const options = { cozyDomain: 'cozy.tools', cozyToken: 'abc123' }
+
+      const globalQuerySelectorBefore = document.querySelector
+      document.querySelector = jest.fn().mockReturnValue({ dataset: options })
+
+      const client = new CozyClient({})
+      client.loadInstanceOptionsFromDOM()
+      expect(client.getInstanceOptions()).toEqual(options)
+
+      document.querySelector = globalQuerySelectorBefore
+    })
+  })
 })


### PR DESCRIPTION
Adds a method for CozyClient to expose the options injected by the stack into our web page templates.