### PR TITLE
Add onerror handler to fetch XHR

### DIFF
--- a/packages/cozy-stack-client/src/xhrFetch.js
+++ b/packages/cozy-stack-client/src/xhrFetch.js
@@ -34,6 +34,10 @@ const fetchWithXMLHttpRequest = async (fullpath, options) => {
       }
     }
 
+    xhr.onerror = function(err) {
+      reject(err)
+    }
+
     xhr.open(options.method, fullpath, true)
     xhr.withCredentials = true
     for (let [headerName, headerValue] of Object.entries(options.headers)) {


### PR DESCRIPTION
Otherwise errors are not propagated to the caller :facepalm:.