### PR TITLE
feat(cozy-client): Add getStoreURL method to applications model

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -67,6 +67,9 @@ from a Cozy. <code>QueryDefinition</code>s are sent to links.</p>
 <dt><a href="#muteError">muteError</a> ⇒ <code>object</code></dt>
 <dd><p>muteError - Adds an error to the list of muted errors for the given account</p>
 </dd>
+<dt><a href="#getStoreURL">getStoreURL</a> ⇒ <code>string</code></dt>
+<dd><p>Returns the store URL of an app/konnector</p>
+</dd>
 <dt><a href="#getStoreInstallationURL">getStoreInstallationURL</a> ⇒ <code>string</code></dt>
 <dd><p>Returns the store URL to install/update an app/konnector</p>
 </dd>
@@ -1278,6 +1281,19 @@ muteError - Adds an error to the list of muted errors for the given account
 | --- | --- | --- |
 | account | <code>object</code> | io.cozy.accounts |
 | errorType | <code>string</code> | The type of the error to mute |
+
+<a name="getStoreURL"></a>
+
+## getStoreURL ⇒ <code>string</code>
+Returns the store URL of an app/konnector
+
+**Kind**: global constant  
+**Returns**: <code>string</code> - URL as string  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [appData] | <code>Array</code> | <code>[]</code> | Apps data, as returned by endpoint /apps/ or /konnectors |
+| [app] | <code>object</code> | <code>{}</code> | AppObject |
 
 <a name="getStoreInstallationURL"></a>
 

--- a/packages/cozy-client/src/models/applications.js
+++ b/packages/cozy-client/src/models/applications.js
@@ -2,14 +2,13 @@ import get from 'lodash/get'
 const STORE_SLUG = 'store'
 
 /**
- * Returns the store URL to install/update an app/konnector
+ * Returns the store URL of an app/konnector
  *
- * @param  {Array}  [appData=[]]   Apps data, as returned by endpoint /apps/ or
- * /konnectors/
- * @param  {object} [app={}] AppObject
- * @returns {string}                URL as string
+ * @param {Array} [appData=[]] Apps data, as returned by endpoint /apps/ or /konnectors
+ * @param {object} [app={}] AppObject
+ * @returns {string} URL as string
  */
-export const getStoreInstallationURL = (appData = [], app = {}) => {
+export const getStoreURL = (appData = [], app = {}) => {
   if (!app.slug) {
     throw new Error('Expected app / konnector with the defined slug')
   }
@@ -21,7 +20,25 @@ export const getStoreInstallationURL = (appData = [], app = {}) => {
 
   if (!storeUrl) return null
 
-  return `${storeUrl}#/discover/${app.slug}/install`
+  return `${storeUrl}#/discover/${app.slug}`
+}
+
+/**
+ * Returns the store URL to install/update an app/konnector
+ *
+ * @param  {Array}  [appData=[]]   Apps data, as returned by endpoint /apps/ or
+ * /konnectors/
+ * @param  {object} [app={}] AppObject
+ * @returns {string}                URL as string
+ */
+export const getStoreInstallationURL = (appData = [], app = {}) => {
+  const storeUrl = getStoreURL(appData, app)
+
+  if (!storeUrl) {
+    return null
+  }
+
+  return `${storeUrl}/install`
 }
 
 /**

--- a/packages/cozy-client/src/models/applications.spec.js
+++ b/packages/cozy-client/src/models/applications.spec.js
@@ -1,5 +1,5 @@
 import { applications } from './'
-const { getAppDisplayName } = applications
+const { getAppDisplayName, getStoreURL, getStoreInstallationURL } = applications
 
 describe('applications model', () => {
   describe('application name', () => {
@@ -79,6 +79,58 @@ describe('applications model', () => {
           lang
         )
       ).toBe('Test One')
+    })
+  })
+
+  describe('get store url', () => {
+    const contactsApp = { slug: 'contacts' }
+
+    describe('when the store app is not installed', () => {
+      it('should return null', () => {
+        expect(getStoreURL([], contactsApp)).toBe(null)
+      })
+    })
+
+    describe('when the store app is installed', () => {
+      it('should return the store url for the given app', () => {
+        const storeApp = {
+          attributes: {
+            slug: 'store'
+          },
+          links: {
+            related: 'http://store.cozy.tools:8080/'
+          }
+        }
+        expect(getStoreURL([storeApp], contactsApp)).toBe(
+          'http://store.cozy.tools:8080/#/discover/contacts'
+        )
+      })
+    })
+  })
+
+  describe('get store installation url', () => {
+    const contactsApp = { slug: 'contacts' }
+
+    describe('when the store app is not installed', () => {
+      it('should return null', () => {
+        expect(getStoreInstallationURL([], contactsApp)).toBe(null)
+      })
+    })
+
+    describe('when the store app is installed', () => {
+      it('should return the store installation url for the given app', () => {
+        const storeApp = {
+          attributes: {
+            slug: 'store'
+          },
+          links: {
+            related: 'http://store.cozy.tools:8080/'
+          }
+        }
+        expect(getStoreInstallationURL([storeApp], contactsApp)).toBe(
+          'http://store.cozy.tools:8080/#/discover/contacts/install'
+        )
+      })
     })
   })
 })


### PR DESCRIPTION
With getStoreInstallationURL, the user was redirected to the store page
with the permissions modal. We want to be able to redirect to the app's
store page and make the user click on the "install" button, otherwise he
may not know what he is going to install. The getStoreURL method returns
the app's root page. And getStoreInstallationURL now uses it to return
the installation URL.

Also added tests for both methods.

There's a discussion about unifying the behavior in places where we use getStoreInstallationURL and now getStoreURL. See https://mattermost.cozycloud.cc/cozycloud/pl/bhwaet9md7gifg3y9g1tqyzzby