### PR TITLE
feat: Add isShortcut method

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -93,6 +93,8 @@ example.</p>
 <dd></dd>
 <dt><a href="#isNote">isNote</a></dt>
 <dd></dd>
+<dt><a href="#isShortcurt">isShortcurt</a> ⇒ <code>boolean</code></dt>
+<dd></dd>
 <dt><a href="#shouldDisplayOffers">shouldDisplayOffers</a></dt>
 <dd><p>Returns whether an instance is concerned by our offers</p>
 </dd>
@@ -1458,6 +1460,16 @@ getAppDisplayName - Combines the translated prefix and name of the app into a si
 
 ## isNote
 **Kind**: global constant  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| file | <code>File</code> | io.cozy.files |
+
+<a name="isShortcurt"></a>
+
+## isShortcurt ⇒ <code>boolean</code>
+**Kind**: global constant  
+**Returns**: <code>boolean</code> - true if the file is a shortcut  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -34,6 +34,14 @@ export const isNote = file => {
 }
 
 /**
+ *
+ * @param {File} file io.cozy.files
+ * @returns {boolean} true if the file is a shortcut
+ */
+export const isShortcurt = file => {
+  return file && file.class === 'shortcut'
+}
+/**
  * Normalizes an object representing a io.cozy.files object
  *
  * Ensures existence of `_id` and `_type`

--- a/packages/cozy-client/src/models/file.spec.js
+++ b/packages/cozy-client/src/models/file.spec.js
@@ -30,6 +30,21 @@ describe('File Model', () => {
     expect(file.isNote(note2)).toBe(true)
   })
 
+  it('test if a file is a shortcut or not', () => {
+    const shortcut = {
+      type: 'file',
+      class: 'shortcut'
+    }
+
+    const image = {
+      type: 'file',
+      class: 'image'
+    }
+
+    expect(file.isShortcurt(shortcut)).toBe(true)
+    expect(file.isShortcurt(image)).toBe(false)
+  })
+
   describe('normalizeFile', () => {
     const id = 'uuid123'
     const type = 'io.cozy.files'


### PR DESCRIPTION
Small PR... to spread the word ;) 

Just add a new method in the File's model to know if the current file is a shortcut or not. 

Shortcut is a new "kind" of io.cozy.files (https://github.com/cozy/cozy-stack/pull/2387) 

Since doc is ok now: https://docs.cozy.io/en/cozy-stack/shortcuts/