### PR TITLE
 feat: Use bookmark pagination for queryAll

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -1034,7 +1034,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 **Kind**: global class  
 
 * [QueryDefinition](#QueryDefinition)
-    * [new QueryDefinition(doctype, id, ids, selector, fields, indexedFields, sort, includes, referenced, limit, skip)](#new_QueryDefinition_new)
+    * [new QueryDefinition(doctype, id, ids, selector, fields, indexedFields, sort, includes, referenced, limit, skip, cursor, bookmark)](#new_QueryDefinition_new)
     * [.getById(id)](#QueryDefinition+getById) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
     * [.getByIds(ids)](#QueryDefinition+getByIds) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
     * [.where(selector)](#QueryDefinition+where) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
@@ -1045,11 +1045,12 @@ from a Cozy. `QueryDefinition`s are sent to links.
     * [.limitBy(limit)](#QueryDefinition+limitBy) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
     * [.offset(skip)](#QueryDefinition+offset) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
     * [.offsetCursor(cursor)](#QueryDefinition+offsetCursor) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
+    * [.offsetBookmark()](#QueryDefinition+offsetBookmark)
     * [.referencedBy(document)](#QueryDefinition+referencedBy) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
 
 <a name="new_QueryDefinition_new"></a>
 
-### new QueryDefinition(doctype, id, ids, selector, fields, indexedFields, sort, includes, referenced, limit, skip)
+### new QueryDefinition(doctype, id, ids, selector, fields, indexedFields, sort, includes, referenced, limit, skip, cursor, bookmark)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1064,6 +1065,8 @@ from a Cozy. `QueryDefinition`s are sent to links.
 | referenced | <code>string</code> | The referenced document. |
 | limit | <code>number</code> | The document's limit to return. |
 | skip | <code>number</code> | The number of docs to skip. |
+| cursor | <code>number</code> | The cursor to paginate views. |
+| bookmark | <code>number</code> | The bookmark to paginate mango queries. |
 
 <a name="QueryDefinition+getById"></a>
 
@@ -1195,6 +1198,15 @@ Use the last docid of each query as startkey_docid to paginate or leave blank fo
 | --- | --- | --- |
 | cursor | <code>Array</code> | The cursor for pagination. |
 
+<a name="QueryDefinition+offsetBookmark"></a>
+
+### queryDefinition.offsetBookmark()
+Use [bookmark](https://docs.couchdb.org/en/2.2.0/api/database/find.html#pagination) pagination.
+Note this only applies for mango-queries (not views) and is way more efficient than skip pagination.
+The bookmark is a string returned by the _find response and can be seen as a pointer in
+the index for the next query.
+
+**Kind**: instance method of [<code>QueryDefinition</code>](#QueryDefinition)  
 <a name="QueryDefinition+referencedBy"></a>
 
 ### queryDefinition.referencedBy(document) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)

--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -1045,7 +1045,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
     * [.limitBy(limit)](#QueryDefinition+limitBy) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
     * [.offset(skip)](#QueryDefinition+offset) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
     * [.offsetCursor(cursor)](#QueryDefinition+offsetCursor) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
-    * [.offsetBookmark()](#QueryDefinition+offsetBookmark)
+    * [.offsetBookmark(bookmark)](#QueryDefinition+offsetBookmark) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
     * [.referencedBy(document)](#QueryDefinition+referencedBy) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
 
 <a name="new_QueryDefinition_new"></a>
@@ -1200,13 +1200,19 @@ Use the last docid of each query as startkey_docid to paginate or leave blank fo
 
 <a name="QueryDefinition+offsetBookmark"></a>
 
-### queryDefinition.offsetBookmark()
+### queryDefinition.offsetBookmark(bookmark) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
 Use [bookmark](https://docs.couchdb.org/en/2.2.0/api/database/find.html#pagination) pagination.
 Note this only applies for mango-queries (not views) and is way more efficient than skip pagination.
 The bookmark is a string returned by the _find response and can be seen as a pointer in
 the index for the next query.
 
 **Kind**: instance method of [<code>QueryDefinition</code>](#QueryDefinition)  
+**Returns**: [<code>QueryDefinition</code>](#QueryDefinition) - The QueryDefinition object.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| bookmark | <code>string</code> | The bookmark to continue a previous paginated query. |
+
 <a name="QueryDefinition+referencedBy"></a>
 
 ### queryDefinition.referencedBy(document) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)

--- a/packages/cozy-client/examples/perfs.js
+++ b/packages/cozy-client/examples/perfs.js
@@ -1,0 +1,116 @@
+const { QueryDefinition, default: CozyClient } = require('../dist')
+global.fetch = require('node-fetch') // in the browser we have native fetch
+
+let client = {}
+
+const schema = {
+  contacts: {
+    doctype: 'io.cozy.contacts'
+  }
+}
+
+const createContactsBulk = async count => {
+  const contacts = []
+  for (let i = 0; i < count; i++) {
+    const familyName = `Fake${i}`
+    const givenName = `Faky${i}`
+    const address = `${familyName}@${givenName}.com`
+    const contact = {
+      name: { familyName, givenName },
+      email: [{ address }]
+    }
+    contacts.push(contact)
+  }
+  await client.stackClient.collection('io.cozy.contacts').updateAll(contacts)
+}
+
+const deleteAllContactsBulk = async () => {
+  const contacts = await getAllContacts()
+  await client.stackClient.collection('io.cozy.contacts').destroyAll(contacts)
+}
+
+const getAllContacts = async () => {
+  const query = new QueryDefinition({
+    doctype: 'io.cozy.contacts',
+    limit: null
+  })
+  const resp = await client.query(query)
+  return resp.data
+}
+
+const getAllContactsSkip = async () => {
+  const query = new QueryDefinition({
+    doctype: 'io.cozy.contacts',
+    limit: 100
+  })
+  const contacts = []
+  let resp = { next: true }
+
+  while (resp && resp.next) {
+    resp = await client.query(query.offset(contacts.length), {
+      as: 'skip-query'
+    })
+    contacts.push(...resp.data)
+  }
+  return contacts
+}
+
+const getAllContactsBookmark = async () => {
+  const query = new QueryDefinition({
+    doctype: 'io.cozy.contacts',
+    limit: 100
+  })
+  const contacts = await client.queryAll(query, { as: 'bookmark-query' })
+  return contacts
+}
+
+/**
+ * Measure query performances
+ *
+ * The given performances were made on a i7-8550U CPU, with a CouchDB locally installed.
+ *
+ * Execution time taken for:
+ *
+ * - 1 000 docs:
+ *   - no pagination: ~108 ms
+ *   - skip pagination: ~1 429 ms
+ *   - bookmark pagination: ~563 ms
+ *
+ * - 10 000 docs:
+ *   - no pagination: ~932 ms
+ *   - skip pagination: ~165 741ms
+ *   - bookmark pagination: ~7 850 ms
+ */
+const main = async _args => {
+  const uri = process.env.COZY_URL || 'http://cozy.tools:8080'
+  const token = process.env.COZY_TOKEN
+  if (!token) {
+    throw new Error('You should provide COZY_TOKEN as an environement variable')
+  }
+  client = new CozyClient({ uri, token, schema })
+
+  const count = 10000
+
+  await deleteAllContactsBulk()
+  await createContactsBulk(count)
+  // reset store to avoid side effects from previous queries
+  client.store = null
+
+  console.time(count + ' contacts no pagination')
+  await getAllContacts()
+  console.timeEnd(count + ' contacts no pagination')
+
+  client.store = null
+
+  console.time(count + ' contacts skip')
+  await getAllContactsSkip()
+  console.timeEnd(count + ' contacts skip')
+
+  client.store = null
+
+  console.time(count + ' contacts bookmark')
+  await getAllContactsBookmark()
+  console.timeEnd(count + ' contacts bookmark')
+}
+
+main(process.argv).catch(e => console.error(e))

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -597,7 +597,10 @@ class CozyClient {
     let resp = { next: true }
 
     while (resp && resp.next) {
-      resp = await this.query(queryDefinition.offset(documents.length), options)
+      resp = await this.query(
+        queryDefinition.offsetBookmark(resp.bookmark),
+        options
+      )
       documents.push(...resp.data)
     }
 

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -18,6 +18,8 @@ class QueryDefinition {
    * @param {string} referenced - The referenced document.
    * @param {number} limit - The document's limit to return.
    * @param {number} skip - The number of docs to skip.
+   * @param {number} cursor - The cursor to paginate views.
+   * @param {number} bookmark - The bookmark to paginate mango queries.
    */
   constructor({
     doctype,
@@ -31,7 +33,8 @@ class QueryDefinition {
     referenced,
     limit,
     skip,
-    cursor
+    cursor,
+    bookmark
   } = {}) {
     this.doctype = doctype
     this.id = id
@@ -45,6 +48,7 @@ class QueryDefinition {
     this.limit = limit
     this.skip = skip
     this.cursor = cursor
+    this.bookmark = bookmark
   }
 
   /**
@@ -170,6 +174,19 @@ class QueryDefinition {
   }
 
   /**
+   * Use [bookmark](https://docs.couchdb.org/en/2.2.0/api/database/find.html#pagination) pagination.
+   * Note this only applies for mango-queries (not views) and is way more efficient than skip pagination.
+   * The bookmark is a string returned by the _find response and can be seen as a pointer in
+   * the index for the next query.
+   *
+   * @param {string} bookmark The bookmark to continue a previous paginated query.
+   * @returns {QueryDefinition}  The QueryDefinition object.
+   */
+  offsetBookmark(bookmark) {
+    return new QueryDefinition({ ...this.toDefinition(), bookmark })
+  }
+
+  /**
    * Use the [file reference system](https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/)
    *
    * @param {object} document The reference document
@@ -192,7 +209,8 @@ class QueryDefinition {
       referenced: this.referenced,
       limit: this.limit,
       skip: this.skip,
-      cursor: this.cursor
+      cursor: this.cursor,
+      bookmark: this.bookmark
     }
   }
 }

--- a/packages/cozy-client/src/store/__snapshots__/queries.spec.js.snap
+++ b/packages/cozy-client/src/store/__snapshots__/queries.spec.js.snap
@@ -6,6 +6,7 @@ Object {
     "count": 0,
     "data": Array [],
     "definition": QueryDefinition {
+      "bookmark": undefined,
       "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
@@ -38,6 +39,7 @@ Object {
       "67890",
     ],
     "definition": QueryDefinition {
+      "bookmark": undefined,
       "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
@@ -69,6 +71,7 @@ Object {
       "54321",
     ],
     "definition": QueryDefinition {
+      "bookmark": undefined,
       "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
@@ -95,6 +98,7 @@ Object {
       "54321",
     ],
     "definition": QueryDefinition {
+      "bookmark": undefined,
       "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
@@ -131,6 +135,7 @@ Object {
       "54321",
     ],
     "definition": QueryDefinition {
+      "bookmark": undefined,
       "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
@@ -157,6 +162,7 @@ Object {
       "54321",
     ],
     "definition": QueryDefinition {
+      "bookmark": undefined,
       "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
@@ -191,6 +197,7 @@ Object {
       "67890",
     ],
     "definition": QueryDefinition {
+      "bookmark": undefined,
       "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
@@ -218,6 +225,7 @@ Object {
       "67890",
     ],
     "definition": QueryDefinition {
+      "bookmark": undefined,
       "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
@@ -247,6 +255,7 @@ Object {
     "count": 0,
     "data": Array [],
     "definition": QueryDefinition {
+      "bookmark": undefined,
       "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
@@ -271,6 +280,7 @@ Object {
     "count": 0,
     "data": Array [],
     "definition": QueryDefinition {
+      "bookmark": undefined,
       "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
@@ -302,6 +312,7 @@ Object {
       "54321",
     ],
     "definition": QueryDefinition {
+      "bookmark": undefined,
       "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,
@@ -326,6 +337,7 @@ Object {
     "count": 0,
     "data": Array [],
     "definition": QueryDefinition {
+      "bookmark": undefined,
       "cursor": undefined,
       "doctype": "io.cozy.todos",
       "fields": undefined,

--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -1,7 +1,7 @@
 import mapValues from 'lodash/mapValues'
-import union from 'lodash/union'
 import difference from 'lodash/difference'
 import intersection from 'lodash/intersection'
+import concat from 'lodash/concat'
 import isPlainObject from 'lodash/isPlainObject'
 
 import { getDocumentFromSlice } from './documents'
@@ -141,8 +141,10 @@ const updateData = (query, newData) => {
   const toUpdate = intersection(originalIds, matchedIds)
 
   const changed = toRemove.length || toAdd.length || toUpdate.length
-
-  const updatedData = difference(union(originalIds, toAdd), toRemove)
+  // concat doesn't check duplicates (contrarily to union), which is ok as
+  // toAdd does not contain any id present in originalIds, by construction.
+  // It is also faster than union.
+  const updatedData = difference(concat(originalIds, toAdd), toRemove)
 
   return {
     ...query,


### PR DESCRIPTION
This enables [bookmark pagination](https://docs.couchdb.org/en/2.2.0/api/database/find.html#pagination) for "all" documents queries (the "find" queries will come afterwards).

It also adds a performance example, with some measures:
- 1 000 docs:
    - no pagination: ~108 ms
    - skip pagination: ~1 429 ms
    - bookmark pagination: ~563 ms
 
- 10 000 docs:
  - no pagination: ~932 ms
  - skip pagination: ~165 741ms
  - bookmark pagination: ~7 850 ms