### PR TITLE
fix: Method to get contact index and contact initials

### DIFF
--- a/packages/cozy-client/src/models/contact.js
+++ b/packages/cozy-client/src/models/contact.js
@@ -130,16 +130,21 @@ export const getDisplayName = contact =>
  * @param {object} contact - A contact
  * @returns {string} - the contact's 'byFamilyNameGivenNameEmailCozyUrl' index
  */
-export const getIndexByFamilyNameGivenNameEmailCozyUrl = contact =>
-  get(
+export const getIndexByFamilyNameGivenNameEmailCozyUrl = contact => {
+  const indexByFamilyNameGivenNameEmailCozyUrl = [
+    get(contact, 'name.familyName', ''),
+    get(contact, 'name.givenName', ''),
+    getPrimaryEmail(contact),
+    getPrimaryCozyDomain(contact)
+  ]
+    .join('')
+    .trim()
+
+  return get(
     contact,
     'indexes.byFamilyNameGivenNameEmailCozyUrl',
-    [
-      get(contact, 'name.familyName', ''),
-      get(contact, 'name.givenName', ''),
-      getPrimaryEmail(contact),
-      getPrimaryCozyDomain(contact)
-    ]
-      .join('')
-      .trim()
+    indexByFamilyNameGivenNameEmailCozyUrl.length === 0
+      ? {}
+      : indexByFamilyNameGivenNameEmailCozyUrl
   )
+}

--- a/packages/cozy-client/src/models/contact.js
+++ b/packages/cozy-client/src/models/contact.js
@@ -1,4 +1,4 @@
-import get from 'lodash/get'
+import { get, capitalize } from 'lodash'
 import logger from 'cozy-logger'
 
 export const getPrimaryOrFirst = property => obj =>
@@ -131,14 +131,16 @@ export const getDisplayName = contact =>
  * @returns {string} - the contact's 'byFamilyNameGivenNameEmailCozyUrl' index
  */
 export const getIndexByFamilyNameGivenNameEmailCozyUrl = contact => {
-  const indexByFamilyNameGivenNameEmailCozyUrl = [
-    get(contact, 'name.familyName', ''),
-    get(contact, 'name.givenName', ''),
-    getPrimaryEmail(contact),
-    getPrimaryCozyDomain(contact)
-  ]
-    .join('')
-    .trim()
+  const indexByFamilyNameGivenNameEmailCozyUrl = capitalize(
+    [
+      get(contact, 'name.familyName', ''),
+      get(contact, 'name.givenName', ''),
+      getPrimaryEmail(contact),
+      getPrimaryCozyDomain(contact)
+    ]
+      .join('')
+      .trim()
+  )
 
   return get(
     contact,

--- a/packages/cozy-client/src/models/contact.js
+++ b/packages/cozy-client/src/models/contact.js
@@ -1,5 +1,4 @@
-import { get, capitalize } from 'lodash'
-import logger from 'cozy-logger'
+import { get, capitalize, isEmpty } from 'lodash'
 
 export const getPrimaryOrFirst = property => obj =>
   !obj[property] || obj[property].length === 0
@@ -13,7 +12,7 @@ export const getPrimaryOrFirst = property => obj =>
  * @returns {string} - the contact's initials
  */
 export const getInitials = contact => {
-  if (contact.name) {
+  if (contact.name && !isEmpty(contact.name)) {
     return ['givenName', 'familyName']
       .map(part => get(contact, ['name', part, 0], ''))
       .join('')
@@ -25,7 +24,11 @@ export const getInitials = contact => {
     return email[0].toUpperCase()
   }
 
-  logger.warn('Contact has no name and no email.')
+  const cozy = getPrimaryCozyDomain(contact)
+  if (cozy) {
+    return cozy[0].toUpperCase()
+  }
+
   return ''
 }
 

--- a/packages/cozy-client/src/models/contact.spec.js
+++ b/packages/cozy-client/src/models/contact.spec.js
@@ -81,6 +81,34 @@ describe('getInitials', () => {
     expect(result).toEqual('A')
   })
 
+  it('should return the first letter of the primary email if contact has empty name', () => {
+    const contact = {
+      name: {},
+      email: [
+        {
+          address: 'arya.stark@thenorth.westeros',
+          primary: true
+        }
+      ]
+    }
+    const result = getInitials(contact)
+    expect(result).toEqual('A')
+  })
+
+  it('should return the first letter of the cozy domain if contact has empty name, an empty email but has a cozy url', () => {
+    const contact = {
+      name: {},
+      cozy: [
+        {
+          url: 'https://john.mycozy.cloud',
+          primary: true
+        }
+      ]
+    }
+    const result = getInitials(contact)
+    expect(result).toEqual('J')
+  })
+
   it('should return an empty string if contact has no name/email', () => {
     const result = getInitials({})
     expect(result).toEqual('')

--- a/packages/cozy-client/src/models/contact.spec.js
+++ b/packages/cozy-client/src/models/contact.spec.js
@@ -397,7 +397,7 @@ describe('getIndexByFamilyNameGivenNameEmailCozyUrl', () => {
     expect(result).toEqual('smith.mycozy.cloud')
   })
 
-  it('should returns empty string if no givenName, familyName, email and cozy url', () => {
+  it('should returns empty object if no givenName, familyName, email and cozy url', () => {
     const contact = {
       name: {},
       fullname: '',
@@ -405,7 +405,7 @@ describe('getIndexByFamilyNameGivenNameEmailCozyUrl', () => {
       cozy: []
     }
     const result = getIndexByFamilyNameGivenNameEmailCozyUrl(contact)
-    expect(result).toEqual('')
+    expect(result).toEqual({})
   })
 
   it('should returns concatenated string of givenName and cozy url if no familyName and email', () => {

--- a/packages/cozy-client/src/models/contact.spec.js
+++ b/packages/cozy-client/src/models/contact.spec.js
@@ -361,7 +361,7 @@ describe('getIndexByFamilyNameGivenNameEmailCozyUrl', () => {
       ]
     }
     const result = getIndexByFamilyNameGivenNameEmailCozyUrl(contact)
-    expect(result).toEqual('SmithJohnjohn.smith@cozy.ccjohn.mycozy.cloud')
+    expect(result).toEqual('Smithjohnjohn.smith@cozy.ccjohn.mycozy.cloud')
   })
 
   it('should returns only familyName if no givenName, email and cozy url', () => {
@@ -394,7 +394,7 @@ describe('getIndexByFamilyNameGivenNameEmailCozyUrl', () => {
       cozy: [{ url: 'https://smith.mycozy.cloud' }]
     }
     const result = getIndexByFamilyNameGivenNameEmailCozyUrl(contact)
-    expect(result).toEqual('smith.mycozy.cloud')
+    expect(result).toEqual('Smith.mycozy.cloud')
   })
 
   it('should returns empty object if no givenName, familyName, email and cozy url', () => {
@@ -425,7 +425,7 @@ describe('getIndexByFamilyNameGivenNameEmailCozyUrl', () => {
       cozy: [{ url: '' }]
     }
     const result = getIndexByFamilyNameGivenNameEmailCozyUrl(contact)
-    expect(result).toEqual('john.smith@cozy.cc')
+    expect(result).toEqual('John.smith@cozy.cc')
   })
 })
 


### PR DESCRIPTION
- The method to get index by FamilyNameGivenNameEmailCozyUrl returns now an empty object instead of empty string when empty. This is a little trick to get empty value at the end, according to https://docs.couchdb.org/en/2.3.1/ddocs/views/collation.html#collation-specification
- Besides, the method capitalize the returned value to simplify things for sorting contacts in the application
- getInitials() now deals with cozy url and empty name object