### PR TITLE
test: Increase timeout for pouch

### DIFF
--- a/packages/cozy-pouch-link/src/helpers.spec.js
+++ b/packages/cozy-pouch-link/src/helpers.spec.js
@@ -24,6 +24,7 @@ describe('Helpers', () => {
         rows: [{ id: 'goodId' }, { id: '_design/wrongId' }],
         total_rows: 2
       }
+      jest.setTimeout(10000)
     })
     it('should remove design document', () => {
       const filteredResponse = withoutDesignDocuments(response)


### PR DESCRIPTION
On a busy CPU, e.g. while running zoom + VM and/or mining coins, some heavy pouchdb tests might fail because of the default jest timeout, set to 5000ms (e.g. querying 2000 docs).
We increase the timeout to 10000ms for these tests to fix that.