### PR TITLE
fix: Allow custom token file path in createClientInteractive

### DIFF
--- a/packages/cozy-client/src/cli/index.js
+++ b/packages/cozy-client/src/cli/index.js
@@ -146,7 +146,7 @@ const readJSON = (fs, filename) => {
  * ```
  */
 const createClientInteractive = (clientOptions, serverOpts) => {
-  const serverOptions = merge(serverOpts, DEFAULT_SERVER_OPTIONS)
+  const serverOptions = merge(DEFAULT_SERVER_OPTIONS, serverOpts)
   const createClientFS = serverOptions.fs || fs
 
   const mergedClientOptions = merge(


### PR DESCRIPTION
lodash/merge option were in the wrong order for server options