### PR TITLE
PouchLink improvements

### DIFF
--- a/docs/api/cozy-pouch-link.md
+++ b/docs/api/cozy-pouch-link.md
@@ -36,9 +36,23 @@ to respond to queries and mutations.
 **Kind**: global class  
 
 * [PouchLink](#PouchLink)
+    * [new PouchLink([opts])](#new_PouchLink_new)
     * [.handleOnSync()](#PouchLink+handleOnSync)
     * [.startReplication()](#PouchLink+startReplication) ⇒ <code>void</code>
     * [.stopReplication()](#PouchLink+stopReplication) ⇒ <code>void</code>
+
+<a name="new_PouchLink_new"></a>
+
+### new PouchLink([opts])
+constructor - Initializes a new PouchLink
+
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [opts] | <code>object</code> | <code>{}</code> |  |
+| [opts.replicationInterval] | <code>number</code> |  | Milliseconds between replications |
+| opts.doctypes | <code>Array.&lt;string&gt;</code> |  | Doctypes to replicate |
+| opts.doctypesReplicationOptions | <code>Array.&lt;object&gt;</code> |  | A mapping from doctypes to replication options. All pouch replication options can be used, as well as the "strategy" option that determines which way the replication is done (can be "sync", "fromRemote" or "toRemote") |
 
 <a name="PouchLink+handleOnSync"></a>
 

--- a/docs/mobile-guide.md
+++ b/docs/mobile-guide.md
@@ -182,3 +182,24 @@ The `PouchLink` will create the PouchDB databases for all offline doctypes and
 synchronize them with the distant CouchDB. All doctypes that are not managed by
 the `PouchLink` will be passed to the next link in the chain (in the previous
 example, the `StackLink`).
+
+Additionally, it is possible to replicate some doctypes only in a specific direction:
+
+```js
+
+const pouchLink = new PouchLink({
+  doctypes: ['io.cozy.todos', 'io.cozy.files', 'io.cozy.localtype'],
+  doctypesReplicationOptions: {
+    'io.cozy.todos': {
+      strategy: 'sync' // default, replicate both ways
+    },
+    'io.cozy.files': {
+      strategy: 'fromRemote' // replicate changes from the remote locally, but don't push any changes
+    },
+    'io.cozy.localtype': {
+      strategy: 'toRemote' // push changes to remote, but don't replicate changes from it
+    }
+  }
+  initialSync: true
+})
+```

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -276,7 +276,16 @@ class PouchLink extends CozyLink {
     }
   }
 
-  async executeQuery({ doctype, selector, sort, fields, limit, id, ids }) {
+  async executeQuery({
+    doctype,
+    selector,
+    sort,
+    fields,
+    limit,
+    id,
+    ids,
+    skip
+  }) {
     const db = this.getPouch(doctype)
     let res, withRows
     if (id) {
@@ -295,10 +304,13 @@ class PouchLink extends CozyLink {
         sort,
         selector,
         fields,
-        limit
+        limit,
+        skip
       }
       await this.ensureIndex(doctype, findOpts)
       res = await find(db, findOpts)
+      res.offset = skip
+      res.limit = limit
       withRows = true
     }
     return jsonapi.fromPouchResult(res, withRows, doctype)

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -49,10 +49,21 @@ const normalizeAll = (docs, doctype) => {
  * to respond to queries and mutations.
  */
 class PouchLink extends CozyLink {
+  /**
+   * constructor - Initializes a new PouchLink
+   *
+   * @param {object} [opts={}]
+   * @param {number} [opts.replicationInterval] Milliseconds between replications
+   * @param {string[]} opts.doctypes Doctypes to replicate
+   * @param {object[]} opts.doctypesReplicationOptions A mapping from doctypes to replication options. All pouch replication options can be used, as well as the "strategy" option that determines which way the replication is done (can be "sync", "fromRemote" or "toRemote")
+   *
+   * @returns {object} The PouchLink instance
+   */
+
   constructor(opts = {}) {
     const options = defaults({}, opts, DEFAULT_OPTIONS)
     super(options)
-    const { doctypes } = options
+    const { doctypes, doctypesReplicationOptions } = options
     this.options = options
     if (!doctypes) {
       throw new Error(
@@ -60,6 +71,7 @@ class PouchLink extends CozyLink {
       )
     }
     this.doctypes = doctypes
+    this.doctypesReplicationOptions = doctypesReplicationOptions
     this.indexes = {}
   }
 
@@ -121,6 +133,7 @@ class PouchLink extends CozyLink {
     this.pouches = new PouchManager(this.doctypes, {
       pouch: this.options.pouch,
       getReplicationURL: this.getReplicationURL.bind(this),
+      doctypesReplicationOptions: this.doctypesReplicationOptions,
       onError: err => this.onSyncError(err),
       onSync: this.handleOnSync.bind(this),
       prefix

--- a/packages/cozy-pouch-link/src/jsonapi.js
+++ b/packages/cozy-pouch-link/src/jsonapi.js
@@ -26,7 +26,7 @@ export const fromPouchResult = (res, withRows, doctype) => {
       data: docs.map(doc => normalizeDoc(doc, doctype)),
       meta: { count: docs.length },
       skip: offset,
-      next: offset + docs.length <= res.total_rows
+      next: offset + docs.length <= res.total_rows || docs.length >= res.limit
     }
   } else {
     return {


### PR DESCRIPTION
PouchLink can now be configured to replicate certain doctypes only in one direction, which is useful for `io.cozy.files` for example that can't be replicated to the stack, but we'd still like to have the content in the local database. 

The API is debatable; fo the main use case (bi-directional replication), I think the current API is great (`new PouchLink({
  doctypes: ['io.cozy.whatever'] })`) and doesn't need to move. I added support for a second, more advanced format, which is `new PouchLink({
  doctypes: { readWrite: ['io.cozy.whatever'], readOnly: ['io.cozy.files'] } })`. It's flexible, duplication free and extandable with a `writeOnly` if we ever need that.

This PR also adds detection for next pages when results are paginated with `skip` and `limit`, which is how the `pouch.find` API uses.