### PR TITLE
feat: Add revokeAllRecipients for a sharing

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -988,6 +988,10 @@ Implements the `DocumentCollection` API along with specific methods for
 * [SharingCollection](#SharingCollection)
     * [.share(document, recipients, sharingType, description, [previewPath])](#SharingCollection+share)
     * [.getDiscoveryLink(sharingId, sharecode)](#SharingCollection+getDiscoveryLink) ⇒ <code>string</code>
+    * [.addRecipients(sharing, recipients, sharingType)](#SharingCollection+addRecipients)
+    * [.revokeRecipient(sharing, recipientIndex)](#SharingCollection+revokeRecipient)
+    * [.revokeSelf(sharing)](#SharingCollection+revokeSelf)
+    * [.revokeAllRecipients(sharing)](#SharingCollection+revokeAllRecipients)
 
 <a name="SharingCollection+share"></a>
 
@@ -1015,6 +1019,54 @@ getDiscoveryLink - Returns the URL of the page that can be used to accept a shar
 | --- | --- |
 | sharingId | <code>string</code> | 
 | sharecode | <code>string</code> | 
+
+<a name="SharingCollection+addRecipients"></a>
+
+### sharingCollection.addRecipients(sharing, recipients, sharingType)
+Add an array of contacts to the Sharing
+
+**Kind**: instance method of [<code>SharingCollection</code>](#SharingCollection)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| sharing | <code>object</code> | Sharing Object |
+| recipients | <code>Array</code> | Array of {id:1, type:"io.cozy.contacts"} |
+| sharingType | <code>string</code> | Read and write: two-way. Other only read |
+
+<a name="SharingCollection+revokeRecipient"></a>
+
+### sharingCollection.revokeRecipient(sharing, recipientIndex)
+Revoke only one recipient of the sharing.
+
+**Kind**: instance method of [<code>SharingCollection</code>](#SharingCollection)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| sharing | <code>object</code> | Sharing Object |
+| recipientIndex | <code>number</code> | Index of this recipient in the members array of the sharing |
+
+<a name="SharingCollection+revokeSelf"></a>
+
+### sharingCollection.revokeSelf(sharing)
+Remove self from the sharing.
+
+**Kind**: instance method of [<code>SharingCollection</code>](#SharingCollection)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| sharing | <code>object</code> | Sharing Object |
+
+<a name="SharingCollection+revokeAllRecipients"></a>
+
+### sharingCollection.revokeAllRecipients(sharing)
+Revoke the sharing for all the members. Must be called
+from the owner's cozy
+
+**Kind**: instance method of [<code>SharingCollection</code>](#SharingCollection)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| sharing | <code>object</code> | Sharing Objects |
 
 <a name="TriggerCollection"></a>
 

--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -67,7 +67,13 @@ class SharingCollection extends DocumentCollection {
       `/sharings/${sharingId}/discovery?sharecode=${sharecode}`
     )
   }
-
+  /**
+   * Add an array of contacts to the Sharing
+   *
+   * @param {object} sharing Sharing Object
+   * @param {Array} recipients Array of {id:1, type:"io.cozy.contacts"}
+   * @param {string} sharingType Read and write: two-way. Other only read
+   */
   async addRecipients(sharing, recipients, sharingType) {
     const recipientsPayload = {
       data: recipients.map(({ _id, _type }) => ({
@@ -95,18 +101,39 @@ class SharingCollection extends DocumentCollection {
     )
     return { data: normalizeSharing(resp.data) }
   }
-
+  /**
+   * Revoke only one recipient of the sharing.
+   *
+   * @param {object} sharing Sharing Object
+   * @param {number} recipientIndex Index of this recipient in the members array of the sharing
+   */
   revokeRecipient(sharing, recipientIndex) {
     return this.stackClient.fetchJSON(
       'DELETE',
       uri`/sharings/${sharing._id}/recipients/${recipientIndex}`
     )
   }
-
+  /**
+   * Remove self from the sharing.
+   *
+   * @param {object} sharing Sharing Object
+   */
   revokeSelf(sharing) {
     return this.stackClient.fetchJSON(
       'DELETE',
       uri`/sharings/${sharing._id}/recipients/self`
+    )
+  }
+  /**
+   * Revoke the sharing for all the members. Must be called
+   * from the owner's cozy
+   *
+   * @param {object} sharing Sharing Objects
+   */
+  revokeAllRecipients(sharing) {
+    return this.stackClient.fetchJSON(
+      'DELETE',
+      uri`/sharings/${sharing._id}/recipients`
     )
   }
 }

--- a/packages/cozy-stack-client/src/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/SharingCollection.spec.js
@@ -18,6 +18,9 @@ const RECIPIENT = {
   }
 }
 
+const SHARING = {
+  _id: 'sharing_1'
+}
 describe('SharingCollection', () => {
   const client = new CozyStackClient()
   const collection = new SharingCollection('io.cozy.sharings', client)
@@ -50,6 +53,21 @@ describe('SharingCollection', () => {
     it('should call the right route with the right payload', async () => {
       await collection.share(FOLDER, [RECIPIENT], 'one-way', 'foo', '/preview')
       expect(client.fetchJSON).toMatchSnapshot()
+    })
+  })
+
+  describe('revokeAllRecipients', () => {
+    beforeAll(() => {
+      client.fetch.mockReset()
+      client.fetchJSON.mockReturnValue(Promise.resolve({ data: [] }))
+    })
+
+    it('should call the right route', async () => {
+      await collection.revokeAllRecipients(SHARING)
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'DELETE',
+        `/sharings/${SHARING._id}/recipients`
+      )
     })
   })
 })


### PR DESCRIPTION
This route was not implemented yet in the SharingCollection. 

The idea is to be able to revoke all the members of a sharing if I'm the owner of this sharing. 