### PR TITLE
feat: Add ttl params to create Permissions

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -1014,6 +1014,7 @@ It can also associates one or more codes to it, via the codes parameter
 | --- | --- | --- |
 | permission | <code>object</code> |  |
 | permission.codes | <code>string</code> | A comma separed list of values (defaulted to code) |
+| permission.ttl | <code>string</code> | Make the codes expire after a delay (bigduration format) bigduration format: https://github.com/justincampbell/bigduration/blob/master/README.md |
 
 <a name="PermissionCollection+add"></a>
 

--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -17,21 +17,25 @@ class PermissionCollection extends DocumentCollection {
       data: normalizePermission(resp.data)
     }
   }
-
   /**
    * Create a new set of permissions
    * It can also associates one or more codes to it, via the codes parameter
    *
    * @param {object} permission
    * @param {string} permission.codes A comma separed list of values (defaulted to code)
+   * @param {string} permission.ttl Make the codes expire after a delay (bigduration format)
    *
+   * bigduration format: https://github.com/justincampbell/bigduration/blob/master/README.md
    * @see https://docs.cozy.io/en/cozy-stack/permissions/#post-permissions
    *
    */
-  async create({ _id, _type, codes = 'code', ...attributes }) {
+  async create({ _id, _type, codes = 'code', ttl, ...attributes }) {
+    const searchParams = new URLSearchParams()
+    searchParams.append('codes', codes)
+    if (ttl) searchParams.append('ttl', ttl)
     const resp = await this.stackClient.fetchJSON(
       'POST',
-      uri`/permissions?codes=${codes}`,
+      `/permissions?${searchParams}`,
       {
         data: {
           type: 'io.cozy.permissions',

--- a/packages/cozy-stack-client/src/PermissionCollection.spec.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.spec.js
@@ -43,6 +43,18 @@ describe('PermissionCollection', () => {
           '/permissions?codes=code',
           { data: { attributes: {}, type: 'io.cozy.permissions' } }
         )
+
+        await collection.create({
+          _type: 'io.cozy.permissions',
+          _id: 'a340d5e0d64711e6b66c5fc9ce1e17c6',
+          codes: 'a,b',
+          ttl: '1D'
+        })
+        expect(client.fetchJSON).toHaveBeenCalledWith(
+          'POST',
+          '/permissions?codes=a%2Cb&ttl=1D',
+          { data: { attributes: {}, type: 'io.cozy.permissions' } }
+        )
       })
     })
     it('should get its own permissions', async () => {


### PR DESCRIPTION
We can add a ttl param in order to create temporary permission. The permission will expire after this ttl 