### PR TITLE
fix: Refresh token on expiration

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -127,6 +127,7 @@ Main API against the `cozy-stack` server.
     * [.checkForRevocation()](#CozyStackClient+checkForRevocation)
     * [.refreshToken()](#CozyStackClient+refreshToken) ⇒ <code>Promise</code>
     * [.fetchJSON(method, path, body, options)](#CozyStackClient+fetchJSON) ⇒ <code>object</code>
+    * [.setToken(token)](#CozyStackClient+setToken)
     * [.getAccessToken()](#CozyStackClient+getAccessToken) ⇒ <code>string</code>
 
 <a name="CozyStackClient+collection"></a>
@@ -193,6 +194,17 @@ Fetches JSON in an authorized way.
 | path | <code>string</code> | The URI. |
 | body | <code>object</code> | The payload. |
 | options | <code>object</code> |  |
+
+<a name="CozyStackClient+setToken"></a>
+
+### cozyStackClient.setToken(token)
+Change or set the API token
+
+**Kind**: instance method of [<code>CozyStackClient</code>](#CozyStackClient)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| token | <code>string</code> \| <code>AppToken</code> \| <code>AccessToken</code> | Stack API token |
 
 <a name="CozyStackClient+getAccessToken"></a>
 

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -1,6 +1,7 @@
 import cloneDeep from 'lodash/cloneDeep'
 import AppCollection, { APPS_DOCTYPE } from './AppCollection'
 import AppToken from './AppToken'
+import AccessToken from './AccessToken'
 import DocumentCollection from './DocumentCollection'
 import FileCollection from './FileCollection'
 import JobCollection, { JOBS_DOCTYPE } from './JobCollection'
@@ -254,9 +255,25 @@ class CozyStackClient {
     return this.getAuthorizationHeader()
   }
 
+  /**
+   * Change or set the API token
+   *
+   * @param {string|AppToken|AccessToken} token - Stack API token
+   */
   setToken(token) {
-    this.token = token ? new AppToken(token) : null
-    if (token) {
+    if (!token) {
+      this.token = null
+    } else {
+      if (token.toAuthHeader) {
+        // AppToken or AccessToken
+        this.token = token
+      } else if (typeof token === 'string') {
+        // jwt string
+        this.token = new AppToken(token)
+      } else {
+        console.warn('Cozy-Client: Unknown token format', token)
+        throw new Error('Cozy-Client: Unknown token format')
+      }
       this.onRevocationChange(false)
     }
   }

--- a/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
@@ -6,6 +6,7 @@ import DocumentCollection from '../DocumentCollection'
 import JobCollection from '../JobCollection'
 import KonnectorCollection from '../KonnectorCollection'
 import jestFetchMock from 'jest-fetch-mock'
+import AppToken from '../AppToken'
 
 const FAKE_RESPONSE = {
   offset: 0,
@@ -50,6 +51,25 @@ describe('CozyStackClient', () => {
     })
 
     expect(stackClient.konnectors instanceof KonnectorCollection).toBe(true)
+  })
+
+  describe('setToken', () => {
+    it('allows a JWT string', () => {
+      const client = new CozyStackClient(FAKE_INIT_OPTIONS)
+      const jwt =
+        'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhcHAiLCJpYXQiOjE1NzkxOTAyODEsImlzcyI6ImNvenkudG9vbHM6ODA4MCIsInN1YiI6Im5vdGVzIiwic2Vzc2lvbl9pZCI6ImViMjM5NTBlZjY1NmY3MzllYjg4Y2E2MWZhMDA2ZmZiIn0.WvadOrBnidB3HBl8mCRuQUf0E-EFVQzNHzLPO923Zyv67aRguIdQyWvj6abjEHDcmk5OTEICeM7L5Um1tFWNlg'
+      client.setToken(jwt)
+      expect(client.token).toHaveProperty('token', jwt)
+    })
+
+    it('allows an AccessToken', () => {
+      const client = new CozyStackClient(FAKE_INIT_OPTIONS)
+      const jwt =
+        'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhcHAiLCJpYXQiOjE1NzkxOTAyODEsImlzcyI6ImNvenkudG9vbHM6ODA4MCIsInN1YiI6Im5vdGVzIiwic2Vzc2lvbl9pZCI6ImViMjM5NTBlZjY1NmY3MzllYjg4Y2E2MWZhMDA2ZmZiIn0.WvadOrBnidB3HBl8mCRuQUf0E-EFVQzNHzLPO923Zyv67aRguIdQyWvj6abjEHDcmk5OTEICeM7L5Um1tFWNlg'
+      const appToken = new AppToken(jwt)
+      client.setToken(appToken)
+      expect(client.token).toHaveProperty('token', jwt)
+    })
   })
 
   describe('collection', () => {


### PR DESCRIPTION
When Cozy-Client detect an expired token, it calls
`setToken` with the result of `refreshToken`.

Problem : refreshToken returns an AppToken but
setToken expect a jwt string.

OAuthClient has a code dealing with this. StackClient
doesn't. This change fix StackClient.