### PR TITLE
Fix query props

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
     "jsdoc/require-param": 0, // --fix breaks docstrings without params
     "jsdoc/require-returns": 0, // too much warnings for now
     "jsdoc/require-returns-description": 0, // too much warnings for now
-    "jsdoc/check-param-names": 2
+    "no-param-reassign": 2
   },
   "settings": {
     "react": {

--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -229,9 +229,6 @@ if there are N queries, only 1 extra level of nesting is introduced.</p>
 <dt><a href="#isForType">isForType(permission, type)</a></dt>
 <dd><p>Checks if the permission item is about a specific doctype</p>
 </dd>
-<dt><a href="#currentResult">currentResult()</a> ⇒ <code>HydratedQueryState</code></dt>
-<dd><p>Returns the query from the store with hydrated documents.</p>
-</dd>
 <dt><a href="#fetchMore">fetchMore()</a></dt>
 <dd><p>Generates and executes a query that is offsetted by the number of documents
 we have in the store.</p>
@@ -260,7 +257,10 @@ we have in the store.</p>
 <dd></dd>
 <dt><a href="#PermissionItem">PermissionItem</a> : <code>object</code></dt>
 <dd></dd>
-<dt><a href="#Registry">Registry</a> : <code>RegistryApp</code></dt>
+<dt><a href="#HydratedQueryState">HydratedQueryState</a> ⇒ <code><a href="#HydratedQueryState">HydratedQueryState</a></code></dt>
+<dd><p>Returns the query from the store with hydrated documents.</p>
+</dd>
+<dt><a href="#RegistryApp">RegistryApp</a> : <code>object</code></dt>
 <dd></dd>
 </dl>
 
@@ -680,7 +680,7 @@ Responsible for
         * [.query(queryDefinition, options)](#CozyClient+query) ⇒ <code>QueryResult</code>
         * [.queryAll(queryDefinition, options)](#CozyClient+queryAll) ⇒ <code>Array</code>
         * [.hydrateDocuments(doctype, documents)](#CozyClient+hydrateDocuments) ⇒ <code>Array.&lt;HydratedDocument&gt;</code>
-        * [.hydrateDocument(document, schema)](#CozyClient+hydrateDocument) ⇒ <code>HydratedDocument</code>
+        * [.hydrateDocument(document, schemaArg)](#CozyClient+hydrateDocument) ⇒ <code>HydratedDocument</code>
         * [.makeNewDocument()](#CozyClient+makeNewDocument)
         * [.getAssociation()](#CozyClient+getAssociation)
         * [.getRelationshipStoreAccessors()](#CozyClient+getRelationshipStoreAccessors)
@@ -896,7 +896,7 @@ Instead, the relationships will have null documents.
 
 <a name="CozyClient+hydrateDocument"></a>
 
-### cozyClient.hydrateDocument(document, schema) ⇒ <code>HydratedDocument</code>
+### cozyClient.hydrateDocument(document, schemaArg) ⇒ <code>HydratedDocument</code>
 Resolves relationships on a document.
 
 The original document is kept in the target attribute of
@@ -907,7 +907,7 @@ the relationship
 | Param | Type | Description |
 | --- | --- | --- |
 | document | [<code>Document</code>](#Document) | for which relationships must be resolved |
-| schema | [<code>Schema</code>](#Schema) | for the document doctype |
+| schemaArg | [<code>Schema</code>](#Schema) | for the document doctype |
 
 <a name="CozyClient+makeNewDocument"></a>
 
@@ -2056,12 +2056,6 @@ Checks if the permission item is about a specific doctype
 | permission | [<code>PermissionItem</code>](#PermissionItem) | - |
 | type | <code>string</code> | doctype |
 
-<a name="currentResult"></a>
-
-## currentResult() ⇒ <code>HydratedQueryState</code>
-Returns the query from the store with hydrated documents.
-
-**Kind**: global function  
 <a name="fetchMore"></a>
 
 ## fetchMore()
@@ -2137,65 +2131,21 @@ Couchdb document like an io.cozy.files
 | values | <code>Array.&lt;string&gt;</code> |  |
 | type | <code>string</code> | a couch db database like 'io.cozy.files' |
 
-<a name="Registry"></a>
+<a name="HydratedQueryState"></a>
 
-## Registry : <code>RegistryApp</code>
+## HydratedQueryState ⇒ [<code>HydratedQueryState</code>](#HydratedQueryState)
+Returns the query from the store with hydrated documents.
+
 **Kind**: global typedef  
+<a name="RegistryApp"></a>
 
-* [Registry](#Registry) : <code>RegistryApp</code>
-    * [.installApp(app, source)](#Registry+installApp) ⇒ <code>Promise</code>
-    * [.uninstallApp()](#Registry+uninstallApp)
-    * [.fetchApps(params)](#Registry+fetchApps) ⇒ <code>Array.&lt;RegistryApp&gt;</code>
-    * [.fetchAppsInMaintenance()](#Registry+fetchAppsInMaintenance) ⇒ <code>Array.&lt;RegistryApp&gt;</code>
-    * [.fetchApp(slug)](#Registry+fetchApp) ⇒ <code>RegistryApp</code>
+## RegistryApp : <code>object</code>
+**Kind**: global typedef  
+**Properties**
 
-<a name="Registry+installApp"></a>
-
-### registry.installApp(app, source) ⇒ <code>Promise</code>
-Installs or updates an app from a source.
-
-Accepts the terms if the app has them.
-
-**Kind**: instance method of [<code>Registry</code>](#Registry)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| app | <code>RegistryApp</code> | App to be installed |
-| source | <code>string</code> | String (ex: registry://drive/stable) |
-
-<a name="Registry+uninstallApp"></a>
-
-### registry.uninstallApp()
-Uninstalls an app.
-
-**Kind**: instance method of [<code>Registry</code>](#Registry)  
-<a name="Registry+fetchApps"></a>
-
-### registry.fetchApps(params) ⇒ <code>Array.&lt;RegistryApp&gt;</code>
-Fetch at most 200 apps from the channel
-
-**Kind**: instance method of [<code>Registry</code>](#Registry)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| params | <code>string</code> | Fetching parameters |
-| params.type | <code>string</code> | "webapp" or "konnector" |
-| params.channel | <code>string</code> | "dev"/"beta"/"stable" |
-
-<a name="Registry+fetchAppsInMaintenance"></a>
-
-### registry.fetchAppsInMaintenance() ⇒ <code>Array.&lt;RegistryApp&gt;</code>
-Fetch the list of apps that are in maintenance mode
-
-**Kind**: instance method of [<code>Registry</code>](#Registry)  
-<a name="Registry+fetchApp"></a>
-
-### registry.fetchApp(slug) ⇒ <code>RegistryApp</code>
-Fetch the status of a single app on the registry
-
-**Kind**: instance method of [<code>Registry</code>](#Registry)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| slug | <code>string</code> | The slug of the app to fetch |
+| Name | Type |
+| --- | --- |
+| slug | <code>string</code> | 
+| terms | <code>object</code> | 
+| installed | <code>boolean</code> | 
 

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -86,6 +86,9 @@ through OAuth.</p>
 <dt><a href="#FileDocument">FileDocument</a> : <code>object</code></dt>
 <dd><p>Document representing a io.cozy.files</p>
 </dd>
+<dt><a href="#Stream">Stream</a> : <code>object</code></dt>
+<dd><p>Stream is not defined in a browser, but is on NodeJS environment</p>
+</dd>
 </dl>
 
 <a name="AppCollection"></a>
@@ -174,7 +177,7 @@ Fetches an endpoint in an authorized way.
 | method | <code>string</code> | The HTTP method. |
 | path | <code>string</code> | The URI. |
 | body | <code>object</code> | The payload. |
-| opts | <code>object</code> |  |
+| opts | <code>object</code> | Options for fetch |
 
 <a name="CozyStackClient+checkForRevocation"></a>
 
@@ -406,7 +409,7 @@ files associated to a specific document
     * [.createDirectoryByPath(path)](#FileCollection+createDirectoryByPath) ⇒ <code>object</code>
     * [.createFileMetadata(attributes)](#FileCollection+createFileMetadata) ⇒ <code>object</code>
     * [.updateMetadataAttribute(id, metadata)](#FileCollection+updateMetadataAttribute) ⇒ <code>object</code>
-    * [.doUpload(data, path, options, method)](#FileCollection+doUpload)
+    * [.doUpload(dataArg, path, options, method)](#FileCollection+doUpload)
 
 <a name="FileCollection+get"></a>
 
@@ -582,7 +585,7 @@ async deleteFilePermanently - Definitely delete a file
 
 | Param | Type | Description |
 | --- | --- | --- |
-| data | <code>File</code> \| <code>Blob</code> \| <code>Stream</code> \| <code>string</code> \| <code>ArrayBuffer</code> | file to be uploaded |
+| data | <code>File</code> \| <code>Blob</code> \| [<code>Stream</code>](#Stream) \| <code>string</code> \| <code>ArrayBuffer</code> | file to be uploaded |
 | dirPath | <code>string</code> | Path to upload the file to. ie : /Administative/XXX/ |
 
 <a name="FileCollection+create"></a>
@@ -731,7 +734,7 @@ see : https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.files_metadata/
 
 <a name="FileCollection+doUpload"></a>
 
-### fileCollection.doUpload(data, path, options, method)
+### fileCollection.doUpload(dataArg, path, options, method)
 This method should not be called directly to upload a file.
 You should use `createFile`
 
@@ -739,7 +742,7 @@ You should use `createFile`
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| data | <code>File</code> \| <code>Blob</code> \| <code>Stream</code> \| <code>string</code> \| <code>ArrayBuffer</code> |  | file to be uploaded |
+| dataArg | <code>File</code> \| <code>Blob</code> \| [<code>Stream</code>](#Stream) \| <code>string</code> \| <code>ArrayBuffer</code> |  | file to be uploaded |
 | path | <code>string</code> |  | Uri to call the stack from. Something like `/files/${dirId}?Name=${name}&Type=file&Executable=${executable}&MetadataID=${metadataId}` |
 | options | <code>object</code> |  | Additional headers |
 | method | <code>string</code> | <code>&quot;POST&quot;</code> | POST / PUT / PATCH |
@@ -829,7 +832,7 @@ through OAuth.
     * [.generateStateCode()](#OAuthClient+generateStateCode) ⇒ <code>string</code>
     * [.getAuthCodeURL(stateCode, scopes)](#OAuthClient+getAuthCodeURL) ⇒ <code>string</code>
     * [.getAccessCodeFromURL(pageURL, stateCode)](#OAuthClient+getAccessCodeFromURL) ⇒ <code>string</code>
-    * [.fetchAccessToken(accessCode, oauthOptions, uri)](#OAuthClient+fetchAccessToken) ⇒ <code>Promise</code>
+    * [.fetchAccessToken(accessCode, oauthOptionsArg, uri)](#OAuthClient+fetchAccessToken) ⇒ <code>Promise</code>
     * [.refreshToken()](#OAuthClient+refreshToken) ⇒ <code>Promise</code>
     * [.setToken(token)](#OAuthClient+setToken)
     * [.setOAuthOptions(options)](#OAuthClient+setOAuthOptions)
@@ -932,7 +935,7 @@ Retrieves the access code contained in the URL to which the user is redirected a
 
 <a name="OAuthClient+fetchAccessToken"></a>
 
-### oAuthClient.fetchAccessToken(accessCode, oauthOptions, uri) ⇒ <code>Promise</code>
+### oAuthClient.fetchAccessToken(accessCode, oauthOptionsArg, uri) ⇒ <code>Promise</code>
 Exchanges an access code for an access token. This function does **not** update the client's token.
 
 **Kind**: instance method of [<code>OAuthClient</code>](#OAuthClient)  
@@ -945,7 +948,7 @@ Exchanges an access code for an access token. This function does **not** update 
 | Param | Type | Description |
 | --- | --- | --- |
 | accessCode | <code>string</code> | The access code contained in the redirection URL — see `client.getAccessCodeFromURL()` |
-| oauthOptions | <code>object</code> | — To use when OAuthClient is not yet registered (during login process) |
+| oauthOptionsArg | <code>object</code> | — To use when OAuthClient is not yet registered (during login process) |
 | uri | <code>string</code> | — To use when OAuthClient is not yet registered (during login process) |
 
 <a name="OAuthClient+refreshToken"></a>
@@ -1362,3 +1365,9 @@ Document representing a io.cozy.files
 | --- | --- | --- |
 | _id | <code>string</code> | Id of the file |
 
+<a name="Stream"></a>
+
+## Stream : <code>object</code>
+Stream is not defined in a browser, but is on NodeJS environment
+
+**Kind**: global typedef  

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.2",
     "eslint": "5.16.0",
-    "eslint-config-cozy-app": "1.4.0",
+    "eslint-config-cozy-app": "1.6.0",
     "eslint-config-react-app": "^5.2.0",
     "eslint-plugin-flowtype": "^4.6.0",
     "eslint-plugin-import": "^2.20.1",

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -215,8 +215,8 @@ class CozyClient {
   }
 
   /** In konnector/service context, CozyClient can be instantiated from environment variables */
-  static fromEnv(env, options = {}) {
-    env = env || (typeof process !== 'undefined' ? process.env : {})
+  static fromEnv(envArg, options = {}) {
+    const env = envArg || (typeof process !== 'undefined' ? process.env : {})
     const { COZY_URL, COZY_CREDENTIALS, NODE_ENV } = env
     if (!COZY_URL || !COZY_CREDENTIALS) {
       throw new Error(
@@ -850,14 +850,14 @@ client.query(Q('io.cozy.bills'))`)
    * the relationship
    *
    * @param  {Document} document for which relationships must be resolved
-   * @param  {Schema} schema for the document doctype
+   * @param  {Schema} schemaArg for the document doctype
    * @returns {HydratedDocument}
    */
-  hydrateDocument(document, schema) {
+  hydrateDocument(document, schemaArg) {
     if (!document) {
       return document
     }
-    schema = schema || this.schema.getDoctypeSchema(document._type)
+    const schema = schemaArg || this.schema.getDoctypeSchema(document._type)
     return {
       ...document,
       ...this.hydrateRelationships(document, schema.relationships)

--- a/packages/cozy-client/src/ObservableQuery.js
+++ b/packages/cozy-client/src/ObservableQuery.js
@@ -34,6 +34,8 @@ export default class ObservableQuery {
   /**
    * Returns the query from the store with hydrated documents.
    *
+   * @typedef HydratedQueryState
+   *
    * @returns {HydratedQueryState}
    */
   currentResult() {

--- a/packages/cozy-client/src/Query.jsx
+++ b/packages/cozy-client/src/Query.jsx
@@ -143,9 +143,11 @@ Query.contextTypes = {
   store: PropTypes.object
 }
 
+const queryPropType = PropTypes.object
+
 Query.propTypes = {
   /** Query definition that will be executed and observed */
-  query: PropTypes.func.isRequired,
+  query: PropTypes.oneOfType([PropTypes.func, queryPropType]).isRequired,
   /** Name of the query */
   as: PropTypes.string,
   /** Function called with the data from the query */

--- a/packages/cozy-client/src/associations/HasMany.js
+++ b/packages/cozy-client/src/associations/HasMany.js
@@ -102,13 +102,13 @@ class HasMany extends Association {
    * We certainly should use something like `updateRelationship`
    *
    */
-  addById(ids) {
+  addById(idsArg) {
     if (!this.target.relationships) this.target.relationships = {}
     if (!this.target.relationships[this.name]) {
       this.target.relationships[this.name] = { data: [] }
     }
 
-    ids = Array.isArray(ids) ? ids : [ids]
+    const ids = Array.isArray(idsArg) ? idsArg : [idsArg]
 
     const newRelations = ids
       .filter(id => !this.existsById(id))
@@ -123,8 +123,8 @@ class HasMany extends Association {
     return this.save(this.target)
   }
 
-  removeById(ids) {
-    ids = Array.isArray(ids) ? ids : [ids]
+  removeById(idsArg) {
+    const ids = Array.isArray(idsArg) ? idsArg : [idsArg]
 
     this.target.relationships[this.name].data = this.target.relationships[
       this.name

--- a/packages/cozy-client/src/associations/HasManyFiles.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.js
@@ -41,8 +41,8 @@ export default class HasManyFiles extends HasMany {
     })
   }
 
-  async addById(ids) {
-    ids = Array.isArray(ids) ? ids : [ids]
+  async addById(idsArg) {
+    const ids = Array.isArray(idsArg) ? idsArg : [idsArg]
     const relations = ids.map(id => ({
       _id: id,
       _type: this.doctype
@@ -52,8 +52,8 @@ export default class HasManyFiles extends HasMany {
     await super.addById(ids)
   }
 
-  async removeById(ids) {
-    ids = Array.isArray(ids) ? ids : [ids]
+  async removeById(idsArg) {
+    const ids = Array.isArray(idsArg) ? idsArg : [idsArg]
     const relations = ids.map(id => ({
       _id: id,
       _type: this.doctype

--- a/packages/cozy-client/src/helpers.js
+++ b/packages/cozy-client/src/helpers.js
@@ -2,7 +2,8 @@ import { Association } from './associations'
 
 export const dehydrate = document => {
   const dehydrated = Object.entries(document).reduce(
-    (document, [key, value]) => {
+    (documentArg, [key, value]) => {
+      let document = documentArg
       if (!(value instanceof Association)) {
         document[key] = value
       } else if (value.dehydrate) {

--- a/packages/cozy-client/src/hoc.jsx
+++ b/packages/cozy-client/src/hoc.jsx
@@ -27,6 +27,7 @@ const withQuery = (dest, queryOpts, Original) => {
       `withQuery has no options for ${dest} (wrapping ${Original.name})`
     )
   }
+
   return Component => {
     const Wrapper = (props, context) => {
       if (!context.client) {
@@ -35,14 +36,16 @@ const withQuery = (dest, queryOpts, Original) => {
         )
       }
 
-      queryOpts = typeof queryOpts === 'function' ? queryOpts(props) : queryOpts
+      const queryOptsRes =
+        typeof queryOpts === 'function' ? queryOpts(props) : queryOpts
+
       if (queryOpts.doc) {
         console.warn('queryOpts.doc is deprecated')
-        return <Component {...{ [dest]: queryOpts.doc, ...props }} />
+        return <Component {...{ [dest]: queryOptsRes.doc, ...props }} />
       }
 
       return (
-        <Query {...queryOpts}>
+        <Query {...queryOptsRes}>
           {result => <Component {...{ [dest]: result, ...props }} />}
         </Query>
       )

--- a/packages/cozy-client/src/hoc.spec.jsx
+++ b/packages/cozy-client/src/hoc.spec.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Provider as ReduxProvider } from 'react-redux'
 import { mount } from 'enzyme'
 
@@ -88,6 +88,42 @@ describe('queryConnect', () => {
         .prop('upperSimpsons')
         .data.map(x => x.name)
     ).toEqual(['HOMER', 'MARGE'])
+  })
+
+  it('should be possible to pass props', () => {
+    const WithQuery = queryConnect({
+      simpson: props => ({
+        query: Q('io.cozy.simpsons').getById(props.simpsonId),
+        as: `simpsons/${props.simpsonId}`
+      })
+    })(Component)
+    const client = setupClient()
+    const Wrapper = ({ client }) => {
+      const [id, setId] = useState('marge')
+      return (
+        <Provider client={client}>
+          <div>
+            <WithQuery simpsonId={id} />
+            <button onClick={() => setId('homer')}>change to homer</button>
+          </div>
+        </Provider>
+      )
+    }
+    const uut = mount(<Wrapper client={client} />)
+    const props = uut.find('Query').props()
+    expect(props.query).toEqual(
+      expect.objectContaining({
+        id: 'marge'
+      })
+    )
+    uut.find('button').simulate('click')
+    uut.update()
+    const props2 = uut.find('Query').props()
+    expect(props2.query).toEqual(
+      expect.objectContaining({
+        id: 'homer'
+      })
+    )
   })
 })
 

--- a/packages/cozy-client/src/registry.js
+++ b/packages/cozy-client/src/registry.js
@@ -16,7 +16,10 @@ const getBaseRoute = app => {
 }
 
 /**
- *@typedef {RegistryApp}
+ * @typedef {object} RegistryApp
+ * @property {string} slug
+ * @property {object} terms
+ * @property {boolean} installed
  */
 
 class Registry {

--- a/packages/cozy-stack-client/src/AccessToken.js
+++ b/packages/cozy-stack-client/src/AccessToken.js
@@ -1,5 +1,6 @@
 export default class AccessToken {
-  constructor(data) {
+  constructor(dataArg) {
+    let data = dataArg
     if (typeof data === 'string') data = JSON.parse(data)
 
     this.tokenType = data.token_type || data.tokenType

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -20,7 +20,8 @@ import { fetchWithXMLHttpRequest, shouldXMLHTTPRequestBeUsed } from './xhrFetch'
 import MicroEE from 'microee'
 import { FetchError } from './errors'
 
-const normalizeUri = uri => {
+const normalizeUri = uriArg => {
+  let uri = uriArg
   if (uri === null) return null
   while (uri[uri.length - 1] === '/') {
     uri = uri.slice(0, -1)
@@ -92,7 +93,7 @@ class CozyStackClient {
    * @param  {string} method The HTTP method.
    * @param  {string} path The URI.
    * @param  {object} body The payload.
-   * @param  {object} opts
+   * @param  {object} opts Options for fetch
    * @returns {object}
    * @throws {FetchError}
    */
@@ -241,13 +242,14 @@ class CozyStackClient {
     }
   }
 
-  async fetchJSONWithCurrentToken(method, path, body, options = {}) {
+  async fetchJSONWithCurrentToken(method, path, bodyArg, options = {}) {
     //Since we modify the object later by adding in some case a
     //content-type, let's clone this object to scope the modification
     const clonedOptions = cloneDeep(options)
     const headers = (clonedOptions.headers = clonedOptions.headers || {})
     headers['Accept'] = 'application/json'
 
+    let body = bodyArg
     if (method !== 'GET' && method !== 'HEAD' && body !== undefined) {
       if (!headers['Content-Type']) {
         headers['Content-Type'] = 'application/json'

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -33,6 +33,12 @@ import { FetchError } from './errors'
  * @property {string} _id - Id of the file
  */
 
+/**
+ * Stream is not defined in a browser, but is on NodeJS environment
+ *
+ * @typedef {object} Stream
+ */
+
 const ROOT_DIR_ID = 'io.cozy.files.root-dir'
 const CONTENT_TYPE_OCTET_STREAM = 'application/octet-stream'
 
@@ -311,7 +317,6 @@ class FileCollection extends DocumentCollection {
     return resp.data
   }
   /**
-   *
    * @param {File|Blob|Stream|string|ArrayBuffer} data file to be uploaded
    * @param {string} dirPath Path to upload the file to. ie : /Administative/XXX/
    * @returns {object} Created io.cozy.files

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -358,8 +358,16 @@ class FileCollection extends DocumentCollection {
    */
   async createFile(
     data,
-    { name, dirId = '', executable, metadata, ...options } = {}
+    {
+      name: nameOption,
+      dirId = '',
+      executable: executableOption,
+      metadata,
+      ...options
+    } = {}
   ) {
+    let name = nameOption
+    let executable = executableOption
     // handle case where data is a file and contains the name
     if (!name && typeof data.name === 'string') {
       name = data.name
@@ -780,16 +788,18 @@ class FileCollection extends DocumentCollection {
    * This method should not be called directly to upload a file.
    * You should use `createFile`
    *
-   * @param {File|Blob|Stream|string|ArrayBuffer} data file to be uploaded
+   * @param {File|Blob|Stream|string|ArrayBuffer} dataArg file to be uploaded
    * @param {string} path Uri to call the stack from. Something like
    * `/files/${dirId}?Name=${name}&Type=file&Executable=${executable}&MetadataID=${metadataId}`
    * @param {object} options Additional headers
    * @param {string} method POST / PUT / PATCH
    */
-  async doUpload(data, path, options, method = 'POST') {
+  async doUpload(dataArg, path, options, method = 'POST') {
+    let data = dataArg
     if (!data) {
       throw new Error('missing data argument')
     }
+
     // transform any ArrayBufferView to ArrayBuffer
     if (data.buffer && data.buffer instanceof ArrayBuffer) {
       data = data.buffer

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -330,15 +330,16 @@ class OAuthClient extends CozyStackClient {
    *
    * @throws {NotRegisteredException} When the client doesn't have it's registration information
    * @param   {string} accessCode - The access code contained in the redirection URL — see `client.getAccessCodeFromURL()`
-   * @param   {object} oauthOptions — To use when OAuthClient is not yet registered (during login process)
+   * @param   {object} oauthOptionsArg — To use when OAuthClient is not yet registered (during login process)
    * @param   {string} uri — To use when OAuthClient is not yet registered (during login process)
    * @returns {Promise} A promise that resolves with an AccessToken object.
    */
-  async fetchAccessToken(accessCode, oauthOptions, uri) {
-    if (!this.isRegistered() && !oauthOptions)
+  async fetchAccessToken(accessCode, oauthOptionsArg, uri) {
+    if (!this.isRegistered() && !oauthOptionsArg) {
       throw new NotRegisteredException()
+    }
 
-    oauthOptions = oauthOptions || this.oauthOptions
+    let oauthOptions = oauthOptionsArg || this.oauthOptions
     const data = {
       grant_type: 'authorization_code',
       code: accessCode,

--- a/packages/cozy-stack-client/src/urls.js
+++ b/packages/cozy-stack-client/src/urls.js
@@ -11,7 +11,8 @@ export function getCozyURL() {
   return isNode ? getNodeCozyURL() : getBrowserCozyURL()
 }
 
-export function isSecureProtocol(url) {
+export function isSecureProtocol(urlArg) {
+  let url = urlArg
   if (url === undefined) url = getCozyURL()
 
   return url.protocol === SECURED_PROTOCOL

--- a/yarn.lock
+++ b/yarn.lock
@@ -6187,10 +6187,10 @@ escodegen@~1.9.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-cozy-app@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-cozy-app/-/eslint-config-cozy-app-1.4.0.tgz#fb751b78cafc4384f90b22570459376f5f775ff9"
-  integrity sha512-0XYwjd9XO6Sl3Rp5aiZnlCkXReg1xBrLWGnlDATgO2/EoHMEe9AUX7/Y7ui/j1YJwThZ5twjdkcjb8YJXgOX1w==
+eslint-config-cozy-app@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-cozy-app/-/eslint-config-cozy-app-1.6.0.tgz#68b4c24adb341c445dc44825255fe3f2ae3e8fc0"
+  integrity sha512-5Cc9Vdp7KR/McWEeG/9Git+zN525/2YbI9AUzXlPjNPHTLo/5yYIFyWWDk2OAvuKCKt7kJ4xFyADWB3q/Y2rwg==
   dependencies:
     babel-eslint "10.0.1"
     eslint "5.16.0"


### PR DESCRIPTION
If queryConnect had one of its collection whose queryOpts was a
function, for the "query" and "as" to change based on props, there
was a problem : the queryDefinition would not change based on props,
and it would keep the 1st queryDefinition. This was due to reassignment
to function params.

After fixing the bug, and adding a test, I activated the eslint rule
to have it as errors, and fixed the other cases in all the repo.

Here is a simple example of the bug:

```
const hoc = queryOpts => Component => {
  return props => {
    queryOpts = typeof queryOpts === "function" ? queryOpts(props) : queryOpts;
    Component(queryOpts)
  }
}

const queryOpts = props => ({ docId: props.id })

const Component = queryOpts => {
  console.log('Rendering the component', queryOpts)
} 

const hComponent = hoc(queryOpts)(Component)

hComponent({ id: 1 })
hComponent({ id: 2 })

// Rendering the component { docId: 1 }
// Rendering the component { docId: 1 }
```
