### PR TITLE
fix(cozy-stack-client): Allow fetch to work in node environment

### DIFF
--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -114,7 +114,7 @@ class CozyStackClient {
 
     const fetcher = shouldXMLHTTPRequestBeUsed(method, path, options)
       ? fetchWithXMLHttpRequest
-      : window.fetch
+      : fetch
 
     try {
       const response = await fetcher(fullPath, options)


### PR DESCRIPTION
Or else you get `ReferenceError: window is not defined` error message

Solves https://github.com/konnectors/libs/issues/673