### PR TITLE
fix: Test if note

### DIFF
--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -22,10 +22,10 @@ export const isNote = file => {
     file.name.endsWith('.cozy-note') &&
     file.type === FILE_TYPE &&
     file.metadata &&
-    file.metadata.content &&
-    file.metadata.schema &&
-    file.metadata.title &&
-    file.metadata.version
+    file.metadata.content !== undefined &&
+    file.metadata.schema !== undefined &&
+    file.metadata.title !== undefined &&
+    file.metadata.version !== undefined
   )
     return true
   return false

--- a/packages/cozy-client/src/models/file.spec.js
+++ b/packages/cozy-client/src/models/file.spec.js
@@ -13,9 +13,20 @@ describe('File Model', () => {
         content: 'content',
         schema: [],
         title: 'title',
-        version: '0'
+        version: 1
       }
     }
     expect(file.isNote(note)).toBe(true)
+    const note2 = {
+      type: 'file',
+      name: 'test.cozy-note',
+      metadata: {
+        content: 'content',
+        schema: [],
+        title: '',
+        version: 0
+      }
+    }
+    expect(file.isNote(note2)).toBe(true)
   })
 })


### PR DESCRIPTION
My previous version was just checking if the attributes was existing, but since `version` is a number and not a string, if version === 0, then `(version && true) === false` 

