### PR TITLE
Feat/add use fetch shortcut

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -93,7 +93,7 @@ example.</p>
 <dd></dd>
 <dt><a href="#isNote">isNote</a></dt>
 <dd></dd>
-<dt><a href="#isShortcurt">isShortcurt</a> ⇒ <code>boolean</code></dt>
+<dt><a href="#isShortcut">isShortcut</a> ⇒ <code>boolean</code></dt>
 <dd></dd>
 <dt><a href="#ensureMagicFolder">ensureMagicFolder</a> ⇒ <code>object</code></dt>
 <dd><p>Returns a &quot;Magic Folder&quot;, given its id. See <a href="https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.apps/#special-iocozyapps-doctypes">https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.apps/#special-iocozyapps-doctypes</a></p>
@@ -1474,9 +1474,9 @@ getAppDisplayName - Combines the translated prefix and name of the app into a si
 | --- | --- | --- |
 | file | <code>File</code> | io.cozy.files |
 
-<a name="isShortcurt"></a>
+<a name="isShortcut"></a>
 
-## isShortcurt ⇒ <code>boolean</code>
+## isShortcut ⇒ <code>boolean</code>
 **Kind**: global constant  
 **Returns**: <code>boolean</code> - true if the file is a shortcut  
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -4,3 +4,4 @@ In addition to our [React Integration](./react-integration), Cozy Client comes w
 
 - [useAppLinkWithStoreFallback](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hooks/useAppLinkWithStoreFallback.jsx): Returns the URL of an app if this app is installed. If not, returns the URL to the store to install it. 
 - [useCapabilities](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hooks/useCapabilities.jsx): Returns the [capabilities](https://docs.cozy.io/en/cozy-stack/settings/#get-settingscapabilities) for an instance
+- [useFetchShortcut](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hooks/useFetchShortcut.jsx): Returns the data for a shortcut

--- a/packages/cozy-client/src/hooks/index.js
+++ b/packages/cozy-client/src/hooks/index.js
@@ -1,4 +1,5 @@
 import useAppLinkWithStoreFallback from './useAppLinkWithStoreFallback'
 import useCapabilities from './useCapabilities'
-export { useAppLinkWithStoreFallback, useCapabilities }
+import useFetchShortcut from './useFetchShortcut'
+export { useAppLinkWithStoreFallback, useCapabilities, useFetchShortcut }
 export { default as useClient } from './useClient'

--- a/packages/cozy-client/src/hooks/useFetchShortcut.jsx
+++ b/packages/cozy-client/src/hooks/useFetchShortcut.jsx
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react'
+
+const useFetchShortcut = (client, id) => {
+  const [shortcutInfos, setShortcutInfos] = useState()
+  const [shortcurtImg, setShotcutImg] = useState()
+  const [fetchStatus, setFetchStatus] = useState('idle')
+  const [shouldDisplayImg, setShouldDisplayImg] = useState(false)
+  useEffect(() => {
+    let timeout
+    const fetchData = async () => {
+      setFetchStatus('loading')
+      try {
+        const shortcutInfosResult = await client
+          .getStackClient()
+          .fetchJSON('GET', `/shortcuts/${id}`)
+        const shortcutRemoteUrl = new URL(
+          shortcutInfosResult.data.attributes.url
+        )
+
+        const imgUrl = `${client.getStackClient().uri}/bitwarden/icons/${
+          shortcutRemoteUrl.host
+        }/icon.png`
+
+        setShotcutImg(imgUrl)
+        // this is used in conjonction with CSS display none/block to
+        // make the http request to load the image and not having a blank
+        // element for a few ms
+        timeout = setTimeout(() => setShouldDisplayImg(true), 400)
+        setShortcutInfos(shortcutInfosResult)
+        setFetchStatus('loaded')
+      } catch (e) {
+        setFetchStatus('failed')
+      }
+    }
+    fetchData()
+    return () => clearTimeout(timeout)
+  }, [client, id])
+
+  return {
+    shortcutInfos,
+    shortcurtImg,
+    fetchStatus,
+    shouldDisplayImg
+  }
+}
+
+export default useFetchShortcut

--- a/packages/cozy-client/src/hooks/useFetchShortcut.jsx
+++ b/packages/cozy-client/src/hooks/useFetchShortcut.jsx
@@ -4,9 +4,7 @@ const useFetchShortcut = (client, id) => {
   const [shortcutInfos, setShortcutInfos] = useState()
   const [shortcurtImg, setShotcutImg] = useState()
   const [fetchStatus, setFetchStatus] = useState('idle')
-  const [shouldDisplayImg, setShouldDisplayImg] = useState(false)
   useEffect(() => {
-    let timeout
     const fetchData = async () => {
       setFetchStatus('loading')
       try {
@@ -22,10 +20,6 @@ const useFetchShortcut = (client, id) => {
         }/icon.png`
 
         setShotcutImg(imgUrl)
-        // this is used in conjonction with CSS display none/block to
-        // make the http request to load the image and not having a blank
-        // element for a few ms
-        timeout = setTimeout(() => setShouldDisplayImg(true), 400)
         setShortcutInfos(shortcutInfosResult)
         setFetchStatus('loaded')
       } catch (e) {
@@ -33,14 +27,12 @@ const useFetchShortcut = (client, id) => {
       }
     }
     fetchData()
-    return () => clearTimeout(timeout)
   }, [client, id])
 
   return {
     shortcutInfos,
     shortcurtImg,
-    fetchStatus,
-    shouldDisplayImg
+    fetchStatus
   }
 }
 

--- a/packages/cozy-client/src/hooks/useFetchShortcut.spec.jsx
+++ b/packages/cozy-client/src/hooks/useFetchShortcut.spec.jsx
@@ -51,7 +51,6 @@ describe('useFetchShortcut', () => {
     )
 
     await waitForNextUpdate()
-    expect(result.current.shouldDisplayImg).toEqual(false)
     expect(result.current.shortcutInfos).toEqual({
       data: {
         type: 'io.cozy.files.shortcuts',
@@ -69,7 +68,5 @@ describe('useFetchShortcut', () => {
     expect(result.current.shortcurtImg).toEqual(
       `${mockClient.getStackClient().uri}/bitwarden/icons/cozy.io/icon.png`
     )
-    await waitForNextUpdate()
-    expect(result.current.shouldDisplayImg).toEqual(true)
   })
 })

--- a/packages/cozy-client/src/hooks/useFetchShortcut.spec.jsx
+++ b/packages/cozy-client/src/hooks/useFetchShortcut.spec.jsx
@@ -1,0 +1,75 @@
+import { renderHook } from '@testing-library/react-hooks'
+import useFetchShortcut from './useFetchShortcut'
+import { createMockClient } from '../../dist/mock'
+describe('useFetchShortcut', () => {
+  const mockClient = createMockClient({})
+  const id = '1'
+  it('should change loading status', async () => {
+    mockClient.stackClient.fetchJSON.mockResolvedValue({
+      data: {
+        attributes: {
+          url: 'http://foo.cozy.bar'
+        }
+      }
+    })
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useFetchShortcut(mockClient, id)
+    )
+    expect(result.current.fetchStatus).toEqual('loading')
+    await waitForNextUpdate()
+    expect(result.current.fetchStatus).toEqual('loaded')
+  })
+
+  it('should inform when an error occurs', async () => {
+    mockClient.stackClient.fetchJSON.mockRejectedValue('error')
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useFetchShortcut(mockClient, id)
+    )
+    expect(result.current.fetchStatus).toEqual('loading')
+    await waitForNextUpdate()
+    expect(result.current.fetchStatus).toEqual('failed')
+  })
+
+  it('should return the data of a shortcut and change the display value', async () => {
+    mockClient.stackClient.fetchJSON.mockResolvedValue({
+      data: {
+        type: 'io.cozy.files.shortcuts',
+        id: 'b7470059d40c88e4bd30031d5e0109d3',
+        attributes: {
+          _id: '',
+          name: 'cozy.url',
+          dir_id: '8034db0016d0548ded99b9627e003270',
+          url: 'https://cozy.io',
+          metadata: { extractor_version: 2 }
+        },
+        meta: { rev: '1-60e1359e63fa7fa9fa000a2726d5d4c7' }
+      }
+    })
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useFetchShortcut(mockClient, id)
+    )
+
+    await waitForNextUpdate()
+    expect(result.current.shouldDisplayImg).toEqual(false)
+    expect(result.current.shortcutInfos).toEqual({
+      data: {
+        type: 'io.cozy.files.shortcuts',
+        id: 'b7470059d40c88e4bd30031d5e0109d3',
+        attributes: {
+          _id: '',
+          name: 'cozy.url',
+          dir_id: '8034db0016d0548ded99b9627e003270',
+          url: 'https://cozy.io',
+          metadata: { extractor_version: 2 }
+        },
+        meta: { rev: '1-60e1359e63fa7fa9fa000a2726d5d4c7' }
+      }
+    })
+    expect(result.current.shortcurtImg).toEqual(
+      `${mockClient.getStackClient().uri}/bitwarden/icons/cozy.io/icon.png`
+    )
+    await waitForNextUpdate()
+    expect(result.current.shouldDisplayImg).toEqual(true)
+  })
+})

--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -38,7 +38,7 @@ export const isNote = file => {
  * @param {File} file io.cozy.files
  * @returns {boolean} true if the file is a shortcut
  */
-export const isShortcurt = file => {
+export const isShortcut = file => {
   return file && file.class === 'shortcut'
 }
 /**

--- a/packages/cozy-client/src/models/file.spec.js
+++ b/packages/cozy-client/src/models/file.spec.js
@@ -41,8 +41,8 @@ describe('File Model', () => {
       class: 'image'
     }
 
-    expect(file.isShortcurt(shortcut)).toBe(true)
-    expect(file.isShortcurt(image)).toBe(false)
+    expect(file.isShortcut(shortcut)).toBe(true)
+    expect(file.isShortcut(image)).toBe(false)
   })
 
   describe('normalizeFile', () => {


### PR DESCRIPTION
We now have a new shortcut file's type and a dedicated API endpoint to retrieve the data. 

This hook is here to easily request them and also add a timeout to display the image (if we want). I added that, in order to be able to make the http request for the image before displaying it to avoid a blank between the placeholder and the final image