### PR TITLE
feat: Basic Notes collection

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -21,6 +21,9 @@ specific collections.</p>
 special routes are to be used, and there is a notion of referenced files, aka
 files associated to a specific document</p>
 </dd>
+<dt><a href="#NotesCollection">NotesCollection</a></dt>
+<dd><p>Implements <code>DocumentCollection</code> API to interact with the /notes endpoint of the stack</p>
+</dd>
 <dt><a href="#OAuthClient">OAuthClient</a></dt>
 <dd><p>Specialized <code>CozyStackClient</code> for mobile, implementing stack registration
 through OAuth.</p>
@@ -674,6 +677,37 @@ You should use `createFile`
 | path | <code>string</code> |  | Uri to call the stack from. Something like `/files/${dirId}?Name=${name}&Type=file&Executable=${executable}&MetadataID=${metadataId}` |
 | options | <code>object</code> |  | Additional headers |
 | method | <code>string</code> | <code>&quot;POST&quot;</code> | POST / PUT / PATCH |
+
+<a name="NotesCollection"></a>
+
+## NotesCollection
+Implements `DocumentCollection` API to interact with the /notes endpoint of the stack
+
+**Kind**: global class  
+
+* [NotesCollection](#NotesCollection)
+    * [.all()](#NotesCollection+all) ⇒ <code>Object</code>
+    * [.destroy(note)](#NotesCollection+destroy) ⇒ <code>Object</code>
+
+<a name="NotesCollection+all"></a>
+
+### notesCollection.all() ⇒ <code>Object</code>
+all - Fetches all notes
+
+**Kind**: instance method of [<code>NotesCollection</code>](#NotesCollection)  
+**Returns**: <code>Object</code> - The JSON API conformant response.  
+<a name="NotesCollection+destroy"></a>
+
+### notesCollection.destroy(note) ⇒ <code>Object</code>
+destroy - Destroys the note on the server
+
+**Kind**: instance method of [<code>NotesCollection</code>](#NotesCollection)  
+**Returns**: <code>Object</code> - The deleted note  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| note | <code>io.cozy.notes</code> | The note document to destroy |
+| note._id | <code>string</code> | The note's id |
 
 <a name="OAuthClient"></a>
 

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -9,6 +9,7 @@ import SharingCollection from './SharingCollection'
 import PermissionCollection from './PermissionCollection'
 import TriggerCollection, { TRIGGERS_DOCTYPE } from './TriggerCollection'
 import SettingsCollection, { SETTINGS_DOCTYPE } from './SettingsCollection'
+import NotesCollection, { NOTES_DOCTYPE } from './NotesCollection'
 import getIconURL from './getIconURL'
 import logDeprecate from './logDeprecate'
 import errors from './errors'
@@ -67,6 +68,8 @@ class CozyStackClient {
         return new JobCollection(this)
       case SETTINGS_DOCTYPE:
         return new SettingsCollection(this)
+      case NOTES_DOCTYPE:
+        return new NotesCollection(this)
       default:
         return new DocumentCollection(doctype, this)
     }

--- a/packages/cozy-stack-client/src/NotesCollection.js
+++ b/packages/cozy-stack-client/src/NotesCollection.js
@@ -1,0 +1,54 @@
+import DocumentCollection from './DocumentCollection'
+import { uri } from './utils'
+
+export const NOTES_DOCTYPE = 'io.cozy.notes'
+
+const normalizeDoc = DocumentCollection.normalizeDoctypeJsonApi(NOTES_DOCTYPE)
+const normalizeNote = note => ({
+  ...normalizeDoc(note),
+  ...note.attributes
+})
+
+/**
+ * Implements `DocumentCollection` API to interact with the /notes endpoint of the stack
+ */
+class NotesCollection extends DocumentCollection {
+  constructor(stackClient) {
+    super(NOTES_DOCTYPE, stackClient)
+  }
+
+  /**
+   * all - Fetches all notes
+   *
+   * @returns {{data, links, meta}} The JSON API conformant response.
+   */
+  async all() {
+    //TODO: add support for pagination
+    const resp = await this.stackClient.fetchJSON('GET', '/notes')
+
+    return {
+      ...resp,
+      data: resp.data.map(normalizeNote)
+    }
+  }
+
+  /**
+   * destroy - Destroys the note on the server
+   *
+   * @param {io.cozy.notes} note     The note document to destroy
+   * @param {string}   note._id The note's id
+   *
+   * @returns {{ data }} The deleted note
+   */
+  async destroy({ _id }) {
+    // io.cozy.notes are in fact io.cozy.files, but with a special endpoint. However there is no dedicated route to delete a note, so we use the /files endpoint.
+    const resp = await this.stackClient.fetchJSON('DELETE', uri`/files/${_id}`)
+    return {
+      data: { ...normalizeNote(resp.data), _deleted: true }
+    }
+  }
+}
+
+NotesCollection.normalizeDoctype = DocumentCollection.normalizeDoctypeJsonApi
+
+export default NotesCollection

--- a/packages/cozy-stack-client/src/NotesCollection.spec.js
+++ b/packages/cozy-stack-client/src/NotesCollection.spec.js
@@ -1,0 +1,76 @@
+import NotesCollection from './NotesCollection'
+import CozyStackClient from './CozyStackClient'
+
+describe('NotesCollection', () => {
+  const setup = () => {
+    const stackClient = new CozyStackClient()
+    const collection = new NotesCollection(stackClient)
+
+    return { stackClient, collection }
+  }
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('all', () => {
+    const { stackClient, collection } = setup()
+
+    it('should call the appropriate route', async () => {
+      jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue({
+        data: [],
+        links: {},
+        meta: { count: 0 }
+      })
+
+      await collection.all()
+      expect(stackClient.fetchJSON).toHaveBeenCalledWith('GET', '/notes')
+    })
+
+    it('should normalize documents', async () => {
+      jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue({
+        data: [{ _id: '1', attributes: { title: 'Test Note' } }],
+        links: {},
+        meta: { count: 0 }
+      })
+      const result = await collection.all()
+      expect(result.data).toEqual([
+        {
+          _id: '1',
+          _type: 'io.cozy.notes',
+          id: '1',
+          title: 'Test Note',
+          attributes: { title: 'Test Note' }
+        }
+      ])
+    })
+  })
+
+  describe('destroy', () => {
+    const { stackClient, collection } = setup()
+
+    const note = {
+      _id: '1'
+    }
+
+    beforeEach(() => {
+      jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue({
+        data: { ...note, trashed: true }
+      })
+    })
+
+    it('should call the appropriate route', async () => {
+      await collection.destroy({ _id: '1' })
+      expect(stackClient.fetchJSON).toHaveBeenCalledWith('DELETE', '/files/1')
+    })
+
+    it('should add _deleted to the response', async () => {
+      const result = await collection.destroy({ _id: '1' })
+      expect(result.data._deleted).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
This PR adds a basic collection for `io.cozy.notes`. Here is the corresponding doc: https://docs.cozy.io/en/cozy-stack/notes/

I say basic because:

1. It doesn't support all the special routes
2. It has no pagination support yet, I'm creating an issue detailing the problem right away