### PR TITLE
fix: Support multiple ids in store query updates

### DIFF
--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -128,6 +128,8 @@ const getSelectorFilterFn = queryDefinition => {
     return sift(convert$gtNullSelectors(queryDefinition.selector))
   } else if (queryDefinition.id) {
     return sift({ _id: queryDefinition.id })
+  } else if (queryDefinition.ids) {
+    return sift({ _id: { $in: queryDefinition.ids } })
   } else {
     return null
   }

--- a/packages/cozy-client/src/store/queries.spec.js
+++ b/packages/cozy-client/src/store/queries.spec.js
@@ -89,6 +89,25 @@ describe('queries reducer', () => {
       expect(state).toMatchSnapshot()
     })
 
+    it('should correctly update a query with several ids', () => {
+      const query = new QueryDefinition({
+        doctype: 'io.cozy.todos'
+      })
+      applyAction(initQuery('b', query.getByIds([TODO_1._id, TODO_2._id])))
+      applyAction(
+        receiveQueryResult('b', {
+          data: [TODO_1, TODO_2]
+        })
+      )
+      expect(state.b.data).toEqual([TODO_1._id, TODO_2._id])
+      applyAction(
+        receiveQueryResult('a', {
+          data: [TODO_3]
+        })
+      )
+      expect(state.b.data).toEqual([TODO_1._id, TODO_2._id]) // TODO_3 does not appear in the results of query b, because it is not part of the specified ids
+    })
+
     it('should correctly update a query with a $gt: null selector', () => {
       const query = new QueryDefinition({
         doctype: 'io.cozy.todos'


### PR DESCRIPTION
When receiving a query result, queries using `getByIds` would always be affected by new results, even if they had different ids.