### PR TITLE
feat: Uses the new context api and adds hooks

### DIFF
--- a/packages/cozy-client/src/Query.jsx
+++ b/packages/cozy-client/src/Query.jsx
@@ -1,6 +1,8 @@
 import { Component } from 'react'
 import PropTypes from 'prop-types'
 
+import CozyContext from './reactContext'
+
 const dummyState = {}
 
 // Need to have this since Query and ObservableQuery might come from
@@ -138,10 +140,7 @@ export default class Query extends Component {
   }
 }
 
-Query.contextTypes = {
-  client: PropTypes.object,
-  store: PropTypes.object
-}
+Query.contextTypes = CozyContext
 
 Query.propTypes = {
   /** Query definition that will be executed and observed */

--- a/packages/cozy-client/src/connect.jsx
+++ b/packages/cozy-client/src/connect.jsx
@@ -1,8 +1,8 @@
 import React, { Component } from 'react'
 import { connect as reduxConnect } from 'react-redux'
-import PropTypes from 'prop-types'
 
 import { getQueryFromState } from './store'
+import CozyContext from './reactContext'
 
 const connect = (query, options = {}) => {
   console.warn(
@@ -22,9 +22,7 @@ const connect = (query, options = {}) => {
     )
 
     class Wrapper extends Component {
-      static contextTypes = {
-        client: PropTypes.object
-      }
+      static contextTypes = CozyContext
 
       constructor(props, context) {
         super(props, context)

--- a/packages/cozy-client/src/hoc.js
+++ b/packages/cozy-client/src/hoc.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import compose from 'lodash/flowRight'
 import Query from './Query'
+import { useClient } from './reactHooks' 
 
 /**
  * @function
@@ -11,13 +12,11 @@ import Query from './Query'
  * @returns {Function} - Component that will receive client as prop
  */
 export const withClient = Component => {
-  const Wrapped = (props, context) => (
-    <Component {...props} client={context.client} />
-  )
-  Wrapped.displayName = `withClient(${Component.displayName || Component.name})`
-  Wrapped.contextTypes = {
-    client: PropTypes.object
+  const Wrapped = (props) => {
+    const client = useClient()
+    return <Component {...props} client={client} />
   }
+  Wrapped.displayName = `withClient(${Component.displayName || Component.name})`
   return Wrapped
 }
 
@@ -28,9 +27,10 @@ const withQuery = (dest, queryOpts, Original) => {
     )
   }
   return Component => {
-    const Wrapped = (props, context) => {
+    const Wrapped = (props) => {
+      const client = useClient()
       queryOpts = typeof queryOpts === 'function' ? queryOpts(props) : queryOpts
-      if (!context.client) {
+      if (!client) {
         throw new Error(
           'Should be used with client in context (use CozyProvider to set context)'
         )
@@ -45,9 +45,6 @@ const withQuery = (dest, queryOpts, Original) => {
           {result => <Component {...{ [dest]: result, ...props }} />}
         </Query>
       )
-    }
-    Wrapped.contextTypes = {
-      client: PropTypes.object
     }
     Wrapped.displayName = `withQuery(${Component.displayName ||
       Component.name})`

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -25,12 +25,14 @@ export { default as Registry } from './registry'
 import * as manifest from './manifest'
 export { manifest }
 
-export { default as CozyProvider } from './Provider'
+export { default as CozyProvider, CozyContextProvider, CozyLegacyProvider } from './Provider'
 export { default as connect } from './connect'
 export { default as withMutation } from './withMutation'
 export { default as withMutations } from './withMutations'
 export { default as Query } from './Query'
 export { queryConnect, withClient } from './hoc'
+export { useClient, useStore } from './reactHooks'
+export { default as CozyContext } from './reactContext'
 
 import * as models from './models'
 export { models }

--- a/packages/cozy-client/src/react.js
+++ b/packages/cozy-client/src/react.js
@@ -1,6 +1,12 @@
-export { default as CozyProvider } from './Provider'
+export {
+  default as CozyProvider,
+  CozyLegacyProvider,
+  CozyContextProvider
+} from './Provider'
+export { useClient, useStore } from './reactHooks'
 export { default as connect } from './connect'
 export { default as withMutation } from './withMutation'
 export { default as withMutations } from './withMutations'
 export { default as Query } from './Query'
 export { queryConnect, withClient } from './hoc'
+export { default as CozyContext } from './reactContext'

--- a/packages/cozy-client/src/reactContext.js
+++ b/packages/cozy-client/src/reactContext.js
@@ -1,0 +1,6 @@
+import React from 'react'
+
+const CozyContext = React.createContext(undefined)
+CozyContext.displayName = 'CozyContext'
+
+export default CozyContext

--- a/packages/cozy-client/src/reactHooks.js
+++ b/packages/cozy-client/src/reactHooks.js
@@ -1,0 +1,33 @@
+import { useContext } from 'react'
+
+import CozyContext from './context'
+
+/**
+ * React hooks to get a cozyClient from the context.
+ * Use Cozy CozyProvider to set the client instance in your React tree
+ */
+
+/**
+ * Get the cozyClient instance from the context (React hook)
+ * If provided a cozyClient instance, will return this instance 
+ * instead of the context one.
+ * @param {CozyClient} propsClient - cozy client instance
+ * @returns {CozyClient} cozy client instance
+ */
+export function useClient(propsClient) {
+  const { client } = useContext(CozyContext)
+  return propsClient || client
+}
+
+/**
+ * Get the cozyClient store from the context (React hook)
+ * If provided a store, will return this store
+ * instead of the context one.
+ * @param {Store} propsStore - cozy client store
+ * @returns {Store} cozy client store
+ */
+export function useClientStore(propsStore) {
+  const { store } = useContext(CozyContext)
+  return propsStore || store
+}
+

--- a/packages/cozy-client/src/withMutation.jsx
+++ b/packages/cozy-client/src/withMutation.jsx
@@ -1,18 +1,18 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types'
+
+import CozyContext from './reactContext'
 
 const withMutation = (mutation, options = {}) => WrappedComponent => {
   const wrappedDisplayName =
     WrappedComponent.displayName || WrappedComponent.name || 'Component'
 
   class Wrapper extends Component {
-    static contextTypes = {
-      client: PropTypes.object
-    }
+    static contextTypes = CozyContext
 
     constructor(props, context) {
       super(props, context)
       this.client = props.client || context.client
+
       if (!this.client) {
         throw new Error(
           `Could not find "client" in either the context or props of ${wrappedDisplayName}`

--- a/packages/cozy-client/src/withMutations.jsx
+++ b/packages/cozy-client/src/withMutations.jsx
@@ -1,6 +1,7 @@
 import merge from 'lodash/merge'
 import React, { Component } from 'react'
-import PropTypes from 'prop-types'
+
+import CozyContext from './reactContext'
 
 const makeMutationsObject = (mutations, client, props) => {
   return merge(
@@ -24,9 +25,7 @@ const withMutations = (...mutations) => WrappedComponent => {
     WrappedComponent.displayName || WrappedComponent.name || 'Component'
 
   class Wrapper extends Component {
-    static contextTypes = {
-      client: PropTypes.object
-    }
+    static contextTypes = CozyContext
 
     constructor(props, context) {
       super(props, context)


### PR DESCRIPTION
ref #547
Objectif : implémenter un hook `useClient` avec la nouvelle API de context.

J'avais fait ça rapidement (je n'ai pas mis à jour les tests, ça doit être fait si on veut le mener plus loin) mais je me rends compte que les apps actuelles récupèrent souvent le client et/ou le store directement dans le contexte via l'ancienne API.

Ca veut dire pas mal de travail dans les app pour encapsuler dans des HOC tous les composants qui aujourd'hui utilisent le contexte pour récupérer le client ou le store, et surtout pas mal de travail pour reformater les tests qui utilisent aussi ce même contexte.

Du coup je ne sais pas si ça a du sens. Je propose à discussion
