### PR TITLE
feat: Add fake import to trigger lint error

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -36,6 +36,7 @@ import zip from 'lodash/zip'
 import forEach from 'lodash/forEach'
 import get from 'lodash/get'
 import MicroEE from 'microee'
+import MicroEE from 'microee'
 
 const ensureArray = arr => (Array.isArray(arr) ? arr : [arr])
 


### PR DESCRIPTION
I want to test that the script on Travis correctly exits as soon as
one command fails, and that it makes the build red.