### PR TITLE
feat: Emit event during PouchLifeCycle

### DIFF
--- a/docs/api/cozy-pouch-link.md
+++ b/docs/api/cozy-pouch-link.md
@@ -61,12 +61,16 @@ Receives PouchDB updates (documents grouped by doctype).
 Normalizes the data (.id -> ._id, .rev -> _rev).
 Passes the data to the client and to the onSync handler.
 
+Emits an event (pouchlink:sync:end) when the sync (all doctypes) is done
+
 **Kind**: instance method of [<code>PouchLink</code>](#PouchLink)  
 <a name="PouchLink+startReplication"></a>
 
 ### pouchLink.startReplication() ⇒ <code>void</code>
 User of the link can call this to start ongoing replications.
 Typically, it can be used when the application regains focus.
+
+Emits pouchlink:sync:start event when the replication begins
 
 **Kind**: instance method of [<code>PouchLink</code>](#PouchLink)  
 **Access**: public  
@@ -75,6 +79,8 @@ Typically, it can be used when the application regains focus.
 ### pouchLink.stopReplication() ⇒ <code>void</code>
 User of the link can call this to stop ongoing replications.
 Typically, it can be used when the applications loses focus.
+
+Emits pouchlink:sync:stop event
 
 **Kind**: instance method of [<code>PouchLink</code>](#PouchLink)  
 **Access**: public  

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -157,6 +157,8 @@ class PouchLink extends CozyLink {
    * Receives PouchDB updates (documents grouped by doctype).
    * Normalizes the data (.id -> ._id, .rev -> _rev).
    * Passes the data to the client and to the onSync handler.
+   *
+   * Emits an event (pouchlink:sync:end) when the sync (all doctypes) is done
    */
   handleOnSync(doctypeUpdates) {
     const normalizedData = mapValues(doctypeUpdates, normalizeAll)
@@ -169,16 +171,20 @@ class PouchLink extends CozyLink {
     if (process.env.NODE_ENV !== 'production') {
       logger.info('Pouch synced')
     }
+    this.client.emit('pouchlink:sync:end')
   }
 
   /**
    * User of the link can call this to start ongoing replications.
    * Typically, it can be used when the application regains focus.
    *
+   * Emits pouchlink:sync:start event when the replication begins
+   *
    * @public
    * @returns {void}
    */
   startReplication() {
+    this.client.emit('pouchlink:sync:start')
     this.pouches.startReplicationLoop()
     if (this.options.onStartReplication) {
       this.options.onStartReplication.apply(this)
@@ -189,6 +195,8 @@ class PouchLink extends CozyLink {
    * User of the link can call this to stop ongoing replications.
    * Typically, it can be used when the applications loses focus.
    *
+   * Emits pouchlink:sync:stop event
+   *
    * @public
    * @returns {void}
    */
@@ -197,6 +205,7 @@ class PouchLink extends CozyLink {
     if (this.options.onStopReplication) {
       this.options.onStopReplication.apply(this)
     }
+    this.client.emit('pouchlink:sync:stop')
   }
 
   async onSyncError(error) {

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -36,7 +36,7 @@ async function setup(linkOpts = {}) {
       todos: omit(SCHEMA.todos, ['relationships'])
     }
   })
-
+  client.emit = jest.fn()
   await link.onLogin()
   client.setData = jest.fn()
 }
@@ -220,6 +220,7 @@ describe('CozyPouchLink', () => {
       link.handleOnSync({
         'io.cozy.todos': [{ ...TODO_1, rev: '1-deadbeef' }]
       })
+
       expect(client.setData).toHaveBeenCalledTimes(1)
       expect(client.setData).toHaveBeenCalledWith({
         'io.cozy.todos': [
@@ -233,9 +234,25 @@ describe('CozyPouchLink', () => {
           }
         ]
       })
+      expect(client.emit).toHaveBeenCalledWith('pouchlink:sync:end')
     })
   })
+  describe('startReplication', () => {
+    it('should emit the event', async () => {
+      await setup()
+      link.startReplication()
 
+      expect(client.emit).toHaveBeenCalledWith('pouchlink:sync:start')
+    })
+  })
+  describe('stopReplication', () => {
+    it('should emit the event', async () => {
+      await setup()
+      link.stopReplication()
+
+      expect(client.emit).toHaveBeenCalledWith('pouchlink:sync:stop')
+    })
+  })
   describe('onLogin', () => {
     let spy
 


### PR DESCRIPTION
Pouch replication can be : 
- time consuming 
- resource consuming

Dispatching those events give the opportunity to the app to react differently. For instance, I don't want to launch the "photo backup process" on Drive if Pouch is doing its replication since both are very expensive