### PR TITLE
Draft: feat: Debug module in cozy-client to activate debug

### DIFF
--- a/packages/cozy-client/src/debug.js
+++ b/packages/cozy-client/src/debug.js
@@ -1,0 +1,5 @@
+const debug = {
+  debug: false
+}
+
+export default debug

--- a/packages/cozy-client/src/store/documents.js
+++ b/packages/cozy-client/src/store/documents.js
@@ -4,6 +4,7 @@ import keyBy from 'lodash/keyBy'
 import get from 'lodash/get'
 import isEqual from 'lodash/isEqual'
 import { properId } from './helpers'
+import debug from '../debug'
 
 const storeDocument = (state, document) => {
   const type = document._type
@@ -88,7 +89,7 @@ export const getDocumentFromSlice = (state = {}, doctype, id) => {
     )
   }
   if (!state[doctype]) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env.NODE_ENV !== 'production' && debug.debug) {
       console.warn(
         `getDocumentFromSlice: ${doctype} is absent from the store's documents. State is`,
         state
@@ -96,7 +97,7 @@ export const getDocumentFromSlice = (state = {}, doctype, id) => {
     }
     return null
   } else if (!state[doctype][id]) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env.NODE_ENV !== 'production' && debug.debug) {
       console.warn(
         `getDocumentFromSlice: ${doctype}:${id} is absent from the store documents. State is`,
         state
@@ -113,7 +114,7 @@ export const getCollectionFromSlice = (state = {}, doctype) => {
       'getDocumentFromSlice: Cannot retrieve document with undefined doctype'
     )
   }
-  if (!state[doctype]) {
+  if (!state[doctype] && debug.debug) {
     if (process.env.NODE_ENV !== 'production') {
       console.warn(
         `getCollectionFromSlice: ${doctype} is absent from the store documents. State is`,


### PR DESCRIPTION
Logging when a document is not present is detrimental to performance
and is not always wanted. Here we can activate debug easily.

This is in draft as I would prefer to use minilog.