### PR TITLE
fix: Consider data object from stat

### DIFF
--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -466,8 +466,8 @@ class FileCollection extends DocumentCollection {
     }
     if (!childPath) {
       const childDoc = await this.statById(childID)
-      childPath = childDoc.path
-      childDirID = childDoc.dirID
+      childPath = childDoc.data.path
+      childDirID = childDoc.data.dirID
     }
 
     // Build hierarchy paths

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -656,6 +656,34 @@ describe('FileCollection', () => {
       )
     })
 
+    it('should find the parent with id', async () => {
+      client.fetchJSON
+        .mockReturnValueOnce({
+          data: {
+            _id: 'root-id',
+            dir_id: '',
+            path: '/'
+          }
+        })
+        .mockReturnValueOnce({
+          data: {
+            _id: '123',
+            dir_id: 'root-id',
+            path: '/a'
+          }
+        })
+        .mockReturnValueOnce({
+          data: {
+            _id: 'file-id',
+            dir_id: '123',
+            path: '/a/b'
+          }
+        })
+
+      const res = await collection.isChildOf('file-id', 'root-id')
+      expect(res).toEqual(true)
+    })
+
     it('should find the parent with dirID', async () => {
       const child = { _id: 'file-id', path: '/a/b/c', dirID: 'root-id' }
       const parent = 'root-id'


### PR DESCRIPTION
`isChildOf` was failing if the given child wasn't an object and the hierarchy deeper than 1