### PR TITLE
fix: Reset other offsets in queries

### DIFF
--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -150,8 +150,8 @@ class QueryDefinition {
   offset(skip) {
     return new QueryDefinition({
       ...this.toDefinition(),
-      bookmark: null,
-      cursor: null,
+      bookmark: undefined,
+      cursor: undefined,
       skip
     })
   }
@@ -170,8 +170,8 @@ class QueryDefinition {
   offsetCursor(cursor) {
     return new QueryDefinition({
       ...this.toDefinition(),
-      bookmark: null,
-      skip: null,
+      bookmark: undefined,
+      skip: undefined,
       cursor
     })
   }
@@ -188,8 +188,8 @@ class QueryDefinition {
   offsetBookmark(bookmark) {
     return new QueryDefinition({
       ...this.toDefinition(),
-      skip: null,
-      cursor: null,
+      skip: undefined,
+      cursor: undefined,
       bookmark
     })
   }

--- a/packages/cozy-client/src/queries/dsl.spec.js
+++ b/packages/cozy-client/src/queries/dsl.spec.js
@@ -32,4 +32,27 @@ describe('QueryDefinition', () => {
       doctype: 'io.cozy.files'
     })
   })
+
+  it('paginates only one way', () => {
+    const q = Q('io.cozy.files')
+    const withSkip = q.offset(2)
+    expect(withSkip.skip).toEqual(2)
+    expect(withSkip.bookmark).toBeUndefined()
+    expect(withSkip.cursor).toBeUndefined()
+
+    const withCursor = withSkip.offsetCursor('cursor-id')
+    expect(withCursor.cursor).toEqual('cursor-id')
+    expect(withCursor.bookmark).toBeUndefined()
+    expect(withCursor.skip).toBeUndefined()
+
+    const withBookmark = withCursor.offsetBookmark('bookmark-id')
+    expect(withBookmark.bookmark).toEqual('bookmark-id')
+    expect(withBookmark.cursor).toBeUndefined()
+    expect(withBookmark.skip).toBeUndefined()
+
+    const withSkipAgain = withBookmark.offset(2)
+    expect(withSkipAgain.skip).toEqual(2)
+    expect(withSkipAgain.bookmark).toBeUndefined()
+    expect(withSkipAgain.cursor).toBeUndefined()
+  })
 })


### PR DESCRIPTION
`null` values are sent through JSON and are interpreted by the stack, which can lead to errors when specifying invalid bookmarks. `undefined` on the other hand has the desired behavior of not being seriliazed to JSON.