### PR TITLE
useClient hook

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,9 @@
     ],
     "jsdoc/require-jsdoc": 0, // --fix adds empty jsdocs 
     "jsdoc/require-param": 0, // --fix breaks docstrings without params
-    "jsdoc/require-returns": 0 // too much warnings for now
+    "jsdoc/require-returns": 0, // too much warnings for now
+    "jsdoc/require-returns-description": 0, // too much warnings for now
+    "jsdoc/check-param-names": 2
   },
   "settings": {
     "react": {

--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -131,7 +131,7 @@ is loading.</p>
 ## Functions
 
 <dl>
-<dt><a href="#createClientInteractive">createClientInteractive()</a></dt>
+<dt><a href="#createClientInteractive">createClientInteractive(clientOptions)</a></dt>
 <dd><p>Creates a client with interactive authentication.</p>
 <ul>
 <li>Will start an OAuth flow and open an authentication page</li>
@@ -139,19 +139,13 @@ is loading.</p>
 <li>Resolves with the client after user authentication</li>
 </ul>
 </dd>
-<dt><a href="#withClient">withClient(Component)</a> ⇒ <code>function</code></dt>
-<dd><p>HOC to provide client from context as prop</p>
-</dd>
-<dt><a href="#queryConnect">queryConnect(querySpecs)</a> ⇒ <code>function</code></dt>
-<dd><p>HOC creator to connect component to several queries in a declarative manner</p>
-</dd>
 <dt><a href="#sanitizeCategories">sanitizeCategories()</a></dt>
 <dd><p>Filters unauthorized categories. Defaults to [&#39;others&#39;] if no suitable category.</p>
 </dd>
 <dt><a href="#sanitize">sanitize(manifest)</a> ⇒ <code>Manifest</code></dt>
 <dd><p>Normalize app manifest, retrocompatibility for old manifests</p>
 </dd>
-<dt><a href="#createMockClient">createMockClient()</a> ⇒ <code><a href="#CozyClient">CozyClient</a></code></dt>
+<dt><a href="#createMockClient">createMockClient(options)</a> ⇒ <code><a href="#CozyClient">CozyClient</a></code></dt>
 <dd><p>Creates a client suitable for use in tests</p>
 <ul>
 <li>client.{query,save} are mocked</li>
@@ -195,6 +189,8 @@ we have in the store.</p>
 <dt><a href="#PermissionVerb">PermissionVerb</a> : <code>&#x27;ALL&#x27;</code> | <code>&#x27;GET&#x27;</code> | <code>&#x27;PATCH&#x27;</code> | <code>&#x27;POST&#x27;</code> | <code>&#x27;PUT&#x27;</code> | <code>&#x27;DELETE&#x27;</code></dt>
 <dd></dd>
 <dt><a href="#PermissionItem">PermissionItem</a> : <code>object</code></dt>
+<dd></dd>
+<dt><a href="#Registry">Registry</a> : <code>RegistryApp</code></dt>
 <dd></dd>
 </dl>
 
@@ -621,11 +617,11 @@ Responsible for
         * [.getRelationshipStoreAccessors()](#CozyClient+getRelationshipStoreAccessors)
         * [.getCollectionFromState(type)](#CozyClient+getCollectionFromState) ⇒ [<code>Array.&lt;Document&gt;</code>](#Document)
         * [.getDocumentFromState(type, id)](#CozyClient+getDocumentFromState) ⇒ [<code>Document</code>](#Document)
-        * [.getQueryFromState(id)](#CozyClient+getQueryFromState) ⇒ [<code>QueryState</code>](#QueryState)
+        * [.getQueryFromState(id, options)](#CozyClient+getQueryFromState) ⇒ [<code>QueryState</code>](#QueryState)
         * [.register(cozyURL)](#CozyClient+register) ⇒ <code>object</code>
         * [.startOAuthFlow(openURLCallback)](#CozyClient+startOAuthFlow) ⇒ <code>object</code>
         * [.renewAuthorization()](#CozyClient+renewAuthorization) ⇒ <code>object</code>
-        * [.setStore(store)](#CozyClient+setStore)
+        * [.setStore(store, options)](#CozyClient+setStore)
         * [.checkForRevocation()](#CozyClient+checkForRevocation)
         * [.handleRevocationChange()](#CozyClient+handleRevocationChange)
         * [.handleTokenRefresh()](#CozyClient+handleTokenRefresh)
@@ -635,7 +631,7 @@ Responsible for
         * [.setData(data)](#CozyClient+setData)
     * _static_
         * [.fromOldClient()](#CozyClient.fromOldClient)
-        * [.fromOldOAuthClient()](#CozyClient.fromOldOAuthClient)
+        * [.fromOldOAuthClient()](#CozyClient.fromOldOAuthClient) ⇒ [<code>CozyClient</code>](#CozyClient)
         * [.fromEnv()](#CozyClient.fromEnv)
         * [.registerHook(doctype, name, fn)](#CozyClient.registerHook)
 
@@ -795,7 +791,7 @@ executes its query when mounted if no fetch policy has been indicated.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| queryDefinition | [<code>QueryDefinition</code>](#QueryDefinition) |  |
+| queryDefinition | [<code>QueryDefinition</code>](#QueryDefinition) | Definition that will be executed |
 | options | <code>string</code> | Options |
 | options.as | <code>string</code> | Names the query so it can be reused (by multiple components for example) |
 
@@ -811,7 +807,7 @@ result in a lot of network requests.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| queryDefinition | [<code>QueryDefinition</code>](#QueryDefinition) |  |
+| queryDefinition | [<code>QueryDefinition</code>](#QueryDefinition) | Definition to be executed |
 | options | <code>object</code> | Options to the query |
 
 <a name="CozyClient+fetchRelationships"></a>
@@ -906,7 +902,7 @@ Get a document from the internal store.
 
 <a name="CozyClient+getQueryFromState"></a>
 
-### cozyClient.getQueryFromState(id) ⇒ [<code>QueryState</code>](#QueryState)
+### cozyClient.getQueryFromState(id, options) ⇒ [<code>QueryState</code>](#QueryState)
 Get a query from the internal store.
 
 **Kind**: instance method of [<code>CozyClient</code>](#CozyClient)  
@@ -915,6 +911,7 @@ Get a query from the internal store.
 | Param | Type | Description |
 | --- | --- | --- |
 | id | <code>string</code> | Id of the query (set via Query.props.as) |
+| options | <code>object</code> | Options |
 | options.hydrated | <code>boolean</code> | Whether documents should be returned already hydrated (default: false) |
 
 <a name="CozyClient+register"></a>
@@ -952,7 +949,7 @@ has expired.
 **Returns**: <code>object</code> - Contains the fetched token and the client information.  
 <a name="CozyClient+setStore"></a>
 
-### cozyClient.setStore(store)
+### cozyClient.setStore(store, options)
 Sets the internal store of the client. Use this when you want to have cozy-client's
 internal store colocated with your existing Redux store.
 
@@ -965,6 +962,7 @@ use options.force = true.
 | Param | Type | Description |
 | --- | --- | --- |
 | store | <code>ReduxStore</code> | A redux store |
+| options | <code>object</code> | Options |
 | options.force | <code>boolean</code> | Will deactivate throwing when client's store already exists |
 
 **Example**  
@@ -1044,13 +1042,14 @@ a client with a cookie-based instance of cozy-client-js.
 **Kind**: static method of [<code>CozyClient</code>](#CozyClient)  
 <a name="CozyClient.fromOldOAuthClient"></a>
 
-### CozyClient.fromOldOAuthClient()
+### CozyClient.fromOldOAuthClient() ⇒ [<code>CozyClient</code>](#CozyClient)
 To help with the transition from cozy-client-js to cozy-client, it is possible to instantiate
 a client with an OAuth-based instance of cozy-client-js.
 
 Warning: unlike other instantiators, this one needs to be awaited.
 
 **Kind**: static method of [<code>CozyClient</code>](#CozyClient)  
+**Returns**: [<code>CozyClient</code>](#CozyClient) - An instance of a client, configured from the old client  
 <a name="CozyClient.fromEnv"></a>
 
 ### CozyClient.fromEnv()
@@ -1089,12 +1088,12 @@ from a Cozy. `QueryDefinition`s are sent to links.
 **Kind**: global class  
 
 * [QueryDefinition](#QueryDefinition)
-    * [new QueryDefinition(doctype, id, ids, selector, fields, indexedFields, sort, includes, referenced, limit, skip, cursor, bookmark)](#new_QueryDefinition_new)
+    * [new QueryDefinition(options)](#new_QueryDefinition_new)
     * [.getById(id)](#QueryDefinition+getById) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
     * [.getByIds(ids)](#QueryDefinition+getByIds) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
     * [.where(selector)](#QueryDefinition+where) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
     * [.select(fields)](#QueryDefinition+select) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
-    * [.indexFields(fields)](#QueryDefinition+indexFields) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
+    * [.indexFields(indexedFields)](#QueryDefinition+indexFields) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
     * [.sortBy(sort)](#QueryDefinition+sortBy) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
     * [.include(includes)](#QueryDefinition+include) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
     * [.limitBy(limit)](#QueryDefinition+limitBy) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
@@ -1105,23 +1104,24 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 <a name="new_QueryDefinition_new"></a>
 
-### new QueryDefinition(doctype, id, ids, selector, fields, indexedFields, sort, includes, referenced, limit, skip, cursor, bookmark)
+### new QueryDefinition(options)
 
 | Param | Type | Description |
 | --- | --- | --- |
-| doctype | <code>string</code> | The doctype of the doc. |
-| id | <code>string</code> | The id of the doc. |
-| ids | <code>Array</code> | The ids of the docs. |
-| selector | <code>object</code> | The selector to query the docs. |
-| fields | <code>Array</code> | The fields to return. |
-| indexedFields | <code>Array</code> | The fields to index. |
-| sort | <code>Array</code> | The sorting params. |
-| includes | <code>string</code> | The docs to include. |
-| referenced | <code>string</code> | The referenced document. |
-| limit | <code>number</code> | The document's limit to return. |
-| skip | <code>number</code> | The number of docs to skip. |
-| cursor | <code>number</code> | The cursor to paginate views. |
-| bookmark | <code>number</code> | The bookmark to paginate mango queries. |
+| options | <code>object</code> | Initial options for the query definition |
+| options.doctype | <code>string</code> | The doctype of the doc. |
+| options.id | <code>string</code> | The id of the doc. |
+| options.ids | <code>Array</code> | The ids of the docs. |
+| options.selector | <code>object</code> | The selector to query the docs. |
+| options.fields | <code>Array</code> | The fields to return. |
+| options.indexedFields | <code>Array</code> | The fields to index. |
+| options.sort | <code>Array</code> | The sorting params. |
+| options.includes | <code>string</code> | The docs to include. |
+| options.referenced | <code>string</code> | The referenced document. |
+| options.limit | <code>number</code> | The document's limit to return. |
+| options.skip | <code>number</code> | The number of docs to skip. |
+| options.cursor | <code>number</code> | The cursor to paginate views. |
+| options.bookmark | <code>number</code> | The bookmark to paginate mango queries. |
 
 <a name="QueryDefinition+getById"></a>
 
@@ -1174,7 +1174,7 @@ Specify which fields of each object should be returned. If it is omitted, the en
 
 <a name="QueryDefinition+indexFields"></a>
 
-### queryDefinition.indexFields(fields) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
+### queryDefinition.indexFields(indexedFields) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
 Specify which fields should be indexed. This prevent the automatic indexing of the mango fields.
 
 **Kind**: instance method of [<code>QueryDefinition</code>](#QueryDefinition)  
@@ -1182,7 +1182,7 @@ Specify which fields should be indexed. This prevent the automatic indexing of t
 
 | Param | Type | Description |
 | --- | --- | --- |
-| fields | <code>Array</code> | The fields to index. |
+| indexedFields | <code>Array</code> | The fields to index. |
 
 <a name="QueryDefinition+sortBy"></a>
 
@@ -1638,7 +1638,7 @@ Returns whether a query has been loaded at least once
 **Kind**: global constant  
 <a name="createClientInteractive"></a>
 
-## createClientInteractive()
+## createClientInteractive(clientOptions)
 Creates a client with interactive authentication.
 
 - Will start an OAuth flow and open an authentication page
@@ -1646,7 +1646,11 @@ Creates a client with interactive authentication.
 - Resolves with the client after user authentication
 
 **Kind**: global function  
-**Params**: <code>Object</code> clientOptions Same as CozyClient::constructor.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| clientOptions | <code>object</code> | Same as CozyClient::constructor. |
+
 **Example**  
 ```
 import { createClientInteractive } from 'cozy-client/dist/cli'
@@ -1658,30 +1662,6 @@ await createClientInteractive({
   }
 })
 ```
-<a name="withClient"></a>
-
-## withClient(Component) ⇒ <code>function</code>
-HOC to provide client from context as prop
-
-**Kind**: global function  
-**Returns**: <code>function</code> - - Component that will receive client as prop  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| Component | <code>Component</code> | wrapped component |
-
-<a name="queryConnect"></a>
-
-## queryConnect(querySpecs) ⇒ <code>function</code>
-HOC creator to connect component to several queries in a declarative manner
-
-**Kind**: global function  
-**Returns**: <code>function</code> - - HOC to apply to a component  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| querySpecs | <code>object</code> | Definition of the queries |
-
 <a name="sanitizeCategories"></a>
 
 ## sanitizeCategories()
@@ -1701,7 +1681,7 @@ Normalize app manifest, retrocompatibility for old manifests
 
 <a name="createMockClient"></a>
 
-## createMockClient() ⇒ [<code>CozyClient</code>](#CozyClient)
+## createMockClient(options) ⇒ [<code>CozyClient</code>](#CozyClient)
 Creates a client suitable for use in tests
 
 - client.{query,save} are mocked
@@ -1711,6 +1691,7 @@ Creates a client suitable for use in tests
 
 | Param | Type | Description |
 | --- | --- | --- |
+| options | <code>object</code> | Options |
 | options.queries | <code>object</code> | Prefill queries inside the store |
 | options.remote | <code>object</code> | Mock data from the server |
 | options.clientOptions | <code>object</code> | Options passed to the client |
@@ -1828,4 +1809,66 @@ Couchdb document like an io.cozy.files
 | selector | <code>string</code> | defaults to `id` |
 | values | <code>Array.&lt;string&gt;</code> |  |
 | type | <code>string</code> | a couch db database like 'io.cozy.files' |
+
+<a name="Registry"></a>
+
+## Registry : <code>RegistryApp</code>
+**Kind**: global typedef  
+
+* [Registry](#Registry) : <code>RegistryApp</code>
+    * [.installApp(app, source)](#Registry+installApp) ⇒ <code>Promise</code>
+    * [.uninstallApp()](#Registry+uninstallApp)
+    * [.fetchApps(params)](#Registry+fetchApps) ⇒ <code>Array.&lt;RegistryApp&gt;</code>
+    * [.fetchAppsInMaintenance()](#Registry+fetchAppsInMaintenance) ⇒ <code>Array.&lt;RegistryApp&gt;</code>
+    * [.fetchApp(slug)](#Registry+fetchApp) ⇒ <code>RegistryApp</code>
+
+<a name="Registry+installApp"></a>
+
+### registry.installApp(app, source) ⇒ <code>Promise</code>
+Installs or updates an app from a source.
+
+Accepts the terms if the app has them.
+
+**Kind**: instance method of [<code>Registry</code>](#Registry)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| app | <code>RegistryApp</code> | App to be installed |
+| source | <code>string</code> | String (ex: registry://drive/stable) |
+
+<a name="Registry+uninstallApp"></a>
+
+### registry.uninstallApp()
+Uninstalls an app.
+
+**Kind**: instance method of [<code>Registry</code>](#Registry)  
+<a name="Registry+fetchApps"></a>
+
+### registry.fetchApps(params) ⇒ <code>Array.&lt;RegistryApp&gt;</code>
+Fetch at most 200 apps from the channel
+
+**Kind**: instance method of [<code>Registry</code>](#Registry)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| params | <code>string</code> | Fetching parameters |
+| params.type | <code>string</code> | "webapp" or "konnector" |
+| params.channel | <code>string</code> | "dev"/"beta"/"stable" |
+
+<a name="Registry+fetchAppsInMaintenance"></a>
+
+### registry.fetchAppsInMaintenance() ⇒ <code>Array.&lt;RegistryApp&gt;</code>
+Fetch the list of apps that are in maintenance mode
+
+**Kind**: instance method of [<code>Registry</code>](#Registry)  
+<a name="Registry+fetchApp"></a>
+
+### registry.fetchApp(slug) ⇒ <code>RegistryApp</code>
+Fetch the status of a single app on the registry
+
+**Kind**: instance method of [<code>Registry</code>](#Registry)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| slug | <code>string</code> | The slug of the app to fetch |
 

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -126,7 +126,7 @@ Main API against the `cozy-stack` server.
 
 * [CozyStackClient](#CozyStackClient)
     * [.collection(doctype)](#CozyStackClient+collection) ⇒ [<code>DocumentCollection</code>](#DocumentCollection)
-    * [.fetch(method, path, body, options)](#CozyStackClient+fetch) ⇒ <code>object</code>
+    * [.fetch(method, path, body, opts)](#CozyStackClient+fetch) ⇒ <code>object</code>
     * [.checkForRevocation()](#CozyStackClient+checkForRevocation)
     * [.refreshToken()](#CozyStackClient+refreshToken) ⇒ <code>Promise</code>
     * [.fetchJSON(method, path, body, options)](#CozyStackClient+fetchJSON) ⇒ <code>object</code>
@@ -146,7 +146,7 @@ Creates a [DocumentCollection](#DocumentCollection) instance.
 
 <a name="CozyStackClient+fetch"></a>
 
-### cozyStackClient.fetch(method, path, body, options) ⇒ <code>object</code>
+### cozyStackClient.fetch(method, path, body, opts) ⇒ <code>object</code>
 Fetches an endpoint in an authorized way.
 
 **Kind**: instance method of [<code>CozyStackClient</code>](#CozyStackClient)  
@@ -160,7 +160,7 @@ Fetches an endpoint in an authorized way.
 | method | <code>string</code> | The HTTP method. |
 | path | <code>string</code> | The URI. |
 | body | <code>object</code> | The payload. |
-| options | <code>object</code> |  |
+| opts | <code>object</code> |  |
 
 <a name="CozyStackClient+checkForRevocation"></a>
 
@@ -1117,7 +1117,7 @@ Implements `DocumentCollection` API along with specific methods for `io.cozy.tri
     * [.create(attributes)](#TriggerCollection+create) ⇒ <code>object</code>
     * [.destroy(document)](#TriggerCollection+destroy) ⇒ <code>object</code>
     * [.find(selector, options)](#TriggerCollection+find) ⇒ <code>Object</code>
-    * [.launch(Trigger)](#TriggerCollection+launch) ⇒ <code>object</code>
+    * [.launch(trigger)](#TriggerCollection+launch) ⇒ <code>object</code>
 
 <a name="TriggerCollection+all"></a>
 
@@ -1184,7 +1184,7 @@ See https://github.com/cozy/cozy-stack/pull/2010
 
 <a name="TriggerCollection+launch"></a>
 
-### triggerCollection.launch(Trigger) ⇒ <code>object</code>
+### triggerCollection.launch(trigger) ⇒ <code>object</code>
 Force given trigger execution.
 
 **Kind**: instance method of [<code>TriggerCollection</code>](#TriggerCollection)  
@@ -1193,7 +1193,7 @@ Force given trigger execution.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| Trigger | <code>object</code> | to launch |
+| trigger | <code>object</code> | Trigger to launch |
 
 <a name="dontThrowNotFoundError"></a>
 

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -196,6 +196,8 @@ class CozyClient {
    * a client with an OAuth-based instance of cozy-client-js.
    *
    * Warning: unlike other instantiators, this one needs to be awaited.
+   *
+   * @returns {CozyClient} An instance of a client, configured from the old client
    */
   static async fromOldOAuthClient(oldClient, options) {
     const hasOauthCreds = oldClient._oauth && oldClient._authcreds != null
@@ -588,7 +590,7 @@ client.query(Q('io.cozy.bills'))`)
    * `getQueryFromState` or directly using `<Query />`. `<Query />` automatically
    * executes its query when mounted if no fetch policy has been indicated.
    *
-   * @param  {QueryDefinition} queryDefinition
+   * @param  {QueryDefinition} queryDefinition - Definition that will be executed
    * @param  {string} options - Options
    * @param  {string} options.as - Names the query so it can be reused (by multiple components for example)
    * @returns {QueryResult}
@@ -616,7 +618,7 @@ client.query(Q('io.cozy.bills'))`)
    * documents if the total of documents is superior to the pagination limit. Can
    * result in a lot of network requests.
    *
-   * @param  {QueryDefinition} queryDefinition
+   * @param  {QueryDefinition} queryDefinition - Definition to be executed
    * @param  {object} options - Options to the query
    * @returns {Array} All documents matching the query
    */
@@ -922,6 +924,7 @@ client.query(Q('io.cozy.bills'))`)
    * Get a query from the internal store.
    *
    * @param {string} id - Id of the query (set via Query.props.as)
+   * @param {object} options - Options
    * @param {boolean} options.hydrated - Whether documents should be returned already hydrated (default: false)
    *
    * @returns {QueryState} - Query state or null if it does not exist.
@@ -949,9 +952,9 @@ client.query(Q('io.cozy.bills'))`)
    * @param   {string} cozyURL Receives the URL of the cozy instance.
    * @returns {object}   Contains the fetched token and the client information.
    */
-  register(cozyUrl) {
+  register(cozyURL) {
     const stackClient = this.getStackClient()
-    stackClient.setUri(cozyUrl)
+    stackClient.setUri(cozyURL)
     return this.startOAuthFlow(authenticateWithCordova)
   }
 
@@ -1021,6 +1024,7 @@ client.query(Q('io.cozy.bills'))`)
    * ```
    *
    * @param {ReduxStore} store - A redux store
+   * @param {object} options - Options
    * @param {boolean} options.force - Will deactivate throwing when client's store already exists
    */
   setStore(store, { force = false } = {}) {

--- a/packages/cozy-client/src/Provider.jsx
+++ b/packages/cozy-client/src/Provider.jsx
@@ -1,24 +1,18 @@
-import { Component } from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import clientContext from './context'
+
+const storePropType = PropTypes.shape({
+  subscribe: PropTypes.func.isRequired,
+  dispatch: PropTypes.func.isRequired,
+  getState: PropTypes.func.isRequired
+})
 
 export default class CozyProvider extends Component {
   static propTypes = {
-    store: PropTypes.shape({
-      subscribe: PropTypes.func.isRequired,
-      dispatch: PropTypes.func.isRequired,
-      getState: PropTypes.func.isRequired
-    }),
+    store: storePropType,
     client: PropTypes.object.isRequired,
     children: PropTypes.element.isRequired
-  }
-
-  static childContextTypes = {
-    store: PropTypes.object,
-    client: PropTypes.object.isRequired
-  }
-
-  static contextTypes = {
-    store: PropTypes.object
   }
 
   constructor(props, context) {
@@ -31,6 +25,15 @@ export default class CozyProvider extends Component {
     }
   }
 
+  static childContextTypes = {
+    store: PropTypes.object,
+    client: PropTypes.object.isRequired
+  }
+
+  static contextTypes = {
+    store: PropTypes.object
+  }
+
   getChildContext() {
     return {
       store: this.props.store || this.context.store || this.props.client.store,
@@ -39,8 +42,10 @@ export default class CozyProvider extends Component {
   }
 
   render() {
-    if (!this.props.children) return null
-    if (!Array.isArray(this.props.children)) return this.props.children
-    return this.props.children[0]
+    return (
+      <clientContext.Provider value={this.getChildContext()}>
+        {this.props.children}
+      </clientContext.Provider>
+    )
   }
 }

--- a/packages/cozy-client/src/__tests__/Provider.spec.jsx
+++ b/packages/cozy-client/src/__tests__/Provider.spec.jsx
@@ -3,7 +3,7 @@ jest.mock('../CozyClient')
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import configureStore from 'redux-mock-store'
-import { shallow } from 'enzyme'
+import { mount, shallow } from 'enzyme'
 
 import Provider from '../Provider'
 import CozyClient from '../CozyClient'
@@ -33,15 +33,12 @@ describe('Provider', () => {
         return <button onClick={this.onClick} />
       }
     }
-    const wrapper = shallow(
+    const wrapper = mount(
       <Provider client={client} store={store}>
         <FakeComponent />
       </Provider>
     )
-    wrapper
-      .dive({ context: { client } }) // because of https://github.com/airbnb/enzyme/issues/664... This defeats a bit the purpose of the test...
-      .find('button')
-      .simulate('click')
+    wrapper.find('button').simulate('click')
     expect(client.query).toHaveBeenCalledWith('foo')
   })
 })

--- a/packages/cozy-client/src/__tests__/mocks.js
+++ b/packages/cozy-client/src/__tests__/mocks.js
@@ -21,7 +21,8 @@ export const client = implementations => {
     getAssociation: jest.fn(),
     makeObservableQuery: jest.fn(),
     requestQuery: jest.fn(),
-    all: jest.fn()
+    all: jest.fn(),
+    setStore: jest.fn()
   }
   mockImplementations(base, implementations)
   return base

--- a/packages/cozy-client/src/cli/index.js
+++ b/packages/cozy-client/src/cli/index.js
@@ -16,6 +16,7 @@ global.btoa = require('btoa')
 /**
  * Creates and starts and HTTP server suitable for OAuth authentication
  *
+ * @param  {Function} serverOptions - OAuth callback server options
  * @param  {Function} serverOptions.onAuthentication - Additional callback called
  * when the user authenticates
  * @param  {Function} serverOptions.route - Route used for authentication
@@ -52,7 +53,8 @@ const createCallbackServer = serverOptions => {
  * When the server is started, the authentication page is opened on the
  * desktop browser of the user.
  *
- * @param {Integer} serverOptions.port - Port used for the OAuth callback server
+ * @param {object} serverOptions - Options for the OAuth callback server
+ * @param {integer} serverOptions.port - Port used for the OAuth callback server
  * @param {Function} serverOptions.onAuthentication - Callback when the user authenticates
  * @param {Function} serverOptions.onListen - Callback called with the authentication URL
  * when the server starts
@@ -157,7 +159,7 @@ const readJSON = (fs, filename) => {
  * - Starts a local server to listen for the oauth callback
  * - Resolves with the client after user authentication
  *
- * @params {Object} clientOptions Same as CozyClient::constructor.
+ * @param {object} clientOptions Same as CozyClient::constructor.
  *
  * @example
  * ```

--- a/packages/cozy-client/src/context.js
+++ b/packages/cozy-client/src/context.js
@@ -1,0 +1,8 @@
+import { createContext } from 'react'
+
+export const clientContext = createContext({
+  client: null,
+  store: null
+})
+
+export default clientContext

--- a/packages/cozy-client/src/hoc.jsx
+++ b/packages/cozy-client/src/hoc.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import compose from 'lodash/flowRight'
 import Query from './Query'
+import useClient from './hooks/useClient'
 
 /**
  * @function
@@ -11,13 +12,11 @@ import Query from './Query'
  * @returns {Function} - Component that will receive client as prop
  */
 export const withClient = Component => {
-  const Wrapped = (props, context) => (
-    <Component {...props} client={context.client} />
-  )
-  Wrapped.displayName = `withClient(${Component.displayName || Component.name})`
-  Wrapped.contextTypes = {
-    client: PropTypes.object
+  const Wrapped = props => {
+    const client = useClient()
+    return <Component {...props} client={client} />
   }
+  Wrapped.displayName = `withClient(${Component.displayName || Component.name})`
   return Wrapped
 }
 

--- a/packages/cozy-client/src/hoc.spec.jsx
+++ b/packages/cozy-client/src/hoc.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 import { withClient, queryConnect } from './hoc'
 import * as mocks from './__tests__/mocks'
+import Provider from './Provider'
 
 import { Q } from 'cozy-client'
 
@@ -20,17 +21,25 @@ class Component extends React.Component {
 }
 
 describe('with client', () => {
-  it('should pass the client to its children', () => {
-    const fakeClient = mocks.client()
-    const context = { client: fakeClient }
-    const WithClientComponent = withClient(Component)
-    const uut = mount(<WithClientComponent />, { context })
-    expect(uut.find(Component).prop('client')).toBe(fakeClient)
-  })
-
   it('should give a display name', () => {
     const WithClientComponent = withClient(Component)
     expect(WithClientComponent.displayName).toBe('withClient(Component)')
+  })
+
+  it('should work with Provider', () => {
+    const client = mocks.client()
+    const store = {
+      dispatch: jest.fn(),
+      subscribe: jest.fn(),
+      getState: jest.fn()
+    }
+    const WithClientComponent = withClient(Component)
+    const uut = mount(
+      <Provider client={client} store={store}>
+        <WithClientComponent />
+      </Provider>
+    )
+    expect(uut.find(Component).prop('client')).toBe(client)
   })
 })
 

--- a/packages/cozy-client/src/hooks/index.js
+++ b/packages/cozy-client/src/hooks/index.js
@@ -1,3 +1,4 @@
 import useAppLinkWithStoreFallback from './useAppLinkWithStoreFallback'
 import useCapabilities from './useCapabilities'
 export { useAppLinkWithStoreFallback, useCapabilities }
+export { default as useClient } from './useClient'

--- a/packages/cozy-client/src/hooks/useAppLinkWithStoreFallback.spec.jsx
+++ b/packages/cozy-client/src/hooks/useAppLinkWithStoreFallback.spec.jsx
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks'
-import { useAppLinkWithStoreFallback } from 'cozy-client'
+import useAppLinkWithStoreFallback from './useAppLinkWithStoreFallback'
+
 describe('useAppLinkWithStoreFallback', () => {
   const mockClient = { query: jest.fn() }
 

--- a/packages/cozy-client/src/hooks/useClient.js
+++ b/packages/cozy-client/src/hooks/useClient.js
@@ -1,0 +1,9 @@
+import { useContext } from 'react'
+import clientContext from '../context'
+
+const useClient = () => {
+  const { client } = useContext(clientContext)
+  return client
+}
+
+export default useClient

--- a/packages/cozy-client/src/hooks/useClient.spec.jsx
+++ b/packages/cozy-client/src/hooks/useClient.spec.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import useClient from './useClient'
+import Provider from '../Provider'
+import { mount } from 'enzyme'
+
+describe('useClient', () => {
+  const Component = () => {
+    const client = useClient()
+    return <div>{client.stackClient.uri}</div>
+  }
+  it('should work', () => {
+    const client = { stackClient: { uri: 'https://test.mycozy.cloud' } }
+    const root = mount(
+      <Provider client={client}>
+        <Component />
+      </Provider>
+    )
+    expect(root.html()).toBe('<div>https://test.mycozy.cloud</div>')
+  })
+})

--- a/packages/cozy-client/src/mock.js
+++ b/packages/cozy-client/src/mock.js
@@ -34,6 +34,7 @@ const mockedQueryFromMockedRemoteData = remoteData => qdef => {
  * - client.{query,save} are mocked
  * - client.stackClient.fetchJSON is mocked
  *
+ * @param  {object} options Options
  * @param  {object} options.queries Prefill queries inside the store
  * @param  {object} options.remote Mock data from the server
  * @param  {object} options.clientOptions Options passed to the client

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -1,54 +1,45 @@
 const isString = require('lodash/isString')
 
 /**
+ * typedef QueryDefinition
+ */
+
+/**
  * Chainable API to create query definitions to retrieve documents
  * from a Cozy. `QueryDefinition`s are sent to links.
  */
 class QueryDefinition {
   /**
    * @class
-   * @param {string} doctype - The doctype of the doc.
-   * @param {string} id - The id of the doc.
-   * @param {Array} ids - The ids of the docs.
-   * @param {object} selector - The selector to query the docs.
-   * @param {Array} fields - The fields to return.
-   * @param {Array} indexedFields - The fields to index.
-   * @param {Array} sort - The sorting params.
-   * @param {string} includes - The docs to include.
-   * @param {string} referenced - The referenced document.
-   * @param {number} limit - The document's limit to return.
-   * @param {number} skip - The number of docs to skip.
-   * @param {number} cursor - The cursor to paginate views.
-   * @param {number} bookmark - The bookmark to paginate mango queries.
+   * @param {object} options Initial options for the query definition
+   * @param {string} options.doctype - The doctype of the doc.
+   * @param {string} options.id - The id of the doc.
+   * @param {Array} options.ids - The ids of the docs.
+   * @param {object} options.selector - The selector to query the docs.
+   * @param {Array} options.fields - The fields to return.
+   * @param {Array} options.indexedFields - The fields to index.
+   * @param {Array} options.sort - The sorting params.
+   * @param {string} options.includes - The docs to include.
+   * @param {string} options.referenced - The referenced document.
+   * @param {number} options.limit - The document's limit to return.
+   * @param {number} options.skip - The number of docs to skip.
+   * @param {number} options.cursor - The cursor to paginate views.
+   * @param {number} options.bookmark - The bookmark to paginate mango queries.
    */
-  constructor({
-    doctype,
-    id,
-    ids,
-    selector,
-    fields,
-    indexedFields,
-    sort,
-    includes,
-    referenced,
-    limit,
-    skip,
-    cursor,
-    bookmark
-  } = {}) {
-    this.doctype = doctype
-    this.id = id
-    this.ids = ids
-    this.selector = selector
-    this.fields = fields
-    this.indexedFields = indexedFields
-    this.sort = sort
-    this.includes = includes
-    this.referenced = referenced
-    this.limit = limit
-    this.skip = skip
-    this.cursor = cursor
-    this.bookmark = bookmark
+  constructor(options = {}) {
+    this.doctype = options.doctype
+    this.id = options.id
+    this.ids = options.ids
+    this.selector = options.selector
+    this.fields = options.fields
+    this.indexedFields = options.indexedFields
+    this.sort = options.sort
+    this.includes = options.includes
+    this.referenced = options.referenced
+    this.limit = options.limit
+    this.skip = options.skip
+    this.cursor = options.cursor
+    this.bookmark = options.bookmark
   }
 
   /**
@@ -95,7 +86,7 @@ class QueryDefinition {
   /**
    * Specify which fields should be indexed. This prevent the automatic indexing of the mango fields.
    *
-   * @param {Array} fields The fields to index.
+   * @param {Array} indexedFields The fields to index.
    * @returns {QueryDefinition}  The QueryDefinition object.
    */
   indexFields(indexedFields) {

--- a/packages/cozy-client/src/registry.js
+++ b/packages/cozy-client/src/registry.js
@@ -15,6 +15,10 @@ const getBaseRoute = app => {
   return `/${route}`
 }
 
+/**
+ *@typedef {RegistryApp}
+ */
+
 class Registry {
   constructor(options) {
     if (!options.client) {
@@ -62,6 +66,7 @@ class Registry {
   /**
    * Fetch at most 200 apps from the channel
    *
+   * @param  {string} params - Fetching parameters
    * @param  {string} params.type - "webapp" or "konnector"
    * @param  {string} params.channel - "dev"/"beta"/"stable"
    *

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -82,7 +82,7 @@ class CozyStackClient {
    * @param  {string} method The HTTP method.
    * @param  {string} path The URI.
    * @param  {object} body The payload.
-   * @param  {object} options
+   * @param  {object} opts
    * @returns {object}
    * @throws {FetchError}
    */

--- a/packages/cozy-stack-client/src/TriggerCollection.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.js
@@ -136,7 +136,7 @@ class TriggerCollection extends DocumentCollection {
    * Force given trigger execution.
    *
    * @see https://docs.cozy.io/en/cozy-stack/jobs/#post-jobstriggerstrigger-idlaunch
-   * @param {object} Trigger to launch
+   * @param {object} trigger Trigger to launch
    * @returns {object} Stack response, containing job launched by trigger, under `data` attribute.
    */
   async launch(trigger) {


### PR DESCRIPTION
We can now use a hook to get access to the CozyClient in
the context. Backward compatibility with withClient and
old context API is assured.

This is the first part of the ["hooks" PR](https://github.com/cozy/cozy-client/pull/547) that was
a bit too big, and takes a long time to be merged since
there is the useQuery work inside that still needs work. I think it is preferable
to split and get the useClient merged.