### PR TITLE
CreateClientInteractive improvements

### DIFF
--- a/packages/cozy-client/src/cli/index.js
+++ b/packages/cozy-client/src/cli/index.js
@@ -192,4 +192,22 @@ const createClientInteractive = (clientOptions, serverOpts) => {
   })
 }
 
+const main = async () => {
+  const client = await createClientInteractive({
+    scope: ['io.cozy.files'],
+    uri: 'http://cozy.tools:8080',
+    oauth: {
+      softwareID: 'io.cozy.client.cli'
+    }
+  })
+  console.log(client.toJSON())
+}
+
+if (require.main === module) {
+  main().catch(e => {
+    console.error(e)
+    process.exit(1)
+  })
+}
+
 export { createClientInteractive }

--- a/packages/cozy-client/src/cli/index.js
+++ b/packages/cozy-client/src/cli/index.js
@@ -63,7 +63,12 @@ const mkServerFlowCallback = serverOptions => authenticationURL =>
           'debug',
           'OAuth callback server started, waiting for authentication'
         )
-        opn(authenticationURL, { wait: false })
+        if (serverOptions.shouldOpenAuthenticationPage !== false) {
+          opn(authenticationURL, { wait: false })
+        }
+        if (serverOptions.onListen) {
+          serverOptions.onListen({ authenticationURL })
+        }
       }
     })
 

--- a/packages/cozy-client/src/cli/index.js
+++ b/packages/cozy-client/src/cli/index.js
@@ -13,16 +13,29 @@ const log = logger.namespace('create-cli-client')
 global.fetch = require('isomorphic-fetch')
 global.btoa = require('btoa')
 
+/**
+ * Creates and starts and HTTP server suitable for OAuth authentication
+ *
+ * @param  {Function} serverOptions.onAuthentication - Additional callback called
+ * when the user authenticates
+ * @param  {Function} serverOptions.route - Route used for authentication
+ * @param  {Function} serverOptions.route - Port on which the server will listen
+ * @param  {Function} serverOptions.onListen - Callback called when the
+ * server starts
+ *
+ * @private
+ */
 const createCallbackServer = serverOptions => {
+  const { route, onListen, onAuthentication, port } = serverOptions
   const server = http.createServer((request, response) => {
-    if (request.url.indexOf(serverOptions.route) === 0) {
-      serverOptions.onAuthentication(request.url)
+    if (request.url.indexOf(route) === 0) {
+      onAuthentication(request.url)
       response.write('Authentication successful, you can close this page.')
       response.end()
     }
   })
-  server.listen(serverOptions.port, () => {
-    serverOptions.onListen()
+  server.listen(port, () => {
+    onListen()
   })
   enableDestroy(server)
   return server
@@ -38,6 +51,13 @@ const createCallbackServer = serverOptions => {
  *
  * When the server is started, the authentication page is opened on the
  * desktop browser of the user.
+ *
+ * @param {Integer} serverOptions.port - Port used for the OAuth callback server
+ * @param {Function} serverOptions.onAuthentication - Callback when the user authenticates
+ * @param {Function} serverOptions.onListen - Callback called with the authentication URL
+ * when the server starts
+ * @param {boolean} serverOptions.shouldOpenAuthenticationPage - Whether the authentication
+ * page should be automatically opened (default: true)
  *
  * @private
  */


### PR DESCRIPTION
### Remove open handles

After resolve/reject of the oauth process, it is important to clean all
timeouts, otherwise it leaves open handles that prevent node process
to completely shutdown. It was particularly visible since there was a
30 sec rejection timeout

### Option for fully automatic oauth client creation

See commit description for more details