### PR TITLE
fix: Invert private / public params for a note url

### DIFF
--- a/packages/cozy-client/src/models/note.js
+++ b/packages/cozy-client/src/models/note.js
@@ -33,23 +33,24 @@ export const fetchURL = async (client, file) => {
     .getStackClient()
     .collection('io.cozy.notes')
     .fetchURL({ _id: file.id })
-  const searchParams = [['id', note_id]]
-  let pathname = ''
-  let publicArgs = {}
   if (sharecode) {
+    const searchParams = [['id', note_id]]
     searchParams.push(['sharecode', sharecode])
-    pathname = sharecode ? '/public/' : ''
-    publicArgs = { hash: `/n/${note_id}` }
+    if (public_name) searchParams.push(['username', public_name])
+    return generateWebLink({
+      cozyUrl: `${protocol}://${instance}`,
+      searchParams,
+      pathname: '/public/',
+      slug: 'notes',
+      subDomainType: subdomain
+    })
+  } else {
+    return generateWebLink({
+      cozyUrl: `${protocol}://${instance}`,
+      pathname: '',
+      slug: 'notes',
+      subDomainType: subdomain,
+      hash: `/n/${note_id}`
+    })
   }
-  if (public_name) searchParams.push(['username', public_name])
-
-  const url = generateWebLink({
-    cozyUrl: `${protocol}://${instance}`,
-    searchParams,
-    pathname,
-    slug: 'notes',
-    subDomainType: subdomain,
-    ...publicArgs
-  })
-  return url
 }

--- a/packages/cozy-client/src/models/note.spec.js
+++ b/packages/cozy-client/src/models/note.spec.js
@@ -30,9 +30,7 @@ describe('note model', () => {
         id: 1
       })
 
-      expect(generatedUrl.toString()).toEqual(
-        'https://foo-notes.mycozy/?id=1#/'
-      )
+      expect(generatedUrl.toString()).toEqual('https://foo-notes.mycozy/#/n/1')
 
       fetchURLspy.mockResolvedValue({
         data: {
@@ -47,7 +45,7 @@ describe('note model', () => {
       })
 
       expect(generatedUrl2.toString()).toEqual(
-        'https://foo-notes.mycozy/public/?id=1&sharecode=hahaha#/n/1'
+        'https://foo-notes.mycozy/public/?id=1&sharecode=hahaha#/'
       )
 
       fetchURLspy.mockResolvedValue({
@@ -64,7 +62,7 @@ describe('note model', () => {
       })
 
       expect(generatedUrl3.toString()).toEqual(
-        'https://foo-notes.mycozy/public/?id=1&sharecode=hahaha&username=Crash#/n/1'
+        'https://foo-notes.mycozy/public/?id=1&sharecode=hahaha&username=Crash#/'
       )
     })
   })


### PR DESCRIPTION
We need a hash for the private url and a search params for the public one. I was doing the oposite. 