### PR TITLE
feat: Add deprecation message for withMutations

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -443,7 +443,7 @@ Responsible for
 
 * [HasMany](#HasMany)
     * [new HasMany()](#new_HasMany_new)
-    * [.count](#HasMany+count) ⇒ <code>Number</code>
+    * [.count](#HasMany+count) ⇒ <code>number</code>
     * [.addById()](#HasMany+addById)
 
 <a name="new_HasMany_new"></a>
@@ -477,13 +477,13 @@ const todo = {
 
 <a name="HasMany+count"></a>
 
-### hasMany.count ⇒ <code>Number</code>
+### hasMany.count ⇒ <code>number</code>
 Returns the total number of documents in the relationship.
 Does not handle documents absent from the store. If you want
 to do that, you can use .data.length.
 
 **Kind**: instance property of [<code>HasMany</code>](#HasMany)  
-**Returns**: <code>Number</code> - - Total number of documents in the relationships  
+**Returns**: <code>number</code> - - Total number of documents in the relationships  
 <a name="HasMany+addById"></a>
 
 ### hasMany.addById()
@@ -550,20 +550,20 @@ Association used for konnectors to retrieve all their related triggers.
 
 * [HasManyTriggers](#HasManyTriggers) ⇐ [<code>HasMany</code>](#HasMany)
     * _instance_
-        * [.count](#HasMany+count) ⇒ <code>Number</code>
+        * [.count](#HasMany+count) ⇒ <code>number</code>
         * [.addById()](#HasMany+addById)
     * _static_
         * [.query()](#HasManyTriggers.query)
 
 <a name="HasMany+count"></a>
 
-### hasManyTriggers.count ⇒ <code>Number</code>
+### hasManyTriggers.count ⇒ <code>number</code>
 Returns the total number of documents in the relationship.
 Does not handle documents absent from the store. If you want
 to do that, you can use .data.length.
 
 **Kind**: instance property of [<code>HasManyTriggers</code>](#HasManyTriggers)  
-**Returns**: <code>Number</code> - - Total number of documents in the relationships  
+**Returns**: <code>number</code> - - Total number of documents in the relationships  
 <a name="HasMany+addById"></a>
 
 ### hasManyTriggers.addById()

--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -281,33 +281,7 @@ function TodoList(props) {
 const ConnectedTodoList = withClient(TodoList)
 ```
 
-Alternatively, you have `withMutation()` which returns an HOC. This HOC forwards you a `createDocument`, a `saveDocument` and a `deleteDocument` in your props. They are the `create()`, `save()`and `delete()` functions from CozyClient, bound to the instance you gave to the `<CozyProvider />`.
-
-```jsx
-import { withMutations } from 'cozy-client'
-
-function TodoList(props) {
-  const { createDocument } = props
-  const createNewTodo = e => createDocument(
-    'io.cozy.todos', 
-    { label: e.target.elements['new-todo'], checked: false }
-  )
-  return (
-    <ul>
-      {/* todo items */}
-    </ul>
-    <form onSubmit={createNewTodo}>
-      <label htmlFor="new-todo">Todo</label>
-      <input id="new-todo" name="new-todo" />
-      <button type="submit">Add todo</button>
-    </form>
-  )
-}
-
-const ConnectedTodoList = withMutations()(TodoList)
-```
-
-Finally, `<Query />` also takes a `mutations` optional props. It should have a function that will receive the CozyClient instance, the query requested and the rest of props given to the component, and should return a keyed object which will be added to the props of your wrapped component.
+`<Query />` also takes a `mutations` optional props. It should have a function that will receive the CozyClient instance, the query requested and the rest of props given to the component, and should return a keyed object which will be added to the props of your wrapped component.
 
 ```jsx
 import { Query } from 'cozy-client'

--- a/packages/cozy-client/src/associations/HasMany.js
+++ b/packages/cozy-client/src/associations/HasMany.js
@@ -66,7 +66,7 @@ class HasMany extends Association {
    * Does not handle documents absent from the store. If you want
    * to do that, you can use .data.length.
    *
-   * @returns {Number} - Total number of documents in the relationships
+   * @returns {number} - Total number of documents in the relationships
    */
   get count() {
     const relationship = this.getRelationship()

--- a/packages/cozy-client/src/withMutations.jsx
+++ b/packages/cozy-client/src/withMutations.jsx
@@ -12,8 +12,8 @@ const makeMutationsObject = (mutations, client, props) => {
 
 /**
  * @function
- * @description HOC to provide mutations to components. Needs client in context
- * or as prop.
+ * @description HOC to provide mutations to components. Needs client in context or as prop.
+ * @deprecated Prefer to use withClient and access directly the client.
  * @param  {Function} mutations One ore more mutations, which are function
  * taking CozyClient as parameter and returning an object containing one or
  * more mutations as attributes.
@@ -31,6 +31,9 @@ const withMutations = (...mutations) => WrappedComponent => {
     constructor(props, context) {
       super(props, context)
       const client = props.client || context.client
+      console.warn(
+        `Deprecation: withMutations will be removed in the near future, prefer to use withClient to access the client. See https://github.com/cozy/cozy-client/pull/638 for more information.`
+      )
       if (!client) {
         throw new Error(
           `Could not find "client" in either the context or props of ${wrappedDisplayName}`

--- a/packages/cozy-client/src/withMutations.spec.jsx
+++ b/packages/cozy-client/src/withMutations.spec.jsx
@@ -23,6 +23,14 @@ describe('withMutations', () => {
     jest.spyOn(console, 'error').mockImplementation(message => {
       throw new Error(message)
     })
+    const originalWarn = console.warn
+    jest.spyOn(console, 'warn').mockImplementation(function(message) {
+      if (message.includes('Deprecation: withMutations')) {
+        return
+      } else {
+        return originalWarn.apply(this, arguments)
+      }
+    })
     const mutationsMock = client => ({
       myMutation1: () => {},
       myMutation2: () => {}


### PR DESCRIPTION
Instead of using withMutations, we have found that we prefer to use
withClient and methods using this client.

```
const doSomethingWithClient = client => {
  ...
}

const Component = withClient(({ client  }) => {
  const handleClick = () => {
    return doSomethingWithClient(client)
  }
  return <button onClick={handleClick}>click</button>
})
```