### PR TITLE
fix: URL is already encoded, re-encoding it leads to a stack error

### DIFF
--- a/packages/cozy-client/src/cli/index.js
+++ b/packages/cozy-client/src/cli/index.js
@@ -64,7 +64,7 @@ const mkServerFlowCallback = serverOptions => authenticationURL =>
           'debug',
           'OAuth callback server started, waiting for authentication'
         )
-        opn(authenticationURL, { wait: false, url: true })
+        opn(authenticationURL, { wait: false })
       }
     })
 


### PR DESCRIPTION
Without this fix, when creating an interactive client, we have an
error on the login page from the stack:  "The redirect_uri parameter doesn\'t match the
registered ones"

With the parameter `url: true`, we have redirect_uri that is double
encoded.

```
before (wrong): redirect_uri=http%253A%252F%252Flocalhost%253A3333%252Fdo_access
after (correct): redirect_uri=http%3A%2F%2Flocalhost%3A3333%2Fdo_access
```