### PR TITLE
feat: Add mockClient creation for use in tests

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -46,6 +46,16 @@ const deprecatedHandler = msg => ({
   }
 })
 
+/**
+ * @typedef {object} Link
+ * @typedef {object} Mutation
+ * @typedef {object} DocumentCollection
+ * @typedef {object} QueryResult
+ * @typedef {object} HydratedDocument
+ * @typedef {object} ReduxStore
+ * @typedef {object} QueryState
+ */
+
 const TRIGGER_CREATION = 'creation'
 const TRIGGER_UPDATE = 'update'
 
@@ -59,7 +69,7 @@ const TRIGGER_UPDATE = 'update'
  */
 class CozyClient {
   /**
-   * @param  {object}       options
+   * @param  {object}       options - Options
    * @param  {Link}         options.link   - Backward compatibility
    * @param  {Array.Link}   options.links  - List of links
    * @param  {object}       options.schema - Schema description for each doctypes
@@ -228,8 +238,9 @@ class CozyClient {
    * - "beforeLogin" at the beginning, before links have been set up
    * - "login" when the client is fully logged in and links have been set up
    *
-   * @param  {options.token}   options.token  - If passed, the token is set on the client
-   * @param  {options.uri}   options.uri  - If passed, the uri is set on the client
+   * @param  {object}   options - Options
+   * @param  {string}   options.token  - If passed, the token is set on the client
+   * @param  {string}   options.uri  - If passed, the uri is set on the client
    * @returns {Promise} - Resolves when all links have been setup and client is fully logged in
    *
    */
@@ -328,7 +339,7 @@ class CozyClient {
    * a [DocumentCollection]{@link https://docs.cozy.io/en/cozy-client/api/cozy-stack-client/#DocumentCollection} instance.
    *
    * @param  {string} doctype The collection doctype.
-   * @returns {DocumentCollection}
+   * @returns {DocumentCollection} Collection corresponding to the doctype
    */
   collection(doctype) {
     return this.getStackClient().collection(doctype)
@@ -493,9 +504,9 @@ class CozyClient {
    * })
    * ```
    *
-   * @param  {string}   doctype
-   * @param  {string}   name    Name of the hook
-   * @param  {Function} fn      Callback
+   * @param  {string}   doctype - Doctype on which the hook will be registered
+   * @param  {string}   name    - Name of the hook
+   * @param  {Function} fn      - Callback to be executed
    */
   static registerHook(doctype, name, fn) {
     CozyClient.hooks = CozyClient.hooks || {}
@@ -516,7 +527,7 @@ class CozyClient {
   /**
    * Destroys a document. {before,after}:destroy hooks will be fired.
    *
-   * @param  {Document} document
+   * @param  {Document} document - Document to be deleted
    * @returns {Document} The document that has been deleted
    */
   async destroy(document, mutationOptions = {}) {
@@ -550,6 +561,7 @@ class CozyClient {
    * executes its query when mounted if no fetch policy has been indicated.
    *
    * @param  {QueryDefinition} queryDefinition
+   * @param  {string} options - Options
    * @param  {string} options.as - Names the query so it can be reused (by multiple components for example)
    * @returns {QueryResult}
    */
@@ -778,7 +790,7 @@ class CozyClient {
    *
    * @param  {Document} document for which relationships must be resolved
    * @param  {Schema} schema for the document doctype
-   * @returns {HydrateDocument}
+   * @returns {HydratedDocument}
    */
   hydrateDocument(document, schema) {
     if (!document) {

--- a/packages/cozy-client/src/__mocks__/cozy-stack-client.js
+++ b/packages/cozy-client/src/__mocks__/cozy-stack-client.js
@@ -1,4 +1,8 @@
-const StackClient = jest.requireActual('cozy-stack-client')
+const {
+  default: StackClient,
+  OAuthClient: OriginalOAuthClient,
+  normalizeDoc
+} = jest.requireActual('cozy-stack-client')
 
 const collectionMock = {
   all: jest.fn(() => Promise.resolve()),
@@ -9,17 +13,19 @@ const collectionMock = {
   findReferencedBy: jest.fn(() => Promise.resolve())
 }
 
-class MockedStackClient extends StackClient.default {
+class MockedStackClient extends StackClient {
   constructor(opts) {
     super(opts)
     this.collection = jest.fn(() => collectionMock)
   }
 }
 
-export class OAuthClient extends StackClient.OAuthClient {
+export class OAuthClient extends OriginalOAuthClient {
   constructor(opts) {
     super(opts)
     this.collection = jest.fn(() => collectionMock)
   }
 }
+
 export default MockedStackClient
+export { normalizeDoc }

--- a/packages/cozy-client/src/associations/Association.js
+++ b/packages/cozy-client/src/associations/Association.js
@@ -73,8 +73,8 @@ class Association {
    * @param  {object} target - Original object containing raw data
    * @param  {string} name - Attribute under which the association is stored
    * @param  {string} doctype - Doctype of the documents managed by the association
-   * @param  {Function} options.dispatch - Store's dispatch, comes from the client
    * @param {string} options
+   * @param  {Function} options.dispatch - Store's dispatch, comes from the client
    */
   constructor(target, name, doctype, options) {
     const { dispatch, get, query, mutate, save } = options

--- a/packages/cozy-client/src/mock.js
+++ b/packages/cozy-client/src/mock.js
@@ -1,0 +1,61 @@
+import CozyClient from './CozyClient'
+import { receiveQueryResult, initQuery } from './store'
+import { normalizeDoc } from 'cozy-stack-client'
+
+const fillQueryInsideClient = (client, queryName, queryOptions) => {
+  client.store.dispatch(
+    initQuery(
+      queryName,
+      queryOptions.definition || client.all(queryOptions.doctype)
+    )
+  )
+  client.store.dispatch(
+    receiveQueryResult(queryName, {
+      data: queryOptions.data.map(doc =>
+        normalizeDoc(doc, queryOptions.doctype)
+      )
+    })
+  )
+}
+
+const mockedQueryFromMockedRemoteData = remoteData => qdef => {
+  if (!remoteData) {
+    return { data: null }
+  }
+  if (remoteData[qdef.doctype]) {
+    return { data: remoteData[qdef.doctype] }
+  } else {
+    return { data: [] }
+  }
+}
+
+/**
+ * Creates a client suitable for use in tests
+ *
+ * - client.{query,save} are mocked
+ * - client.stackClient.fetchJSON is mocked
+ *
+ * @param  {object} options.queries Prefill queries inside the store
+ * @param  {object} options.remote Mock data from the server
+ * @param  {object} options.clientOptions Options passed to the client
+ * @returns {CozyClient}
+ */
+const createMockClient = ({ queries, remote, clientOptions }) => {
+  const client = new CozyClient(clientOptions || {})
+  client.ensureStore()
+
+  for (let [queryName, queryOptions] of Object.entries(queries || {})) {
+    fillQueryInsideClient(client, queryName, queryOptions)
+  }
+
+  client.query = jest
+    .fn()
+    .mockImplementation(mockedQueryFromMockedRemoteData(remote))
+
+  client.save = jest.fn()
+  client.stackClient.fetchJSON = jest.fn()
+
+  return client
+}
+
+export { createMockClient }

--- a/packages/cozy-client/src/mock.spec.js
+++ b/packages/cozy-client/src/mock.spec.js
@@ -1,0 +1,46 @@
+import { createMockClient } from './mock'
+
+describe('createMockClient', () => {
+  const simpsonsFixture = [
+    { _id: 'homer', name: 'Homer' },
+    { _id: 'marge', name: 'Marge' }
+  ]
+
+  it('should mock queries inside the store', () => {
+    const client = createMockClient({
+      queries: {
+        simpsons: {
+          data: simpsonsFixture,
+          doctype: 'io.cozy.simpsons'
+        }
+      }
+    })
+    expect(
+      client.getCollectionFromState('io.cozy.simpsons').map(x => x._id)
+    ).toEqual(['homer', 'marge'])
+    expect(client.getQueryFromState('simpsons').data.map(x => x._id)).toEqual([
+      'homer',
+      'marge'
+    ])
+  })
+
+  it('should mock query with data passed in "remote" option', async () => {
+    const client = createMockClient({
+      remote: {
+        'io.cozy.simpsons': simpsonsFixture
+      }
+    })
+    const simpsons = await client.query(client.all('io.cozy.simpsons'))
+    await expect(simpsons.data.map(x => x._id)).toEqual(['homer', 'marge'])
+  })
+
+  it('should mock query even if the doctype has not been mocked', async () => {
+    const client = createMockClient({
+      remote: {
+        'io.cozy.simpsons': simpsonsFixture
+      }
+    })
+    const simpsons = await client.query(client.all('io.cozy.adams'))
+    await expect(simpsons.data.map(x => x._id)).toEqual([])
+  })
+})

--- a/packages/cozy-stack-client/src/index.js
+++ b/packages/cozy-stack-client/src/index.js
@@ -1,3 +1,4 @@
 export { default } from './CozyStackClient'
 export { default as OAuthClient } from './OAuthClient'
 export { default as errors } from './errors'
+export { normalizeDoc } from './DocumentCollection'


### PR DESCRIPTION
Move mock client from banks to here. Client internal store can be
prefilled with data from fixtures and query is mocked so that calls
to the server use fixtures.

Related: https://github.com/cozy/cozy-client/issues/72