### PR TITLE
feat: Refresh stack token when invalid

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -443,7 +443,7 @@ Responsible for
 
 * [HasMany](#HasMany)
     * [new HasMany()](#new_HasMany_new)
-    * [.count](#HasMany+count) ⇒ <code>Number</code>
+    * [.count](#HasMany+count) ⇒ <code>number</code>
     * [.addById()](#HasMany+addById)
 
 <a name="new_HasMany_new"></a>
@@ -477,13 +477,13 @@ const todo = {
 
 <a name="HasMany+count"></a>
 
-### hasMany.count ⇒ <code>Number</code>
+### hasMany.count ⇒ <code>number</code>
 Returns the total number of documents in the relationship.
 Does not handle documents absent from the store. If you want
 to do that, you can use .data.length.
 
 **Kind**: instance property of [<code>HasMany</code>](#HasMany)  
-**Returns**: <code>Number</code> - - Total number of documents in the relationships  
+**Returns**: <code>number</code> - - Total number of documents in the relationships  
 <a name="HasMany+addById"></a>
 
 ### hasMany.addById()
@@ -550,20 +550,20 @@ Association used for konnectors to retrieve all their related triggers.
 
 * [HasManyTriggers](#HasManyTriggers) ⇐ [<code>HasMany</code>](#HasMany)
     * _instance_
-        * [.count](#HasMany+count) ⇒ <code>Number</code>
+        * [.count](#HasMany+count) ⇒ <code>number</code>
         * [.addById()](#HasMany+addById)
     * _static_
         * [.query()](#HasManyTriggers.query)
 
 <a name="HasMany+count"></a>
 
-### hasManyTriggers.count ⇒ <code>Number</code>
+### hasManyTriggers.count ⇒ <code>number</code>
 Returns the total number of documents in the relationship.
 Does not handle documents absent from the store. If you want
 to do that, you can use .data.length.
 
 **Kind**: instance property of [<code>HasManyTriggers</code>](#HasManyTriggers)  
-**Returns**: <code>Number</code> - - Total number of documents in the relationships  
+**Returns**: <code>number</code> - - Total number of documents in the relationships  
 <a name="HasMany+addById"></a>
 
 ### hasManyTriggers.addById()

--- a/packages/cozy-client/src/associations/HasMany.js
+++ b/packages/cozy-client/src/associations/HasMany.js
@@ -66,7 +66,7 @@ class HasMany extends Association {
    * Does not handle documents absent from the store. If you want
    * to do that, you can use .data.length.
    *
-   * @returns {Number} - Total number of documents in the relationships
+   * @returns {number} - Total number of documents in the relationships
    */
   get count() {
     const relationship = this.getRelationship()

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -194,7 +194,10 @@ class CozyStackClient {
     try {
       return await this.fetchJSONWithCurrentToken(method, path, body, options)
     } catch (e) {
-      if (errors.EXPIRED_TOKEN.test(e.message)) {
+      if (
+        errors.EXPIRED_TOKEN.test(e.message) ||
+        errors.INVALID_TOKEN.test(e.message)
+      ) {
         let token
         try {
           token = await this.refreshToken()

--- a/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
@@ -310,6 +310,27 @@ describe('CozyStackClient', () => {
       }
     })
 
+    it('should try to refresh the current token when received an invalid token error', async () => {
+      const client = new CozyStackClient(FAKE_INIT_OPTIONS)
+      global.fetch
+        .mockRejectOnce(
+          new Error(JSON.stringify({ error: 'Invalid JWT token' }))
+        )
+        .once([FAKE_APP_HTML, { status: 200 }])
+        .once([JSON.stringify({ res: 'ok' }), { status: 200 }])
+      await client.fetchJSON('GET', '/test')
+      const token = client.getAccessToken()
+      expect(token).toEqual(FAKE_APP_TOKEN)
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${FAKE_APP_TOKEN}`
+          })
+        })
+      )
+    })
+
     it('should not change option header even if we recall the method after an expired token for instance', async () => {
       jest.spyOn(client, 'fetchJSONWithCurrentToken')
       fetch.mockRejectedValueOnce({ message: 'Expired token' })

--- a/packages/cozy-stack-client/src/errors.js
+++ b/packages/cozy-stack-client/src/errors.js
@@ -1,7 +1,9 @@
 const EXPIRED_TOKEN = /Expired token/
 const CLIENT_NOT_FOUND = /Client not found/
+const INVALID_TOKEN = /Invalid JWT token/
 
 export default {
   EXPIRED_TOKEN,
-  CLIENT_NOT_FOUND
+  CLIENT_NOT_FOUND,
+  INVALID_TOKEN
 }


### PR DESCRIPTION
We were refreshing the app token after expiration. 

Some users sometimes have  invalid token. The exact scenario that make this possible is still unknown  but this change allows cozy-client to try  to fix the problem by itself.