### PR TITLE
feat(cozy-client): Export models in node entry point

### DIFF
--- a/packages/cozy-client/src/node.js
+++ b/packages/cozy-client/src/node.js
@@ -28,3 +28,6 @@ export { manifest }
 export * from './mock'
 
 export * from './cli'
+
+import * as models from './models'
+export { models }


### PR DESCRIPTION
The models can be used in node environment, so they should be exported from the node entrypoint.