### PR TITLE
style: Use params instead of options

### DIFF
--- a/packages/cozy-client/src/registry.js
+++ b/packages/cozy-client/src/registry.js
@@ -27,7 +27,7 @@ class Registry {
    * Installs or updates an app from a source.
    *
    * Accepts the terms if the app has them.
-
+   *
    * @param  {RegistryApp} app - App to be installed
    * @param  {string} source - String (ex: registry://drive/stable)
    * @returns {Promise}

--- a/packages/cozy-client/src/registry.js
+++ b/packages/cozy-client/src/registry.js
@@ -27,7 +27,7 @@ class Registry {
    * Installs or updates an app from a source.
    *
    * Accepts the terms if the app has them.
-   
+
    * @param  {RegistryApp} app - App to be installed
    * @param  {string} source - String (ex: registry://drive/stable)
    * @returns {Promise}
@@ -62,19 +62,19 @@ class Registry {
   /**
    * Fetch at most 200 apps from the channel
    *
-   * @param  {string} options.type - "webapp" or "konnector"
-   * @param  {string} options.channel - "dev"/"beta"/"stable"
+   * @param  {string} params.type - "webapp" or "konnector"
+   * @param  {string} params.channel - "dev"/"beta"/"stable"
    *
    * @returns {Array<RegistryApp>}
    */
-  async fetchApps(options) {
-    const { channel, type } = options
-    const params = {
+  async fetchApps(params) {
+    const { channel, type } = params
+    const searchParams = {
       limit: 200,
       versionsChannel: channel,
       latestChannelVersion: channel
     }
-    let querypart = new URLSearchParams(params).toString()
+    let querypart = new URLSearchParams(searchParams).toString()
     if (type) {
       // Unfortunately, URLSearchParams encodes brackets so we have to do
       // the querypart handling manually

--- a/packages/cozy-client/src/registry.spec.js
+++ b/packages/cozy-client/src/registry.spec.js
@@ -104,10 +104,10 @@ describe('registry api', () => {
     })
 
     it('should call the correct route (filtering)', async () => {
-      await api.fetchApps({ channel: 'beta', type: 'konnectors' })
+      await api.fetchApps({ channel: 'beta', type: 'konnector' })
       expect(fetchJSON).toHaveBeenCalledWith(
         'GET',
-        '/registry?limit=200&versionsChannel=beta&latestChannelVersion=beta&filter[type]=konnectors'
+        '/registry?limit=200&versionsChannel=beta&latestChannelVersion=beta&filter[type]=konnector'
       )
     })
   })


### PR DESCRIPTION
I found a bit misleading the use of `options` in the signature function, which could suggest the parameters are optionnal ;)
