### PR TITLE
feat: Add generateWebLink helper

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -61,6 +61,13 @@ from a Cozy. <code>QueryDefinition</code>s are sent to links.</p>
 ## Constants
 
 <dl>
+<dt><a href="#generateWebLink">generateWebLink</a> ⇒ <code>string</code></dt>
+<dd><p>generateWebLink - Construct a link to a web app</p>
+<p>This function does not get its cozy url from a CozyClient instance so it can
+be used to build urls that point to other Cozies than the user&#39;s own Cozy.
+This is useful when pointing to the Cozy of the owner of a shared note for
+example.</p>
+</dd>
 <dt><a href="#getMutedErrors">getMutedErrors</a> ⇒ <code>Array</code></dt>
 <dd><p>getMutedErrors - Returns the list of errors that have been muted for the given account</p>
 </dd>
@@ -1305,6 +1312,29 @@ Returns the relationship for a given doctype/name
 Validates a document considering the descriptions in schema.attributes.
 
 **Kind**: instance method of [<code>Schema</code>](#Schema)  
+<a name="generateWebLink"></a>
+
+## generateWebLink ⇒ <code>string</code>
+generateWebLink - Construct a link to a web app
+
+This function does not get its cozy url from a CozyClient instance so it can
+be used to build urls that point to other Cozies than the user's own Cozy.
+This is useful when pointing to the Cozy of the owner of a shared note for
+example.
+
+**Kind**: global constant  
+**Returns**: <code>string</code> - Generated URL  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | <code>object</code> | Object of options |
+| options.cozyUrl | <code>string</code> | Base URL of the cozy, eg. cozy.tools or test.mycozy.cloud |
+| options.searchParams | <code>Array</code> | Array of search parameters as [key, value] arrays, eg. ['username', 'bob'] |
+| options.pathname | <code>string</code> | Path to a specific part of the app, eg. /public |
+| options.hash | <code>string</code> | Path inside the app, eg. /files/test.jpg |
+| options.slug | <code>string</code> | Slug of the app |
+| options.subDomainType | <code>string</code> | Whether the cozy is using flat or nested subdomains. Defaults to flat. |
+
 <a name="getMutedErrors"></a>
 
 ## getMutedErrors ⇒ <code>Array</code>

--- a/packages/cozy-client/src/helpers.js
+++ b/packages/cozy-client/src/helpers.js
@@ -18,3 +18,56 @@ export const dehydrate = document => {
   )
   return dehydrated
 }
+
+const ensureFirstSlash = path => {
+  if (!path) {
+    return '/'
+  } else {
+    return path.startsWith('/') ? path : '/' + path
+  }
+}
+
+/**
+ * generateWebLink - Construct a link to a web app
+ *
+ * This function does not get its cozy url from a CozyClient instance so it can
+ * be used to build urls that point to other Cozies than the user's own Cozy.
+ * This is useful when pointing to the Cozy of the owner of a shared note for
+ * example.
+ *
+ * @param {object} options               Object of options
+ * @param {string}   options.cozyUrl       Base URL of the cozy, eg. cozy.tools or test.mycozy.cloud
+ * @param {Array}    options.searchParams  Array of search parameters as [key, value] arrays, eg. ['username', 'bob']
+ * @param {string}   options.pathname      Path to a specific part of the app, eg. /public
+ * @param {string}   options.hash          Path inside the app, eg. /files/test.jpg
+ * @param {string}   options.slug          Slug of the app
+ * @param {string}   options.subDomainType Whether the cozy is using flat or nested subdomains. Defaults to flat.
+ *
+ * @returns {string} Generated URL
+ */
+export const generateWebLink = ({
+  cozyUrl,
+  searchParams = [],
+  pathname,
+  hash,
+  slug,
+  subDomainType
+}) => {
+  const url = new URL(cozyUrl)
+
+  url.host =
+    subDomainType === 'nested'
+      ? `${slug}.${url.host}`
+      : url.host
+          .split('.')
+          .map((x, i) => (i === 0 ? x + '-' + slug : x))
+          .join('.')
+  url.pathname = pathname
+  url.hash = ensureFirstSlash(hash)
+
+  for (const [param, value] of searchParams) {
+    url.searchParams.set(param, value)
+  }
+
+  return url.toString()
+}

--- a/packages/cozy-client/src/helpers.spec.js
+++ b/packages/cozy-client/src/helpers.spec.js
@@ -1,4 +1,4 @@
-import { dehydrate } from './helpers'
+import { dehydrate, generateWebLink } from './helpers'
 
 import {
   HasManyInPlace,
@@ -107,5 +107,37 @@ describe('dehydrate', () => {
     }).toThrowError(
       `Association on key badAssociation should have a dehydrate method`
     )
+  })
+})
+
+describe('generateWebLink', () => {
+  it('should generate the right link to a flat cozy', () => {
+    const sharecode = 'sharingIsCaring'
+    const username = 'alice'
+
+    expect(
+      generateWebLink({
+        cozyUrl: 'http://alice.cozy.tools',
+        searchParams: [['sharecode', sharecode], ['username', username]],
+        pathname: 'public',
+        hash: '/n/4',
+        slug: 'notes',
+        subDomainType: 'flat'
+      })
+    ).toEqual(
+      `http://alice-notes.cozy.tools/public?sharecode=${sharecode}&username=${username}#/n/4`
+    )
+  })
+
+  it('should generate the right link to a nested cozy', () => {
+    expect(
+      generateWebLink({
+        cozyUrl: 'https://alice.cozy.tools',
+        pathname: '/public/',
+        hash: 'files/432432',
+        slug: 'drive',
+        subDomainType: 'nested'
+      })
+    ).toEqual(`https://drive.alice.cozy.tools/public/#/files/432432`)
   })
 })

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -17,7 +17,7 @@ export {
   HasManyInPlace,
   HasManyTriggers
 } from './associations'
-export { dehydrate } from './helpers'
+export { dehydrate, generateWebLink } from './helpers'
 export { cancelable, isQueryLoading, hasQueryBeenLoaded } from './utils'
 export { getQueryFromState } from './store'
 export { default as Registry } from './registry'

--- a/packages/cozy-client/src/node.js
+++ b/packages/cozy-client/src/node.js
@@ -17,7 +17,7 @@ export {
   HasManyInPlace,
   HasManyTriggers
 } from './associations'
-export { dehydrate } from './helpers'
+export { dehydrate, generateWebLink } from './helpers'
 export { cancelable } from './utils'
 export { getQueryFromState } from './store'
 export { default as Registry } from './registry'


### PR DESCRIPTION
This helper meant to build URLs to Cozy applications lived in
`cozy-ui` although it would be useful to apps that don't need
`cozy-ui`.

This version adds the possibility to pass search parameters as well.
This should be useful for apps that need a share code for example.