### PR TITLE
fix: Use query support fetchMore without bookmark + fetchMore return

### DIFF
--- a/packages/cozy-client/src/hooks/useQuery.js
+++ b/packages/cozy-client/src/hooks/useQuery.js
@@ -7,8 +7,10 @@ const resolveToValue = fnOrValue => {
   return typeof resolveToValue === 'function' ? fnOrValue() : fnOrValue
 }
 
-const generateFetchMoreQueryDefinition = collection => {
-  return collection.definition.offsetBookmark(collection.bookmark)
+const generateFetchMoreQueryDefinition = queryResult => {
+  return queryResult.bookmark
+    ? queryResult.definition.offsetBookmark(queryResult.bookmark)
+    : queryResult.definition.offset(queryResult.data.length)
 }
 
 /**
@@ -58,7 +60,7 @@ const useQuery = (queryDefinition, options) => {
 
   const fetchMore = useCallback(() => {
     const queryState = client.getQueryFromState(as)
-    client.query(generateFetchMoreQueryDefinition(queryState), { as })
+    return client.query(generateFetchMoreQueryDefinition(queryState), { as })
   }, [as, client])
 
   return { ...queryState, fetchMore: fetchMore }

--- a/packages/cozy-client/src/hooks/useQuery.spec.jsx
+++ b/packages/cozy-client/src/hooks/useQuery.spec.jsx
@@ -47,7 +47,7 @@ describe('use query', () => {
 
   it('fetches more results with bookmark', async () => {
     const bookmark = 'bookmark-123'
-    const queryDefinition = Q('io.cozy.simpsons').offsetBookmark(bookmark)
+    const queryDefinition = Q('io.cozy.simpsons')
     const {
       hookResult: {
         result: { current }
@@ -62,7 +62,8 @@ describe('use query', () => {
         simpsonsBookmarked: {
           data: simpsonsFixture,
           doctype: 'io.cozy.simpsons',
-          definition: queryDefinition
+          definition: queryDefinition,
+          bookmark
         }
       }
     })
@@ -70,7 +71,7 @@ describe('use query', () => {
     const fetchMoreResult = await current.fetchMore()
     const lastCallArgs =
       client.query.mock.calls[client.query.mock.calls.length - 1][0]
-    expect(lastCallArgs).toMatchObject({ bookmark: 'bookmark-123' })
+    expect(lastCallArgs).toMatchObject({ bookmark })
     expect(fetchMoreResult).toEqual({ data: null })
   })
 

--- a/packages/cozy-client/src/hooks/useQuery.spec.jsx
+++ b/packages/cozy-client/src/hooks/useQuery.spec.jsx
@@ -4,9 +4,10 @@ import useQuery, { useQueries } from './useQuery'
 import { Q } from '../queries/dsl'
 
 import { setupClient, makeWrapper } from '../testing/utils'
+import simpsonsFixture from '../testing/simpsons.json'
 
-const setupQuery = ({ queryDefinition, queryOptions }) => {
-  const client = setupClient()
+const setupQuery = ({ queryDefinition, queryOptions, storeQueries }) => {
+  const client = setupClient({ queries: storeQueries })
   const hookResult = renderHook(() => useQuery(queryDefinition, queryOptions), {
     wrapper: makeWrapper(client)
   })
@@ -42,6 +43,55 @@ describe('use query', () => {
         doctype: 'io.cozy.simpsons'
       })
     })
+  })
+
+  it('fetches more results with bookmark', async () => {
+    const bookmark = 'bookmark-123'
+    const queryDefinition = Q('io.cozy.simpsons').offsetBookmark(bookmark)
+    const {
+      hookResult: {
+        result: { current }
+      },
+      client
+    } = setupQuery({
+      queryOptions: {
+        as: 'simpsonsBookmarked'
+      },
+      queryDefinition: () => queryDefinition,
+      storeQueries: {
+        simpsonsBookmarked: {
+          data: simpsonsFixture,
+          doctype: 'io.cozy.simpsons',
+          definition: queryDefinition
+        }
+      }
+    })
+
+    const fetchMoreResult = await current.fetchMore()
+    const lastCallArgs =
+      client.query.mock.calls[client.query.mock.calls.length - 1][0]
+    expect(lastCallArgs).toMatchObject({ bookmark: 'bookmark-123' })
+    expect(fetchMoreResult).toEqual({ data: null })
+  })
+
+  it('fetches more results with skip', async () => {
+    const {
+      hookResult: {
+        result: { current }
+      },
+      client
+    } = setupQuery({
+      queryOptions: {
+        as: 'simpsons'
+      },
+      queryDefinition: () => Q('io.cozy.simpsons')
+    })
+
+    const fetchMoreResult = await current.fetchMore()
+    const lastCallArgs =
+      client.query.mock.calls[client.query.mock.calls.length - 1][0]
+    expect(lastCallArgs).toMatchObject({ skip: current.data.length })
+    expect(fetchMoreResult).toEqual({ data: null })
   })
 })
 

--- a/packages/cozy-client/src/mock.js
+++ b/packages/cozy-client/src/mock.js
@@ -5,14 +5,12 @@ import { normalizeDoc } from 'cozy-stack-client'
 import { Q } from 'cozy-client'
 
 const fillQueryInsideClient = (client, queryName, queryOptions) => {
-  client.store.dispatch(
-    initQuery(queryName, queryOptions.definition || Q(queryOptions.doctype))
-  )
+  const { definition, doctype, data, ...queryResult } = queryOptions
+  client.store.dispatch(initQuery(queryName, definition || Q(doctype)))
   client.store.dispatch(
     receiveQueryResult(queryName, {
-      data: queryOptions.data.map(doc =>
-        normalizeDoc(doc, queryOptions.doctype)
-      )
+      data: data.map(doc => normalizeDoc(doc, doctype)),
+      ...queryResult
     })
   )
 }

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -148,7 +148,12 @@ class QueryDefinition {
    * @returns {QueryDefinition}  The QueryDefinition object.
    */
   offset(skip) {
-    return new QueryDefinition({ ...this.toDefinition(), skip })
+    return new QueryDefinition({
+      ...this.toDefinition(),
+      bookmark: null,
+      cursor: null,
+      skip
+    })
   }
 
   /**
@@ -163,7 +168,12 @@ class QueryDefinition {
    * @returns {QueryDefinition}  The QueryDefinition object.
    */
   offsetCursor(cursor) {
-    return new QueryDefinition({ ...this.toDefinition(), cursor })
+    return new QueryDefinition({
+      ...this.toDefinition(),
+      bookmark: null,
+      skip: null,
+      cursor
+    })
   }
 
   /**
@@ -176,7 +186,12 @@ class QueryDefinition {
    * @returns {QueryDefinition}  The QueryDefinition object.
    */
   offsetBookmark(bookmark) {
-    return new QueryDefinition({ ...this.toDefinition(), bookmark })
+    return new QueryDefinition({
+      ...this.toDefinition(),
+      skip: null,
+      cursor: null,
+      bookmark
+    })
   }
 
   /**

--- a/packages/cozy-client/src/testing/utils.js
+++ b/packages/cozy-client/src/testing/utils.js
@@ -4,7 +4,7 @@ import simpsonsFixture from '../testing/simpsons.json'
 import ClientProvider from '../Provider'
 import { Provider as ReduxProvider } from 'react-redux'
 
-const setupClient = () => {
+const setupClient = ({ queries } = {}) => {
   const client = createMockClient({
     queries: {
       simpsons: {
@@ -14,7 +14,8 @@ const setupClient = () => {
       upperSimpsons: {
         data: simpsonsFixture.map(x => ({ ...x, name: x.name.toUpperCase() })),
         doctype: 'io.cozy.simpsons-upper'
-      }
+      },
+      ...queries
     }
   })
   client.ensureStore()


### PR DESCRIPTION
- fetchMore returning a promise is in line with ObservableQuery.fetchMore
- queries don't always have a bookmark to fetch more data, especially when coming from pouch