### PR TITLE
fix: Don't import from cozy-client. Import from path

### DIFF
--- a/packages/cozy-client/src/hooks/useAppLinkWithStoreFallback.jsx
+++ b/packages/cozy-client/src/hooks/useAppLinkWithStoreFallback.jsx
@@ -1,7 +1,10 @@
 import { useEffect, useState } from 'react'
-import { Q, models } from 'cozy-client'
-
-const { applications } = models
+import { Q } from '../queries/dsl'
+import {
+  isInstalled as checkIfAppIsInstalled,
+  getStoreURL,
+  getUrl
+} from '../models/applications'
 
 const useAppLinkWithStoreFallback = (slug, client, path = '') => {
   const [fetchStatus, setFetchStatus] = useState('loading')
@@ -13,12 +16,12 @@ const useAppLinkWithStoreFallback = (slug, client, path = '') => {
       try {
         const apps = await client.query(Q('io.cozy.apps'))
         const appDocument = { slug }
-        const appInstalled = applications.isInstalled(apps.data, appDocument)
+        const appInstalled = checkIfAppIsInstalled(apps.data, appDocument)
         setIsInstalled(!!appInstalled)
         if (appInstalled) {
-          setURL(applications.getUrl(appInstalled) + path)
+          setURL(getUrl(appInstalled) + path)
         } else {
-          setURL(applications.getStoreURL(apps.data, appDocument))
+          setURL(getStoreURL(apps.data, appDocument))
         }
         setFetchStatus('loaded')
       } catch (error) {


### PR DESCRIPTION
Importing from the module itself has a side effect while mocking the client with `genMockFromModule`. We ended with a cozy-client instance without `Cozyclient.models.application` and it fails.

By importing methods from file, it works well. 

```jsx
 TypeError: Cannot read property 'applications' of undefined

      18 | var _cozyClient = require("cozy-client");
      19 |
    > 20 | var applications = _cozyClient.models.applications;
         |                                       ^
      21 |
      22 | var useAppLinkWithStoreFallback = function useAppLinkWithStoreFallback(slug, client) {
      23 |   var path = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : '';

      at Object.applications (../cozy-client/packages/cozy-client/dist/hooks/useAppLinkWithStoreFallback.js:20:39)
      at Object.require (../cozy-client/packages/cozy-client/dist/hooks/index.js:15:59)
      at Object.require (../cozy-client/packages/cozy-client/dist/index.js:280:14)
      at Object.genMockFromModule [as user:/Users/quentinvalmori/Sites/cozy-client/packages/cozy-client/dist/index.js:] (src/drive/web/modules/drive/SharingsContainer.spec.jsx:27:30)
      at Object.<anonymous> (src/drive/web/modules/drive/SharingsContainer.spec.jsx:2:1)
```