### PR TITLE
feat: Share a link with special permissions

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -63,6 +63,9 @@ through OAuth.</p>
 <dt><a href="#memoize">memoize()</a></dt>
 <dd><p>Memoize with maxDuration and custom key</p>
 </dd>
+<dt><a href="#getPermissionsFor">getPermissionsFor(document, publicLink, options)</a> ⇒ <code>object</code></dt>
+<dd><p>Build a permission set</p>
+</dd>
 <dt><a href="#getCozyURL">getCozyURL()</a></dt>
 <dd><p>Get a uniform formatted URL and SSL information according to a provided URL</p>
 </dd>
@@ -849,6 +852,7 @@ Implements `DocumentCollection` API along with specific methods for `io.cozy.per
 
 * [PermissionCollection](#PermissionCollection)
     * [.add(document, permission)](#PermissionCollection+add) ⇒ <code>Promise</code>
+    * [.createSharingLink(document, options)](#PermissionCollection+createSharingLink)
     * [.getOwnPermissions()](#PermissionCollection+getOwnPermissions) ⇒ <code>object</code>
 
 <a name="PermissionCollection+add"></a>
@@ -876,6 +880,19 @@ const permissions = await client
     }
  })
 ```
+<a name="PermissionCollection+createSharingLink"></a>
+
+### permissionCollection.createSharingLink(document, options)
+Create a share link
+
+**Kind**: instance method of [<code>PermissionCollection</code>](#PermissionCollection)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | <code>Object</code> | cozy document |
+| options | <code>object</code> | options |
+| options.verbs | <code>Array.&lt;string&gt;</code> | explicit permissions to use |
+
 <a name="PermissionCollection+getOwnPermissions"></a>
 
 ### permissionCollection.getOwnPermissions() ⇒ <code>object</code>
@@ -1071,6 +1088,21 @@ Delete outdated results from cache
 Memoize with maxDuration and custom key
 
 **Kind**: global function  
+<a name="getPermissionsFor"></a>
+
+## getPermissionsFor(document, publicLink, options) ⇒ <code>object</code>
+Build a permission set
+
+**Kind**: global function  
+**Returns**: <code>object</code> - permissions object that can be sent through /permissions/*  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| document | <code>Object</code> |  | cozy document |
+| publicLink | <code>boolean</code> | <code>false</code> | are the permissions for a public link ? |
+| options | <code>object</code> |  | options |
+| options.verbs | <code>Array.&lt;string&gt;</code> |  | explicit permissions to use |
+
 <a name="getCozyURL"></a>
 
 ## getCozyURL()

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -46,6 +46,9 @@ through OAuth.</p>
 <dt><a href="#dontThrowNotFoundError">dontThrowNotFoundError</a> ⇒ <code>object</code></dt>
 <dd><p>Handler for error response which return a empty value for &quot;not found&quot; error</p>
 </dd>
+<dt><a href="#getPermissionsFor">getPermissionsFor</a> ⇒ <code>object</code></dt>
+<dd><p>Build a permission set</p>
+</dd>
 </dl>
 
 ## Functions
@@ -62,9 +65,6 @@ through OAuth.</p>
 </dd>
 <dt><a href="#memoize">memoize()</a></dt>
 <dd><p>Memoize with maxDuration and custom key</p>
-</dd>
-<dt><a href="#getPermissionsFor">getPermissionsFor(document, publicLink, options)</a> ⇒ <code>object</code></dt>
-<dd><p>Build a permission set</p>
 </dd>
 <dt><a href="#getCozyURL">getCozyURL()</a></dt>
 <dd><p>Get a uniform formatted URL and SSL information according to a provided URL</p>
@@ -1060,6 +1060,21 @@ found" error.
 | error | <code>Error</code> |  |
 | data | <code>Array</code> \| <code>object</code> | Data to return in case of "not found" error |
 
+<a name="getPermissionsFor"></a>
+
+## getPermissionsFor ⇒ <code>object</code>
+Build a permission set
+
+**Kind**: global constant  
+**Returns**: <code>object</code> - permissions object that can be sent through /permissions/*  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | <code>Object</code> | cozy document |
+| publicLink | <code>boolean</code> | are the permissions for a public link ? |
+| options | <code>object</code> | options |
+| options.verbs | <code>Array.&lt;string&gt;</code> | explicit permissions to use |
+
 <a name="getAccessToken"></a>
 
 ## getAccessToken() ⇒ <code>string</code>
@@ -1088,21 +1103,6 @@ Delete outdated results from cache
 Memoize with maxDuration and custom key
 
 **Kind**: global function  
-<a name="getPermissionsFor"></a>
-
-## getPermissionsFor(document, publicLink, options) ⇒ <code>object</code>
-Build a permission set
-
-**Kind**: global function  
-**Returns**: <code>object</code> - permissions object that can be sent through /permissions/*  
-
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| document | <code>Object</code> |  | cozy document |
-| publicLink | <code>boolean</code> | <code>false</code> | are the permissions for a public link ? |
-| options | <code>object</code> |  | options |
-| options.verbs | <code>Array.&lt;string&gt;</code> |  | explicit permissions to use |
-
 <a name="getCozyURL"></a>
 
 ## getCozyURL()

--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -120,7 +120,11 @@ class PermissionCollection extends DocumentCollection {
         data: {
           type: 'io.cozy.permissions',
           attributes: {
-            permissions: getPermissionsFor(document, verbs ? { verbs } : true)
+            permissions: getPermissionsFor(
+              document,
+              true,
+              verbs ? { verbs } : {}
+            )
           }
         }
       }
@@ -160,9 +164,13 @@ class PermissionCollection extends DocumentCollection {
  * @param {string[]} options.verbs - explicit permissions to use
  * @returns {object} permissions object that can be sent through /permissions/*
  */
-const getPermissionsFor = (document, publicLink = false, options = {}) => {
+export const getPermissionsFor = (
+  document,
+  publicLink = false,
+  options = {}
+) => {
   const { _id, _type } = document
-  const verbs = options.verbs ? verbs : publicLink ? ['GET'] : ['ALL']
+  const verbs = options.verbs ? options.verbs : publicLink ? ['GET'] : ['ALL']
   // TODO: this works for albums, but it needs to be generalized and integrated
   // with cozy-client ; some sort of doctype "schema" will be needed here
   return isFile(document)

--- a/packages/cozy-stack-client/src/PermissionCollection.spec.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.spec.js
@@ -1,7 +1,7 @@
 jest.mock('./CozyStackClient')
 
 import CozyStackClient from './CozyStackClient'
-import PermissionCollection from './PermissionCollection'
+import PermissionCollection, { getPermissionsFor } from './PermissionCollection'
 
 const fixtures = {
   permission: {
@@ -105,5 +105,79 @@ describe('PermissionCollection', () => {
         )
       })
     })
+  })
+
+  describe('createSharingLink', () => {
+    it('Should be read-only by default', async () => {
+      const document = { _type: 'io.cozy.files', _id: '1234' }
+      await collection.createSharingLink(document)
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        '/permissions?codes=email',
+        {
+          data: {
+            type: 'io.cozy.permissions',
+            attributes: {
+              permissions: {
+                files: {
+                  type: 'io.cozy.files',
+                  verbs: ['GET'],
+                  values: [document._id]
+                }
+              }
+            }
+          }
+        }
+      )
+    })
+
+    it('Should use specific permissions when requested', async () => {
+      const document = { _type: 'io.cozy.files', _id: '1234' }
+      const verbs = ['GET', 'PATCH', 'PUT']
+      const options = { verbs }
+      await collection.createSharingLink(document, options)
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        '/permissions?codes=email',
+        {
+          data: {
+            type: 'io.cozy.permissions',
+            attributes: {
+              permissions: {
+                files: {
+                  type: 'io.cozy.files',
+                  verbs: verbs,
+                  values: [document._id]
+                }
+              }
+            }
+          }
+        }
+      )
+    })
+  })
+})
+
+describe('getPermissionsFor', () => {
+  it('Should give all permissions by default', () => {
+    const document = { _type: 'io.cozy.files', _id: '1234' }
+    const perms = getPermissionsFor(document, false)
+    expect(perms.files.verbs).toEqual(expect.arrayContaining(['ALL']))
+  })
+
+  it('Should give GET permissions for a link', () => {
+    const document = { _type: 'io.cozy.files', _id: '1234' }
+    const perms = getPermissionsFor(document, true)
+    expect(perms.files.verbs).toEqual(expect.arrayContaining(['GET']))
+  })
+
+  it('Should let one set the permissions it want', () => {
+    const document = { _type: 'io.cozy.files', _id: '1234' }
+    const verbs = ['GET', 'PATCH', 'PUT']
+    const options = { verbs }
+    const perms = getPermissionsFor(document, false, options)
+    expect(perms.files.verbs).toEqual(expect.arrayContaining(verbs))
+    const perms2 = getPermissionsFor(document, true, options)
+    expect(perms2.files.verbs).toEqual(expect.arrayContaining(verbs))
   })
 })


### PR DESCRIPTION
This will be useful for cozy-notes. We want links to accept PATCH and PUT so the recipient can edit the note.