### PR TITLE
fix: Correctly call callback for tokenRefresh passed in options

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -196,7 +196,7 @@ Fetches JSON in an authorized way.
 | method | <code>string</code> | The HTTP method. |
 | path | <code>string</code> | The URI. |
 | body | <code>object</code> | The payload. |
-| options | <code>object</code> |  |
+| options | <code>object</code> | Options |
 
 <a name="CozyStackClient+setToken"></a>
 

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -1095,7 +1095,7 @@ instantiation of the client.`
     this.emit('tokenRefreshed')
     if (this.options.onTokenRefresh) {
       deprecatedHandler(
-        `Using onTokenRefresh is deprecated, please use events like this: cozyClient.on('tokenUpdated', token => console.log('Token is updated', token)). https://git.io/fj3M3`
+        `Using onTokenRefresh is deprecated, please use events like this: cozyClient.on('tokenRefreshed', token => console.log('Token has been refreshed', token)). https://git.io/fj3M3`
       )
       this.options.onTokenRefresh(token)
     }

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -133,6 +133,12 @@ class CozyStackClient {
     }
   }
 
+  onTokenRefresh(token) {
+    if (this.options && this.options.onTokenRefresh) {
+      this.options.onTokenRefresh(token)
+    }
+  }
+
   onRevocationChange(state) {
     if (this.options && this.options.onRevocationChange) {
       this.options.onRevocationChange(state)
@@ -194,9 +200,7 @@ class CozyStackClient {
       )
     }
     const newToken = new AppToken(cozyToken)
-    if (this.onTokenRefresh && typeof this.onTokenRefresh === 'function') {
-      this.onTokenRefresh(newToken)
-    }
+    this.onTokenRefresh(newToken)
     return newToken
   }
 
@@ -206,7 +210,7 @@ class CozyStackClient {
    * @param  {string} method The HTTP method.
    * @param  {string} path The URI.
    * @param  {object} body The payload.
-   * @param  {object} options
+   * @param  {object} options Options
    * @returns {object}
    * @throws {FetchError}
    */

--- a/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
@@ -386,10 +386,11 @@ describe('CozyStackClient', () => {
       fetch.mockResponse(FAKE_APP_HTML)
     })
 
-    const getClient = () =>
+    const getClient = (options = {}) =>
       new CozyStackClient({
         uri: 'http://cozy.tools:8080/',
-        token: 'azertyuio'
+        token: 'azertyuio',
+        ...options
       })
 
     it('should return a new token', async () => {
@@ -399,13 +400,14 @@ describe('CozyStackClient', () => {
     })
 
     it('should have called onRefreshToken`', async () => {
-      const client = getClient()
-      const promise = new Promise(function(res, rej) {
-        client.onTokenRefresh = tok => res(tok)
+      const handleRefresh = jest.fn()
+      const client = getClient({
+        onTokenRefresh: handleRefresh
       })
-      client.refreshToken()
-      const newToken = await promise
-      expect(newToken.token).toEqual(FAKE_APP_TOKEN)
+      await client.refreshToken()
+      expect(handleRefresh).toHaveBeenCalledWith({
+        token: FAKE_APP_TOKEN
+      })
     })
 
     it('should fail without repeat on server error', async () => {


### PR DESCRIPTION
CozyClient passes the onTokenRefresh callback with options.onTokenRefresh.

This is not a breaking change since application that do set `cozyStackClient.onTokenRefresh` will still work after this change (since we call `this.onTokenRefresh` when receiving the token).