### PR TITLE
fix: Make query data duplicate free

### DIFF
--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -3,6 +3,7 @@ import difference from 'lodash/difference'
 import intersection from 'lodash/intersection'
 import concat from 'lodash/concat'
 import isPlainObject from 'lodash/isPlainObject'
+import uniq from 'lodash/uniq'
 
 import { getDocumentFromSlice } from './documents'
 import { isReceivingMutationResult } from './mutations'
@@ -71,7 +72,7 @@ const query = (state = queryInitialState, action) => {
           response.meta && response.meta.count
             ? response.meta.count
             : response.data.length,
-        data: [...state.data, ...response.data.map(properId)]
+        data: uniq([...state.data, ...response.data.map(properId)])
       }
     }
     case RECEIVE_QUERY_ERROR:

--- a/packages/cozy-client/src/store/queries.spec.js
+++ b/packages/cozy-client/src/store/queries.spec.js
@@ -50,6 +50,13 @@ describe('queries reducer', () => {
         })
       )
       expect(state).toMatchSnapshot()
+      expect(state['a'].data).toEqual([TODO_1._id, TODO_2._id])
+      applyAction(
+        receiveQueryResult('a', {
+          data: [TODO_1, TODO_2]
+        })
+      )
+      expect(state['a'].data).toEqual([TODO_1._id, TODO_2._id])
     })
     it('should correctly update two queries', () => {
       applyAction(


### PR DESCRIPTION
This is not an actual PR at this point, I just. want to discuss the issue and evaluate if it needs fixing, and if so how.

The problem occurs after the following steps:

1. Init query `toto` 👉query data is empty
2. Receive results for that query 👉query data contains some ids
3. Init query `toto` again 👉[query data still contains the ids](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/store/queries.js#L41)
4. Receive the same results for the same query 👉[query data gets duplicated](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/store/queries.js#L74)

To me this is a legitimate use case, it can happen simply by navigating several times to a view that makes the same query.

I'm less sure about the correct fix. initially I felt that when we init a query, we should not keep the previous data (eg. fix step n°3). Not only because it's an `init`, but also because the definition could have changed.  
But fixing the problem that way caused [this test to fail](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/__tests__/ObservableQuery.spec.js#L127-L138), so it seems like we *do* want to keep the previous data around, presumably to display something while we load the new results, which I can understand.

So the other option is to fix at step n°4, it breaks no tests and is probably correct.

Another option would be to run the query against the stored documents at init time (using [this](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/store/queries.js#L120)). This would be a breaking change but possibly a good one? It means query's would immediately return cached results, and update again once the actual results are received.

Let me know what you think!