### PR TITLE
Fix: initQuery doesn't set fetchStatus: loading on queries for noninitial calls

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -889,10 +889,10 @@ Instead, the relationships will have null documents.
 
 **Kind**: instance method of [<code>CozyClient</code>](#CozyClient)  
 
-| Param | Type |
-| --- | --- |
-| doctype | <code>string</code> | 
-| documents | [<code>Array.&lt;Document&gt;</code>](#Document) | 
+| Param | Type | Description |
+| --- | --- | --- |
+| doctype | <code>string</code> | Doctype of the documents being hydrated |
+| documents | [<code>Array.&lt;Document&gt;</code>](#Document) | Documents to be hydrated |
 
 <a name="CozyClient+hydrateDocument"></a>
 
@@ -1090,7 +1090,7 @@ set some data in the store.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| data | <code>Object</code> | { doctype: [data] } |
+| data | <code>object</code> | Data that is inserted in the store. Shape: { doctype: [data] } |
 
 <a name="CozyClient.fromOldClient"></a>
 

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -15,6 +15,7 @@ import {
   default as reducer,
   createStore,
   initQuery,
+  loadQuery,
   receiveQueryResult,
   receiveQueryError,
   initMutation,
@@ -620,6 +621,7 @@ client.query(Q('io.cozy.bills'))`)
       }
     }
     try {
+      this.dispatch(loadQuery(queryId))
       const response = await this.requestQuery(queryDefinition)
       this.dispatch(
         receiveQueryResult(queryId, response, {

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -828,8 +828,8 @@ client.query(Q('io.cozy.bills'))`)
    * If related documents are not in the store, they will not be fetched automatically.
    * Instead, the relationships will have null documents.
    *
-   * @param  {string} doctype
-   * @param  {Array<Document>} documents
+   * @param  {string} doctype - Doctype of the documents being hydrated
+   * @param  {Array<Document>} documents - Documents to be hydrated
    * @returns {Array<HydratedDocument>}
    */
   hydrateDocuments(doctype, documents) {
@@ -1224,7 +1224,7 @@ instantiation of the client.`
    * This is useful for cases like Pouch replication, which wants to
    * set some data in the store.
    *
-   * @param data {Object} { doctype: [data] }
+   * @param {object} data - Data that is inserted in the store. Shape: { doctype: [data] }
    */
   setData(data) {
     this.ensureStore()

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -915,7 +915,9 @@ describe('CozyClient', () => {
     it('should then dispatch a RECEIVE_QUERY_RESULT action', async () => {
       requestHandler.mockReturnValueOnce(Promise.resolve(fakeResponse))
       await client.query(query, { as: 'allTodos' })
-      expect(client.store.dispatch.mock.calls[1][0]).toEqual(
+      const dispatchCalls = client.store.dispatch.mock.calls
+      const lastDispatchCall = dispatchCalls[dispatchCalls.length - 1]
+      expect(lastDispatchCall[0]).toEqual(
         receiveQueryResult('allTodos', fakeResponse)
       )
     })
@@ -926,9 +928,9 @@ describe('CozyClient', () => {
       try {
         await client.query(query, { as: 'allTodos' })
       } catch (e) {} // eslint-disable-line no-empty
-      expect(client.store.dispatch.mock.calls[1][0]).toEqual(
-        receiveQueryError('allTodos', error)
-      )
+      const dispatchCalls = client.store.dispatch.mock.calls
+      const lastDispatchCall = dispatchCalls[dispatchCalls.length - 1]
+      expect(lastDispatchCall[0]).toEqual(receiveQueryError('allTodos', error))
     })
 
     it('should resolve to the query response', async () => {
@@ -1057,10 +1059,10 @@ describe('CozyClient', () => {
     it('should do nothing if fetch policy returns false', async () => {
       jest.spyOn(client, 'requestQuery')
       const fetchPolicy = jest.fn(() => false)
-      const fakeQueryState = {}
-      jest.spyOn(client, 'getQueryFromState').mockReturnValue(fakeQueryState)
       await client.query(query, { as: 'allTodos', fetchPolicy })
-      expect(fetchPolicy).toHaveBeenCalledWith(fakeQueryState)
+      const state = client.store.getState()
+      const queryState = getQueryFromState(state.cozy, 'allTodos')
+      expect(fetchPolicy).toHaveBeenCalledWith(queryState)
       expect(client.requestQuery).not.toHaveBeenCalled()
     })
 
@@ -1091,7 +1093,9 @@ describe('CozyClient', () => {
       })
       query.skip = 100
       await client.query(query, { as: 'allTodos' })
-      expect(client.store.dispatch.mock.calls[0][0]).toEqual(
+      const dispatchCalls = client.store.dispatch.mock.calls
+      const lastDispatchCall = dispatchCalls[dispatchCalls.length - 1]
+      expect(lastDispatchCall[0]).toEqual(
         receiveQueryResult('allTodos', fakeResponse)
       )
     })
@@ -1101,9 +1105,11 @@ describe('CozyClient', () => {
       getQueryFromState.mockReturnValueOnce({
         fetchStatus: 'loaded'
       })
-      query.bookmark = 'ohhimark'
+      query.bookmark = 'fake-bookmark'
       await client.query(query, { as: 'allTodos' })
-      expect(client.store.dispatch.mock.calls[0][0]).toEqual(
+      const dispatchCalls = client.store.dispatch.mock.calls
+      const lastDispatchCall = dispatchCalls[dispatchCalls.length - 1]
+      expect(lastDispatchCall[0]).toEqual(
         receiveQueryResult('allTodos', fakeResponse)
       )
     })

--- a/packages/cozy-client/src/Query.spec.jsx
+++ b/packages/cozy-client/src/Query.spec.jsx
@@ -72,7 +72,7 @@ describe('Query', () => {
       }
       expect(spy).toHaveBeenNthCalledWith(1, initQueryDispatch)
       expect(spy).toHaveBeenNthCalledWith(2, initQueryDispatch)
-      expect(spy).toHaveBeenCalledTimes(2)
+      expect(spy).toHaveBeenCalledTimes(3)
     })
   })
 

--- a/packages/cozy-client/src/cli/index.js
+++ b/packages/cozy-client/src/cli/index.js
@@ -54,7 +54,7 @@ const createCallbackServer = serverOptions => {
  * desktop browser of the user.
  *
  * @param {object} serverOptions - Options for the OAuth callback server
- * @param {integer} serverOptions.port - Port used for the OAuth callback server
+ * @param {number} serverOptions.port - Port used for the OAuth callback server
  * @param {Function} serverOptions.onAuthentication - Callback when the user authenticates
  * @param {Function} serverOptions.onListen - Callback called with the authentication URL
  * when the server starts

--- a/packages/cozy-client/src/store/index.js
+++ b/packages/cozy-client/src/store/index.js
@@ -106,7 +106,12 @@ export const getQueryFromState = (state, queryId) =>
 export const getRawQueryFromState = (state, queryId) =>
   getQueryFromSlice(getStateRoot(state).queries, queryId)
 
-export { initQuery, receiveQueryResult, receiveQueryError } from './queries'
+export {
+  initQuery,
+  loadQuery,
+  receiveQueryResult,
+  receiveQueryError
+} from './queries'
 
 export { resetState }
 

--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -15,6 +15,7 @@ import sift from 'sift'
 import get from 'lodash/get'
 
 const INIT_QUERY = 'INIT_QUERY'
+const LOAD_QUERY = 'LOAD_QUERY'
 const RECEIVE_QUERY_RESULT = 'RECEIVE_QUERY_RESULT'
 const RECEIVE_QUERY_ERROR = 'RECEIVE_QUERY_ERROR'
 
@@ -59,6 +60,19 @@ const query = (state = queryInitialState, action, nextDocuments) => {
         ...state,
         id: action.queryId,
         definition: action.queryDefinition,
+
+        // When the query is new, we set "fetchStatus" to "loading"
+        // directly since we know it will be loaded right away.
+        // This way, the loadQuery action will have no effect, and
+        // we save an additional render.
+        fetchStatus: state.lastUpdate ? state.fetchStatus : 'loading'
+      }
+    case LOAD_QUERY:
+      if (state.fetchStatus === 'loading') {
+        return state
+      }
+      return {
+        ...state,
         fetchStatus: 'loading'
       }
     case RECEIVE_QUERY_RESULT: {
@@ -297,6 +311,13 @@ export const initQuery = (queryId, queryDefinition) => {
     type: INIT_QUERY,
     queryId,
     queryDefinition
+  }
+}
+
+export const loadQuery = queryId => {
+  return {
+    type: LOAD_QUERY,
+    queryId
   }
 }
 

--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -56,6 +56,13 @@ const updateQueryDataFromResponse = (queryState, response, nextDocuments) => {
 const query = (state = queryInitialState, action, nextDocuments) => {
   switch (action.type) {
     case INIT_QUERY:
+      if (
+        state.lastUpdate &&
+        state.id === action.queryId &&
+        state.definition === action.queryDefinition
+      ) {
+        return state
+      }
       return {
         ...state,
         id: action.queryId,
@@ -275,9 +282,14 @@ const queries = (
   haveDocumentsChanged = true
 ) => {
   if (action.type == INIT_QUERY) {
+    const newQueryState = query(state[action.queryId], action)
+    // Do not create new object unnecessarily
+    if (newQueryState === state[action.queryId]) {
+      return state
+    }
     return {
       ...state,
-      [action.queryId]: query(state[action.queryId], action)
+      [action.queryId]: newQueryState
     }
   }
   if (isQueryAction(action)) {

--- a/packages/cozy-client/src/store/queries.spec.js
+++ b/packages/cozy-client/src/store/queries.spec.js
@@ -22,15 +22,26 @@ describe('queries reducer', () => {
   })
 
   it('should init correctly', () => {
-    applyAction(
-      initQuery(
-        'a',
-        new QueryDefinition({
-          doctype: 'io.cozy.todos'
-        })
-      )
-    )
+    const qdef = new QueryDefinition({
+      doctype: 'io.cozy.todos'
+    })
+    applyAction(initQuery('a', qdef))
     expect(state).toMatchSnapshot()
+  })
+
+  test('init should have no effect after receiveQueryResult', () => {
+    const qdef = new QueryDefinition({
+      doctype: 'io.cozy.todos'
+    })
+    applyAction(initQuery('a', qdef))
+    applyAction(
+      receiveQueryResult('a', {
+        data: [TODO_1, TODO_2]
+      })
+    )
+    let state1 = state
+    applyAction(initQuery('a', qdef))
+    expect(state1).toBe(state)
   })
 
   test('init should not set status to loading after receiveQueryResult', () => {

--- a/packages/cozy-client/src/store/queries.spec.js
+++ b/packages/cozy-client/src/store/queries.spec.js
@@ -33,6 +33,20 @@ describe('queries reducer', () => {
     expect(state).toMatchSnapshot()
   })
 
+  test('init should not set status to loading after receiveQueryResult', () => {
+    const qdef = new QueryDefinition({
+      doctype: 'io.cozy.todos'
+    })
+    applyAction(initQuery('a', qdef))
+    applyAction(
+      receiveQueryResult('a', {
+        data: [TODO_1, TODO_2]
+      })
+    )
+    applyAction(initQuery('a', qdef))
+    expect(state.a.fetchStatus).toBe('loaded')
+  })
+
   describe('updates', () => {
     beforeEach(() => {
       applyAction(
@@ -44,6 +58,7 @@ describe('queries reducer', () => {
         )
       )
     })
+
     it('should correctly update', () => {
       applyAction(
         receiveQueryResult('a', {
@@ -59,6 +74,7 @@ describe('queries reducer', () => {
       )
       expect(state['a'].data).toEqual([TODO_1._id, TODO_2._id])
     })
+
     it('should correctly update two queries', () => {
       applyAction(
         initQuery(


### PR DESCRIPTION
This fixes a long standing bug : #526

Previously, after an initial load of data through query(), subsequent calls
to query() would set the fetchStatus to loading. It causes a problem in
case of fetchPolicy : if the fetchPolicy returns false, the
receiveQueryResult will never been dispatched and queryState.fetchStatus 
will stay to false.

To prevent the problem, an additional loadQuery call is introduced which 
sets the fetchStatus to loading. initQuery now does not set the fetchStatus
to loading if the query already has been fetched.