### PR TITLE
feat: Support query defs with multiple ids in pouch link

### DIFF
--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -276,12 +276,16 @@ class PouchLink extends CozyLink {
     }
   }
 
-  async executeQuery({ doctype, selector, sort, fields, limit, id }) {
+  async executeQuery({ doctype, selector, sort, fields, limit, id, ids }) {
     const db = this.getPouch(doctype)
     let res, withRows
     if (id) {
       res = await db.get(id)
       withRows = false
+    } else if (ids) {
+      res = await allDocs(db, { include_docs: true, keys: ids })
+      res = withoutDesignDocuments(res)
+      withRows = true
     } else if (!selector && !fields && !sort) {
       res = await allDocs(db, { include_docs: true, limit })
       res = withoutDesignDocuments(res)

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -103,6 +103,19 @@ describe('CozyPouchLink', () => {
       expect(resp.data.label).toBe('Make PouchDB link work')
     })
 
+    it('should be possible to query multiple docs', async () => {
+      await setup()
+      link.pouches.isSynced = jest.fn().mockReturnValue(true)
+      const db = link.getPouch(TODO_DOCTYPE)
+      await db.bulkDocs(docs.map(x => omit(x, '_type')))
+      const ids = [TODO_1._id, TODO_3._id]
+      const query = Q(TODO_DOCTYPE).getByIds(ids)
+      const resp = await link.request(query)
+      expect(resp.data.length).toEqual(2)
+      expect(resp.data[0]._id).toEqual(TODO_1._id)
+      expect(resp.data[1]._id).toEqual(TODO_3._id)
+    })
+
     it('should be possible to select', async () => {
       await setup()
       link.pouches.isSynced = jest.fn().mockReturnValue(true)


### PR DESCRIPTION
Query definitions support a `getByIds` method that is handled by the StackLink, but was so far ignored by the PouchLink.