### PR TITLE
feat: We can pass a codes argument at the perm creation

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -996,9 +996,24 @@ Implements `DocumentCollection` API along with specific methods for `io.cozy.per
 **Kind**: global class  
 
 * [PermissionCollection](#PermissionCollection)
+    * [.create(permission)](#PermissionCollection+create)
     * [.add(document, permission)](#PermissionCollection+add) ⇒ <code>Promise</code>
     * [.createSharingLink(document, options)](#PermissionCollection+createSharingLink)
     * [.getOwnPermissions()](#PermissionCollection+getOwnPermissions) ⇒ <code>object</code>
+
+<a name="PermissionCollection+create"></a>
+
+### permissionCollection.create(permission)
+Create a new set of permissions
+It can also associates one or more codes to it, via the codes parameter
+
+**Kind**: instance method of [<code>PermissionCollection</code>](#PermissionCollection)  
+**See**: https://docs.cozy.io/en/cozy-stack/permissions/#post-permissions  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| permission | <code>object</code> |  |
+| permission.codes | <code>string</code> | A comma separed list of values (defaulted to code) |
 
 <a name="PermissionCollection+add"></a>
 

--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -18,13 +18,27 @@ class PermissionCollection extends DocumentCollection {
     }
   }
 
-  async create({ _id, _type, ...attributes }) {
-    const resp = await this.stackClient.fetchJSON('POST', uri`/permissions`, {
-      data: {
-        type: 'io.cozy.permissions',
-        attributes
+  /**
+   * Create a new set of permissions
+   * It can also associates one or more codes to it, via the codes parameter
+   *
+   * @param {object} permission
+   * @param {string} permission.codes A comma separed list of values (defaulted to code)
+   *
+   * @see https://docs.cozy.io/en/cozy-stack/permissions/#post-permissions
+   *
+   */
+  async create({ _id, _type, codes = 'code', ...attributes }) {
+    const resp = await this.stackClient.fetchJSON(
+      'POST',
+      uri`/permissions?codes=${codes}`,
+      {
+        data: {
+          type: 'io.cozy.permissions',
+          attributes
+        }
       }
-    })
+    )
     return {
       data: normalizePermission(resp.data)
     }

--- a/packages/cozy-stack-client/src/PermissionCollection.spec.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.spec.js
@@ -21,7 +21,30 @@ describe('PermissionCollection', () => {
       client.fetch.mockReset()
       client.fetchJSON.mockReturnValue(Promise.resolve({ data: [] }))
     })
+    describe('create', () => {
+      it('calls with the right args', async () => {
+        await collection.create({
+          _type: 'io.cozy.permissions',
+          _id: 'a340d5e0d64711e6b66c5fc9ce1e17c6',
+          codes: 'a,b'
+        })
+        expect(client.fetchJSON).toHaveBeenCalledWith(
+          'POST',
+          '/permissions?codes=a%2Cb',
+          { data: { attributes: {}, type: 'io.cozy.permissions' } }
+        )
 
+        await collection.create({
+          _type: 'io.cozy.permissions',
+          _id: 'a340d5e0d64711e6b66c5fc9ce1e17c6'
+        })
+        expect(client.fetchJSON).toHaveBeenCalledWith(
+          'POST',
+          '/permissions?codes=code',
+          { data: { attributes: {}, type: 'io.cozy.permissions' } }
+        )
+      })
+    })
     it('should get its own permissions', async () => {
       await collection.getOwnPermissions()
       expect(client.fetchJSON).toHaveBeenCalledWith('GET', '/permissions/self')


### PR DESCRIPTION
Use Case: We want to be able to create permission for all kind of doctype. Today, we can do that with createSharingLink() but this method is too much paired to Files. 

We want here, to be able to create a permission with want we want, for instance : 
```
 permissions: { groups: { type: GROUPS_DOCTYPE, verbs: ['GET'] }, contacts: { type: CONTACTS_DOCTYPE, verbs: ['GET'] } }
```

Before the change, we're able to do that, but we can't specify the `codes` we want to produced. Now we can create myCode1 and myCode2 : 
```
create({codes: 'myCode1,myCode2', permissions: { groups: { type: GROUPS_DOCTYPE, verbs: ['GET'] }, contacts: { type: CONTACTS_DOCTYPE, verbs: ['GET'] } } }
==> response 
shortcodes: {"myCode1": "adcdef", "myCode2": "abfdgds"}.
```

BREAKING CHANGE: By default, we defaulted the codes values
to `code` for PermissionsCollection.create. Without we
receive an object without key in response
shortcodes: {"": "abcdfef"}. Now by default we have :
shortcodes: {"code": "adcdef"}.

It's a BC, but this method is not used in our code base for
now.