### PR TITLE
chore: Require regenerator-runtime from @babel/runtime/regenerat…

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,4 @@
-const pacakgeJson = require('./packages/cozy-client/package.json')
+const packageJson = require('./packages/cozy-client/package.json')
 
 module.exports = function(api) {
   api.cache(true)
@@ -12,7 +12,7 @@ module.exports = function(api) {
           rules: [
             {
               search: 'COZY_CLIENT_VERSION_PACKAGE',
-              replace: pacakgeJson.version
+              replace: packageJson.version
             }
           ]
         }

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,20 +1,10 @@
 const pacakgeJson = require('./packages/cozy-client/package.json')
 
 module.exports = function(api) {
-  const isTest = api.env('test')
   api.cache(true)
 
   return {
-    presets: [
-      [
-        'cozy-app',
-        {
-          transformRuntime: {
-            regenerator: isTest
-          }
-        }
-      ]
-    ],
+    presets: [['cozy-app']],
     plugins: [
       [
         'search-and-replace',


### PR DESCRIPTION
From 8.3.0, cozy-client was shipped on npm with regeneratorRuntime
not being correctly imported. It must be because in 1e53a167fa43117d1027423b814f9000f427da87,
the plugin transform-runtime was no longer added to the config, and did not override
the transformRegenerator: false specified in the line just above. As a
lib, cozy-client should not make any assumption on its environment, ie
it should not take regeneratorRuntime from global/root.

Diff on dist files introduced by this commit :

![image](https://user-images.githubusercontent.com/465582/70313058-2c031200-1815-11ea-8ee2-26bd4b6fd5d9.png)

Details: Doing the diff between cozy-client@8.2.0 and cozy-client@8.3.0 , we see that the commits between 8.2.0 and 8.3.0 changed the fact that regeneratorRuntime was imported. 

```bash
$  yarn add cozy-client-8-2-0@npm:cozy-client@8.2.0
$   yarn add cozy-client-8-3-0@npm:cozy-client@8.3.0
$   git diff -- node_modules/cozy-client-8-2-0/dist/CozyClient.js node_modules/cozy-client-8-3-0/dist/CozyClient.js
```

```
-
-var _regenerator = require('babel-runtime/regenerator');
-
-var _regenerator2 = _interopRequireDefault(_regenerator); 
 ...
-        return _regenerator2.default.wrap(function _callee$(_context) {
+        return regeneratorRuntime.wrap(function _callee$(_context) {
```


