### PR TITLE
fix: Get cozyDomain instead of primaryCozy for contact displayName

### DIFF
--- a/packages/cozy-client/src/models/contact.js
+++ b/packages/cozy-client/src/models/contact.js
@@ -119,7 +119,9 @@ export const getDisplayName = contact =>
   get(
     contact,
     'displayName',
-    getFullname(contact) || getPrimaryEmail(contact) || getPrimaryCozy(contact)
+    getFullname(contact) ||
+      getPrimaryEmail(contact) ||
+      getPrimaryCozyDomain(contact)
   )
 
 /**

--- a/packages/cozy-client/src/models/contact.spec.js
+++ b/packages/cozy-client/src/models/contact.spec.js
@@ -289,7 +289,7 @@ describe('getDisplayName', () => {
     expect(result).toEqual('doran.martell@dorne.westeros')
   })
 
-  it("should return the contact's primary cozy url if no fullname, no name and no primary email", () => {
+  it("should return the contact's cozy domain if no fullname, no name and no primary email", () => {
     const contact = {
       fullname: undefined,
       name: undefined,
@@ -300,7 +300,7 @@ describe('getDisplayName', () => {
       ]
     }
     const result = getDisplayName(contact)
-    expect(result).toEqual('https://john.mycozy.cloud')
+    expect(result).toEqual('john.mycozy.cloud')
   })
 })
 


### PR DESCRIPTION
displayName is the name displayed for a contact. If the contact has no name and email, the cozy url is used. In that case, we don't want to show the protocol or pathname of the url, only the domain.