### PR TITLE
chore: Do not truncate logs on script error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,7 @@ cache:
   directories:
   - node_modules
 script:
-- set -e
-- yarn lint
-- yarn build # before tests since packages rely on dist/ files to be available
-- yarn test --runInBand
-- yarn docs
-- set +e
-- (git diff --exit-code -- docs && echo "Docs are up-to-date") || (echo "Docs are not up-to-date, please run yarn docs and repush" && false)
+- ./scripts/travis.sh
 deploy:
   - provider: script
     skip-cleanup: true

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+yarn lint
+yarn build # before tests since packages rely on dist/ files to be available
+yarn test --runInBand
+yarn docs
+
+
+set +e # The following command relies on exit 1
+(git diff --exit-code -- docs && echo "Docs are up-to-date") || (echo "Docs are not up-to-date, please run yarn docs and repush" && false)


### PR DESCRIPTION
By moving the set -e inside its own file, it should prevent Travis bugs
where set -e prevents travis own error handling to pick up the logs

See https://github.com/travis-ci/docs-travis-ci-com/issues/1672 for more
information

https://docs.travis-ci.com/user/job-lifecycle/#breaking-the-build on what happens when a command exits with 1.