### PR TITLE
fix: Fixes to HasOne relationship

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -733,19 +733,25 @@ client.query(Q('io.cozy.bills'))`)
 
     responseDocs.forEach(doc => {
       return forEach(relationshipsByName, (relationship, relName) => {
-        const queryDef = relationship.type.query(doc, this, relationship)
-        const docId = doc._id
+        try {
+          const queryDef = relationship.type.query(doc, this, relationship)
+          const docId = doc._id
 
-        // Used to reattach responses into the relationships attribute of
-        // each document
-        queryDefToDocIdAndRel.set(queryDef, [docId, relName])
+          // Used to reattach responses into the relationships attribute of
+          // each document
+          queryDefToDocIdAndRel.set(queryDef, [docId, relName])
 
-        // Relationships can yield "queries" that are already resolved documents.
-        // These do not need to go through the usual link request mechanism.
-        if (queryDef instanceof QueryDefinition) {
-          definitions.push(queryDef)
-        } else {
-          documents.push(queryDef)
+          // Relationships can yield "queries" that are already resolved documents.
+          // These do not need to go through the usual link request mechanism.
+          if (queryDef instanceof QueryDefinition) {
+            definitions.push(queryDef)
+          } else {
+            documents.push(queryDef)
+          }
+        } catch {
+          // eslint-disable-next-line
+          // We do not crash completely if one the relationship behaves badly and
+          // throws
         }
       })
     })

--- a/packages/cozy-client/src/associations/HasOne.js
+++ b/packages/cozy-client/src/associations/HasOne.js
@@ -47,6 +47,9 @@ export default class HasOne extends Association {
   }
 
   dehydrate(doc) {
+    if (!this.raw) {
+      return doc
+    }
     return {
       ...doc,
       relationships: {

--- a/packages/cozy-client/src/associations/HasOne.js
+++ b/packages/cozy-client/src/associations/HasOne.js
@@ -17,6 +17,9 @@ export default class HasOne extends Association {
 
   static query(doc, client, assoc) {
     const relationship = get(doc, `relationships.${assoc.name}.data`, {})
+    if (!relationship || !relationship._id) {
+      return null
+    }
     return client.get(assoc.doctype, relationship._id)
   }
 

--- a/packages/cozy-client/src/associations/HasOne.spec.js
+++ b/packages/cozy-client/src/associations/HasOne.spec.js
@@ -1,6 +1,7 @@
 import HasOne from './HasOne'
 import { QueryDefinition } from '../queries/dsl'
 import merge from 'lodash/merge'
+import { dehydrate } from '../helpers'
 
 const clientMock = {
   get: (doctype, id) => new QueryDefinition({ doctype, id })
@@ -49,6 +50,20 @@ describe('HasOne', () => {
 
     it('returns null if the relationship has no data', () => {
       expect(hydratedApprentice.padawan.raw).toEqual(null)
+    })
+  })
+
+  describe('dehydrate', () => {
+    it('should not create a relationship attribute if document has no relationship', () => {
+      const dehydrated = dehydrate(hydratedApprentice)
+      expect(dehydrated.relationships).toBe(undefined)
+    })
+
+    it('should dehydrate correctly', () => {
+      const dehydrated = dehydrate(hydratedMaster)
+      expect(dehydrated.relationships).toEqual({
+        padawan: { data: { _id: 'anakin', _type: 'io.cozy.jedis' } }
+      })
     })
   })
 

--- a/packages/cozy-client/src/associations/HasOne.spec.js
+++ b/packages/cozy-client/src/associations/HasOne.spec.js
@@ -1,5 +1,6 @@
 import HasOne from './HasOne'
 import { QueryDefinition } from '../queries/dsl'
+import merge from 'lodash/merge'
 
 const clientMock = {
   get: (doctype, id) => new QueryDefinition({ doctype, id })
@@ -70,6 +71,18 @@ describe('HasOne', () => {
       })
       expect(queryDef.doctype).toEqual('io.cozy.jedis')
       expect(queryDef.id).toEqual(fixtures.apprentice._id)
+    })
+
+    it('returns null if the relationship is invalid', () => {
+      const queryDef = HasOne.query(
+        merge({}, fixtures.jediMaster, { relationships: { padawan: null } }),
+        clientMock,
+        {
+          name: 'padawan',
+          doctype: 'io.cozy.jedis'
+        }
+      )
+      expect(queryDef).toBe(null)
     })
   })
 


### PR DESCRIPTION
Problem: In banks, if a relationship is badly set to `null`, operations are not shown. 

Explanation: When retrieving operations, we retrieve also their relationship, via the query generated by the relationship, here `HasOne`. Since `relationship` was null, `relationship._id` failed and broke the retrieval of operations.

Why was `relationship` null ? Because when setting the category on a document that had not been linked to a recurrence, the dehydrated doc had its `relationships.recurrence.data` set to `null`. This is dealt with in https://github.com/cozy/cozy-client/pull/702/commits/2c5eeca71b6687bcf806591764e8cd3ce5575a7b. Now, when a document is not linked to another document, the relationships is not dehydrated at all, which prevents the creation of a useless `relationships[relationshipName]` field (and of `relationships` if there are not relationships) at dehydration time.

Expectation:

- If a relationship is badly set and we cannot retrieve the _id, we should not fail completely.
- When dehydrating a document with no relationship, no `relationships` field should be created
