### PR TITLE
feat: Add shoulDisplayOffers method

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -61,6 +61,9 @@ from a Cozy. <code>QueryDefinition</code>s are sent to links.</p>
 ## Constants
 
 <dl>
+<dt><a href="#shouldDisplayOffers">shouldDisplayOffers</a></dt>
+<dd><p>Returns whether an instance is concerned by our offers</p>
+</dd>
 <dt><a href="#triggerStates">triggerStates</a></dt>
 <dd><p>Trigger states come from /jobs/triggers</p>
 </dd>
@@ -1183,6 +1186,20 @@ Returns the relationship for a given doctype/name
 Validates a document considering the descriptions in schema.attributes.
 
 **Kind**: instance method of [<code>Schema</code>](#Schema)  
+<a name="shouldDisplayOffers"></a>
+
+## shouldDisplayOffers
+Returns whether an instance is concerned by our offers
+
+**Kind**: global constant  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| data | <code>object</code> | Object containing all the results from /settings/* |
+| data.context | <code>object</code> | Object returned by /settings/context |
+| data.instance | <code>object</code> | Object returned by /settings/instance |
+| data.diskUsage | <code>object</code> | Object returned by /settings/disk-usage |
+
 <a name="triggerStates"></a>
 
 ## triggerStates

--- a/packages/cozy-client/src/models/instance.js
+++ b/packages/cozy-client/src/models/instance.js
@@ -11,10 +11,27 @@ export const arePremiumLinksEnabled = instanceInfo => {
     ? true
     : false
 }
-export const isFreemiumUser = diskUsage => {
-  const quota = get(diskUsage, 'data.attributes.quota', false)
+export const isFreemiumUser = instanceInfo => {
+  const quota = get(instanceInfo, 'diskUsage.data.attributes.quota', false)
   return parseInt(quota) <= PREMIUM_QUOTA
 }
 export const getUuid = instanceInfo => {
   return get(instanceInfo, 'instance.data.attributes.uuid')
+}
+
+/**
+ * Returns whether an instance is concerned by our offers
+ *
+ * @param {object} data Object containing all the results from /settings/*
+ * @param {object} data.context Object returned by /settings/context
+ * @param {object} data.instance Object returned by /settings/instance
+ * @param {object} data.diskUsage Object returned by /settings/disk-usage
+ */
+export const shouldDisplayOffers = data => {
+  return (
+    !isSelfHosted(data) &&
+    arePremiumLinksEnabled(data) &&
+    getUuid(data) &&
+    isFreemiumUser(data)
+  )
 }

--- a/packages/cozy-client/src/models/instance.spec.js
+++ b/packages/cozy-client/src/models/instance.spec.js
@@ -15,6 +15,13 @@ const noSelfHostedInstance = {
         uuid: '1234'
       }
     }
+  },
+  diskUsage: {
+    data: {
+      attributes: {
+        quota: '400000000'
+      }
+    }
   }
 }
 
@@ -22,6 +29,13 @@ const selftHostedInstance = {
   context: {
     data: {
       attributes: {}
+    }
+  },
+  diskUsage: {
+    data: {
+      attributes: {
+        quota: '6000000000000'
+      }
     }
   }
 }
@@ -39,5 +53,17 @@ describe('instance', () => {
   it('should get uuid of the instance', () => {
     expect(instance.getUuid(noSelfHostedInstance)).toBe('1234')
     expect(instance.getUuid(selftHostedInstance)).toBe(undefined)
+  })
+
+  it('should return if the instance is a freemium one', () => {
+    expect(instance.isFreemiumUser(noSelfHostedInstance)).toBe(true)
+    expect(instance.isFreemiumUser(selftHostedInstance)).toBe(false)
+  })
+
+  it('should tell us that this instance is concerned by our offers', () => {
+    expect(instance.shouldDisplayOffers(noSelfHostedInstance)).toBe(true)
+  })
+  it('should tell us that a selfhosted instance is not concerned by our offres', () => {
+    expect(instance.shouldDisplayOffers(selftHostedInstance)).toBe(false)
   })
 })


### PR DESCRIPTION
We now have an standardized way of saying if an instance is concerned by our offers or not. 

Changed the `isFreemiumUser` to take instanceInfo like other methods (as suggested by @ptbrowne in a previous PR) + added a test in order to prevent BC. Since this method is not used yet, I didn't tag the commit as BC

Next PR soon, an helper to wrap those 3 queries (context / instance / diskusage) 