### PR TITLE
fix: Correctly create interactive client from saved credentials

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -684,6 +684,7 @@ through OAuth.
 **Kind**: global class  
 
 * [OAuthClient](#OAuthClient)
+    * [.doRegistration()](#OAuthClient+doRegistration)
     * [.register()](#OAuthClient+register) ⇒ <code>promise</code>
     * [.unregister()](#OAuthClient+unregister) ⇒ <code>promise</code>
     * [.fetchInformation()](#OAuthClient+fetchInformation) ⇒ <code>promise</code>
@@ -697,10 +698,17 @@ through OAuth.
     * [.setOAuthOptions(options)](#OAuthClient+setOAuthOptions)
     * [.resetClient()](#OAuthClient+resetClient)
 
+<a name="OAuthClient+doRegistration"></a>
+
+### oAuthClient.doRegistration()
+Performs the HTTP call to register the client to the server
+
+**Kind**: instance method of [<code>OAuthClient</code>](#OAuthClient)  
 <a name="OAuthClient+register"></a>
 
 ### oAuthClient.register() ⇒ <code>promise</code>
-Registers the currenly configured client with the OAuth server.
+Registers the currenly configured client with the OAuth server and
+sets internal information from the server response
 
 **Kind**: instance method of [<code>OAuthClient</code>](#OAuthClient)  
 **Returns**: <code>promise</code> - A promise that resolves with a complete list of client information, including client ID and client secret.  

--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -31,6 +31,8 @@
   "devDependencies": {
     "@babel/cli": "7.6.2",
     "babel-plugin-search-and-replace": "1.0.1",
+    "btoa": "1.2.1",
+    "cozy-logger": "1.6.0",
     "mockdate": "^2.0.2",
     "react": "16.10.1",
     "server-destroy": "^1.0.1"

--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -32,7 +32,8 @@
     "@babel/cli": "7.6.2",
     "babel-plugin-search-and-replace": "1.0.1",
     "mockdate": "^2.0.2",
-    "react": "16.10.1"
+    "react": "16.10.1",
+    "server-destroy": "^1.0.1"
   },
   "peerDependencies": {
     "react": "^16.7.0"

--- a/packages/cozy-client/src/cli/index.js
+++ b/packages/cozy-client/src/cli/index.js
@@ -101,13 +101,17 @@ const DEFAULT_SERVER_OPTIONS = {
   }
 }
 
+const writeJSON = (fs, filename, data) => {
+  fs.writeFileSync(filename, JSON.stringify(data))
+}
+
 /**
  * Parses a JSON from a file
  * Returns null in case of error
  *
  * @private
  */
-const readJSON = filename => {
+const readJSON = (fs, filename) => {
   try {
     if (!fs.existsSync(filename)) {
       return null
@@ -143,6 +147,7 @@ const readJSON = filename => {
  */
 const createClientInteractive = (clientOptions, serverOpts) => {
   const serverOptions = merge(serverOpts, DEFAULT_SERVER_OPTIONS)
+  const createClientFS = serverOptions.fs || fs
 
   const mergedClientOptions = merge(
     {
@@ -155,8 +160,7 @@ const createClientInteractive = (clientOptions, serverOpts) => {
   )
   const getSavedCredentials = serverOptions.getSavedCredentials
   const savedCredentialsFilename = getSavedCredentials(mergedClientOptions)
-  const savedCredentials = readJSON(savedCredentialsFilename)
-
+  const savedCredentials = readJSON(createClientFS, savedCredentialsFilename)
   const client = new CozyClient(mergedClientOptions)
 
   if (savedCredentials) {
@@ -170,7 +174,8 @@ const createClientInteractive = (clientOptions, serverOpts) => {
     const resolveWithClient = () => {
       resolve(client)
       log('debug', `Saving credentials to ${savedCredentialsFilename}`)
-      fs.writeFileSync(
+      writeJSON(
+        createClientFS,
         savedCredentialsFilename,
         JSON.stringify(client.stackClient.token)
       )

--- a/packages/cozy-client/src/cli/index.js
+++ b/packages/cozy-client/src/cli/index.js
@@ -73,6 +73,19 @@ const mkServerFlowCallback = serverOptions => authenticationURL =>
     }, 30 * 1000)
   })
 
+const hashCode = function(str) {
+  var hash = 0,
+    i,
+    chr
+  if (str.length === 0) return hash
+  for (i = 0; i < str.length; i++) {
+    chr = str.charCodeAt(i)
+    hash = (hash << 5) - hash + chr
+    hash |= 0 // Convert to 32bit integer
+  }
+  return hash
+}
+
 const DEFAULT_SERVER_OPTIONS = {
   port: 3333,
   route: '/do_access',
@@ -80,10 +93,11 @@ const DEFAULT_SERVER_OPTIONS = {
     if (!clientOptions.oauth.softwareID) {
       throw new Error('Please provide oauth.softwareID in your clientOptions.')
     }
+    const doctypeHash = Math.abs(hashCode(JSON.stringify(clientOptions.scope)))
     const sluggedURI = clientOptions.uri
       .replace(/https?:\/\//, '')
       .replace(/\./g, '-')
-    return `/tmp/cozy-client-oauth-${sluggedURI}-${clientOptions.oauth.softwareID}.json`
+    return `/tmp/cozy-client-oauth-${sluggedURI}-${clientOptions.oauth.softwareID}-${doctypeHash}.json`
   }
 }
 

--- a/packages/cozy-client/src/cli/index.js
+++ b/packages/cozy-client/src/cli/index.js
@@ -165,7 +165,8 @@ const createClientInteractive = (clientOptions, serverOpts) => {
 
   if (savedCredentials) {
     log('debug', `Using saved credentials in ${savedCredentialsFilename}`)
-    client.stackClient.setToken(savedCredentials)
+    client.stackClient.setToken(savedCredentials.token)
+    client.stackClient.setOAuthOptions(savedCredentials.oauthOptions)
     return client
   }
 
@@ -174,11 +175,11 @@ const createClientInteractive = (clientOptions, serverOpts) => {
     const resolveWithClient = () => {
       resolve(client)
       log('debug', `Saving credentials to ${savedCredentialsFilename}`)
-      writeJSON(
-        createClientFS,
-        savedCredentialsFilename,
-        JSON.stringify(client.stackClient.token)
-      )
+
+      writeJSON(createClientFS, savedCredentialsFilename, {
+        oauthOptions: client.stackClient.oauthOptions,
+        token: client.stackClient.token
+      })
     }
     await client.startOAuthFlow(mkServerFlowCallback(serverOptions))
     resolveWithClient()

--- a/packages/cozy-client/src/cli/index.spec.js
+++ b/packages/cozy-client/src/cli/index.spec.js
@@ -1,0 +1,162 @@
+import http from 'http'
+import { createClientInteractive } from './index'
+import { OAuthClient } from 'cozy-stack-client'
+import opn from 'opn'
+import fetch from 'node-fetch'
+import { URL } from 'url'
+import logger from 'cozy-logger'
+
+logger.setLevel('error')
+
+jest.mock('opn', () => jest.fn())
+
+describe('createClientInteractive', () => {
+  let servers
+
+  const fs = {
+    existsSync: jest.fn().mockReturnValue(false),
+    readFileSync: jest.fn(() => null),
+    writeFileSync: jest.fn(() => null)
+  }
+
+  beforeEach(() => {
+    servers = []
+    const originalCreateServer = http.createServer
+
+    // Saves created server for destruction in afterEach
+    jest.spyOn(http, 'createServer').mockImplementation(function() {
+      const server = originalCreateServer.apply(this, arguments)
+      servers.push(server)
+      return server
+    })
+  })
+
+  afterEach(() => {
+    http.createServer.mockRestore()
+    servers.forEach(server => {
+      server.destroy()
+    })
+  })
+
+  beforeEach(() => {
+    jest.spyOn(OAuthClient.prototype, 'doRegistration').mockResolvedValue({
+      client_id: 'fake-client-id',
+      client_name: 'fake-client-name',
+      software_id: 'fake-software-id'
+    })
+    jest.spyOn(OAuthClient.prototype, 'fetchAccessToken').mockResolvedValue({
+      access_token: 'fake-access-token',
+      refresh_token: 'fake-refresh-token'
+    })
+  })
+
+  afterEach(() => {
+    OAuthClient.prototype.doRegistration.mockRestore()
+    OAuthClient.prototype.fetchAccessToken.mockRestore()
+  })
+
+  const setup = () => {
+    let clientPromise = createClientInteractive(
+      {
+        uri: 'http://cozy.tools:8080',
+        scope: ['io.cozy.bills'],
+        oauth: {
+          softwareID: 'fake-software-id',
+          clientURI: 'http://testcozy.mycozy.cloud',
+          softwareVersion: '1.1.0',
+          logoURI: 'http://my-logo.com/logo.jpg'
+        }
+      },
+      {
+        fs
+      }
+    )
+
+    // Override opn implementation so that we "click" on the "Authorize"
+    // button in the oauth authorization  page, continuing the OAuth flow
+    opn.mockImplementation(async openedUrl => {
+      const url = new URL(openedUrl)
+      const redirectURI = url.searchParams.get('redirect_uri')
+      const state = url.searchParams.get('state')
+      // Use opn call as a signal that the server has been started
+      await fetch(redirectURI + '?state=' + state)
+    })
+    return { clientPromise }
+  }
+
+  it('should create an oauth server, open a page and save credentials', async () => {
+    const { clientPromise } = setup()
+    const client = await clientPromise
+    expect(http.createServer).toHaveBeenCalled()
+    expect(client.stackClient.oauthOptions).toMatchObject({
+      clientID: 'fake-client-id',
+      clientName: 'fake-client-name',
+      clientURI: 'http://testcozy.mycozy.cloud',
+      redirectURI: 'http://localhost:3333/do_access',
+      softwareID: 'fake-software-id',
+      softwareVersion: '1.1.0'
+    })
+    expect(client.stackClient.token).toMatchObject({
+      accessToken: 'fake-access-token',
+      refreshToken: 'fake-refresh-token'
+    })
+    expect(fs.writeFileSync).toHaveBeenCalled()
+
+    expect(fs.writeFileSync.mock.calls[0][0]).toBe(
+      '/tmp/cozy-client-oauth-cozy-tools:8080-fake-software-id-208358843.json'
+    )
+    expect(JSON.parse(fs.writeFileSync.mock.calls[0][1])).toEqual({
+      oauthOptions: {
+        clientID: 'fake-client-id',
+        clientName: 'fake-client-name',
+        clientKind: '',
+        clientURI: 'http://testcozy.mycozy.cloud',
+        redirectURI: 'http://localhost:3333/do_access',
+        softwareID: 'fake-software-id',
+        softwareVersion: '1.1.0',
+        logoURI: 'http://my-logo.com/logo.jpg',
+        policyURI: '',
+        notificationPlatform: '',
+        notificationDeviceToken: ''
+      },
+      token: {
+        accessToken: 'fake-access-token',
+        refreshToken: 'fake-refresh-token'
+      }
+    })
+  })
+
+  it('should create a client from saved credentials', async () => {
+    fs.existsSync.mockReturnValue(true)
+    fs.readFileSync.mockReturnValue(
+      JSON.stringify({
+        token: {
+          accessToken: 'saved-access-token',
+          refreshToken: 'saved-refresh-token'
+        },
+        oauthOptions: {
+          clientName: 'fake-client-name',
+          clientURI: 'http://testcozy.mycozy.cloud',
+          redirectURI: 'http://localhost:3333/do_access',
+          softwareID: 'fake-software-id',
+          softwareVersion: '1.1.0',
+          clientID: 'client-1337'
+        }
+      })
+    )
+    const { clientPromise } = setup()
+    const client = await clientPromise
+    expect(http.createServer).not.toHaveBeenCalled()
+    expect(client.stackClient.token).toMatchObject({
+      accessToken: 'saved-access-token',
+      refreshToken: 'saved-refresh-token'
+    })
+    expect(client.stackClient.oauthOptions).toMatchObject({
+      clientName: 'fake-client-name',
+      clientURI: 'http://testcozy.mycozy.cloud',
+      redirectURI: 'http://localhost:3333/do_access',
+      softwareID: 'fake-software-id',
+      softwareVersion: '1.1.0'
+    })
+  })
+})

--- a/packages/cozy-client/src/cli/tester.js
+++ b/packages/cozy-client/src/cli/tester.js
@@ -1,0 +1,37 @@
+/* eslint-disable-file no-console */
+
+import { createClientInteractive } from '.'
+import { ArgumentParser } from 'argparse'
+
+const parseArgs = () => {
+  const parser = new ArgumentParser()
+  parser.addArgument('--url', {
+    description: 'HTTP URL of the targeted cozy',
+    defaultValue: 'http://cozy.tools:8080'
+  })
+  const args = parser.parseArgs()
+  return args
+}
+
+const main = async () => {
+  const args = parseArgs()
+  const client = await createClientInteractive({
+    uri: args.url,
+    scope: ['io.cozy.bank.operations'],
+    oauth: {
+      softwareID: 'fake-software-id',
+      clientURI: 'http://testcozy.mycozy.cloud',
+      softwareVersion: '1.1.0',
+      logoURI: 'http://my-logo.com/logo.jpg'
+    }
+  })
+  const { data: docs } = await client
+    .collection('io.cozy.bank.operations')
+    .all()
+  console.log(docs)
+}
+
+main().catch(e => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -111,8 +111,29 @@ class OAuthClient extends CozyStackClient {
     return result
   }
 
+  /** Performs the HTTP call to register the client to the server */
+  doRegistration() {
+    return this.fetchJSON(
+      'POST',
+      '/auth/register',
+      this.snakeCaseOAuthData({
+        redirectURI: this.oauthOptions.redirectURI,
+        clientName: this.oauthOptions.clientName,
+        softwareID: this.oauthOptions.softwareID,
+        clientKind: this.oauthOptions.clientKind,
+        clientURI: this.oauthOptions.clientURI,
+        logoURI: this.oauthOptions.logoURI,
+        policyURI: this.oauthOptions.policyURI,
+        softwareVersion: this.oauthOptions.softwareVersion,
+        notificationPlatform: this.oauthOptions.notificationPlatform,
+        notificationDeviceToken: this.oauthOptions.notificationDeviceToken
+      })
+    )
+  }
+
   /**
-   * Registers the currenly configured client with the OAuth server.
+   * Registers the currenly configured client with the OAuth server and
+   * sets internal information from the server response
    *
    * @throws {Error} When the client is already registered
    * @returns {promise} A promise that resolves with a complete list of client information, including client ID and client secret.
@@ -132,22 +153,7 @@ class OAuthClient extends CozyStackClient {
       )
     }
 
-    const data = await this.fetchJSON(
-      'POST',
-      '/auth/register',
-      this.snakeCaseOAuthData({
-        redirectURI: this.oauthOptions.redirectURI,
-        clientName: this.oauthOptions.clientName,
-        softwareID: this.oauthOptions.softwareID,
-        clientKind: this.oauthOptions.clientKind,
-        clientURI: this.oauthOptions.clientURI,
-        logoURI: this.oauthOptions.logoURI,
-        policyURI: this.oauthOptions.policyURI,
-        softwareVersion: this.oauthOptions.softwareVersion,
-        notificationPlatform: this.oauthOptions.notificationPlatform,
-        notificationDeviceToken: this.oauthOptions.notificationDeviceToken
-      })
-    )
+    const data = await this.doRegistration()
 
     this.setOAuthOptions({
       ...this.oauthOptions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11233,6 +11233,11 @@ serve-static@^1.12.4:
     parseurl "~1.3.2"
     send "0.16.2"
 
+server-destroy@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/server-destroy/-/server-destroy-1.0.1.tgz#f13bf928e42b9c3e79383e61cc3998b5d14e6cdd"
+  integrity sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3184,6 +3184,11 @@ btoa-lite@^1.0.0:
   resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
   integrity sha1-M3dm2hWAEhD92VbCLpxokaudAzc=
 
+btoa@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.2.1.tgz#01a9909f8b2c93f6bf680ba26131eb30f7fa3d73"
+  integrity sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==
+
 buffer-equal@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-0.0.1.tgz#91bc74b11ea405bc916bc6aa908faafa5b4aac4b"
@@ -4034,6 +4039,14 @@ cozy-device-helper@^1.7.3:
   integrity sha512-5L6QdsJYcE+UpKjJGL6Uk5Lc2sSpDS8KQTf7mvIVrd7IOg/UJIEp9rt1aHQnTRevGShe5ANkmGQmlTfI1uKzUg==
   dependencies:
     lodash "4.17.15"
+
+cozy-logger@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-logger/-/cozy-logger-1.6.0.tgz#51675e081e0a40baae6c38c64718cfaee5ee66ff"
+  integrity sha512-UkPR5lQDY6HldNv3N3c8HaxlfgcgAB/iRBFwJNFL2I17lhcM0u7w27vo1nuFeX6geMeFUjvedq/awawxZ1mTQg==
+  dependencies:
+    chalk "^2.4.2"
+    json-stringify-safe "5.0.1"
 
 create-ecdh@^4.0.0:
   version "4.0.3"
@@ -7456,7 +7469,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@5.0.1, json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=


### PR DESCRIPTION
- Fix: Only token was taken from the credentials, which was not sufficient, since
we also need the clientID. Now we save both the token and oauth information, and restore the client from both informations.
- Feat: Added hashed scope to the credentials filename so that we have no collision when changing doctypes
 
Added tests.