### PR TITLE
fix: SettingsCollection fix data response

### DIFF
--- a/packages/cozy-stack-client/src/SettingsCollection.js
+++ b/packages/cozy-stack-client/src/SettingsCollection.js
@@ -18,11 +18,12 @@ class SettingsCollection extends DocumentCollection {
    */
   async get(path) {
     const resp = await this.stackClient.fetchJSON('GET', `/settings/${path}`)
-
-    return DocumentCollection.normalizeDoctypeJsonApi(SETTINGS_DOCTYPE)(
-      resp.data,
-      resp
-    )
+    return {
+      data: DocumentCollection.normalizeDoctypeJsonApi(SETTINGS_DOCTYPE)(
+        resp.data,
+        resp
+      )
+    }
   }
 }
 

--- a/packages/cozy-stack-client/src/SettingsCollection.spec.js
+++ b/packages/cozy-stack-client/src/SettingsCollection.spec.js
@@ -31,6 +31,17 @@ describe('SettingsCollection', () => {
     )
   })
 
+  it('should format correctly the response', async () => {
+    jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue({
+      data: {
+        type: 'io.cozy.settings',
+        id: 'io.cozy.settings.disk-usage'
+      }
+    })
+    const resp = await collection.get('disk-usage')
+    expect(resp.data.id).toBe('io.cozy.settings.disk-usage')
+  })
+
   it('should throw server error', async () => {
     jest
       .spyOn(stackClient, 'fetchJSON')


### PR DESCRIPTION
ATM, if we use `SettingsCollection` as we don't return `data` even if we received a QUERY_RESULT our store is not updated with the latest status (and result). 

It can be considered as a BC but I think it is not currently usable since <Query or queryConnect will be "loading" for ever. I don't know... @y-lohse do you use it already? 