### PR TITLE
feat: Support single cozy dataset in DOM

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -1179,7 +1179,9 @@ instantiation of the client.`
    */
   loadInstanceOptionsFromDOM(selector = '[role=application]') {
     const root = document.querySelector(selector)
-    this.instanceOptions = { ...root.dataset } // convert from DOMStringMap to plain object
+    this.instanceOptions = root.dataset.cozy
+      ? JSON.parse(root.dataset.cozy)
+      : { ...root.dataset } // convert from DOMStringMap to plain object
   }
 
   /**

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -1151,5 +1151,21 @@ describe('CozyClient', () => {
 
       document.querySelector = globalQuerySelectorBefore
     })
+
+    it('should load the single DOM dataset', () => {
+      const options = { domain: 'cozy.tools', token: 'abc123' }
+      const dataset = {
+        cozy: JSON.stringify(options)
+      }
+
+      const globalQuerySelectorBefore = document.querySelector
+      document.querySelector = jest.fn().mockReturnValue({ dataset })
+
+      const client = new CozyClient({})
+      client.loadInstanceOptionsFromDOM()
+      expect(client.getInstanceOptions()).toEqual(options)
+
+      document.querySelector = globalQuerySelectorBefore
+    })
   })
 })


### PR DESCRIPTION
Instead of injecting instance options with a multitude of variables like `{{.Locale}}`, `{{.Domain}}`, etc… we can also inject a single `{{.Cozy}}` variable. We want to support this as well when using `client.getInstanceOptions()`.