### PR TITLE
fix: Split file name accepts empty names

### DIFF
--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -1,4 +1,5 @@
 import get from 'lodash/get'
+import isString from 'lodash/isString'
 
 const FILE_TYPE = 'file'
 const DIR_TYPE = 'directory'
@@ -12,7 +13,7 @@ const FILENAME_WITH_EXTENSION_REGEX = /(.+)(\..*)$/
  * @returns {object}  {filename, extension}
  */
 export const splitFilename = file => {
-  if (!file.name) throw new Error('file should have a name property ')
+  if (!isString(file.name)) throw new Error('file should have a name property ')
 
   if (file.type === 'file') {
     const match = file.name.match(FILENAME_WITH_EXTENSION_REGEX)

--- a/packages/cozy-client/src/models/file.spec.js
+++ b/packages/cozy-client/src/models/file.spec.js
@@ -100,9 +100,9 @@ describe('File Model', () => {
     }
 
     it('should throw an error if the file is not correct', () => {
-      const badFile = {}
-
-      expect(() => file.splitFilename(badFile)).toThrow()
+      expect(() => file.splitFilename({})).toThrow()
+      expect(() => file.splitFilename({ name: null })).toThrow()
+      expect(() => file.splitFilename({ name: '' })).not.toThrow()
     })
     it('should return only the folder name if its a folder', () => {
       const dir = {


### PR DESCRIPTION
`models.files.splitFilename` used to throw an error if the file had an empty string as a name, which is the case for the root folder. But it's still a valid file name, we shouldn't throw an exception in that case.