### PR TITLE
fix: Typo

### DIFF
--- a/packages/cozy-client/src/hooks/useFetchShortcut.jsx
+++ b/packages/cozy-client/src/hooks/useFetchShortcut.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 
 const useFetchShortcut = (client, id) => {
   const [shortcutInfos, setShortcutInfos] = useState()
-  const [shortcurtImg, setShotcutImg] = useState()
+  const [shortcutImg, setShotcutImg] = useState()
   const [fetchStatus, setFetchStatus] = useState('idle')
   useEffect(() => {
     const fetchData = async () => {
@@ -31,7 +31,7 @@ const useFetchShortcut = (client, id) => {
 
   return {
     shortcutInfos,
-    shortcurtImg,
+    shortcutImg,
     fetchStatus
   }
 }

--- a/packages/cozy-client/src/hooks/useFetchShortcut.spec.jsx
+++ b/packages/cozy-client/src/hooks/useFetchShortcut.spec.jsx
@@ -65,7 +65,7 @@ describe('useFetchShortcut', () => {
         meta: { rev: '1-60e1359e63fa7fa9fa000a2726d5d4c7' }
       }
     })
-    expect(result.current.shortcurtImg).toEqual(
+    expect(result.current.shortcutImg).toEqual(
       `${mockClient.getStackClient().uri}/bitwarden/icons/cozy.io/icon.png`
     )
   })


### PR DESCRIPTION
Renamed shortcurtImg to shotcutImg in useFetchShortcut (without the extra R). It's a breaking change that will affect drive and home, but the migration is trivial.