### PR TITLE
fix: Don't change my headers

### DIFF
--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -1,3 +1,4 @@
+import cloneDeep from 'lodash/cloneDeep'
 import AppCollection, { APPS_DOCTYPE } from './AppCollection'
 import AppToken from './AppToken'
 import DocumentCollection from './DocumentCollection'
@@ -205,8 +206,10 @@ class CozyStackClient {
   }
 
   async fetchJSONWithCurrentToken(method, path, body, options = {}) {
-    const headers = (options.headers = options.headers || {})
-
+    //Since we modify the object later by adding in some case a
+    //content-type, let's clone this object to scope the modification
+    const clonedOptions = cloneDeep(options)
+    const headers = (clonedOptions.headers = clonedOptions.headers || {})
     headers['Accept'] = 'application/json'
 
     if (method !== 'GET' && method !== 'HEAD' && body !== undefined) {
@@ -215,8 +218,7 @@ class CozyStackClient {
         body = JSON.stringify(body)
       }
     }
-
-    const resp = await this.fetch(method, path, body, options)
+    const resp = await this.fetch(method, path, body, clonedOptions)
     const contentType = resp.headers.get('content-type')
     const isJson = contentType && contentType.indexOf('json') >= 0
     const data = await (isJson ? resp.json() : resp.text())

--- a/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
@@ -289,6 +289,35 @@ describe('CozyStackClient', () => {
         expect(e.message).toMatch(/Not/)
       }
     })
+
+    it('should not change option header even if we recall the method after an expired token for instance', async () => {
+      jest.spyOn(client, 'fetchJSONWithCurrentToken')
+      fetch.mockRejectedValueOnce({ message: 'Expired token' })
+      jest.spyOn(client, 'refreshToken')
+      client.refreshToken.mockResolvedValue(FAKE_APP_TOKEN)
+      await client.fetchJSON(
+        'POST',
+        '/data/io.cozy.files/_index',
+        { index: { fields: ['dir_id', 'type'] } },
+        {}
+      )
+
+      expect(client.refreshToken).toHaveBeenCalled()
+      expect(client.fetchJSONWithCurrentToken).toHaveBeenNthCalledWith(
+        1,
+        'POST',
+        '/data/io.cozy.files/_index',
+        { index: { fields: ['dir_id', 'type'] } },
+        {}
+      )
+      expect(client.fetchJSONWithCurrentToken).toHaveBeenNthCalledWith(
+        2,
+        'POST',
+        '/data/io.cozy.files/_index',
+        { index: { fields: ['dir_id', 'type'] } },
+        {}
+      )
+    })
   })
 
   describe('refreshToken', () => {


### PR DESCRIPTION
We fount out a strange behavior in drive when our token was expired and we called a `find` with indexes and sort in the same time. 

The call to refresh token was done and we got a new token, but the recall of this find failed with a nice error  

<img width="1028" alt="Capture d’écran 2019-12-04 à 12 21 27" src="https://user-images.githubusercontent.com/1107936/70232425-b89dc980-175c-11ea-92b8-f5e84b1ec514.png">

After looking in my request panel, I find out that my request had a strange payload... 

<img width="184" alt="Capture d’écran 2019-12-05 à 08 44 27" src="https://user-images.githubusercontent.com/1107936/70232457-c9e6d600-175c-11ea-9b99-4a6797b18746.png">


With the help of @y-lohse we fixed the issue. 

It's pretty simple but deceitful in the same time. The fact is that we are adding a Content-Type header (https://github.com/cozy/cozy-client/blob/master/packages/cozy-stack-client/src/CozyStackClient.js#L214) to `options`. But since options is an object, the scope of this change is not the one we want. By adding this header, in the second call, we do not stringify our body (resulting in the `Object object`).

To fix it, we simply cloned the option before adding parameters. 

I added a test to be sure that the second call of `fetch` is done with the same arguments than the first one