### PR TITLE
Add bookmark support for documents find queries

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -571,7 +571,11 @@ client.query(Q('io.cozy.bills'))`)
     this.ensureStore()
     const existingQuery = getQueryFromState(this.store.getState(), queryId)
     // Don't trigger the INIT_QUERY for fetchMore() calls
-    if (existingQuery.fetchStatus !== 'loaded' || !queryDefinition.skip) {
+    if (
+      existingQuery.fetchStatus !== 'loaded' ||
+      !queryDefinition.skip ||
+      !queryDefinition.bookmark
+    ) {
       this.dispatch(initQuery(queryId, queryDefinition))
     }
   }
@@ -1024,8 +1028,8 @@ client.query(Q('io.cozy.bills'))`)
     } else if (this.store && !force) {
       throw new Error(
         `Client already has a store, it is forbidden to change store.
-setStore must be called before any query is executed. Try to 
-call setStore earlier in your code, preferably just after the 
+setStore must be called before any query is executed. Try to
+call setStore earlier in your code, preferably just after the
 instantiation of the client.`
       )
     }

--- a/packages/cozy-client/src/associations/helpers.js
+++ b/packages/cozy-client/src/associations/helpers.js
@@ -17,7 +17,8 @@ export const responseToRelationship = response =>
     data: applyHelper(pickTypeAndId, response.data),
     meta: response.meta,
     next: response.next,
-    skip: response.skip
+    skip: response.skip,
+    bookmark: response.bookmark
   })
 
 const attachRelationship = (doc, relationships) => {

--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -69,10 +69,7 @@ const query = (state = queryInitialState, action) => {
           response.meta && response.meta.count
             ? response.meta.count
             : response.data.length,
-        data:
-          response.skip === 0
-            ? response.data.map(properId)
-            : [...state.data, ...response.data.map(properId)]
+        data: [...state.data, ...response.data.map(properId)]
       }
     }
     case RECEIVE_QUERY_ERROR:

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -157,8 +157,8 @@ class DocumentCollection {
    * The returned documents are paginated by the stack.
    *
    * @param  {object} selector The Mango selector.
-   * @param  {{sort, fields, limit, skip, indexId}} options The query options.
-   * @returns {{data, meta, skip, next}} The JSON API conformant response.
+   * @param  {{sort, fields, limit, skip, bookmark, indexId}} options The query options.
+   * @returns {{data, skip, bookmark, next}} The JSON API conformant response.
    * @throws {FetchError}
    */
   async find(selector, options = {}) {
@@ -175,14 +175,9 @@ class DocumentCollection {
     }
     return {
       data: resp.docs.map(doc => normalizeDoc(doc, this.doctype)),
-      // Mango queries don't return the total count of rows, so if next = true,
-      // we return a `meta.count` greater than the count of rows we have so that
-      // 'fetchMore' features would work
-      meta: {
-        count: resp.next ? skip + resp.docs.length + 1 : resp.docs.length
-      },
       next: resp.next,
-      skip
+      skip,
+      bookmark: resp.bookmark
     }
   }
 
@@ -316,7 +311,7 @@ class DocumentCollection {
 
   async toMangoOptions(selector, options = {}) {
     let { sort, indexedFields } = options
-    const { fields, skip = 0, limit } = options
+    const { fields, skip = 0, limit, bookmark } = options
 
     if (sort && !Array.isArray(sort)) {
       console.warn(
@@ -356,6 +351,7 @@ class DocumentCollection {
       fields: fields ? [...fields, '_id', '_type', 'class'] : undefined,
       limit,
       skip,
+      bookmark,
       sort
     }
   }

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -401,6 +401,22 @@ describe('DocumentCollection', () => {
       )
     })
 
+    it('should accept bookmark option', async () => {
+      const collection = new DocumentCollection('io.cozy.todos', client)
+      await collection.find({ done: false }, { bookmark: 'himark', limit: 200 })
+      expect(client.fetchJSON).toHaveBeenLastCalledWith(
+        'POST',
+        '/data/io.cozy.todos/_find',
+        {
+          limit: 200,
+          selector: { done: false },
+          skip: 0,
+          bookmark: 'himark',
+          use_index: '_design/123456'
+        }
+      )
+    })
+
     it('should accept a sort option', async () => {
       const collection = new DocumentCollection('io.cozy.todos', client)
       await collection.find({ done: false }, { sort: [{ label: 'desc' }] })

--- a/packages/cozy-stack-client/src/__tests__/setup.js
+++ b/packages/cozy-stack-client/src/__tests__/setup.js
@@ -5,13 +5,6 @@ expect.extend({
     if (!Array.isArray(received.data) && typeof received.data !== 'object')
       return fail('expected response to have a `data` property')
     if (Array.isArray(received.data)) {
-      if (
-        typeof received.meta !== 'object' ||
-        !received.meta.hasOwnProperty('count')
-      )
-        return fail(
-          'expected response to have a `meta` property with a `count`'
-        )
       if (typeof received.next !== 'boolean')
         return fail('expected response to have a boolean `next` property')
       if (typeof received.skip !== 'number')


### PR DESCRIPTION
Add support for bookmark pagination for documents `find` queries. For the record, bookmark are now the [preferred way to paginate](https://github.com/cozy/cozy-stack/blob/master/docs/mango.md#pagination-cookbook), as it performs way faster than skip.

Note we remove the `meta: {count}` response, as we can no longer know the total count of returned docs, at the query level. This shouldn't be a problem as we can easily retrieve this information by doing a `data.length`, but it might break existing code if some apps are relying on it.