### PR TITLE
feat: Throw if scope is not passed

### DIFF
--- a/packages/cozy-client/src/cli/index.js
+++ b/packages/cozy-client/src/cli/index.js
@@ -186,6 +186,11 @@ const createClientInteractive = (clientOptions, serverOpts) => {
     },
     clientOptions
   )
+
+  if (!clientOptions.scope) {
+    throw new Error('scope must be provided in client options')
+  }
+
   const getSavedCredentials = serverOptions.getSavedCredentials
   const savedCredentialsFilename = getSavedCredentials(mergedClientOptions)
   const savedCredentials = readJSON(createClientFS, savedCredentialsFilename)


### PR DESCRIPTION
When scope was not passed to createClientInteractive, the error
was a bit difficult to understand.