### PR TITLE
feat: Add model functions to deal with sharing shortcuts

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -125,6 +125,21 @@ example.</p>
 <dd></dd>
 <dt><a href="#isShortcut">isShortcut</a> ⇒ <code>boolean</code></dt>
 <dd></dd>
+<dt><a href="#getSharingShortcutStatus">getSharingShortcutStatus</a> ⇒ <code>string</code></dt>
+<dd><p>Returns the status of a sharing shortcut.</p>
+</dd>
+<dt><a href="#getSharingShortcutTargetMime">getSharingShortcutTargetMime</a> ⇒ <code>string</code></dt>
+<dd><p>Returns the mime type of the target of the sharing shortcut, if it is a file.</p>
+</dd>
+<dt><a href="#getSharingShortcutTargetDoctype">getSharingShortcutTargetDoctype</a> ⇒ <code>string</code></dt>
+<dd><p>Returns the doctype of the target of the sharing shortcut.</p>
+</dd>
+<dt><a href="#isSharingShorcut">isSharingShorcut</a> ⇒ <code>boolean</code></dt>
+<dd><p>Returns whether the file is a shortcut to a sharing</p>
+</dd>
+<dt><a href="#isSharingShorcutNew">isSharingShorcutNew</a> ⇒ <code>boolean</code></dt>
+<dd><p>Returns whether the sharing shortcut is new</p>
+</dd>
 <dt><a href="#ensureMagicFolder">ensureMagicFolder</a> ⇒ <code>object</code></dt>
 <dd><p>Returns a &quot;Magic Folder&quot;, given its id. See <a href="https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.apps/#special-iocozyapps-doctypes">https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.apps/#special-iocozyapps-doctypes</a></p>
 </dd>
@@ -1653,6 +1668,64 @@ Returns base filename and extension
 | Param | Type | Description |
 | --- | --- | --- |
 | file | <code>File</code> | io.cozy.files |
+
+<a name="getSharingShortcutStatus"></a>
+
+## getSharingShortcutStatus ⇒ <code>string</code>
+Returns the status of a sharing shortcut.
+
+**Kind**: global constant  
+**Returns**: <code>string</code> - A description of the status  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| file | <code>object</code> | io.cozy.files document |
+
+<a name="getSharingShortcutTargetMime"></a>
+
+## getSharingShortcutTargetMime ⇒ <code>string</code>
+Returns the mime type of the target of the sharing shortcut, if it is a file.
+
+**Kind**: global constant  
+**Returns**: <code>string</code> - The mime-type of the target file, or an empty string is the target is not a file.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| file | <code>object</code> | io.cozy.files document |
+
+<a name="getSharingShortcutTargetDoctype"></a>
+
+## getSharingShortcutTargetDoctype ⇒ <code>string</code>
+Returns the doctype of the target of the sharing shortcut.
+
+**Kind**: global constant  
+**Returns**: <code>string</code> - A doctype  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| file | <code>object</code> | io.cozy.files document |
+
+<a name="isSharingShorcut"></a>
+
+## isSharingShorcut ⇒ <code>boolean</code>
+Returns whether the file is a shortcut to a sharing
+
+**Kind**: global constant  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| file | <code>object</code> | io.cozy.files document |
+
+<a name="isSharingShorcutNew"></a>
+
+## isSharingShorcutNew ⇒ <code>boolean</code>
+Returns whether the sharing shortcut is new
+
+**Kind**: global constant  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| file | <code>object</code> | io.cozy.files document |
 
 <a name="ensureMagicFolder"></a>
 

--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -103,3 +103,52 @@ export function getParentFolderId(file) {
   const parentId = get(file, 'attributes.dir_id')
   return parentId === '' ? null : parentId
 }
+
+/**
+ * Returns the status of a sharing shortcut.
+ *
+ * @param {object} file  - io.cozy.files document
+ *
+ * @returns {string} A description of the status
+ */
+export const getSharingShortcutStatus = file =>
+  get(file, 'metadata.sharing.status')
+
+/**
+ * Returns the mime type of the target of the sharing shortcut, if it is a file.
+ *
+ * @param {object} file  - io.cozy.files document
+ *
+ * @returns {string} The mime-type of the target file, or an empty string is the target is not a file.
+ */
+export const getSharingShortcutTargetMime = file =>
+  get(file, 'metadata.target.mime')
+
+/**
+ * Returns the doctype of the target of the sharing shortcut.
+ *
+ * @param {object} file  - io.cozy.files document
+ *
+ * @returns {string} A doctype
+ */
+export const getSharingShortcutTargetDoctype = file =>
+  get(file, 'metadata.target._type')
+
+/**
+ * Returns whether the file is a shortcut to a sharing
+ *
+ * @param {object} file  - io.cozy.files document
+ *
+ * @returns {boolean}
+ */
+export const isSharingShorcut = file => Boolean(getSharingShortcutStatus(file))
+
+/**
+ * Returns whether the sharing shortcut is new
+ *
+ * @param {object} file  - io.cozy.files document
+ *
+ * @returns {boolean}
+ */
+export const isSharingShorcutNew = file =>
+  getSharingShortcutStatus(file) === 'new'

--- a/packages/cozy-client/src/models/file.spec.js
+++ b/packages/cozy-client/src/models/file.spec.js
@@ -146,4 +146,73 @@ describe('File Model', () => {
       )
     })
   })
+
+  describe('Sharing shortcuts', () => {
+    const id = 'abc123'
+    const type = 'io.cozy.files'
+
+    const nonSharingShortcutDocument = { id, type }
+    const sharingShortcutDocument = {
+      ...nonSharingShortcutDocument,
+      metadata: {
+        sharing: { status: 'seen' },
+        target: {
+          mime: 'target-mimetype',
+          _type: 'io.cozy.files'
+        }
+      }
+    }
+    const newShortcutDocument = {
+      ...nonSharingShortcutDocument,
+      metadata: {
+        sharing: { status: 'new' },
+        target: {
+          mime: 'target-mimetype-2',
+          _type: 'io.cozy.files'
+        }
+      }
+    }
+
+    it('identifies a sharing shortcut', () => {
+      expect(file.isSharingShorcut(sharingShortcutDocument)).toBe(true)
+      expect(file.isSharingShorcut(nonSharingShortcutDocument)).toBe(false)
+    })
+
+    it('detects if a sharing shortcut is new', () => {
+      expect(file.isSharingShorcutNew(newShortcutDocument)).toBe(true)
+      expect(file.isSharingShorcutNew(nonSharingShortcutDocument)).toBe(false)
+      expect(file.isSharingShorcutNew(sharingShortcutDocument)).toBe(false)
+    })
+
+    it('returns the sharring shortcut status', () => {
+      expect(file.getSharingShortcutStatus(newShortcutDocument)).toBe('new')
+      expect(file.getSharingShortcutStatus(sharingShortcutDocument)).toBe(
+        'seen'
+      )
+      expect(
+        file.getSharingShortcutStatus(nonSharingShortcutDocument)
+      ).toBeUndefined()
+    })
+
+    it('returns the sharring shortcut target mime type', () => {
+      expect(file.getSharingShortcutTargetMime(newShortcutDocument)).toBe(
+        'target-mimetype-2'
+      )
+      expect(file.getSharingShortcutTargetMime(sharingShortcutDocument)).toBe(
+        'target-mimetype'
+      )
+      expect(
+        file.getSharingShortcutTargetMime(nonSharingShortcutDocument)
+      ).toBeUndefined()
+    })
+
+    it('returns the sharring shortcut target doctype', () => {
+      expect(
+        file.getSharingShortcutTargetDoctype(sharingShortcutDocument)
+      ).toBe('io.cozy.files')
+      expect(
+        file.getSharingShortcutTargetMime(nonSharingShortcutDocument)
+      ).toBeUndefined()
+    })
+  })
 })


### PR DESCRIPTION
We now have a type of file that's a bit special:

- they are `io.cozy.files`
- they are shortcut files (.url files)
- they point to a sharing preview page
- they get deleted when the sharing is accepted

I've added some functions to help us work with them in the files model.