### PR TITLE
docs: Make DocumentCollection.create visible in the documentation

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -229,7 +229,7 @@ Abstracts a collection of documents of the same doctype, providing CRUD methods 
     * [.get(id)](#DocumentCollection+get) ⇒ <code>object</code>
     * [.getAll()](#DocumentCollection+getAll)
     * [.create(doc)](#DocumentCollection+create)
-    * [.update(doc)](#DocumentCollection+update)
+    * [.update(document)](#DocumentCollection+update)
     * [.destroy(doc)](#DocumentCollection+destroy)
     * [.updateAll(docs)](#DocumentCollection+updateAll)
     * [.destroyAll(docs)](#DocumentCollection+destroyAll)
@@ -303,14 +303,14 @@ Creates a document
 
 <a name="DocumentCollection+update"></a>
 
-### documentCollection.update(doc)
+### documentCollection.update(document)
 Updates a document
 
 **Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| doc | <code>object</code> | Document to update. Do not forget the _id attribute |
+| document | <code>object</code> | Document to update. Do not forget the _id attribute |
 
 <a name="DocumentCollection+destroy"></a>
 
@@ -330,9 +330,9 @@ Updates several documents in one batch
 
 **Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
 
-| Param | Type |
-| --- | --- |
-| docs | <code>Array.&lt;Document&gt;</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| docs | <code>Array.&lt;Document&gt;</code> | Documents to be updated |
 
 <a name="DocumentCollection+destroyAll"></a>
 

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -228,8 +228,9 @@ Abstracts a collection of documents of the same doctype, providing CRUD methods 
     * [.find(selector, options)](#DocumentCollection+find) ⇒ <code>Object</code>
     * [.get(id)](#DocumentCollection+get) ⇒ <code>object</code>
     * [.getAll()](#DocumentCollection+getAll)
-    * [.update()](#DocumentCollection+update)
-    * [.destroy()](#DocumentCollection+destroy)
+    * [.create(doc)](#DocumentCollection+create)
+    * [.update(doc)](#DocumentCollection+update)
+    * [.destroy(doc)](#DocumentCollection+destroy)
     * [.updateAll(docs)](#DocumentCollection+updateAll)
     * [.destroyAll(docs)](#DocumentCollection+destroyAll)
     * [.fetchChanges(couchOptions, options)](#DocumentCollection+fetchChanges)
@@ -289,18 +290,39 @@ Get a document by id
 Get many documents by id
 
 **Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
+<a name="DocumentCollection+create"></a>
+
+### documentCollection.create(doc)
+Creates a document
+
+**Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| doc | <code>object</code> | Document to create. Optional: you can force the id with the _id attribute |
+
 <a name="DocumentCollection+update"></a>
 
-### documentCollection.update()
+### documentCollection.update(doc)
 Updates a document
 
 **Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| doc | <code>object</code> | Document to update. Do not forget the _id attribute |
+
 <a name="DocumentCollection+destroy"></a>
 
-### documentCollection.destroy()
+### documentCollection.destroy(doc)
 Destroys a document
 
 **Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| doc | <code>object</code> | Document to destroy. Do not forget _id and _rev attributes |
+
 <a name="DocumentCollection+updateAll"></a>
 
 ### documentCollection.updateAll(docs)

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -224,6 +224,8 @@ class DocumentCollection {
 
   /**
    * Creates a document
+   *
+   * @param {object} doc - Document to create. Optional: you can force the id with an _id attribute
    */
   async create({ _id, _type, ...document }) {
     // In case of a fixed id, let's use the dedicated creation endpoint
@@ -239,6 +241,8 @@ class DocumentCollection {
 
   /**
    * Updates a document
+   *
+   * @param {object} doc - Document to update. Do not forget _id attribute
    */
   async update(document) {
     const resp = await this.stackClient.fetchJSON(
@@ -253,6 +257,8 @@ class DocumentCollection {
 
   /**
    * Destroys a document
+   *
+   * @param {object} doc - Document to destroy. Do not forget _id and _rev attributes
    */
   async destroy({ _id, _rev, ...document }) {
     const resp = await this.stackClient.fetchJSON(

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -225,7 +225,7 @@ class DocumentCollection {
   /**
    * Creates a document
    *
-   * @param {object} doc - Document to create. Optional: you can force the id with an _id attribute
+   * @param {object} doc - Document to create. Optional: you can force the id with the _id attribute
    */
   async create({ _id, _type, ...document }) {
     // In case of a fixed id, let's use the dedicated creation endpoint

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -222,6 +222,9 @@ class DocumentCollection {
     }
   }
 
+  /**
+   * Creates a document
+   */
   async create({ _id, _type, ...document }) {
     // In case of a fixed id, let's use the dedicated creation endpoint
     // https://github.com/cozy/cozy-stack/blob/master/docs/data-system.md#create-a-document-with-a-fixed-id

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -242,7 +242,7 @@ class DocumentCollection {
   /**
    * Updates a document
    *
-   * @param {object} doc - Document to update. Do not forget _id attribute
+   * @param {object} doc - Document to update. Do not forget the _id attribute
    */
   async update(document) {
     const resp = await this.stackClient.fetchJSON(

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -15,7 +15,7 @@ const DATABASE_DOES_NOT_EXIST = 'Database does not exist.'
  * Normalize a document, adding its doctype if needed
  *
  * @param {object} doc - Document to normalize
- * @param {string} doctype
+ * @param {string} doctype - Document doctype
  * @returns {object} normalized document
  * @private
  */
@@ -42,7 +42,7 @@ class DocumentCollection {
    * Provides a callback for `Collection.get`
    *
    * @private
-   * @param {string} doctype
+   * @param {string} doctype - Document doctype
    * @returns {Function} (data, response) => normalizedDocument
    *                                        using `normalizeDoc`
    */
@@ -54,7 +54,7 @@ class DocumentCollection {
    * `normalizeDoctype` for api end points returning json api responses
    *
    * @private
-   * @param {string} doctype
+   * @param {string} doctype - Document doctype
    * @returns {Function} (data, response) => normalizedDocument
    *                                        using `normalizeDoc`
    */
@@ -69,7 +69,7 @@ class DocumentCollection {
    * `normalizeDoctype` for api end points returning raw documents
    *
    * @private
-   * @param {string} doctype
+   * @param {string} doctype - Document doctype
    * @returns {Function} (data, response) => normalizedDocument
    *                                        using `normalizeDoc`
    */
@@ -242,7 +242,7 @@ class DocumentCollection {
   /**
    * Updates a document
    *
-   * @param {object} doc - Document to update. Do not forget the _id attribute
+   * @param {object} document - Document to update. Do not forget the _id attribute
    */
   async update(document) {
     const resp = await this.stackClient.fetchJSON(
@@ -276,7 +276,7 @@ class DocumentCollection {
   /**
    * Updates several documents in one batch
    *
-   * @param  {Document[]} docs
+   * @param  {Document[]} docs Documents to be updated
    */
   async updateAll(docs) {
     const stackClient = this.stackClient


### PR DESCRIPTION
The create method has no jsdoc and I suppose this is why the create method is not visible in
https://docs.cozy.io/en/cozy-client/api/cozy-stack-client/#DocumentCollection