### PR TITLE
feat: Add splitfilename method

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -87,6 +87,9 @@ example.</p>
 <dt><a href="#getAppDisplayName">getAppDisplayName</a> ⇒ <code>string</code></dt>
 <dd><p>getAppDisplayName - Combines the translated prefix and name of the app into a single string.</p>
 </dd>
+<dt><a href="#splitFilename">splitFilename</a> ⇒ <code>object</code></dt>
+<dd><p>Returns base filename and extension</p>
+</dd>
 <dt><a href="#isFile">isFile</a></dt>
 <dd></dd>
 <dt><a href="#isDirectory">isDirectory</a></dt>
@@ -1453,6 +1456,18 @@ getAppDisplayName - Combines the translated prefix and name of the app into a si
 | --- | --- | --- |
 | app | <code>object</code> | io.cozy.apps or io.cozy.konnectors document |
 | lang | <code>string</code> | Locale to use |
+
+<a name="splitFilename"></a>
+
+## splitFilename ⇒ <code>object</code>
+Returns base filename and extension
+
+**Kind**: global constant  
+**Returns**: <code>object</code> - {filename, extension}  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| file | <code>object</code> | An io.cozy.files |
 
 <a name="isFile"></a>
 

--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -3,6 +3,26 @@ import get from 'lodash/get'
 const FILE_TYPE = 'file'
 const DIR_TYPE = 'directory'
 
+const FILENAME_WITH_EXTENSION_REGEX = /(.+)(\..*)$/
+
+/**
+ * Returns base filename and extension
+ *
+ * @param {object} file An io.cozy.files
+ * @returns {object}  {filename, extension}
+ */
+export const splitFilename = file => {
+  if (!file.name) throw new Error('file should have a name property ')
+
+  if (file.type === 'file') {
+    const match = file.name.match(FILENAME_WITH_EXTENSION_REGEX)
+    if (match) {
+      return { filename: match[1], extension: match[2] }
+    }
+  }
+  return { filename: file.name, extension: '' }
+}
+
 /**
  *
  * @param {File} file io.cozy.files

--- a/packages/cozy-client/src/models/file.spec.js
+++ b/packages/cozy-client/src/models/file.spec.js
@@ -1,4 +1,5 @@
-import { file } from './'
+import * as file from './file'
+
 describe('File Model', () => {
   it('should test if a file is a note or not', () => {
     const fileDocument = {
@@ -68,6 +69,51 @@ describe('File Model', () => {
     it('should default to "io.cozy.files"', () => {
       const doc = { id }
       expect(file.normalize(doc)).toHaveProperty('_type', 'io.cozy.files')
+    })
+  })
+
+  describe('splitFilename', () => {
+    const joinName = ({ filename, extension }) => filename + extension
+    const mkFile = expectation => ({
+      type: 'file',
+      name: joinName(expectation)
+    })
+    const { stringify } = JSON
+
+    const scenarios = [
+      { filename: 'file', extension: '.ext' },
+      { filename: 'file', extension: '' },
+      { filename: 'file.html', extension: '.ejs' },
+      { filename: 'file', extension: '.' },
+      { filename: 'file.', extension: '.' },
+      { filename: 'file.', extension: '.ext' },
+      { filename: '.file', extension: '' },
+      { filename: '.file', extension: '.ext' }
+    ]
+
+    for (const expectation of scenarios) {
+      it(`splits ${stringify(joinName(expectation))} into ${stringify(
+        expectation
+      )}`, () => {
+        expect(file.splitFilename(mkFile(expectation))).toEqual(expectation)
+      })
+    }
+
+    it('should throw an error if the file is not correct', () => {
+      const badFile = {}
+
+      expect(() => file.splitFilename(badFile)).toThrow()
+    })
+    it('should return only the folder name if its a folder', () => {
+      const dir = {
+        name: 'foo',
+        type: 'directory'
+      }
+      const result = file.splitFilename(dir)
+      expect(result).toEqual({
+        filename: 'foo',
+        extension: ''
+      })
     })
   })
 


### PR DESCRIPTION
splitFilename was originally in cozy-doctypes. We prefer
to move all the methods there to cozy-client as it is
tree-shakeable.