### PR TITLE
feat: Expose permission.fetchOwn

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -196,6 +196,9 @@ if there are N queries, only 1 extra level of nesting is introduced.</p>
 <dt><a href="#getParentFolderId">getParentFolderId(file)</a> ⇒ <code>string</code> | <code>null</code></dt>
 <dd><p>Get the id of the parent folder (<code>null</code> for the root folder)</p>
 </dd>
+<dt><a href="#fetchOwn">fetchOwn(client)</a> ⇒ <code><a href="#PermissionItem">Array.&lt;PermissionItem&gt;</a></code></dt>
+<dd><p>Fetches the list of permissions blocks</p>
+</dd>
 <dt><a href="#isForType">isForType(permission, type)</a></dt>
 <dd><p>Checks if the permission item is about a specific doctype</p>
 </dd>
@@ -1893,6 +1896,18 @@ Get the id of the parent folder (`null` for the root folder)
 | Param | Type | Description |
 | --- | --- | --- |
 | file | <code>object</code> | io.cozy.files document |
+
+<a name="fetchOwn"></a>
+
+## fetchOwn(client) ⇒ [<code>Array.&lt;PermissionItem&gt;</code>](#PermissionItem)
+Fetches the list of permissions blocks
+
+**Kind**: global function  
+**Returns**: [<code>Array.&lt;PermissionItem&gt;</code>](#PermissionItem) - list of permissions  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| client | [<code>CozyClient</code>](#CozyClient) | - |
 
 <a name="isForType"></a>
 

--- a/packages/cozy-client/src/models/permission.js
+++ b/packages/cozy-client/src/models/permission.js
@@ -40,13 +40,12 @@ export function isReadOnly(perm, options = {}) {
 }
 
 /**
- * Get the list of permissions blocks
+ * Fetches the list of permissions blocks
  *
- * @private
  * @param {CozyClient} client -
  * @returns {PermissionItem[]} list of permissions
  */
-async function fetchOwn(client) {
+export async function fetchOwn(client) {
   const collection = client.collection('io.cozy.permissions')
   const data = await collection.getOwnPermissions()
   const permissions = get(data, 'data.attributes.permissions')

--- a/packages/cozy-client/src/models/permission.spec.js
+++ b/packages/cozy-client/src/models/permission.spec.js
@@ -1,4 +1,4 @@
-import { isReadOnly, isDocumentReadOnly } from './permission'
+import { isReadOnly, isDocumentReadOnly, fetchOwn } from './permission'
 
 function getById(id, doctype) {
   const parents = {
@@ -147,5 +147,17 @@ describe('isDocumentReadOnly', () => {
         })
       })
     })
+  })
+})
+
+describe('fetchOwn', () => {
+  it('returns a list of permissions', async () => {
+    const client = setupClient()
+    const result = await fetchOwn(client)
+
+    expect(result).toEqual([
+      { type: 'io.cozy.files', values: ['first', 'other'], verbs: [] },
+      { type: 'io.cozy.photo.albums', values: ['third'], verbs: [] }
+    ])
   })
 })


### PR DESCRIPTION
`fetchOwn` was only used in `findPermissionFor`, but it is generally useful to load and parse our own permissions. In https://github.com/cozy/cozy-drive/pull/2017 for example, we don't want to know the permissions for a certain document, we need them for the general permission set.