### PR TITLE
fix: Normalize PermissionsCollection.add response

### DIFF
--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -78,7 +78,7 @@ class PermissionCollection extends DocumentCollection {
       }
     })
 
-    return resp.data
+    return { data: normalizePermission(resp.data) }
   }
 
   destroy(permission) {

--- a/packages/cozy-stack-client/src/PermissionCollection.spec.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.spec.js
@@ -104,6 +104,31 @@ describe('PermissionCollection', () => {
           )
         )
       })
+
+      it('normalizes the resulting document', async () => {
+        client.fetchJSON.mockReturnValue({
+          data: {
+            type: 'io.cozy.permissions',
+            id: 'a340d5e0d64711e6b66c5fc9ce1e17c6',
+            attributes: {
+              permissions: fixtures.permission
+            }
+          }
+        })
+        const resp = await collection.add(
+          {
+            _type: 'io.cozy.permissions',
+            _id: 'a340d5e0d64711e6b66c5fc9ce1e17c6'
+          },
+          fixtures.permission
+        )
+
+        expect(resp.data.type).toEqual('io.cozy.permissions')
+        expect(resp.data._type).toEqual('io.cozy.permissions')
+        expect(resp.data.id).toEqual('a340d5e0d64711e6b66c5fc9ce1e17c6')
+        expect(resp.data._id).toEqual('a340d5e0d64711e6b66c5fc9ce1e17c6')
+        expect(resp.data.attributes.permissions).toEqual(fixtures.permission)
+      })
     })
   })
 


### PR DESCRIPTION
`PermissionsCollection.add` did not normalize it's response, which means it didn't have a `_type` field, only a `type`. But all the functions in the collection, including `add` itself, expect the documents to have the `_type` field.