### PR TITLE
feat: Deprecate client.all in favor of Q

### DIFF
--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -227,7 +227,8 @@ be fetched and false otherwise. It is important to name the query with `as` when
 otherwise query data cannot be shared across components.
 
 ```jsx
-const query = client => client.all('io.cozy.todos')
+import { Q } from 'cozy-client'
+const query = () => Q('io.cozy.todos')
 
 // io.cozy.todos will not be refetched if there are already io.cozy.todos
 // in the store and the data is fresh (updated less than 30s ago). 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "lint": "eslint 'packages/*/src/**/*.{js,jsx}' 'packages/*/examples/**/*.{js,jsx}'",
-    "test": "jest --verbose",
+    "test": "jest",
     "watch": "lerna run watch --parallel",
     "build": "lerna run build",
     "commitmsg": "commitlint -e $GIT_PARAMS",

--- a/packages/cozy-client/codemods/use-q.js
+++ b/packages/cozy-client/codemods/use-q.js
@@ -1,0 +1,27 @@
+import makeUtils from 'cozy-ui/codemods/utils'
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift
+  const root = j(file.source)
+  const utils = makeUtils(j)
+
+  const clientAllExpressions = root.find(j.CallExpression, {
+    callee: { object: { name: 'client' }, property: { name: 'all' } }
+  })
+
+  clientAllExpressions.forEach(path => {
+    path.node.callee = 'Q'
+  })
+
+  if (clientAllExpressions.length > 0) {
+    utils.imports.add(
+      root,
+      {
+        Q: true
+      },
+      'cozy-client'
+    )
+  }
+
+  return root.toSource()
+}

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -7,7 +7,7 @@ import {
   attachRelationships
 } from './associations/helpers'
 import { dehydrate } from './helpers'
-import { QueryDefinition, Mutations } from './queries/dsl'
+import { QueryDefinition, Mutations, Q } from './queries/dsl'
 import CozyStackClient, { OAuthClient } from 'cozy-stack-client'
 import { authenticateWithCordova } from './authentication/mobile'
 import optimizeQueryDefinitions from './queries/optimize'
@@ -350,7 +350,12 @@ class CozyClient {
   }
 
   all(doctype) {
-    return new QueryDefinition({ doctype })
+    console.warn(`
+client.all is deprecated, prefer to use the Q helper to build a new QueryDefinition.
+
+import { Q } from 'cozy-client'
+client.query(Q('io.cozy.bills'))`)
+    return Q(doctype)
   }
 
   find(doctype, selector = undefined) {

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -28,6 +28,8 @@ import {
 import { HasManyFiles, Association, HasMany } from './associations'
 import mapValues from 'lodash/mapValues'
 
+import { Q } from 'cozy-client'
+
 const normalizeData = data =>
   mapValues(data, (docs, doctype) => {
     return docs.map(doc => ({
@@ -449,7 +451,7 @@ describe('CozyClient', () => {
 
   describe('all', () => {
     it('should return a QueryDefinition', () => {
-      expect(client.all('io.cozy.todos')).toEqual({ doctype: 'io.cozy.todos' })
+      expect(Q('io.cozy.todos')).toEqual({ doctype: 'io.cozy.todos' })
     })
   })
 
@@ -843,7 +845,7 @@ describe('CozyClient', () => {
   describe('query', () => {
     let query, fakeResponse
     beforeEach(() => {
-      query = client.all('io.cozy.todos')
+      query = Q('io.cozy.todos')
       fakeResponse = { data: 'FAKE!!!' }
     })
 
@@ -908,7 +910,7 @@ describe('CozyClient', () => {
         .mockReturnValueOnce(Promise.resolve({ data: [], included: [] }))
 
       const resp = await client.query(
-        client.all('io.cozy.todos').include(['attachments'])
+        Q('io.cozy.todos').include(['attachments'])
       )
 
       expect(requestHandler).toHaveBeenCalledTimes(4)
@@ -954,7 +956,7 @@ describe('CozyClient', () => {
     let query
 
     beforeEach(() => {
-      query = client.all('io.cozy.todos')
+      query = Q('io.cozy.todos')
     })
 
     afterEach(() => {

--- a/packages/cozy-client/src/__tests__/ObservableQuery.spec.js
+++ b/packages/cozy-client/src/__tests__/ObservableQuery.spec.js
@@ -8,6 +8,8 @@ import { queryResultFromData } from './utils'
 import { SCHEMA, TODO_1, TODO_2 } from './fixtures'
 import omit from 'lodash/omit'
 
+import { Q } from 'cozy-client'
+
 const AUTHORS = [
   {
     _id: 1234,
@@ -34,7 +36,7 @@ describe('ObservableQuery', () => {
 
   describe('notifications', () => {
     const setup = async () => {
-      const def = client.all('io.cozy.todos')
+      const def = Q('io.cozy.todos')
       const observer = jest.fn()
       const query = new ObservableQuery('allTodos', def, client)
       jest.spyOn(query, 'subscribeToStore')
@@ -75,7 +77,7 @@ describe('ObservableQuery', () => {
 
   describe('fetch', () => {
     let query
-    const def = client.all('io.cozy.todos')
+    const def = Q('io.cozy.todos')
     const observer = jest.fn()
 
     beforeEach(async () => {
@@ -103,7 +105,7 @@ describe('ObservableQuery', () => {
     let query
 
     it('should be able to return its results', async () => {
-      const def = client.all('io.cozy.todos')
+      const def = Q('io.cozy.todos')
       await store.dispatch(initQuery('allTodos', def))
       query = new ObservableQuery('allTodos', def, client)
       await store.dispatch(

--- a/packages/cozy-client/src/__tests__/StackLink.spec.js
+++ b/packages/cozy-client/src/__tests__/StackLink.spec.js
@@ -3,6 +3,8 @@ import StackLink from '../StackLink'
 
 import { SCHEMA } from './fixtures'
 
+import { Q } from 'cozy-client'
+
 describe('StackLink', () => {
   let stackClient, link, client
 
@@ -14,7 +16,7 @@ describe('StackLink', () => {
 
   describe('query execution', () => {
     it('should execute queries without a selector', async () => {
-      const query = client.all('io.cozy.todos')
+      const query = Q('io.cozy.todos')
       stackClient.collection().all.mockReset()
       await link.request(query)
       expect(stackClient.collection().all).toHaveBeenCalled()
@@ -32,7 +34,7 @@ describe('StackLink', () => {
     })
 
     it('should use find if a sort option is given', async () => {
-      const query = client.all('io.cozy.todos').sortBy([{ name: 'asc' }])
+      const query = Q('io.cozy.todos').sortBy([{ name: 'asc' }])
       stackClient.collection().find.mockReset()
       await link.request(query)
       expect(stackClient.collection().find).toHaveBeenCalled()
@@ -40,7 +42,7 @@ describe('StackLink', () => {
     })
 
     it('should use all if a no sort option is given', async () => {
-      const query = client.all('io.cozy.todos')
+      const query = Q('io.cozy.todos')
       stackClient.collection().all.mockReset()
       await link.request(query)
       expect(stackClient.collection().all).toHaveBeenCalled()

--- a/packages/cozy-client/src/__tests__/connect.spec.jsx
+++ b/packages/cozy-client/src/__tests__/connect.spec.jsx
@@ -10,6 +10,8 @@ import { getQueryFromState, initQuery } from '../store'
 
 import { TODO_1, TODO_2, TODO_3 } from './fixtures'
 
+import { Q } from 'cozy-client'
+
 beforeEach(() => {
   jest.spyOn(console, 'warn').mockImplementation(() => {})
 })
@@ -27,7 +29,7 @@ describe('connect', () => {
     const store = configureMockStore()({})
     client.setStore(store, { force: true })
     const Foo = () => <div>Foo</div>
-    const query = client.all('io.cozy.todos')
+    const query = Q('io.cozy.todos')
     const ConnectedFoo = connect(
       query,
       { as: 'allTodos' }
@@ -68,7 +70,7 @@ describe('connect', () => {
         </ul>
       )
 
-    const query = client.all('io.cozy.todos')
+    const query = Q('io.cozy.todos')
     const ConnectedTodoList = connect(
       query,
       { as: 'allTodos' }

--- a/packages/cozy-client/src/associations/HasManyTriggers.js
+++ b/packages/cozy-client/src/associations/HasManyTriggers.js
@@ -1,5 +1,7 @@
 import HasMany from './HasMany'
 
+import { Q } from 'cozy-client'
+
 const TRIGGERS_DOCTYPE = 'io.cozy.triggers'
 
 /**
@@ -18,7 +20,7 @@ class HasManyTriggers extends HasMany {
    * `message.konnector` attribute
    */
   static query(doc, client) {
-    return client.all(TRIGGERS_DOCTYPE).where({ worker: 'konnector' })
+    return Q(TRIGGERS_DOCTYPE).where({ worker: 'konnector' })
   }
 }
 

--- a/packages/cozy-client/src/hoc.spec.js
+++ b/packages/cozy-client/src/hoc.spec.js
@@ -3,6 +3,8 @@ import { mount } from 'enzyme'
 import { withClient, queryConnect } from './hoc'
 import * as mocks from './__tests__/mocks'
 
+import { Q } from 'cozy-client'
+
 beforeEach(() => {
   jest.spyOn(console, 'warn').mockImplementation(() => {})
 })
@@ -53,8 +55,8 @@ describe('queryConnect', () => {
     })
 
     const WithQueries = queryConnect({
-      toto: { query: client => client.all('io.cozy.toto') },
-      tata: { query: client => client.all('io.cozy.tata') }
+      toto: { query: client => Q('io.cozy.toto') },
+      tata: { query: client => Q('io.cozy.tata') }
     })(Component)
 
     return { WithQueries, client }

--- a/packages/cozy-client/src/mock.js
+++ b/packages/cozy-client/src/mock.js
@@ -2,12 +2,11 @@ import CozyClient from './CozyClient'
 import { receiveQueryResult, initQuery } from './store'
 import { normalizeDoc } from 'cozy-stack-client'
 
+import { Q } from 'cozy-client'
+
 const fillQueryInsideClient = (client, queryName, queryOptions) => {
   client.store.dispatch(
-    initQuery(
-      queryName,
-      queryOptions.definition || client.all(queryOptions.doctype)
-    )
+    initQuery(queryName, queryOptions.definition || Q(queryOptions.doctype))
   )
   client.store.dispatch(
     receiveQueryResult(queryName, {

--- a/packages/cozy-client/src/mock.spec.js
+++ b/packages/cozy-client/src/mock.spec.js
@@ -1,5 +1,7 @@
 import { createMockClient } from './mock'
 
+import { Q } from 'cozy-client'
+
 describe('createMockClient', () => {
   const simpsonsFixture = [
     { _id: 'homer', name: 'Homer' },
@@ -30,7 +32,7 @@ describe('createMockClient', () => {
         'io.cozy.simpsons': simpsonsFixture
       }
     })
-    const simpsons = await client.query(client.all('io.cozy.simpsons'))
+    const simpsons = await client.query(Q('io.cozy.simpsons'))
     await expect(simpsons.data.map(x => x._id)).toEqual(['homer', 'marge'])
   })
 
@@ -40,7 +42,7 @@ describe('createMockClient', () => {
         'io.cozy.simpsons': simpsonsFixture
       }
     })
-    const simpsons = await client.query(client.all('io.cozy.adams'))
+    const simpsons = await client.query(Q('io.cozy.adams'))
     await expect(simpsons.data.map(x => x._id)).toEqual([])
   })
 })

--- a/packages/cozy-client/src/node.js
+++ b/packages/cozy-client/src/node.js
@@ -6,7 +6,8 @@ export {
   QueryDefinition,
   Mutations,
   MutationTypes,
-  getDoctypeFromOperation
+  getDoctypeFromOperation,
+  Q
 } from './queries/dsl'
 export {
   Association,

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -133,7 +133,7 @@ describe('CozyPouchLink', () => {
     })
   })
 
-  describe('mutations', async () => {
+  describe('mutations', () => {
     it('should be possible to save a new document', async () => {
       await setup()
       link.pouches.isSynced = jest.fn().mockReturnValue(true)
@@ -169,7 +169,7 @@ describe('CozyPouchLink', () => {
     })
   })
 
-  describe('reset', async () => {
+  describe('reset', () => {
     let spy
 
     afterEach(async () => {

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -6,6 +6,8 @@ import { SCHEMA, TODO_1, TODO_2, TODO_3, TODO_4 } from './__tests__/fixtures'
 import PouchDB from 'pouchdb-browser'
 import PouchDBMemoryAdapterPlugin from 'pouchdb-adapter-memory'
 
+import { Q } from 'cozy-client'
+
 // Necessary to have the memory adapter for the tests since neither
 // IndexedDB nor WebSQL adapter can be used in Jest
 PouchDB.plugin(PouchDBMemoryAdapterPlugin)
@@ -55,7 +57,7 @@ describe('CozyPouchLink', () => {
   describe('request handling', () => {
     it('should check if the doctype is supported and forward if not', async () => {
       await setup()
-      const query = client.all('io.cozy.rockets')
+      const query = Q('io.cozy.rockets')
       await link.request(query, null, () => {
         expect(true).toBe(true)
         return Promise.resolve()
@@ -64,7 +66,7 @@ describe('CozyPouchLink', () => {
 
     it('should check if the pouch is synced and forward if not', async () => {
       await setup()
-      const query = client.all(TODO_DOCTYPE)
+      const query = Q(TODO_DOCTYPE)
       expect.assertions(1)
       await link.request(query, null, () => {
         expect(true).toBe(true)
@@ -82,7 +84,7 @@ describe('CozyPouchLink', () => {
         label: 'Make PouchDB link work',
         done: false
       })
-      const query = client.all(TODO_DOCTYPE)
+      const query = Q(TODO_DOCTYPE)
       const docs = await link.request(query)
       expect(docs.data.length).toBe(1)
     })

--- a/packages/cozy-pouch-link/src/mango.spec.js
+++ b/packages/cozy-pouch-link/src/mango.spec.js
@@ -1,17 +1,10 @@
-import CozyClient from 'cozy-client'
+import { Q } from 'cozy-client'
 
 import { getIndexFields } from './mango'
-import { SCHEMA } from './__tests__/fixtures'
 
 describe('mango utils', () => {
-  const client = new CozyClient({
-    schema: SCHEMA
-  })
-
   it('should be able to get the fields from the selector', () => {
-    const query = client
-      .all('io.cozy.rockets')
-      .sortBy([{ label: true }, { _id: true }])
+    const query = Q('io.cozy.rockets').sortBy([{ label: true }, { _id: true }])
     const fields = getIndexFields(query)
     expect(fields).toEqual(['_id', 'label'])
   })

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -480,9 +480,13 @@ describe('FileCollection', () => {
       })
     })
   })
+
   describe('download', () => {
     beforeEach(() => {
       client.fetchJSON.mockResolvedValue({
+        links: {
+          related: 'http://downloadable-link'
+        },
         data: {}
       })
     })
@@ -496,7 +500,7 @@ describe('FileCollection', () => {
         _id: '42',
         name: 'fileName'
       }
-      collection.download(file)
+      await collection.download(file)
       const expectPath = `/files/downloads?Id=${file._id}&Filename=${file.name}`
       expect(client.fetchJSON).toHaveBeenCalledWith('POST', expectPath)
     })
@@ -506,7 +510,7 @@ describe('FileCollection', () => {
         _id: '42',
         name: 'fileName'
       }
-      collection.download(file, '123')
+      await collection.download(file, '123')
       const expectPath = `/files/downloads?VersionId=123&Filename=${file.name}`
       expect(client.fetchJSON).toHaveBeenCalledWith('POST', expectPath)
     })
@@ -516,11 +520,12 @@ describe('FileCollection', () => {
         _id: '42',
         name: 'fileName'
       }
-      collection.download(file, '123', 'myFileName')
+      await collection.download(file, '123', 'myFileName')
       const expectPath = `/files/downloads?VersionId=123&Filename=myFileName`
       expect(client.fetchJSON).toHaveBeenCalledWith('POST', expectPath)
     })
   })
+
   describe('createFile', () => {
     const data = new File([''], 'mydoc.epub')
     const id = '59140416-b95f'
@@ -601,6 +606,7 @@ describe('FileCollection', () => {
       })
     })
   })
+
   describe('isChild', () => {
     beforeEach(() => {
       client.fetchJSON


### PR DESCRIPTION
- all is a bad name since it implies in the mind of the developer
  that no pagination is done (whereas pagination is automatic
  when using queries built with all)
- Q does the same as client.all but does not necessitate a client
  (since no client is necessary to build a queryDefinition)
- Add a codemod to transform client.all into Q (and add the import
  if necessary)