### PR TITLE
feat: Expose cozy client's version

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,5 @@
+const pacakgeJson = require('./packages/cozy-client/package.json')
+
 module.exports = function(api) {
   const isTest = api.env('test')
   api.cache(true)
@@ -10,6 +12,19 @@ module.exports = function(api) {
           transformRuntime: {
             regenerator: isTest
           }
+        }
+      ]
+    ],
+    plugins: [
+      [
+        'search-and-replace',
+        {
+          rules: [
+            {
+              search: 'COZY_CLIENT_VERSION_PACKAGE',
+              replace: pacakgeJson.version
+            }
+          ]
         }
       ]
     ]

--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@babel/cli": "7.6.2",
+    "babel-plugin-search-and-replace": "1.0.1",
     "mockdate": "^2.0.2",
     "react": "16.10.1"
   },

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -1144,8 +1144,9 @@ class CozyClient {
     })
   }
 }
-
 CozyClient.fetchPolicies = fetchPolicies
+//COZY_CLIENT_VERSION_PACKAGE in replaced by babel. See babel config
+CozyClient.version = 'COZY_CLIENT_VERSION_PACKAGE'
 
 MicroEE.mixin(CozyClient)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2826,6 +2826,11 @@ babel-plugin-jest-hoist@^24.9.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-search-and-replace@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-search-and-replace/-/babel-plugin-search-and-replace-1.0.1.tgz#04701015116e9223ee183ea014ffd1a1efea70ac"
+  integrity sha512-/DBaV38i2/kj2iQK99zW8Te6XxMntMwV/1wfGSvBOIC0xAv7gc9vLxaCgi2gZbI76dpHsvH0vd6Rx7Bxu04WEw==
+
 babel-plugin-syntax-flow@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
@@ -3760,6 +3765,11 @@ commander@^2.8.1:
   version "2.20.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.1.tgz#3863ce3ca92d0831dcf2a102f5fb4b5926afd0f9"
   integrity sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==
+
+comment-parser@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-0.6.2.tgz#b71e8fcacad954bea616779391838150d0096dcb"
+  integrity sha512-Wdms0Q8d4vvb2Yk72OwZjwNWtMklbC5Re7lD9cjCP/AG1fhocmc0TrxGBBAXPLy8fZQPrfHGgyygwI0lA7pbzA==
 
 commitlint-config-cozy@0.4.0:
   version "0.4.0"


### PR DESCRIPTION
In order to be able to make a call to a new API or dealing with
new / old version, exposing the version makes it easier.

At the beginning I created a `getVersion` function in order to get the version, but I don't think it makes sense and brings complexecity since we'll have, in the app, to check if `getVersion` exists before calling it (or try/catch). Here, we juste have to do check if the result is not undefined 

To compare the versions, we just use something like this package : https://github.com/substack/semver-compare 