### PR TITLE
fix: FileCollection.statById pagination

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -398,6 +398,7 @@ files associated to a specific document
     * [.fetchFileContent(id)](#FileCollection+fetchFileContent)
     * [.getBeautifulSize(file, decimal)](#FileCollection+getBeautifulSize)
     * [.isChildOf(child, parent)](#FileCollection+isChildOf) ⇒ <code>boolean</code>
+    * [.statById(id, [options])](#FileCollection+statById) ⇒ <code>object</code>
     * [.createDirectoryByPath(path)](#FileCollection+createDirectoryByPath) ⇒ <code>object</code>
     * [.createFileMetadata(attributes)](#FileCollection+createFileMetadata) ⇒ <code>object</code>
     * [.updateMetadataAttribute(id, metadata)](#FileCollection+updateMetadataAttribute) ⇒ <code>object</code>
@@ -650,6 +651,22 @@ Checks if the file belongs to the parent's hierarchy.
 | --- | --- | --- |
 | child | <code>string</code> \| <code>object</code> | The file which can either be an id or an object |
 | parent | <code>string</code> \| <code>object</code> | The parent target which can either be an id or an object |
+
+<a name="FileCollection+statById"></a>
+
+### fileCollection.statById(id, [options]) ⇒ <code>object</code>
+statById - Fetches the metadata about a document. For folders, the results include the list of child files and folders.
+
+**Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
+**Returns**: <code>object</code> - A promise resolving to an object containing "data" (the document metadata), "included" (the child documents) and "links" (pagination informations)  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| id | <code>string</code> |  | ID of the document |
+| [options] | <code>object</code> | <code>{}</code> | Description |
+| [options.page[limit]] | <code>number</code> |  | Max number of children documents to return |
+| [options.page[skip]] | <code>number</code> |  | Number of children documents to skip from the start |
+| [options.page[cursor]] | <code>string</code> |  | A cursor id for pagination |
 
 <a name="FileCollection+createDirectoryByPath"></a>
 

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -45,11 +45,11 @@ describe('FileCollection', () => {
   const collection = new FileCollection('io.cozy.files', client)
 
   describe('statById', () => {
-    beforeAll(() => {
+    beforeEach(() => {
       client.fetchJSON.mockReturnValue(Promise.resolve(STAT_BY_ID_RESPONSE))
     })
 
-    afterAll(() => {
+    afterEach(() => {
       client.fetchJSON.mockReset()
     })
 
@@ -58,9 +58,17 @@ describe('FileCollection', () => {
       expect(client.fetchJSON).toHaveBeenCalledWith('GET', '/files/42')
     })
 
-    it('should accept skip and limit options', async () => {
-      await collection.statById(42, { skip: 50, limit: 200 })
-      expect(client.fetchJSON).toHaveBeenCalledWith('GET', '/files/42')
+    it('should accept skip, cursor and limit options', async () => {
+      await collection.statById(42, {
+        'page[skip]': 50,
+        'page[limit]': 200,
+        'page[cursor]': 'abc123',
+        ignoredOption: 'not-included'
+      })
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'GET',
+        '/files/42?page[limit]=200&page[skip]=50&page[cursor]=abc123'
+      )
     })
 
     it('should return a correct JSON API response', async () => {


### PR DESCRIPTION
`FileCollection.statById` supports pagination, but in a way that is incompatible with the stack. The [stack route](https://docs.cozy.io/en/cozy-stack/files/#get-filesfile-id) expects a [JSON API style pagination](https://docs.cozy.io/en/cozy-stack/jsonapi/#pagination) with URL params such as `page[limit]` or `page[skip]`, but we only send plain `limit` and `skip` which are ignored.

I also added support for cursor based pagination, which involves supporting a `page[cursor]` param, and returning the `links` part of the response to get the next cursor.