### PR TITLE
feat: Connection to multiple queries with less nesting

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -157,6 +157,11 @@ is loading.</p>
 <dt><a href="#queryConnect">queryConnect(querySpecs)</a> ⇒ <code>function</code></dt>
 <dd><p>HOC creator to connect component to several queries in a declarative manner</p>
 </dd>
+<dt><a href="#queryConnectFlat">queryConnectFlat(querySpecs)</a> ⇒ <code>function</code></dt>
+<dd><p>HOC creator to connect component to several queries in a declarative manner
+The only difference with queryConnect is that it does not wrap the component in N component
+if there are N queries, only 1 extra level of nesting is introduced.</p>
+</dd>
 <dt><a href="#getErrorComponent">getErrorComponent(error)</a> ⇒ <code>function</code> | <code>null</code></dt>
 <dd><p>Returns the handler for an error</p>
 </dd>
@@ -1756,6 +1761,20 @@ HOC to provide client from context as prop
 
 ## queryConnect(querySpecs) ⇒ <code>function</code>
 HOC creator to connect component to several queries in a declarative manner
+
+**Kind**: global function  
+**Returns**: <code>function</code> - - HOC to apply to a component  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| querySpecs | <code>object</code> | Definition of the queries |
+
+<a name="queryConnectFlat"></a>
+
+## queryConnectFlat(querySpecs) ⇒ <code>function</code>
+HOC creator to connect component to several queries in a declarative manner
+The only difference with queryConnect is that it does not wrap the component in N component
+if there are N queries, only 1 extra level of nesting is introduced.
 
 **Kind**: global function  
 **Returns**: <code>function</code> - - HOC to apply to a component  

--- a/packages/cozy-client/src/hoc.jsx
+++ b/packages/cozy-client/src/hoc.jsx
@@ -27,15 +27,16 @@ const withQuery = (dest, queryOpts, Original) => {
     )
   }
   return Component => {
-    const Wrapped = (props, context) => {
-      queryOpts = typeof queryOpts === 'function' ? queryOpts(props) : queryOpts
+    const Wrapper = (props, context) => {
       if (!context.client) {
         throw new Error(
           'Should be used with client in context (use CozyProvider to set context)'
         )
       }
 
+      queryOpts = typeof queryOpts === 'function' ? queryOpts(props) : queryOpts
       if (queryOpts.doc) {
+        console.warn('queryOpts.doc is deprecated')
         return <Component {...{ [dest]: queryOpts.doc, ...props }} />
       }
 
@@ -45,12 +46,12 @@ const withQuery = (dest, queryOpts, Original) => {
         </Query>
       )
     }
-    Wrapped.contextTypes = {
+    Wrapper.contextTypes = {
       client: PropTypes.object
     }
-    Wrapped.displayName = `withQuery(${Component.displayName ||
+    Wrapper.displayName = `withQuery(${Component.displayName ||
       Component.name})`
-    return Wrapped
+    return Wrapper
   }
 }
 

--- a/packages/cozy-client/src/hoc.jsx
+++ b/packages/cozy-client/src/hoc.jsx
@@ -73,6 +73,8 @@ export const queryConnect = querySpecs => Component => {
 /**
  * @function
  * @description HOC creator to connect component to several queries in a declarative manner
+ * The only difference with queryConnect is that it does not wrap the component in N component
+ * if there are N queries, only 1 extra level of nesting is introduced.
  *
  * @param  {object} querySpecs - Definition of the queries
  * @returns {Function} - HOC to apply to a component

--- a/packages/cozy-client/src/hoc.jsx
+++ b/packages/cozy-client/src/hoc.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import compose from 'lodash/flowRight'
 import Query from './Query'
 import useClient from './hooks/useClient'
+import { useQueries } from './hooks/useQuery'
 
 /**
  * @function
@@ -67,4 +68,21 @@ export const queryConnect = querySpecs => Component => {
     withQuery(dest, querySpecs[dest], Component)
   )
   return compose.apply(null, enhancers)(Component)
+}
+
+/**
+ * @function
+ * @description HOC creator to connect component to several queries in a declarative manner
+ *
+ * @param  {object} querySpecs - Definition of the queries
+ * @returns {Function} - HOC to apply to a component
+ */
+export const queryConnectFlat = querySpecs => Component => {
+  const Wrapper = props => {
+    const queryResults = useQueries(querySpecs)
+    return <Component {...props} {...queryResults} />
+  }
+  Wrapper.displayName = `queryConnectFlat(${Component.displayName ||
+    Component.name})`
+  return Wrapper
 }

--- a/packages/cozy-client/src/hoc.spec.jsx
+++ b/packages/cozy-client/src/hoc.spec.jsx
@@ -44,17 +44,21 @@ describe('with client', () => {
   })
 })
 
+const queryConns = {
+  simpsons: { query: client => Q('io.cozy.simpsons'), as: 'simpsons' },
+  upperSimpsons: {
+    query: client => Q('io.cozy.simpsons-upper'),
+    as: 'upperSimpsons'
+  }
+}
+
 describe('queryConnect', () => {
   const setup = () => {
     const client = setupClient()
     const WithQueries = queryConnect({
-      simpsons: { query: client => Q('io.cozy.simpsons'), as: 'simpsons' },
-      upperSimpsons: {
-        query: client => Q('io.cozy.simpsons-upper'),
-        as: 'upperSimpsons'
-      }
+      simpsons: queryConns.simpsons,
+      upperSimpsons: queryConns.upperSimpsons
     })(Component)
-
     return { WithQueries, client }
   }
 

--- a/packages/cozy-client/src/hoc.spec.jsx
+++ b/packages/cozy-client/src/hoc.spec.jsx
@@ -128,4 +128,18 @@ describe('queryConnectFlat', () => {
         .data.map(x => x.name)
     ).toEqual(['HOMER', 'MARGE'])
   })
+
+  it('should have Component as direct children of queryConnectFlag', () => {
+    const { WithQueries, client } = setup()
+    const uut = mount(
+      <ReduxProvider store={client.store}>
+        <Provider client={client}>
+          <WithQueries />
+        </Provider>
+      </ReduxProvider>
+    )
+    const queryConnectFlatComponent = uut.find('queryConnectFlat(Component)')
+    expect(queryConnectFlatComponent.length).toBe(1)
+    expect(queryConnectFlatComponent.children().is('Component')).toBe(true)
+  })
 })

--- a/packages/cozy-client/src/hoc.spec.jsx
+++ b/packages/cozy-client/src/hoc.spec.jsx
@@ -4,6 +4,7 @@ import { withClient, queryConnect } from './hoc'
 import * as mocks from './__tests__/mocks'
 import Provider from './Provider'
 
+import { setupClient } from './testing/utils'
 import { Q } from 'cozy-client'
 
 beforeEach(() => {
@@ -45,27 +46,13 @@ describe('with client', () => {
 
 describe('queryConnect', () => {
   const setup = () => {
-    const fakeData = {
-      'io.cozy.toto': 'hello',
-      'io.cozy.tata': 'hello2'
-    }
-    const queryDefinitionFromDoctype = doctype => ({ doctype })
-    const observableQueryFromDefinition = definition => {
-      return mocks.observableQuery({
-        currentResult: () => ({
-          data: fakeData[definition.doctype]
-        })
-      })
-    }
-
-    const client = mocks.client({
-      all: doctype => queryDefinitionFromDoctype(doctype),
-      makeObservableQuery: queryDef => observableQueryFromDefinition(queryDef)
-    })
-
+    const client = setupClient()
     const WithQueries = queryConnect({
-      toto: { query: client => Q('io.cozy.toto') },
-      tata: { query: client => Q('io.cozy.tata') }
+      simpsons: { query: client => Q('io.cozy.simpsons'), as: 'simpsons' },
+      upperSimpsons: {
+        query: client => Q('io.cozy.simpsons-upper'),
+        as: 'upperSimpsons'
+      }
     })(Component)
 
     return { WithQueries, client }
@@ -82,7 +69,17 @@ describe('queryConnect', () => {
       client
     }
     const uut = mount(<WithQueries />, { context })
-    expect(uut.find(Component).prop('toto').data).toBe('hello')
-    expect(uut.find(Component).prop('tata').data).toBe('hello2')
+    expect(
+      uut
+        .find(Component)
+        .prop('simpsons')
+        .data.map(x => x.name)
+    ).toEqual(['Homer', 'Marge'])
+    expect(
+      uut
+        .find(Component)
+        .prop('upperSimpsons')
+        .data.map(x => x.name)
+    ).toEqual(['HOMER', 'MARGE'])
   })
 })

--- a/packages/cozy-client/src/hooks/useQuery.js
+++ b/packages/cozy-client/src/hooks/useQuery.js
@@ -64,4 +64,13 @@ const useQuery = (queryDefinition, options) => {
   return { ...queryState, fetchMore: fetchMore }
 }
 
+export const useQueries = querySpecs => {
+  const res = {}
+  for (const [queryAttrName, queryOpts] of Object.entries(querySpecs)) {
+    // eslint-disable-next-line
+    res[queryAttrName] = useQuery(queryOpts.query, queryOpts)
+  }
+  return res
+}
+
 export default useQuery

--- a/packages/cozy-client/src/hooks/useQuery.spec.jsx
+++ b/packages/cozy-client/src/hooks/useQuery.spec.jsx
@@ -1,36 +1,9 @@
-import React from 'react'
 import { renderHook } from '@testing-library/react-hooks'
 
 import useQuery, { useQueries } from './useQuery'
 import { Q } from '../queries/dsl'
-import ClientProvider from '../Provider'
-import { Provider as ReduxProvider } from 'react-redux'
 
-import { createMockClient } from '../mock'
-import simpsonsFixture from '../testing/simpsons.json'
-
-const setupClient = () => {
-  const client = createMockClient({
-    queries: {
-      simpsons: {
-        data: simpsonsFixture,
-        doctype: 'io.cozy.simpsons'
-      },
-      upperSimpsons: {
-        data: simpsonsFixture.map(x => ({ ...x, name: x.name.toUpperCase() })),
-        doctype: 'io.cozy.simpsons-upper'
-      }
-    }
-  })
-  client.ensureStore()
-  return client
-}
-
-const makeWrapper = client => ({ children }) => (
-  <ReduxProvider store={client.store}>
-    <ClientProvider client={client}>{children}</ClientProvider>
-  </ReduxProvider>
-)
+import { setupClient, makeWrapper } from '../testing/utils'
 
 const setupQuery = ({ queryDefinition, queryOptions }) => {
   const client = setupClient()

--- a/packages/cozy-client/src/hooks/useQuery.spec.jsx
+++ b/packages/cozy-client/src/hooks/useQuery.spec.jsx
@@ -9,31 +9,34 @@ import { Provider as ReduxProvider } from 'react-redux'
 import { createMockClient } from '../mock'
 import simpsonsFixture from '../testing/simpsons.json'
 
-describe('use query', () => {
-  const setup = ({ queryDefinition, queryOptions }) => {
-    const client = createMockClient({
-      queries: {
-        simpsons: {
-          data: simpsonsFixture,
-          doctype: 'io.cozy.simpsons'
-        }
+const setupClient = () => {
+  const client = createMockClient({
+    queries: {
+      simpsons: {
+        data: simpsonsFixture,
+        doctype: 'io.cozy.simpsons'
       }
-    })
-    client.ensureStore()
-    const wrapper = ({ children }) => (
-      <ReduxProvider store={client.store}>
-        <ClientProvider client={client}>{children}</ClientProvider>
-      </ReduxProvider>
-    )
-    const hookResult = renderHook(
-      () => useQuery(queryDefinition, queryOptions),
-      {
-        wrapper
-      }
-    )
-    return { client, hookResult }
-  }
+    }
+  })
+  client.ensureStore()
+  return client
+}
 
+const makeWrapper = client => ({ children }) => (
+  <ReduxProvider store={client.store}>
+    <ClientProvider client={client}>{children}</ClientProvider>
+  </ReduxProvider>
+)
+
+const setup = ({ queryDefinition, queryOptions }) => {
+  const client = setupClient()
+  const hookResult = renderHook(() => useQuery(queryDefinition, queryOptions), {
+    wrapper: makeWrapper(client)
+  })
+  return { client, hookResult }
+}
+
+describe('use query', () => {
   it('should return the correct data', () => {
     const {
       hookResult: {

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -30,7 +30,7 @@ export { default as connect } from './connect'
 export { default as withMutation } from './withMutation'
 export { default as withMutations } from './withMutations'
 export { default as Query } from './Query'
-export { queryConnect, withClient } from './hoc'
+export { queryConnect, queryConnectFlat, withClient } from './hoc'
 
 import * as models from './models'
 export { models }

--- a/packages/cozy-client/src/testing/utils.js
+++ b/packages/cozy-client/src/testing/utils.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import { createMockClient } from '../mock'
+import simpsonsFixture from '../testing/simpsons.json'
+import ClientProvider from '../Provider'
+import { Provider as ReduxProvider } from 'react-redux'
+
+const setupClient = () => {
+  const client = createMockClient({
+    queries: {
+      simpsons: {
+        data: simpsonsFixture,
+        doctype: 'io.cozy.simpsons'
+      },
+      upperSimpsons: {
+        data: simpsonsFixture.map(x => ({ ...x, name: x.name.toUpperCase() })),
+        doctype: 'io.cozy.simpsons-upper'
+      }
+    }
+  })
+  client.ensureStore()
+  return client
+}
+
+const makeWrapper = client => ({ children }) => (
+  <ReduxProvider store={client.store}>
+    <ClientProvider client={client}>{children}</ClientProvider>
+  </ReduxProvider>
+)
+
+export { setupClient, makeWrapper }


### PR DESCRIPTION
### Problem

queryConnect entails one nesting level for each query, which leads to a lot of nesting in Banks.

Example:

```jsx
const Component = () => {}

export default queryConnect({
  transactions: { ... }, // query options for transactions
  triggers: { ... }, // query options for triggers
  accounts: { ... }, // query options for accounts
  groups: { ... }, // query options for groups
})
```

When rendered, it will look like:

```jsx
<Query query={ transactionsQuery }>
    <Query query={ accountsQuery }>
        <Query query={ groupsQuery }>
            <Query query={ triggersQuery }>
            </Query>
        </Query>
    </Query>
</Query>
```

This makes it hard to debug in Banks and adds noise.

### Solution

Add a new `useQueries` based on `useQuery` that returns an object
will all the responses.

queryConnect2 uses this hook to provide thoses responses as props
(exactly like queryConnect) but only with 1 nesting level.