### PR TITLE
fix: Handle correctly KO result

### DIFF
--- a/packages/cozy-stack-client/src/xhrFetch.js
+++ b/packages/cozy-stack-client/src/xhrFetch.js
@@ -51,7 +51,9 @@ const fetchWithXMLHttpRequest = async (fullpath, options) => {
     headers: headersFromString(response.getAllResponseHeaders()),
     ok: response.status >= 200 && response.status < 300,
     text: async () => response.responseText,
-    json: async () => JSON.parse(response.responseText)
+    json: async () => JSON.parse(response.responseText),
+    status: response.status,
+    statusText: response.statusText
   }
 }
 


### PR DESCRIPTION
We should return the status and statusText to be
coherent with the fetch method since in a few apps
we test the status to know what to do