### PR TITLE
fix: Mute trigger errors without success

### DIFF
--- a/packages/cozy-client/src/models/trigger.js
+++ b/packages/cozy-client/src/models/trigger.js
@@ -74,7 +74,7 @@ const triggers = {
     const isErrorMuted = mutedErrors.some(mutedError => {
       return (
         mutedError.type === lastErrorType &&
-        new Date(mutedError.mutedAt) > lastSuccessDate
+        (!lastSuccess || new Date(mutedError.mutedAt) > lastSuccessDate)
       )
     })
 

--- a/packages/cozy-client/src/models/trigger.spec.js
+++ b/packages/cozy-client/src/models/trigger.spec.js
@@ -191,13 +191,13 @@ describe('trigger model', () => {
         mutedErrors: [
           {
             type: 'LOGIN_FAILED',
-            mutedAt: '2010-09-01T00:00' // muted before the last_success in the trigger
+            mutedAt: '2010-09-01T00:00'
           }
         ]
       }
       expect(
         triggerModel.isLatestErrorMuted(triggerWithNoSuccess, account)
-      ).toBe(false)
+      ).toBe(true)
     })
   })
 })


### PR DESCRIPTION
There was a straight up mistake in one of the tests, which means an error that is muted for a trigger that has no last success date was still being displayed.