### PR TITLE
fix: Remove deleted document from store

### DIFF
--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -607,6 +607,34 @@ describe('CozyClient', () => {
     })
   })
 
+  describe('destroy', () => {
+    let doc
+    beforeEach(() => {
+      client.setData(
+        normalizeData({
+          'io.cozy.todos': [TODO_1]
+        })
+      )
+      doc = { ...TODO_1, label: 'Buy croissants' }
+      client.store.dispatch.mockReset()
+    })
+
+    it('should remove the document from the store', async () => {
+      await client.destroy(doc)
+      expect(client.store.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          definition: {
+            document: expect.objectContaining({
+              _id: 'todo_1'
+            }),
+            mutationType: 'DELETE_DOCUMENT'
+          },
+          mutationId: 1
+        })
+      )
+    })
+  })
+
   describe('getDocumentSavePlan', () => {
     it('should handle missing _rev and _id', () => {
       const NEW_FOO = {

--- a/packages/cozy-client/src/store/documents.js
+++ b/packages/cozy-client/src/store/documents.js
@@ -1,8 +1,10 @@
 import { isReceivingData } from './queries'
+import { MutationTypes } from '../queries/dsl'
 import { isReceivingMutationResult } from './mutations'
 import keyBy from 'lodash/keyBy'
 import get from 'lodash/get'
 import isEqual from 'lodash/isEqual'
+import omit from 'lodash/omit'
 import { properId } from './helpers'
 
 const storeDocument = (state, document) => {
@@ -62,8 +64,22 @@ const documents = (state = {}, action) => {
     return state
   }
 
+  if (
+    action &&
+    action.definition &&
+    action.definition.mutationType === MutationTypes.DELETE_DOCUMENT
+  ) {
+    const docId = action.definition.document._id
+    const _type = action.definition.document._type
+    return {
+      ...state,
+      [_type]: omit(state[_type], docId)
+    }
+  }
+
   const { data, included } = action.response
   if (!data || (Array.isArray(data) && data.length === 0)) return state
+
   const updatedStateWithIncluded = included
     ? included.reduce(storeDocument, state)
     : state

--- a/packages/cozy-client/src/store/documents.spec.js
+++ b/packages/cozy-client/src/store/documents.spec.js
@@ -2,6 +2,7 @@ import {
   extractAndMergeDocument,
   mergeDocumentsWithRelationships
 } from './documents'
+
 describe('extractAndMerge', () => {
   it('should return the right data', () => {
     const data = {


### PR DESCRIPTION
Previously, deleted documents were removed from queries, but the doc
was staying in the documents slice. This is problematic in the case
of relationships since the "parent" document linked to a document
that has been deleted, will still see the deleted document.

This is also problematic if we simply rely on the documents slice to
know if a document is deleted or not.

This PR fixes both situations.