### PR TITLE
feat: HasMany prunes absent documents before passing them down

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -423,6 +423,7 @@ Responsible for
 
 * [HasMany](#HasMany)
     * [new HasMany()](#new_HasMany_new)
+    * [.count](#HasMany+count) ⇒ <code>Number</code>
     * [.addById()](#HasMany+addById)
 
 <a name="new_HasMany_new"></a>
@@ -454,6 +455,15 @@ const todo = {
 }
 ```
 
+<a name="HasMany+count"></a>
+
+### hasMany.count ⇒ <code>Number</code>
+Returns the total number of documents in the relationship.
+Does not handle documents absent from the store. If you want
+to do that, you can use .data.length.
+
+**Kind**: instance property of [<code>HasMany</code>](#HasMany)  
+**Returns**: <code>Number</code> - - Total number of documents in the relationships  
 <a name="HasMany+addById"></a>
 
 ### hasMany.addById()
@@ -520,10 +530,20 @@ Association used for konnectors to retrieve all their related triggers.
 
 * [HasManyTriggers](#HasManyTriggers) ⇐ [<code>HasMany</code>](#HasMany)
     * _instance_
+        * [.count](#HasMany+count) ⇒ <code>Number</code>
         * [.addById()](#HasMany+addById)
     * _static_
         * [.query()](#HasManyTriggers.query)
 
+<a name="HasMany+count"></a>
+
+### hasManyTriggers.count ⇒ <code>Number</code>
+Returns the total number of documents in the relationship.
+Does not handle documents absent from the store. If you want
+to do that, you can use .data.length.
+
+**Kind**: instance property of [<code>HasManyTriggers</code>](#HasManyTriggers)  
+**Returns**: <code>Number</code> - - Total number of documents in the relationships  
 <a name="HasMany+addById"></a>
 
 ### hasManyTriggers.addById()

--- a/packages/cozy-client/src/associations/HasMany.js
+++ b/packages/cozy-client/src/associations/HasMany.js
@@ -52,15 +52,22 @@ class HasMany extends Association {
   }
 
   get data() {
-    return this.getRelationship().data.map(({ _id, _type }) =>
-      this.get(_type, _id)
-    )
+    return this.getRelationship()
+      .data.map(({ _id, _type }) => this.get(_type, _id))
+      .filter(Boolean)
   }
 
   get hasMore() {
     return this.getRelationship().next
   }
 
+  /**
+   * Returns the total number of documents in the relationship.
+   * Does not handle documents absent from the store. If you want
+   * to do that, you can use .data.length.
+   *
+   * @returns {Number} - Total number of documents in the relationships
+   */
   get count() {
     const relationship = this.getRelationship()
     return relationship.meta
@@ -76,10 +83,14 @@ class HasMany extends Association {
     return this.existsById(document._id)
   }
 
-  existsById(id) {
+  containsById(id) {
     return (
       this.getRelationship().data.find(({ _id }) => id === _id) !== undefined
     )
+  }
+
+  existsById(id) {
+    return this.containsById(id) && Boolean(this.get(this.doctype, id))
   }
 
   /**


### PR DESCRIPTION
BREAKING:

- HasMany::data does not return null values
- existsById changes of semantics
- containsById retains the previous behavior of existsById

---

- containsById does not check for document existence in the store
- existsById checks for existence of the document in the store