### PR TITLE
feat: Destroy all removes the _type from the document

### DIFF
--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -24,7 +24,8 @@ export function normalizeDoc(doc = {}, doctype) {
   return { id, _id: id, _type: doctype, ...doc }
 }
 
-const flagForDeletion = x => Object.assign({}, x, { _deleted: true })
+const prepareForDeletion = x =>
+  Object.assign({}, omit(x, '_type'), { _deleted: true })
 
 /**
  * Abstracts a collection of documents of the same doctype, providing CRUD methods and other helpers.
@@ -294,7 +295,7 @@ class DocumentCollection {
    * @param  {Document[]} docs - Documents to delete
    */
   destroyAll(docs) {
-    return this.updateAll(docs.map(flagForDeletion))
+    return this.updateAll(docs.map(prepareForDeletion))
   }
 
   async toMangoOptions(selector, options = {}) {

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -564,7 +564,7 @@ describe('DocumentCollection', () => {
     it('should do bulk delete', async () => {
       const { collection, client } = setup()
       await collection.destroyAll([
-        { _id: 1, name: 'Marge' },
+        { _id: 1, name: 'Marge', _type: 'io.cozy.simpsons' },
         { _id: 2, name: 'Homer' }
       ])
       expect(client.fetchJSON).toHaveBeenCalledWith(


### PR DESCRIPTION
Otherwise we have an error from the stack, since _type is a reserved
attribute