### PR TITLE
fix: Always have response ids for settings routes

### DIFF
--- a/packages/cozy-stack-client/src/SettingsCollection.js
+++ b/packages/cozy-stack-client/src/SettingsCollection.js
@@ -20,7 +20,7 @@ class SettingsCollection extends DocumentCollection {
     const resp = await this.stackClient.fetchJSON('GET', `/settings/${path}`)
     return {
       data: DocumentCollection.normalizeDoctypeJsonApi(SETTINGS_DOCTYPE)(
-        resp.data,
+        { id: `/settings/${path}`, ...resp.data },
         resp
       )
     }

--- a/packages/cozy-stack-client/src/SettingsCollection.spec.js
+++ b/packages/cozy-stack-client/src/SettingsCollection.spec.js
@@ -32,7 +32,7 @@ describe('SettingsCollection', () => {
   })
 
   it('should format correctly the response', async () => {
-    jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue({
+    jest.spyOn(stackClient, 'fetchJSON').mockResolvedValueOnce({
       data: {
         type: 'io.cozy.settings',
         id: 'io.cozy.settings.disk-usage'
@@ -40,6 +40,15 @@ describe('SettingsCollection', () => {
     })
     const resp = await collection.get('disk-usage')
     expect(resp.data.id).toBe('io.cozy.settings.disk-usage')
+
+    jest.spyOn(stackClient, 'fetchJSON').mockResolvedValueOnce({
+      data: {
+        0: { id: 'client-0' },
+        1: { id: 'client-1' }
+      }
+    })
+    const clientsResp = await collection.get('clients')
+    expect(clientsResp.data.id).toBe('/settings/clients')
   })
 
   it('should throw server error', async () => {


### PR DESCRIPTION
We can query the /settings routes through cozy-client, but these routes don't really return a document. Theywill especially tend not to include an `id` field which causes queries to end in error.

With this PR we now use an arbitrary document id  when there is none in the response.