### PR TITLE
feat: Snapshot the client in a simplified form

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -36,6 +36,7 @@ import zip from 'lodash/zip'
 import forEach from 'lodash/forEach'
 import get from 'lodash/get'
 import MicroEE from 'microee'
+import { CozyClient as SnapshotClient } from './testing/snapshots'
 
 const ensureArray = arr => (Array.isArray(arr) ? arr : [arr])
 
@@ -1194,6 +1195,10 @@ instantiation of the client.`
     Object.entries(data).forEach(([doctype, data]) => {
       this.dispatch(receiveQueryResult(null, { data }))
     })
+  }
+
+  toJSON() {
+    return new SnapshotClient({ uri: this.options.uri })
   }
 }
 CozyClient.fetchPolicies = fetchPolicies

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -1152,4 +1152,11 @@ describe('CozyClient', () => {
       document.querySelector = globalQuerySelectorBefore
     })
   })
+
+  describe('serialization', () => {
+    it('should be snapshotted in a simplified format', () => {
+      const client = new CozyClient({ uri: 'http://localhost:8080' })
+      expect(client).toMatchSnapshot()
+    })
+  })
 })

--- a/packages/cozy-client/src/__snapshots__/CozyClient.spec.js.snap
+++ b/packages/cozy-client/src/__snapshots__/CozyClient.spec.js.snap
@@ -20,3 +20,9 @@ Array [
   },
 ]
 `;
+
+exports[`CozyClient serialization should be snapshotted in a simplified format 1`] = `
+CozyClient {
+  "uri": "http://localhost:8080",
+}
+`;

--- a/packages/cozy-client/src/testing/snapshots.js
+++ b/packages/cozy-client/src/testing/snapshots.js
@@ -1,0 +1,7 @@
+class SnapshotObject {
+  constructor(attrs) {
+    Object.assign(this, attrs)
+  }
+}
+
+export class CozyClient extends SnapshotObject {}


### PR DESCRIPTION
Jest by default uses `jest-pretty-format` to serialize objects
in snapshots. `pretty-format` will introspect the object and print
all internal properties. This makes tests relying on snapshots
that use CozyClient very brittle, as even internal/private properties
will get snapshotted, and every implementation change will break snapshots.

`pretty-format` can use the toJSON method to serialize an object. It allows
us to customize the object that will be serialized into the snapshots.

## Drawbacks/Alternatives

An alternative to using `toJSON` to customize jest serialization would be to use a custom serializer. The problem I see with this approach is that every project wanting to snapshot CozyClient in a sane way would have to add a custom serializer.

Here, CozyClient carries with itself the serialization. It seems better for the developer experience.

A drawback would be that toJSON could be used by other projects/programs, other than Jest. I don't see any example right now though. A possible solution would be to test for `process.env === 'test'` inside `toJSON` to only return the "snapshot" version if we are inside tests.

## Before/after

```patch
  CozyClient {
+   "uri": "http://localhost:8080",
-   "appMetadata": Object {},
-   "chain": CozyLink {
-     "request": [Function],
-   },
-   "client": MockedStackClient {
-     "collection": [MockFunction],
-     "jobs": JobCollection {
-       "stackClient": MockedStackClient {
-         "collection": [MockFunction],
-         "jobs": [Circular],
-         "konnectors": KonnectorCollection {
-           "doctype": "io.cozy.konnectors",
-           "endpoint": "/konnectors/",
-           "indexes": Object {},
-           "stackClient": [Circular],
-         },
-         "options": Object {
-           "onRevocationChange": [Function],
-           "onTokenRefresh": [Function],
-           "uri": "http://localhost:8080",
-         },
-         "token": null,
-         "uri": "http://localhost:8080",
-       },
-     },
-     "konnectors": KonnectorCollection {
-       "doctype": "io.cozy.konnectors",
-       "endpoint": "/konnectors/",
-       "indexes": Object {},
-       "stackClient": MockedStackClient {
-         "collection": [MockFunction],
-         "jobs": JobCollection {
-           "stackClient": [Circular],
-         },
-         "konnectors": [Circular],
-         "options": Object {
-           "onRevocationChange": [Function],
-           "onTokenRefresh": [Function],
-           "uri": "http://localhost:8080",
-         },
-         "token": null,
-         "uri": "http://localhost:8080",
-       },
-     },
-     "options": Object {
-       "onRevocationChange": [Function],
-       "onTokenRefresh": [Function],
-       "uri": "http://localhost:8080",
-     },
-     "token": null,
-     "uri": "http://localhost:8080",
-   },
-   "handleRevocationChange": [Function],
-   "handleTokenRefresh": [Function],
-   "idCounter": 1,
-   "instanceOptions": Object {},
-   "isLogged": false,
-   "links": Array [
-     StackLink {
-       "stackClient": MockedStackClient {
-         "collection": [MockFunction],
-         "jobs": JobCollection {
-           "stackClient": [Circular],
-         },
-         "konnectors": KonnectorCollection {
-           "doctype": "io.cozy.konnectors",
-           "endpoint": "/konnectors/",
-           "indexes": Object {},
-           "stackClient": [Circular],
-         },
-         "options": Object {
-           "onRevocationChange": [Function],
-           "onTokenRefresh": [Function],
-           "uri": "http://localhost:8080",
-         },
-         "token": null,
-         "uri": "http://localhost:8080",
-       },
-     },
-   ],
-   "options": Object {
-     "uri": "http://localhost:8080",
-   },
-   "plugins": Object {},
-   "schema": Schema {
-     "byDoctype": Object {},
-     "client": MockedStackClient {
-       "collection": [MockFunction],
-       "jobs": JobCollection {
-         "stackClient": [Circular],
-       },
-       "konnectors": KonnectorCollection {
-         "doctype": "io.cozy.konnectors",
-         "endpoint": "/konnectors/",
-         "indexes": Object {},
-         "stackClient": [Circular],
-       },
-       "options": Object {
-         "onRevocationChange": [Function],
-         "onTokenRefresh": [Function],
-         "uri": "http://localhost:8080",
-       },
-       "token": null,
-       "uri": "http://localhost:8080",
-     },
-   },
-   "stackClient": MockedStackClient {
-     "collection": [MockFunction],
-     "jobs": JobCollection {
-       "stackClient": [Circular],
-     },
-     "konnectors": KonnectorCollection {
-       "doctype": "io.cozy.konnectors",
-       "endpoint": "/konnectors/",
-       "indexes": Object {},
-       "stackClient": [Circular],
-     },
-     "options": Object {
-       "onRevocationChange": [Function],
-       "onTokenRefresh": [Function],
-       "uri": "http://localhost:8080",
-     },
-     "token": null,
-     "uri": "http://localhost:8080",
-   },
```