### PR TITLE
fix: Use bookmark with fetchMore

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -576,8 +576,7 @@ client.query(Q('io.cozy.bills'))`)
     // Don't trigger the INIT_QUERY for fetchMore() calls
     if (
       existingQuery.fetchStatus !== 'loaded' ||
-      !queryDefinition.skip ||
-      !queryDefinition.bookmark
+      (!queryDefinition.skip && !queryDefinition.bookmark)
     ) {
       this.dispatch(initQuery(queryId, queryDefinition))
     }

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -993,6 +993,16 @@ describe('CozyClient', () => {
       )
     })
 
+    it('should dispatch a INIT_QUERY action if no skip and no bookmark', async () => {
+      getQueryFromState.mockReturnValueOnce({
+        fetchStatus: 'loaded'
+      })
+      await client.query(query, { as: 'allTodos' })
+      expect(client.store.dispatch.mock.calls[0][0]).toEqual(
+        initQuery('allTodos', { doctype: 'io.cozy.todos' })
+      )
+    })
+
     it('should dispatch a RECEIVE_QUERY_RESULT action if query has skip', async () => {
       requestHandler.mockReturnValueOnce(Promise.resolve(fakeResponse))
       getQueryFromState.mockReturnValueOnce({

--- a/packages/cozy-client/src/ObservableQuery.js
+++ b/packages/cozy-client/src/ObservableQuery.js
@@ -60,12 +60,14 @@ export default class ObservableQuery {
    * we have in the store.
    */
   fetchMore() {
-    return this.client.query(
-      this.definition.offset(this.currentRawResult().data.length),
-      {
-        as: this.queryId
-      }
-    )
+    const rawResult = this.currentRawResult()
+    return rawResult.bookmark
+      ? this.client.query(this.definition.offsetBookmark(rawResult.bookmark), {
+          as: this.queryId
+        })
+      : this.client.query(this.definition.offset(rawResult.data.length), {
+          as: this.queryId
+        })
   }
 
   currentRawResult() {


### PR DESCRIPTION
This allows to use bookmark through `fetchMore` when available. 
It also fixes a logic issue that could cause a wrong dispatch of `initQuery` during pagination.