### PR TITLE
feat: Add Notes collection `fetchURL` method

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -706,6 +706,7 @@ Implements `DocumentCollection` API to interact with the /notes endpoint of the 
 * [NotesCollection](#NotesCollection)
     * [.all()](#NotesCollection+all) ⇒ <code>Object</code>
     * [.destroy(note)](#NotesCollection+destroy) ⇒ <code>Object</code>
+    * [.fetchURL(note)](#NotesCollection+fetchURL) ⇒ <code>Object</code>
 
 <a name="NotesCollection+all"></a>
 
@@ -725,6 +726,20 @@ destroy - Destroys the note on the server
 | Param | Type | Description |
 | --- | --- | --- |
 | note | <code>io.cozy.notes</code> | The note document to destroy |
+| note._id | <code>string</code> | The note's id |
+
+<a name="NotesCollection+fetchURL"></a>
+
+### notesCollection.fetchURL(note) ⇒ <code>Object</code>
+Returns the details to build the note's url
+
+**Kind**: instance method of [<code>NotesCollection</code>](#NotesCollection)  
+**Returns**: <code>Object</code> - The note's url details  
+**See**: https://github.com/cozy/cozy-stack/blob/master/docs/notes.md#get-notesidopen  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| note | <code>io.cozy.notes</code> | The note document to open |
 | note._id | <code>string</code> | The note's id |
 
 <a name="OAuthClient"></a>

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -711,14 +711,14 @@ Implements `DocumentCollection` API to interact with the /notes endpoint of the 
 <a name="NotesCollection+all"></a>
 
 ### notesCollection.all() ⇒ <code>Object</code>
-all - Fetches all notes
+Fetches all notes
 
 **Kind**: instance method of [<code>NotesCollection</code>](#NotesCollection)  
 **Returns**: <code>Object</code> - The JSON API conformant response.  
 <a name="NotesCollection+destroy"></a>
 
 ### notesCollection.destroy(note) ⇒ <code>Object</code>
-destroy - Destroys the note on the server
+Destroys the note on the server
 
 **Kind**: instance method of [<code>NotesCollection</code>](#NotesCollection)  
 **Returns**: <code>Object</code> - The deleted note  

--- a/packages/cozy-stack-client/src/NotesCollection.js
+++ b/packages/cozy-stack-client/src/NotesCollection.js
@@ -2,11 +2,17 @@ import DocumentCollection from './DocumentCollection'
 import { uri } from './utils'
 
 export const NOTES_DOCTYPE = 'io.cozy.notes'
+export const NOTES_URL_DOCTYPE = 'io.cozy.notes.url'
 
 const normalizeDoc = DocumentCollection.normalizeDoctypeJsonApi(NOTES_DOCTYPE)
 const normalizeNote = note => ({
   ...normalizeDoc(note),
   ...note.attributes
+})
+
+const normalizeNoteUrl = noteUrl => ({
+  ...DocumentCollection.normalizeDoctypeJsonApi(NOTES_URL_DOCTYPE)(noteUrl),
+  ...noteUrl.attributes
 })
 
 /**
@@ -45,6 +51,26 @@ class NotesCollection extends DocumentCollection {
     const resp = await this.stackClient.fetchJSON('DELETE', uri`/files/${_id}`)
     return {
       data: { ...normalizeNote(resp.data), _deleted: true }
+    }
+  }
+
+  /**
+   * Returns the details to build the note's url
+   *
+   * @see https://github.com/cozy/cozy-stack/blob/master/docs/notes.md#get-notesidopen
+   *
+   * @param {io.cozy.notes} note The note document to open
+   * @param {string}   note._id The note's id
+   *
+   * @returns {{ data }} The note's url details
+   */
+  async fetchURL({ _id }) {
+    const resp = await this.stackClient.fetchJSON(
+      'GET',
+      uri`/notes/${_id}/open`
+    )
+    return {
+      data: normalizeNoteUrl(resp.data)
     }
   }
 }

--- a/packages/cozy-stack-client/src/NotesCollection.js
+++ b/packages/cozy-stack-client/src/NotesCollection.js
@@ -24,7 +24,7 @@ class NotesCollection extends DocumentCollection {
   }
 
   /**
-   * all - Fetches all notes
+   * Fetches all notes
    *
    * @returns {{data, links, meta}} The JSON API conformant response.
    */
@@ -39,7 +39,7 @@ class NotesCollection extends DocumentCollection {
   }
 
   /**
-   * destroy - Destroys the note on the server
+   * Destroys the note on the server
    *
    * @param {io.cozy.notes} note     The note document to destroy
    * @param {string}   note._id The note's id

--- a/packages/cozy-stack-client/src/NotesCollection.spec.js
+++ b/packages/cozy-stack-client/src/NotesCollection.spec.js
@@ -73,4 +73,58 @@ describe('NotesCollection', () => {
       expect(result.data._deleted).toBe(true)
     })
   })
+
+  describe('fetchURL', () => {
+    const { stackClient, collection } = setup()
+
+    const note = {
+      _id: '1'
+    }
+
+    beforeEach(() => {
+      jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue({
+        data: {
+          _id: note._id,
+          type: 'io.cozy.notes.url',
+          attributes: {
+            note_id: '2',
+            subdomain: 'flat',
+            protocol: 'http',
+            instance: 'alice.cozy.example',
+            sharecode: '431431',
+            public_name: 'Bob'
+          }
+        }
+      })
+    })
+
+    it('should call the appropriate route', async () => {
+      await collection.fetchURL({ _id: '1' })
+      expect(stackClient.fetchJSON).toHaveBeenCalledWith('GET', '/notes/1/open')
+    })
+
+    it('should normalize the returned note url document', async () => {
+      const result = await collection.fetchURL({ _id: '1' })
+      expect(result.data).toEqual({
+        _id: '1',
+        type: 'io.cozy.notes.url',
+        id: '1',
+        _type: 'io.cozy.notes.url',
+        note_id: '2',
+        subdomain: 'flat',
+        protocol: 'http',
+        instance: 'alice.cozy.example',
+        sharecode: '431431',
+        public_name: 'Bob',
+        attributes: {
+          note_id: '2',
+          subdomain: 'flat',
+          protocol: 'http',
+          instance: 'alice.cozy.example',
+          sharecode: '431431',
+          public_name: 'Bob'
+        }
+      })
+    })
+  })
 })


### PR DESCRIPTION
This method calls the `/notes/:id/open` stack endpoint to fetch the
required details to build a url that points to the note in the Notes
application on the note's owner's Cozy.

This means that a shared note will return a NoteUrl that points to the
owner Cozy, with the original note's id and a share code to get
permissions to see the note.
If the note is not shared then the details will point to the client's
Cozy and no share code.