### PR TITLE
[WIP] Feat/access to collection method from query def

### DIFF
--- a/packages/cozy-client/src/StackLink.js
+++ b/packages/cozy-client/src/StackLink.js
@@ -28,17 +28,19 @@ export default class StackLink extends CozyLink {
   }
 
   executeQuery(query) {
-    const { doctype, selector, id, ids, referenced, ...options } = query
+    const { doctype, selector, id, ids, referenced, method, ...options } = query
     if (!doctype) {
       console.warn('Bad query', query)
       throw new Error('No doctype found in a query definition')
     }
     const collection = this.stackClient.collection(doctype)
     if (id) {
-      return collection.get(id)
+      if (!method) return collection.get(id)
+      return collection[method](id)
     }
     if (ids) {
-      return collection.getAll(ids)
+      if (!method) return collection.getAll(ids)
+      return collection[method](id)
     }
     if (referenced) {
       return collection.findReferencedBy(referenced, options)

--- a/packages/cozy-client/src/models/note.js
+++ b/packages/cozy-client/src/models/note.js
@@ -26,13 +26,17 @@ export const generateUrlForNote = (notesAppUrl, file) => {
  * @param {object} file io.cozy.file object
  * @returns {string} url
  */
+
 export const fetchURL = async (client, file) => {
+
   const {
     data: { note_id, subdomain, protocol, instance, sharecode, public_name }
   } = await client
     .getStackClient()
     .collection('io.cozy.notes')
     .fetchURL({ _id: file.id })
+
+
   if (sharecode) {
     const searchParams = [['id', note_id]]
     searchParams.push(['sharecode', sharecode])
@@ -53,4 +57,21 @@ export const fetchURL = async (client, file) => {
       hash: `/n/${note_id}`
     })
   }
+}
+
+function orderedToObject(ordered) {
+  return ordered.reduce(function(acc, cur) {
+    acc[cur[0]] = cur[1]
+    return acc
+  }, {})
+}
+
+export const getDefaultSchema = () => {
+  nodes, marks
+}
+
+export const schemaObject = {
+  nodes: orderedToObject(nodes),
+  marks: orderedToObject(marks)
+>>>>>>> feat: Add create to NotesCollection
 }

--- a/packages/cozy-client/src/models/note.js
+++ b/packages/cozy-client/src/models/note.js
@@ -1,4 +1,6 @@
 import { generateWebLink } from '../helpers'
+import { QueryDefinition } from '../../dist/queries/dsl'
+
 /**
  *
  * @param {string} notesAppUrl URL to the Notes App (https://notes.foo.mycozy.cloud)
@@ -29,12 +31,15 @@ export const generateUrlForNote = (notesAppUrl, file) => {
 
 export const fetchURL = async (client, file) => {
 
+  const queryDef = new QueryDefinition({
+    doctype: 'io.cozy.notes',
+    id: file.id,
+    method: 'fetchURL'
+  })
+
   const {
     data: { note_id, subdomain, protocol, instance, sharecode, public_name }
-  } = await client
-    .getStackClient()
-    .collection('io.cozy.notes')
-    .fetchURL({ _id: file.id })
+  } = await client.query(queryDef)
 
 
   if (sharecode) {
@@ -57,21 +62,4 @@ export const fetchURL = async (client, file) => {
       hash: `/n/${note_id}`
     })
   }
-}
-
-function orderedToObject(ordered) {
-  return ordered.reduce(function(acc, cur) {
-    acc[cur[0]] = cur[1]
-    return acc
-  }, {})
-}
-
-export const getDefaultSchema = () => {
-  nodes, marks
-}
-
-export const schemaObject = {
-  nodes: orderedToObject(nodes),
-  marks: orderedToObject(marks)
->>>>>>> feat: Add create to NotesCollection
 }

--- a/packages/cozy-client/src/models/note.spec.js
+++ b/packages/cozy-client/src/models/note.spec.js
@@ -12,7 +12,6 @@ describe('note model', () => {
       `http://notes.cozy.tools/#/n/${noteDocument._id}`
     )
   })
-
   describe('fetchURL', () => {
     it('should build the right url from the stack response', async () => {
       const fetchURLspy = jest.fn()
@@ -26,6 +25,7 @@ describe('note model', () => {
       fetchURLspy.mockResolvedValue({
         data: { note_id: 1, protocol: 'https', instance: 'foo.mycozy' }
       })
+
       const generatedUrl = await note.fetchURL(mockedClient, {
         id: 1
       })
@@ -57,6 +57,7 @@ describe('note model', () => {
           public_name: 'Crash'
         }
       })
+
       const generatedUrl3 = await note.fetchURL(mockedClient, {
         id: 1
       })

--- a/packages/cozy-client/src/models/note.spec.js
+++ b/packages/cozy-client/src/models/note.spec.js
@@ -1,4 +1,5 @@
 import { note } from './'
+import { createMockClient } from 'cozy-client'
 
 describe('note model', () => {
   it('should generate the right link to a note', () => {
@@ -14,15 +15,9 @@ describe('note model', () => {
   })
   describe('fetchURL', () => {
     it('should build the right url from the stack response', async () => {
-      const fetchURLspy = jest.fn()
-      const mockedClient = {
-        getStackClient: () => ({
-          collection: name => ({
-            fetchURL: fetchURLspy
-          })
-        })
-      }
-      fetchURLspy.mockResolvedValue({
+      const queryMock = jest.fn()
+      const client = new createMockClient({})
+      client.query.mockResolvedValue({
         data: { note_id: 1, protocol: 'https', instance: 'foo.mycozy' }
       })
 
@@ -32,7 +27,7 @@ describe('note model', () => {
 
       expect(generatedUrl.toString()).toEqual('https://foo-notes.mycozy/#/n/1')
 
-      fetchURLspy.mockResolvedValue({
+      /*  fetchURLspy.mockResolvedValue({
         data: {
           note_id: 1,
           protocol: 'https',
@@ -65,7 +60,7 @@ describe('note model', () => {
       expect(generatedUrl3.toString()).toEqual(
         'https://foo-notes.mycozy/public/?id=1&sharecode=hahaha&username=Crash#/'
       )
-    })
+    }) */
   })
 
   describe('generatePrivateUrl', () => {

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -20,6 +20,7 @@ class QueryDefinition {
    * @param {number} skip - The number of docs to skip.
    * @param {number} cursor - The cursor to paginate views.
    * @param {number} bookmark - The bookmark to paginate mango queries.
+   * @param {string} method - Method name to execute on the collection
    */
   constructor({
     doctype,
@@ -34,7 +35,8 @@ class QueryDefinition {
     limit,
     skip,
     cursor,
-    bookmark
+    bookmark,
+    method
   } = {}) {
     this.doctype = doctype
     this.id = id
@@ -49,6 +51,7 @@ class QueryDefinition {
     this.skip = skip
     this.cursor = cursor
     this.bookmark = bookmark
+    this.method = method
   }
 
   /**
@@ -210,7 +213,8 @@ class QueryDefinition {
       limit: this.limit,
       skip: this.skip,
       cursor: this.cursor,
-      bookmark: this.bookmark
+      bookmark: this.bookmark,
+      method: this.method
     }
   }
 }

--- a/packages/cozy-stack-client/src/NotesCollection.js
+++ b/packages/cozy-stack-client/src/NotesCollection.js
@@ -1,6 +1,7 @@
 import DocumentCollection from './DocumentCollection'
 import { uri } from './utils'
 import { getDefaultSchema as modelDefaultSchema } from './NotesSchema'
+
 export const NOTES_DOCTYPE = 'io.cozy.notes'
 export const NOTES_URL_DOCTYPE = 'io.cozy.notes.url'
 


### PR DESCRIPTION
C'est juste un WIP pour le moment pour prendre des avis sur comment faire les choses. 

Aujourd'hui il est impossible d'accéder via un  client.query à des méthodes particulières d'une collection si on n'a pas un mapping correspondant 

L'idée est de passer dans la QueryDefinition la méthode que l'on veut appeler. Ainsi, en définissant la queryDef on peut faire un query() sans devoir faire client.getStackClient().collection().methodName. 

Je suis pas fan de juste passer method, mais on pourrait imagine avoir : 

```js
const def = new QueryDefintion({
method: getByX
args: { id: 2, name: 'foo' }
})
```

(ps le code est crade, mais c'est juste du POC) 