### PR TITLE
File creation + keep query sorted

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -131,11 +131,6 @@ example.</p>
 <dd><p>Helper to create a QueryDefinition. Recommended way to create
 query definitions.</p>
 </dd>
-<dt><a href="#makeSorterFromDefinition">makeSorterFromDefinition</a></dt>
-<dd><p>Creates a sort function from a definition.</p>
-<p>Used to sort query results inside the store when creating a file or
-receiving updates.</p>
-</dd>
 <dt><a href="#isQueryLoading">isQueryLoading</a></dt>
 <dd><p>Returns whether the result of a query (given via queryConnect or Query)
 is loading.</p>
@@ -1714,15 +1709,6 @@ import { Q } from 'cozy-client'
 
 const qDef = Q('io.cozy.todos').where({ _id: '1234' })
 ```
-<a name="makeSorterFromDefinition"></a>
-
-## makeSorterFromDefinition
-Creates a sort function from a definition.
-
-Used to sort query results inside the store when creating a file or
-receiving updates.
-
-**Kind**: global constant  
 <a name="isQueryLoading"></a>
 
 ## isQueryLoading

--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -131,6 +131,11 @@ example.</p>
 <dd><p>Helper to create a QueryDefinition. Recommended way to create
 query definitions.</p>
 </dd>
+<dt><a href="#makeSorterFromDefinition">makeSorterFromDefinition</a></dt>
+<dd><p>Creates a sort function from a definition.</p>
+<p>Used to sort query results inside the store when creating a file or
+receiving updates.</p>
+</dd>
 <dt><a href="#isQueryLoading">isQueryLoading</a></dt>
 <dd><p>Returns whether the result of a query (given via queryConnect or Query)
 is loading.</p>
@@ -1709,6 +1714,15 @@ import { Q } from 'cozy-client'
 
 const qDef = Q('io.cozy.todos').where({ _id: '1234' })
 ```
+<a name="makeSorterFromDefinition"></a>
+
+## makeSorterFromDefinition
+Creates a sort function from a definition.
+
+Used to sort query results inside the store when creating a file or
+receiving updates.
+
+**Kind**: global constant  
 <a name="isQueryLoading"></a>
 
 ## isQueryLoading

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -74,6 +74,17 @@ through OAuth.</p>
 </dd>
 </dl>
 
+## Typedefs
+
+<dl>
+<dt><a href="#DirectoryAttributes">DirectoryAttributes</a> : <code>object</code></dt>
+<dd><p>Attributes used for directory creation</p>
+</dd>
+<dt><a href="#FileAttributes">FileAttributes</a> : <code>object</code></dt>
+<dd><p>Attributes used for file creation</p>
+</dd>
+</dl>
+
 <a name="AppCollection"></a>
 
 ## AppCollection
@@ -111,9 +122,9 @@ document as data attribute
 
 | Param | Type | Description |
 | --- | --- | --- |
-| stackClient | <code>object</code> |  |
+| stackClient | [<code>CozyStackClient</code>](#CozyStackClient) | CozyStackClient |
 | endpoint | <code>string</code> | Stack endpoint |
-| options | <code>object</code> |  |
+| options | <code>object</code> | Options of the collection |
 | options.normalize | <code>Func</code> | Callback to normalize response data (default `data => data`) |
 | options.method | <code>string</code> | HTTP method (default `GET`) |
 
@@ -380,7 +391,7 @@ files associated to a specific document
     * [.restore(id)](#FileCollection+restore) ⇒ <code>Promise</code>
     * [.deleteFilePermanently(id)](#FileCollection+deleteFilePermanently) ⇒ <code>object</code>
     * [.upload(data, dirPath)](#FileCollection+upload) ⇒ <code>object</code>
-    * [.createFile(data, params)](#FileCollection+createFile)
+    * [.create(attributes)](#FileCollection+create)
     * [.updateFile(data, params)](#FileCollection+updateFile) ⇒ <code>object</code>
     * [.download(file, versionId, filename)](#FileCollection+download)
     * [.fetchFileContent(id)](#FileCollection+fetchFileContent)
@@ -550,20 +561,18 @@ async deleteFilePermanently - Definitely delete a file
 | data | <code>File</code> \| <code>Blob</code> \| <code>Stream</code> \| <code>string</code> \| <code>ArrayBuffer</code> | file to be uploaded |
 | dirPath | <code>string</code> | Path to upload the file to. ie : /Administative/XXX/ |
 
-<a name="FileCollection+createFile"></a>
+<a name="FileCollection+create"></a>
 
-### fileCollection.createFile(data, params)
+### fileCollection.create(attributes)
+Creates directory or file.
+- Used by StackLink to support CozyClient.create('io.cozy.files', options)
+
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| data | <code>File</code> \| <code>Blob</code> \| <code>Stream</code> \| <code>string</code> \| <code>ArrayBuffer</code> | file to be uploaded |
-| params | <code>object</code> | Additionnal parameters |
-| params.name | <code>string</code> | Name of the file |
-| params.dirId | <code>string</code> | Id of the directory you want to upload the file to |
-| params.executable | <code>boolean</code> | If the file is an executable or not |
-| params.metadata | <code>object</code> | io.cozy.files.metadata to attach to the file |
-| params.options | <code>object</code> | Options to pass to doUpload method (additional headers) |
+| attributes | [<code>FileAttributes</code>](#FileAttributes) \| [<code>DirectoryAttributes</code>](#DirectoryAttributes) | Attributes of the created file/directory |
+| attributes.data | <code>File</code> \| <code>Blob</code> \| <code>string</code> \| <code>ArrayBuffer</code> | Will be used as content of the created file |
 
 <a name="FileCollection+updateFile"></a>
 
@@ -621,7 +630,7 @@ Get a beautified size for a given file
 | Param | Type | Description |
 | --- | --- | --- |
 | file | <code>object</code> | io.cozy.files object |
-| decimal | <code>int</code> | number of decimal |
+| decimal | <code>number</code> | number of decimal |
 
 <a name="FileCollection+isChildOf"></a>
 
@@ -644,9 +653,9 @@ async createDirectoryByPath - Creates one or more folders until the given path e
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
 **Returns**: <code>object</code> - The document corresponding to the last segment of the path  
 
-| Param | Type |
-| --- | --- |
-| path | <code>string</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| path | <code>string</code> | Path of the created directory |
 
 <a name="FileCollection+updateAttributes"></a>
 
@@ -796,10 +805,10 @@ through OAuth.
 
 * [OAuthClient](#OAuthClient)
     * [.doRegistration()](#OAuthClient+doRegistration)
-    * [.register()](#OAuthClient+register) ⇒ <code>promise</code>
-    * [.unregister()](#OAuthClient+unregister) ⇒ <code>promise</code>
-    * [.fetchInformation()](#OAuthClient+fetchInformation) ⇒ <code>promise</code>
-    * [.updateInformation(information, resetSecret)](#OAuthClient+updateInformation) ⇒ <code>promise</code>
+    * [.register()](#OAuthClient+register) ⇒ <code>Promise</code>
+    * [.unregister()](#OAuthClient+unregister) ⇒ <code>Promise</code>
+    * [.fetchInformation()](#OAuthClient+fetchInformation) ⇒ <code>Promise</code>
+    * [.updateInformation(information, resetSecret)](#OAuthClient+updateInformation) ⇒ <code>Promise</code>
     * [.generateStateCode()](#OAuthClient+generateStateCode) ⇒ <code>string</code>
     * [.getAuthCodeURL(stateCode, scopes)](#OAuthClient+getAuthCodeURL) ⇒ <code>string</code>
     * [.getAccessCodeFromURL(pageURL, stateCode)](#OAuthClient+getAccessCodeFromURL) ⇒ <code>string</code>
@@ -817,19 +826,19 @@ Performs the HTTP call to register the client to the server
 **Kind**: instance method of [<code>OAuthClient</code>](#OAuthClient)  
 <a name="OAuthClient+register"></a>
 
-### oAuthClient.register() ⇒ <code>promise</code>
+### oAuthClient.register() ⇒ <code>Promise</code>
 Registers the currenly configured client with the OAuth server and
 sets internal information from the server response
 
 **Kind**: instance method of [<code>OAuthClient</code>](#OAuthClient)  
-**Returns**: <code>promise</code> - A promise that resolves with a complete list of client information, including client ID and client secret.  
+**Returns**: <code>Promise</code> - A promise that resolves with a complete list of client information, including client ID and client secret.  
 **Throws**:
 
 - <code>Error</code> When the client is already registered
 
 <a name="OAuthClient+unregister"></a>
 
-### oAuthClient.unregister() ⇒ <code>promise</code>
+### oAuthClient.unregister() ⇒ <code>Promise</code>
 Unregisters the currenly configured client with the OAuth server.
 
 **Kind**: instance method of [<code>OAuthClient</code>](#OAuthClient)  
@@ -839,7 +848,7 @@ Unregisters the currenly configured client with the OAuth server.
 
 <a name="OAuthClient+fetchInformation"></a>
 
-### oAuthClient.fetchInformation() ⇒ <code>promise</code>
+### oAuthClient.fetchInformation() ⇒ <code>Promise</code>
 Fetches the complete set of client information from the server after it has been registered.
 
 **Kind**: instance method of [<code>OAuthClient</code>](#OAuthClient)  
@@ -849,11 +858,11 @@ Fetches the complete set of client information from the server after it has been
 
 <a name="OAuthClient+updateInformation"></a>
 
-### oAuthClient.updateInformation(information, resetSecret) ⇒ <code>promise</code>
+### oAuthClient.updateInformation(information, resetSecret) ⇒ <code>Promise</code>
 Overwrites the client own information. This method will update both the local information and the remote information on the OAuth server.
 
 **Kind**: instance method of [<code>OAuthClient</code>](#OAuthClient)  
-**Returns**: <code>promise</code> - A promise that resolves to a complete, updated list of client information  
+**Returns**: <code>Promise</code> - Resolves to a complete, updated list of client information  
 **Throws**:
 
 - <code>NotRegisteredException</code> When the client doesn't have it's registration information
@@ -982,10 +991,10 @@ Adds a permission to the given document. Document type must be
 
 **Kind**: instance method of [<code>PermissionCollection</code>](#PermissionCollection)  
 
-| Param | Type |
-| --- | --- |
-| document | <code>object</code> | 
-| permission | <code>object</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| document | <code>object</code> | Document which receives the permission |
+| permission | <code>object</code> | Describes the permission |
 
 **Example**  
 ```
@@ -1063,8 +1072,8 @@ share - Creates a new sharing. See https://docs.cozy.io/en/cozy-stack/sharing/#p
 | --- | --- | --- | --- |
 | document | <code>object</code> |  | The document to share. Should have and _id and a name. |
 | recipients | <code>Array</code> |  | A list of io.cozy.contacts |
-| sharingType | <code>string</code> |  |  |
-| description | <code>string</code> |  |  |
+| sharingType | <code>string</code> |  | If "two-way", will set the open_sharing attribute to true |
+| description | <code>string</code> |  | Describes the sharing |
 | [previewPath] | <code>string</code> | <code>null</code> | Relative URL of the sharings preview page |
 
 <a name="SharingCollection+getDiscoveryLink"></a>
@@ -1074,10 +1083,10 @@ getDiscoveryLink - Returns the URL of the page that can be used to accept a shar
 
 **Kind**: instance method of [<code>SharingCollection</code>](#SharingCollection)  
 
-| Param | Type |
-| --- | --- |
-| sharingId | <code>string</code> | 
-| sharecode | <code>string</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| sharingId | <code>string</code> | Id of the sharing |
+| sharecode | <code>string</code> | Code of the sharing |
 
 <a name="SharingCollection+addRecipients"></a>
 
@@ -1199,10 +1208,10 @@ See https://github.com/cozy/cozy-stack/pull/2010
 - <code>FetchError</code> 
 
 
-| Param | Type |
-| --- | --- |
-| selector | <code>object</code> | 
-| options | <code>object</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| selector | <code>object</code> | Which kind of worker {konnector,service} |
+| options | <code>object</code> | Options |
 
 <a name="TriggerCollection+launch"></a>
 
@@ -1280,3 +1289,32 @@ Memoize with maxDuration and custom key
 Get a uniform formatted URL and SSL information according to a provided URL
 
 **Kind**: global function  
+<a name="DirectoryAttributes"></a>
+
+## DirectoryAttributes : <code>object</code>
+Attributes used for directory creation
+
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| dirId | <code>string</code> | Id of the parent directory. |
+| name | <code>boolean</code> | Name of the created directory. |
+| executable | <code>boolean</code> | Indicates whether the file will be executable. |
+
+<a name="FileAttributes"></a>
+
+## FileAttributes : <code>object</code>
+Attributes used for file creation
+
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| dirId | <code>string</code> | Id of the parent directory. |
+| name | <code>string</code> | Name of the created file. |
+| lastModifiedDate | <code>Date</code> | Can be used to set the last modified date of a file. |
+| metadata | <code>object</code> | io.cozy.files.metadata to attach to the file |
+

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint": "eslint 'packages/*/src/**/*.{js,jsx}' 'packages/*/examples/**/*.{js,jsx}'",
     "test": "jest",
     "watch": "lerna run watch --parallel",
-    "build": "lerna run build",
+    "build": "lerna run build --parallel",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "clean": "rm -rf packages/*/dist",
     "docs": "node scripts/docs.js"

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -79,7 +79,7 @@ class CozyClient {
    *
    * Cozy-Client will automatically call `this.login()` if provided with a token and an uri
    */
-  constructor({ link, links, schema = {}, appMetadata = {}, ...options }) {
+  constructor({ link, links, schema = {}, appMetadata = {}, ...options } = {}) {
     if (link) {
       console.warn('`link` is deprecated, use `links`')
     }

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -28,7 +28,7 @@ import {
 } from './store'
 import { HasManyFiles, Association, HasMany } from './associations'
 import mapValues from 'lodash/mapValues'
-
+import FileCollection from 'cozy-stack-client/dist/FileCollection'
 import { Q } from 'cozy-client'
 
 const normalizeData = data =>
@@ -1320,5 +1320,62 @@ describe('CozyClient', () => {
       const client = new CozyClient({ uri: 'http://localhost:8080' })
       expect(client).toMatchSnapshot()
     })
+  })
+})
+
+describe('file creation', () => {
+  const setup = () => {
+    const client = new CozyClient({})
+    const fileCol = new FileCollection('io.cozy.files', client.stackClient)
+    client.stackClient.collection.mockReturnValue(fileCol)
+    return { client }
+  }
+
+  it('should be possible to create a directory', async () => {
+    const { client } = setup()
+    client.stackClient.fetchJSON = jest.fn().mockResolvedValue({
+      data: {
+        _id: '1337'
+      }
+    })
+    const { data: doc } = await client.create('io.cozy.files', {
+      dirId: 'dirid1337',
+      type: 'directory',
+      name: 'toto.pdf'
+    })
+    expect(doc._id).toEqual('1337')
+    expect(client.stackClient.fetchJSON).toHaveBeenCalledWith(
+      'POST',
+      '/files/dirid1337?Name=toto.pdf&Type=directory',
+      undefined,
+      { headers: { Date: '' } }
+    )
+  })
+
+  it('should be possible to create a file', async () => {
+    const { client } = setup()
+    client.stackClient.fetchJSON = jest.fn().mockResolvedValue({
+      data: {
+        _id: '1337'
+      }
+    })
+    jest.spyOn(client, 'dispatch')
+    const data = 'file-content'
+    const { data: doc } = await client.create('io.cozy.files', {
+      type: 'file',
+      data: data,
+      name: 'toto.pdf'
+    })
+    expect(doc._id).toEqual('1337')
+    expect(client.stackClient.fetchJSON).toHaveBeenCalledWith(
+      'POST',
+      '/files/?Name=toto.pdf&Type=file&Executable=false&MetadataID=',
+      'file-content',
+      { headers: { 'Content-Type': 'text/plain' }, onUploadProgress: undefined }
+    )
+    expect(client.dispatch.mock.calls.map(x => x[0].type)).toEqual([
+      'INIT_MUTATION',
+      'RECEIVE_MUTATION_RESULT'
+    ])
   })
 })

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -1364,12 +1364,13 @@ describe('file creation', () => {
     const { data: doc } = await client.create('io.cozy.files', {
       type: 'file',
       data: data,
+      dirId: 'folder-id',
       name: 'toto.pdf'
     })
     expect(doc._id).toEqual('1337')
     expect(client.stackClient.fetchJSON).toHaveBeenCalledWith(
       'POST',
-      '/files/?Name=toto.pdf&Type=file&Executable=false&MetadataID=',
+      '/files/folder-id?Name=toto.pdf&Type=file&Executable=false&MetadataID=',
       'file-content',
       { headers: { 'Content-Type': 'text/plain' }, onUploadProgress: undefined }
     )

--- a/packages/cozy-client/src/__tests__/fixtures.js
+++ b/packages/cozy-client/src/__tests__/fixtures.js
@@ -1,5 +1,5 @@
 export const TODO_1 = {
-  _id: '12345',
+  _id: 'todo_1',
   _rev: '4-43bdf4f7123f4d748645ba9536a46daa',
   _type: 'io.cozy.todos',
   label: 'Buy bread',
@@ -7,7 +7,7 @@ export const TODO_1 = {
 }
 
 export const TODO_2 = {
-  _id: '67890',
+  _id: 'todo_2',
   _rev: '2-4e015d830d3246e5a83b3466f437bf1f',
   _type: 'io.cozy.todos',
   label: 'Check email',
@@ -15,14 +15,14 @@ export const TODO_2 = {
 }
 
 export const TODO_3 = {
-  _id: '54321',
+  _id: 'todo_3',
   _rev: '22-6af94ee48bcc4867aa06b72b635837e9',
   _type: 'io.cozy.todos',
   label: 'Build stuff',
   done: true
 }
 export const TODO_4 = {
-  _id: '4',
+  _id: 'todo_4',
   _rev: '19-cc30042f909f4fa7a487c4c7f0a11d19',
   _type: 'io.cozy.todos',
   label: 'Run a semi-marathon',

--- a/packages/cozy-client/src/__tests__/store.spec.js
+++ b/packages/cozy-client/src/__tests__/store.spec.js
@@ -107,6 +107,59 @@ describe('Store', () => {
         )
       ).toEqual(UPDATED_TODO)
     })
+
+    it('should correctly update a query with sort', () => {
+      const query = new Q({
+        doctype: 'io.cozy.todos'
+      })
+      let queryResult
+      store.dispatch(
+        initQuery('my-query-name', query.sortBy([{ label: 'desc' }]))
+      )
+      store.dispatch(
+        initQuery('other-query', query.sortBy([{ label: 'asc' }]))
+      )
+      store.dispatch(
+        receiveQueryResult('my-query-name', {
+          data: [TODO_1, TODO_2]
+        })
+      )
+      queryResult = getQueryFromStore(store, 'my-query-name')
+      expect(queryResult.data.map(x => x._id)).toEqual(['todo_2', 'todo_1'])
+
+      store.dispatch(
+        receiveQueryResult('my-query-name', {
+          data: [TODO_4]
+        })
+      )
+      queryResult = getQueryFromStore(store, 'my-query-name')
+      expect(queryResult.data.map(x => x._id)).toEqual([
+        'todo_4',
+        'todo_2',
+        'todo_1'
+      ])
+
+      store.dispatch(
+        receiveQueryResult('my-query-name', {
+          data: [TODO_3]
+        })
+      )
+      queryResult = getQueryFromStore(store, 'my-query-name')
+      expect(queryResult.data.map(x => x._id)).toEqual([
+        'todo_4',
+        'todo_2',
+        'todo_1',
+        'todo_3'
+      ])
+
+      const otherQueryResult = getQueryFromStore(store, 'other-query')
+      expect(otherQueryResult.data.map(x => x._id)).toEqual([
+        'todo_3',
+        'todo_1',
+        'todo_2',
+        'todo_4'
+      ])
+    })
   })
 
   describe('getDocumentFromState', () => {

--- a/packages/cozy-client/src/__tests__/store.spec.js
+++ b/packages/cozy-client/src/__tests__/store.spec.js
@@ -116,9 +116,7 @@ describe('Store', () => {
       store.dispatch(
         initQuery('my-query-name', query.sortBy([{ label: 'desc' }]))
       )
-      store.dispatch(
-        initQuery('other-query', query.sortBy([{ label: 'asc' }]))
-      )
+      store.dispatch(initQuery('other-query', query.sortBy([{ label: 'asc' }])))
       store.dispatch(
         receiveQueryResult('my-query-name', {
           data: [TODO_1, TODO_2]

--- a/packages/cozy-client/src/hooks/useFetchJSON.spec.js
+++ b/packages/cozy-client/src/hooks/useFetchJSON.spec.js
@@ -3,9 +3,12 @@ import { renderHook } from '@testing-library/react-hooks'
 import useFetchJSON from './useFetchJSON'
 import Provider from '../Provider'
 
-const makeWrapper = client => ({ children }) => (
-  <Provider client={client}>{children}</Provider>
-)
+const makeWrapper = client => {
+  const Wrapper = ({ children }) => (
+    <Provider client={client}>{children}</Provider>
+  )
+  return Wrapper
+}
 
 describe('use fetch json', () => {
   const setup = ({ fetchJSON }) => {

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -282,6 +282,8 @@ export const uploadFile = (file, dirPath) => ({
  *
  * Used to sort query results inside the store when creating a file or
  * receiving updates.
+ *
+ * @private
  */
 export const makeSorterFromDefinition = definition => {
   const sort = definition.sort

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -283,7 +283,6 @@ export const uploadFile = (file, dirPath) => ({
  * Used to sort query results inside the store when creating a file or
  * receiving updates.
  */
-
 export const makeSorterFromDefinition = definition => {
   const sort = definition.sort
   if (!sort) {

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -1,5 +1,4 @@
 const isArray = require('lodash/isArray')
-const orderBy = require('lodash/orderBy')
 
 /**
  * typedef QueryDefinition
@@ -276,31 +275,6 @@ export const uploadFile = (file, dirPath) => ({
   file,
   dirPath
 })
-
-/**
- * Creates a sort function from a definition.
- *
- * Used to sort query results inside the store when creating a file or
- * receiving updates.
- *
- * @private
- */
-export const makeSorterFromDefinition = definition => {
-  const sort = definition.sort
-  if (!sort) {
-    return docs => docs
-  } else if (!isArray(definition.sort)) {
-    console.warn(
-      'Correct update of queries with a sort that is not an array is not supported. Use an array as argument of QueryDefinition::sort'
-    )
-    return docs => docs
-  } else {
-    const attributeOrders = sort.map(x => Object.entries(x)[0])
-    const attrs = attributeOrders.map(x => x[0])
-    const orders = attributeOrders.map(x => x[1])
-    return docs => orderBy(docs, attrs, orders)
-  }
-}
 
 export const getDoctypeFromOperation = operation => {
   if (operation.mutationType) {

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -103,7 +103,9 @@ class QueryDefinition {
   sortBy(sort) {
     if (!isArray(sort)) {
       throw new Error(
-        `Invalid sort, should be an array ([{ label: "desc"}, { name: "asc"}]), you passed ${JSON.stringify(sort)}.`
+        `Invalid sort, should be an array ([{ label: "desc"}, { name: "asc"}]), you passed ${JSON.stringify(
+          sort
+        )}.`
       )
     }
     return new QueryDefinition({ ...this.toDefinition(), sort })
@@ -295,12 +297,7 @@ export const makeSorterFromDefinition = definition => {
     const attributeOrders = sort.map(x => Object.entries(x)[0])
     const attrs = attributeOrders.map(x => x[0])
     const orders = attributeOrders.map(x => x[1])
-    return docs =>
-      orderBy(
-        docs,
-        attrs,
-        orders
-      )
+    return docs => orderBy(docs, attrs, orders)
   }
 }
 

--- a/packages/cozy-client/src/queries/dsl.spec.js
+++ b/packages/cozy-client/src/queries/dsl.spec.js
@@ -1,4 +1,4 @@
-import { QueryDefinition, Q, makeSorterFromDefinition } from '../queries/dsl'
+import { QueryDefinition, Q } from '../queries/dsl'
 
 describe('QueryDefinition', () => {
   it('should build query defs on selected fields', () => {
@@ -31,21 +31,5 @@ describe('QueryDefinition', () => {
       ids: ['id1', 'ids2'],
       doctype: 'io.cozy.files'
     })
-  })
-})
-
-describe('makeSorterFromDefinition', () => {
-  it('should make a sort function from a definition', () => {
-    const q = Q('io.cozy.files').sortBy([{ name: 'desc' }, { label: 'asc' }])
-
-    const sorter = makeSorterFromDefinition(q)
-    const files = [
-      { _id: '1', name: 1, label: 'C' },
-      { _id: '2', name: 2, label: 'B' },
-      { _id: '3', name: 3, label: 'C' },
-      { _id: '4', name: 3, label: 'A' }
-    ]
-    const sorted = sorter(files)
-    expect(sorted.map(x => x._id)).toEqual(['4', '3', '2', '1'])
   })
 })

--- a/packages/cozy-client/src/queries/dsl.spec.js
+++ b/packages/cozy-client/src/queries/dsl.spec.js
@@ -36,7 +36,7 @@ describe('QueryDefinition', () => {
 
 describe('makeSorterFromDefinition', () => {
   it('should make a sort function from a definition', () => {
-    const q = Q('io.cozy.files').sortBy([{ name: 'desc'}, { label: 'asc'}])
+    const q = Q('io.cozy.files').sortBy([{ name: 'desc' }, { label: 'asc' }])
 
     const sorter = makeSorterFromDefinition(q)
     const files = [
@@ -46,9 +46,6 @@ describe('makeSorterFromDefinition', () => {
       { _id: '4', name: 3, label: 'A' }
     ]
     const sorted = sorter(files)
-    expect(sorted.map(x => x._id)).toEqual([
-      '4', '3', '2', '1'
-    ])
-
+    expect(sorted.map(x => x._id)).toEqual(['4', '3', '2', '1'])
   })
 })

--- a/packages/cozy-client/src/queries/dsl.spec.js
+++ b/packages/cozy-client/src/queries/dsl.spec.js
@@ -1,4 +1,4 @@
-import { QueryDefinition, Q } from '../queries/dsl'
+import { QueryDefinition, Q, makeSorterFromDefinition } from '../queries/dsl'
 
 describe('QueryDefinition', () => {
   it('should build query defs on selected fields', () => {
@@ -31,5 +31,24 @@ describe('QueryDefinition', () => {
       ids: ['id1', 'ids2'],
       doctype: 'io.cozy.files'
     })
+  })
+})
+
+describe('makeSorterFromDefinition', () => {
+  it('should make a sort function from a definition', () => {
+    const q = Q('io.cozy.files').sortBy([{ name: 'desc'}, { label: 'asc'}])
+
+    const sorter = makeSorterFromDefinition(q)
+    const files = [
+      { _id: '1', name: 1, label: 'C' },
+      { _id: '2', name: 2, label: 'B' },
+      { _id: '3', name: 3, label: 'C' },
+      { _id: '4', name: 3, label: 'A' }
+    ]
+    const sorted = sorter(files)
+    expect(sorted.map(x => x._id)).toEqual([
+      '4', '3', '2', '1'
+    ])
+
   })
 })

--- a/packages/cozy-client/src/store/__snapshots__/queries.spec.js.snap
+++ b/packages/cozy-client/src/store/__snapshots__/queries.spec.js.snap
@@ -37,8 +37,8 @@ Object {
     "bookmark": null,
     "count": 2,
     "data": Array [
-      "12345",
-      "67890",
+      "todo_1",
+      "todo_2",
     ],
     "definition": QueryDefinition {
       "bookmark": undefined,
@@ -71,7 +71,7 @@ Object {
     "bookmark": null,
     "count": 1,
     "data": Array [
-      "54321",
+      "todo_3",
     ],
     "definition": QueryDefinition {
       "bookmark": undefined,
@@ -99,7 +99,7 @@ Object {
     "bookmark": null,
     "count": 1,
     "data": Array [
-      "54321",
+      "todo_3",
     ],
     "definition": QueryDefinition {
       "bookmark": undefined,
@@ -137,7 +137,7 @@ Object {
     "bookmark": null,
     "count": 1,
     "data": Array [
-      "54321",
+      "todo_3",
     ],
     "definition": QueryDefinition {
       "bookmark": undefined,
@@ -165,7 +165,7 @@ Object {
     "bookmark": null,
     "count": 1,
     "data": Array [
-      "54321",
+      "todo_3",
     ],
     "definition": QueryDefinition {
       "bookmark": undefined,
@@ -200,8 +200,8 @@ Object {
     "bookmark": null,
     "count": 2,
     "data": Array [
-      "12345",
-      "67890",
+      "todo_1",
+      "todo_2",
     ],
     "definition": QueryDefinition {
       "bookmark": undefined,
@@ -229,8 +229,8 @@ Object {
     "bookmark": null,
     "count": 2,
     "data": Array [
-      "12345",
-      "67890",
+      "todo_1",
+      "todo_2",
     ],
     "definition": QueryDefinition {
       "bookmark": undefined,
@@ -320,7 +320,7 @@ Object {
     "bookmark": null,
     "count": 1,
     "data": Array [
-      "54321",
+      "todo_3",
     ],
     "definition": QueryDefinition {
       "bookmark": undefined,

--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -4,13 +4,14 @@ import intersection from 'lodash/intersection'
 import concat from 'lodash/concat'
 import isPlainObject from 'lodash/isPlainObject'
 import uniq from 'lodash/uniq'
+import orderBy from 'lodash/orderBy'
+import isArray from 'lodash/isArray'
 
 import { getDocumentFromSlice } from './documents'
 import { isReceivingMutationResult } from './mutations'
 import { properId } from './helpers'
 import sift from 'sift'
 import get from 'lodash/get'
-import { makeSorterFromDefinition } from '../queries/dsl'
 
 const INIT_QUERY = 'INIT_QUERY'
 const RECEIVE_QUERY_RESULT = 'RECEIVE_QUERY_RESULT'
@@ -143,6 +144,31 @@ const getQueryDocumentsChecker = query => {
     }
     if (datum._deleted) return false
     return true
+  }
+}
+
+/**
+ * Creates a sort function from a definition.
+ *
+ * Used to sort query results inside the store when creating a file or
+ * receiving updates.
+ *
+ * @private
+ */
+export const makeSorterFromDefinition = definition => {
+  const sort = definition.sort
+  if (!sort) {
+    return docs => docs
+  } else if (!isArray(definition.sort)) {
+    console.warn(
+      'Correct update of queries with a sort that is not an array is not supported. Use an array as argument of QueryDefinition::sort'
+    )
+    return docs => docs
+  } else {
+    const attributeOrders = sort.map(x => Object.entries(x)[0])
+    const attrs = attributeOrders.map(x => x[0])
+    const orders = attributeOrders.map(x => x[1])
+    return docs => orderBy(docs, attrs, orders)
   }
 }
 

--- a/packages/cozy-client/src/store/queries.spec.js
+++ b/packages/cozy-client/src/store/queries.spec.js
@@ -1,7 +1,8 @@
 import queries, {
   initQuery,
   receiveQueryResult,
-  convert$gtNullSelectors
+  convert$gtNullSelectors,
+  makeSorterFromDefinition
 } from './queries'
 import { QueryDefinition as Q } from '../queries/dsl'
 import { TODO_1, TODO_2, TODO_3 } from '../__tests__/fixtures'
@@ -191,5 +192,21 @@ describe('selectors', () => {
         $gt: 2
       }
     })
+  })
+})
+
+describe('makeSorterFromDefinition', () => {
+  it('should make a sort function from a definition', () => {
+    const q = Q('io.cozy.files').sortBy([{ name: 'desc' }, { label: 'asc' }])
+
+    const sorter = makeSorterFromDefinition(q)
+    const files = [
+      { _id: '1', name: 1, label: 'C' },
+      { _id: '2', name: 2, label: 'B' },
+      { _id: '3', name: 3, label: 'C' },
+      { _id: '4', name: 3, label: 'A' }
+    ]
+    const sorted = sorter(files)
+    expect(sorted.map(x => x._id)).toEqual(['4', '3', '2', '1'])
   })
 })

--- a/packages/cozy-client/src/testing/utils.js
+++ b/packages/cozy-client/src/testing/utils.js
@@ -21,10 +21,13 @@ const setupClient = () => {
   return client
 }
 
-const makeWrapper = client => ({ children }) => (
-  <ReduxProvider store={client.store}>
-    <ClientProvider client={client}>{children}</ClientProvider>
-  </ReduxProvider>
-)
+const makeWrapper = client => {
+  const Wrapper = ({ children }) => (
+    <ReduxProvider store={client.store}>
+      <ClientProvider client={client}>{children}</ClientProvider>
+    </ReduxProvider>
+  )
+  return Wrapper
+}
 
 export { setupClient, makeWrapper }

--- a/packages/cozy-stack-client/src/AppCollection.js
+++ b/packages/cozy-stack-client/src/AppCollection.js
@@ -1,4 +1,5 @@
 import DocumentCollection, { normalizeDoc } from './DocumentCollection'
+import { FetchError } from './errors'
 
 export const APPS_DOCTYPE = 'io.cozy.apps'
 

--- a/packages/cozy-stack-client/src/Collection.js
+++ b/packages/cozy-stack-client/src/Collection.js
@@ -28,9 +28,9 @@ export class Collection {
   /**
    * Utility method aimed to return only one document.
    *
-   * @param  {object}  stackClient
-   * @param  {string}  endpoint          Stack endpoint
-   * @param  {object}  options
+   * @param  {CozyStackClient}  stackClient - CozyStackClient
+   * @param  {string}  endpoint - Stack endpoint
+   * @param  {object}  options - Options of the collection
    * @param  {Func}    options.normalize Callback to normalize response data
    * (default `data => data`)
    * @param  {string}  options.method    HTTP method (default `GET`)

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -17,6 +17,7 @@ import logDeprecate from './logDeprecate'
 import errors from './errors'
 import { fetchWithXMLHttpRequest, shouldXMLHTTPRequestBeUsed } from './xhrFetch'
 import MicroEE from 'microee'
+import { FetchError } from './errors'
 
 const normalizeUri = uri => {
   if (uri === null) return null
@@ -323,27 +324,6 @@ class CozyStackClient {
 
   getIconURL(opts) {
     return getIconURL(this, opts)
-  }
-}
-
-export class FetchError extends Error {
-  constructor(response, reason) {
-    super()
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor)
-    }
-    // WARN We have to hardcode this because babel doesn't play nice when extending Error
-    this.name = 'FetchError'
-    this.response = response
-    this.url = response.url
-    this.status = response.status
-    this.reason = reason
-
-    Object.defineProperty(this, 'message', {
-      value:
-        reason.message ||
-        (typeof reason === 'string' ? reason : JSON.stringify(reason))
-    })
   }
 }
 

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -8,6 +8,7 @@ import qs from 'qs'
 
 import Collection, { dontThrowNotFoundError } from './Collection'
 import * as querystring from './querystring'
+import { FetchError } from './errors'
 
 const DATABASE_DOES_NOT_EXIST = 'Database does not exist.'
 

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -4,6 +4,8 @@ import get from 'lodash/get'
 import DocumentCollection, { normalizeDoc } from './DocumentCollection'
 import { uri, slugify, forceFileDownload, formatBytes } from './utils'
 import * as querystring from './querystring'
+import { FetchError } from './errors'
+
 const ROOT_DIR_ID = 'io.cozy.files.root-dir'
 const CONTENT_TYPE_OCTET_STREAM = 'application/octet-stream'
 

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -443,7 +443,7 @@ class FileCollection extends DocumentCollection {
    * 102404500404B => 95.37 GB
    *
    * @param {object} file io.cozy.files object
-   * @param {int} decimal number of decimal
+   * @param {number} decimal number of decimal
    */
   getBeautifulSize(file, decimal) {
     return formatBytes(parseInt(file.size), decimal)

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -278,6 +278,19 @@ class FileCollection extends DocumentCollection {
   }
 
   /**
+   * Creates for both directory or file.
+   * - Used by StackLink to support CozyClient.create('io.cozy.files', options)
+   */
+  async create(attributes) {
+    if (attributes.type === 'directory') {
+      return this.createDirectory(attributes)
+    } else {
+      const { data, ...createFileOptions } = attributes
+      return this.createFile(data, createFileOptions)
+    }
+  }
+
+  /**
    *
    * @param {File|Blob|Stream|string|ArrayBuffer} data file to be uploaded
    * @param {object} params Additionnal parameters

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -136,7 +136,7 @@ class OAuthClient extends CozyStackClient {
    * sets internal information from the server response
    *
    * @throws {Error} When the client is already registered
-   * @returns {promise} A promise that resolves with a complete list of client information, including client ID and client secret.
+   * @returns {Promise} A promise that resolves with a complete list of client information, including client ID and client secret.
    */
   async register() {
     if (this.isRegistered()) throw new Error('Client already registered')
@@ -171,7 +171,7 @@ class OAuthClient extends CozyStackClient {
    * Unregisters the currenly configured client with the OAuth server.
    *
    * @throws {NotRegisteredException} When the client doesn't have it's registration information
-   * @returns {promise}
+   * @returns {Promise}
    */
   async unregister() {
     if (!this.isRegistered()) throw new NotRegisteredException()
@@ -190,7 +190,7 @@ class OAuthClient extends CozyStackClient {
    * Fetches the complete set of client information from the server after it has been registered.
    *
    * @throws {NotRegisteredException} When the client doesn't have it's registration information
-   * @returns {promise}
+   * @returns {Promise}
    */
   async fetchInformation() {
     if (!this.isRegistered()) throw new NotRegisteredException()
@@ -213,7 +213,7 @@ class OAuthClient extends CozyStackClient {
    * @throws {NotRegisteredException} When the client doesn't have it's registration information
    * @param   {object} information Set of information to update. Note that some fields such as `clientID` can't be updated.
    * @param   {boolean} resetSecret = false Optionnal, whether to reset the client secret or not
-   * @returns {promise} A promise that resolves to a complete, updated list of client information
+   * @returns {Promise} Resolves to a complete, updated list of client information
    */
   async updateInformation(information, resetSecret = false) {
     if (!this.isRegistered()) throw new NotRegisteredException()

--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -34,8 +34,8 @@ class PermissionCollection extends DocumentCollection {
    * Adds a permission to the given document. Document type must be
    * `io.cozy.apps`, `io.cozy.konnectors` or `io.cozy.permissions`
    *
-   * @param  {object}  document
-   * @param  {object}  permission
+   * @param  {object}  document - Document which receives the permission
+   * @param  {object}  permission - Describes the permission
    * @returns {Promise}
    *
    * @example

--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -25,8 +25,8 @@ class SharingCollection extends DocumentCollection {
    *
    * @param  {object} document The document to share. Should have and _id and a name.
    * @param  {Array} recipients A list of io.cozy.contacts
-   * @param  {string} sharingType
-   * @param  {string} description
+   * @param  {string} sharingType - If "two-way", will set the open_sharing attribute to true
+   * @param  {string} description - Describes the sharing
    * @param  {string=} previewPath Relative URL of the sharings preview page
    */
   async share(
@@ -58,8 +58,8 @@ class SharingCollection extends DocumentCollection {
   /**
    * getDiscoveryLink - Returns the URL of the page that can be used to accept a sharing. See https://docs.cozy.io/en/cozy-stack/sharing/#get-sharingssharing-iddiscovery
    *
-   * @param  {string} sharingId
-   * @param  {string} sharecode
+   * @param  {string} sharingId - Id of the sharing
+   * @param  {string} sharecode - Code of the sharing
    * @returns {string}
    */
   getDiscoveryLink(sharingId, sharecode) {

--- a/packages/cozy-stack-client/src/TriggerCollection.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.js
@@ -3,6 +3,8 @@ import { normalizeDoc } from './DocumentCollection'
 import { normalizeJob } from './JobCollection'
 import { uri } from './utils'
 import DocumentCollection from './DocumentCollection'
+import { FetchError } from './errors'
+
 export const JOBS_DOCTYPE = 'io.cozy.jobs'
 export const TRIGGERS_DOCTYPE = 'io.cozy.triggers'
 
@@ -99,8 +101,8 @@ class TriggerCollection extends DocumentCollection {
    *
    * See https://github.com/cozy/cozy-stack/pull/2010
    *
-   * @param {object} selector
-   * @param {object} options
+   * @param {object} selector - Which kind of worker {konnector,service}
+   * @param {object} options - Options
    * @returns {{data, meta, skip, next}} The JSON API conformant response.
    * @throws {FetchError}
    */

--- a/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/CozyStackClient.spec.js
@@ -1,12 +1,13 @@
 /* eslint-env jest */
 /* global fetch */
 
-import CozyStackClient, { FetchError } from '../CozyStackClient'
+import CozyStackClient from '../CozyStackClient'
 import DocumentCollection from '../DocumentCollection'
 import JobCollection from '../JobCollection'
 import KonnectorCollection from '../KonnectorCollection'
 import jestFetchMock from 'jest-fetch-mock'
 import AppToken from '../AppToken'
+import { FetchError } from '../errors'
 
 const FAKE_RESPONSE = {
   offset: 0,

--- a/packages/cozy-stack-client/src/errors.js
+++ b/packages/cozy-stack-client/src/errors.js
@@ -7,3 +7,24 @@ export default {
   CLIENT_NOT_FOUND,
   INVALID_TOKEN
 }
+
+export class FetchError extends Error {
+  constructor(response, reason) {
+    super()
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor)
+    }
+    // WARN We have to hardcode this because babel doesn't play nice when extending Error
+    this.name = 'FetchError'
+    this.response = response
+    this.url = response.url
+    this.status = response.status
+    this.reason = reason
+
+    Object.defineProperty(this, 'message', {
+      value:
+        reason.message ||
+        (typeof reason === 'string' ? reason : JSON.stringify(reason))
+    })
+  }
+}

--- a/packages/cozy-stack-client/src/index.js
+++ b/packages/cozy-stack-client/src/index.js
@@ -1,4 +1,4 @@
-export { default, FetchError } from './CozyStackClient'
+export { default } from './CozyStackClient'
 export { default as OAuthClient } from './OAuthClient'
-export { default as errors } from './errors'
+export { default as errors, FetchError } from './errors'
 export { normalizeDoc } from './DocumentCollection'


### PR DESCRIPTION
- File creation via client.create('io.cozy.files', { ... })
- Query keep their sort order if it has been configured at
  query definition