### PR TITLE
docs: Not call setStore too late

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -1023,7 +1023,10 @@ client.query(Q('io.cozy.bills'))`)
       throw new Error('Store is undefined')
     } else if (this.store && !force) {
       throw new Error(
-        'Client already has a store, it is forbidden to change store.'
+        `Client already has a store, it is forbidden to change store.
+setStore must be called before any query is executed. Try to 
+call setStore earlier in your code, preferably just after the 
+instantiation of the client.`
       )
     }
 


### PR DESCRIPTION
I was trying to use cozy-client in the bar by making a query. But since I was instancing cozy-bar before making `client.setStore` in Drive, I had this error and I didn't know what to do.

thanks to @ptbrowne, I now know that, when you call a query before setting a store, cozy-client creates by itself its store. So calling setStore later throws an exception. 

Add a line about the error 