### PR TITLE
fix: Client-side query sort is case insensitive

### DIFF
--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -6,6 +6,7 @@ import isPlainObject from 'lodash/isPlainObject'
 import uniq from 'lodash/uniq'
 import orderBy from 'lodash/orderBy'
 import isArray from 'lodash/isArray'
+import isString from 'lodash/isString'
 
 import { getDocumentFromSlice } from './documents'
 import { isReceivingMutationResult } from './mutations'
@@ -147,6 +148,11 @@ const getQueryDocumentsChecker = query => {
   }
 }
 
+const makeCaseInsensitiveStringSorter = attrName => item => {
+  const attrValue = item[attrName]
+  return isString(attrValue) ? attrValue.toLowerCase() : attrValue
+}
+
 /**
  * Creates a sort function from a definition.
  *
@@ -166,7 +172,9 @@ export const makeSorterFromDefinition = definition => {
     return docs => docs
   } else {
     const attributeOrders = sort.map(x => Object.entries(x)[0])
-    const attrs = attributeOrders.map(x => x[0])
+    const attrs = attributeOrders
+      .map(x => x[0])
+      .map(makeCaseInsensitiveStringSorter)
     const orders = attributeOrders.map(x => x[1])
     return docs => orderBy(docs, attrs, orders)
   }

--- a/packages/cozy-client/src/store/queries.spec.js
+++ b/packages/cozy-client/src/store/queries.spec.js
@@ -204,9 +204,10 @@ describe('makeSorterFromDefinition', () => {
       { _id: '1', name: 1, label: 'C' },
       { _id: '2', name: 2, label: 'B' },
       { _id: '3', name: 3, label: 'C' },
-      { _id: '4', name: 3, label: 'A' }
+      { _id: '4', name: 3, label: 'A' },
+      { _id: '5', name: 3, label: 'a' }
     ]
     const sorted = sorter(files)
-    expect(sorted.map(x => x._id)).toEqual(['4', '3', '2', '1'])
+    expect(sorted.map(x => x._id)).toEqual(['4', '5', '3', '2', '1'])
   })
 })


### PR DESCRIPTION
`lodash.sortBy` is case-sensitive when ordering strings, whereas the stack is not. This PR removes the case-sensitivity from our sort.