### PR TITLE
docs: Document `fromOldOAuthclient` method

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -610,6 +610,7 @@ Responsible for
         * [.setData(data)](#CozyClient+setData)
     * _static_
         * [.fromOldClient()](#CozyClient.fromOldClient)
+        * [.fromOldOAuthClient()](#CozyClient.fromOldOAuthClient)
         * [.fromEnv()](#CozyClient.fromEnv)
         * [.registerHook(doctype, name, fn)](#CozyClient.registerHook)
 
@@ -1013,7 +1014,16 @@ set some data in the store.
 
 ### CozyClient.fromOldClient()
 To help with the transition from cozy-client-js to cozy-client, it is possible to instantiate
-a client with an instance of cozy-client-js.
+a client with a cookie-based instance of cozy-client-js.
+
+**Kind**: static method of [<code>CozyClient</code>](#CozyClient)  
+<a name="CozyClient.fromOldOAuthClient"></a>
+
+### CozyClient.fromOldOAuthClient()
+To help with the transition from cozy-client-js to cozy-client, it is possible to instantiate
+a client with an OAuth-based instance of cozy-client-js.
+
+Warning: unlike other instantiators, this one needs to be awaited.
 
 **Kind**: static method of [<code>CozyClient</code>](#CozyClient)  
 <a name="CozyClient.fromEnv"></a>

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -193,6 +193,8 @@ class CozyClient {
   /**
    * To help with the transition from cozy-client-js to cozy-client, it is possible to instantiate
    * a client with an OAuth-based instance of cozy-client-js.
+   *
+   * Warning: unlike other instantiators, this one needs to be awaited.
    */
   static async fromOldOAuthClient(oldClient, options) {
     const hasOauthCreds = oldClient._oauth && oldClient._authcreds != null


### PR DESCRIPTION
Unlike other instantiators, `fromOldOAuthClient` needs to be awaited
so it seems appropriate to add a warning in its description.

The doc was not generated when the method was introduced.