### PR TITLE
fix: Revoke sharing links fetch all the related permissions

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -907,6 +907,9 @@ Implements `DocumentCollection` API along with specific methods for `io.cozy.per
 * [PermissionCollection](#PermissionCollection)
     * [.add(document, permission)](#PermissionCollection+add) ⇒ <code>Promise</code>
     * [.createSharingLink(document, options)](#PermissionCollection+createSharingLink)
+    * [.fetchPermissionsByLink(permissions)](#PermissionCollection+fetchPermissionsByLink)
+    * [.fetchAllLinks(document)](#PermissionCollection+fetchAllLinks) ⇒ <code>object</code>
+    * [.revokeSharingLink(document)](#PermissionCollection+revokeSharingLink)
     * [.getOwnPermissions()](#PermissionCollection+getOwnPermissions) ⇒ <code>object</code>
 
 <a name="PermissionCollection+add"></a>
@@ -946,6 +949,38 @@ Create a share link
 | document | <code>Object</code> | cozy document |
 | options | <code>object</code> | options |
 | options.verbs | <code>Array.&lt;string&gt;</code> | explicit permissions to use |
+
+<a name="PermissionCollection+fetchPermissionsByLink"></a>
+
+### permissionCollection.fetchPermissionsByLink(permissions)
+Follow the next link to fetch the next permissions
+
+**Kind**: instance method of [<code>PermissionCollection</code>](#PermissionCollection)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| permissions | <code>object</code> | JSON-API based permissions document |
+
+<a name="PermissionCollection+fetchAllLinks"></a>
+
+### permissionCollection.fetchAllLinks(document) ⇒ <code>object</code>
+**Kind**: instance method of [<code>PermissionCollection</code>](#PermissionCollection)  
+**Returns**: <code>object</code> - with all the permissions  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | <code>object</code> | Cozy doc |
+
+<a name="PermissionCollection+revokeSharingLink"></a>
+
+### permissionCollection.revokeSharingLink(document)
+Destroy a sharing link and the related permissions
+
+**Kind**: instance method of [<code>PermissionCollection</code>](#PermissionCollection)  
+
+| Param | Type |
+| --- | --- |
+| document | <code>object</code> | 
 
 <a name="PermissionCollection+getOwnPermissions"></a>
 

--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -131,9 +131,38 @@ class PermissionCollection extends DocumentCollection {
     )
     return { data: normalizePermission(resp.data) }
   }
+  /**
+   * Follow the next link to fetch the next permissions
+   *
+   * @param {object} permissions JSON-API based permissions document
+   */
+  async fetchPermissionsByLink(permissions) {
+    if (permissions.links && permissions.links.next) {
+      return await this.stackClient.fetchJSON('GET', permissions.links.next)
+    }
+  }
 
+  /**
+   *
+   * @param {object} document Cozy doc
+   * @returns {object} with all the permissions
+   */
+  async fetchAllLinks(document) {
+    let allLinks = await this.findLinksByDoctype(document._type)
+    let resp = allLinks
+    while (resp.links && resp.links.next) {
+      resp = await this.fetchPermissionsByLink(resp)
+      allLinks.data.push(...resp.data.map(normalizePermission))
+    }
+    return allLinks
+  }
+  /**
+   * Destroy a sharing link and the related permissions
+   *
+   * @param {object} document
+   */
   async revokeSharingLink(document) {
-    const allLinks = await this.findLinksByDoctype(document._type)
+    const allLinks = await this.fetchAllLinks(document)
     const links = allLinks.data.filter(perm =>
       isPermissionRelatedTo(perm, document)
     )

--- a/packages/cozy-stack-client/src/PermissionCollection.spec.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.spec.js
@@ -158,6 +158,92 @@ describe('PermissionCollection', () => {
   })
 })
 
+describe('revokeSharingLink', () => {
+  const client = new CozyStackClient()
+  const collection = new PermissionCollection('io.cozy.permissions', client)
+
+  beforeEach(() => {
+    client.fetchJSON.mockReset()
+    client.fetchJSON.mockReturnValue(Promise.resolve({ data: [] }))
+  })
+
+  it('should revoke a sharing link', async () => {
+    client.fetchJSON.mockReturnValue(
+      Promise.resolve({
+        data: [
+          {
+            type: 'io.cozy.permissions',
+            id: 'perm_id_1',
+            attributes: {
+              type: 'share',
+              permissions: {
+                files: {
+                  type: 'io.cozy.files',
+                  verbs: ['GET'],
+                  values: ['file_1']
+                }
+              }
+            }
+          }
+        ]
+      })
+    )
+    await collection.revokeSharingLink({
+      _id: 'file_1',
+      _type: 'io.cozy.files'
+    })
+    expect(client.fetchJSON).toHaveBeenNthCalledWith(
+      1,
+      'GET',
+      '/permissions/doctype/io.cozy.files/shared-by-link'
+    )
+    expect(client.fetchJSON).toHaveBeenNthCalledWith(
+      2,
+      'DELETE',
+      '/permissions/perm_id_1'
+    )
+  })
+
+  it('it should fetch all the links by calling next links', async () => {
+    client.fetchJSON.mockReturnValueOnce(
+      Promise.resolve({
+        data: [
+          {
+            type: 'io.cozy.permissions',
+            id: 'perm_id_1',
+            attributes: {
+              type: 'share',
+              permissions: {
+                files: {
+                  type: 'io.cozy.files',
+                  verbs: ['GET'],
+                  values: ['file_1']
+                }
+              }
+            }
+          }
+        ],
+        links: {
+          next: '/permissions/next_page'
+        }
+      })
+    )
+    await collection.fetchAllLinks({ _type: 'io.cozy.files' })
+
+    expect(client.fetchJSON).toHaveBeenNthCalledWith(
+      1,
+      'GET',
+      '/permissions/doctype/io.cozy.files/shared-by-link'
+    )
+
+    expect(client.fetchJSON).toHaveBeenNthCalledWith(
+      2,
+      'GET',
+      '/permissions/next_page'
+    )
+  })
+})
+
 describe('getPermissionsFor', () => {
   it('Should give all permissions by default', () => {
     const document = { _type: 'io.cozy.files', _id: '1234' }


### PR DESCRIPTION
If we have more than 30 sharing by links (/sharing-by-links is paginated at 30 per default), we had a bug when deleting a file with a related sharing. 

We now fetch all the sharing by links (by following resp.links.next) and then we map on them to check if they are concerned by the removal. If yes, we destroy the permission. 