### PR TITLE
Client-side query sort can use deep objects properties

### DIFF
--- a/packages/cozy-client/src/models/contact.js
+++ b/packages/cozy-client/src/models/contact.js
@@ -1,4 +1,5 @@
-import { get, capitalize, isEmpty } from 'lodash'
+import get from 'lodash/get'
+import isEmpty from 'lodash/isEmpty'
 
 export const getPrimaryOrFirst = property => obj =>
   !obj[property] || obj[property].length === 0
@@ -134,22 +135,25 @@ export const getDisplayName = contact =>
  * @returns {string} - the contact's 'byFamilyNameGivenNameEmailCozyUrl' index
  */
 export const getIndexByFamilyNameGivenNameEmailCozyUrl = contact => {
-  const indexByFamilyNameGivenNameEmailCozyUrl = capitalize(
-    [
-      get(contact, 'name.familyName', ''),
-      get(contact, 'name.givenName', ''),
-      getPrimaryEmail(contact),
-      getPrimaryCozyDomain(contact)
-    ]
-      .join('')
-      .trim()
-  )
+  if (get(contact, 'indexes.byFamilyNameGivenNameEmailCozyUrl')) {
+    if (isEmpty(contact.indexes.byFamilyNameGivenNameEmailCozyUrl)) {
+      return null
+    }
+    return contact.indexes.byFamilyNameGivenNameEmailCozyUrl
+  }
 
-  return get(
-    contact,
-    'indexes.byFamilyNameGivenNameEmailCozyUrl',
-    indexByFamilyNameGivenNameEmailCozyUrl.length === 0
-      ? {}
-      : indexByFamilyNameGivenNameEmailCozyUrl
-  )
+  const createIndexByFamilyNameGivenNameEmailCozyUrl = [
+    get(contact, 'name.familyName', ''),
+    get(contact, 'name.givenName', ''),
+    getPrimaryEmail(contact),
+    getPrimaryCozyDomain(contact)
+  ]
+    .join('')
+    .trim()
+    .toLowerCase()
+
+  if (createIndexByFamilyNameGivenNameEmailCozyUrl.length === 0) {
+    return null
+  }
+  return createIndexByFamilyNameGivenNameEmailCozyUrl
 }

--- a/packages/cozy-client/src/models/contact.spec.js
+++ b/packages/cozy-client/src/models/contact.spec.js
@@ -389,7 +389,7 @@ describe('getIndexByFamilyNameGivenNameEmailCozyUrl', () => {
       ]
     }
     const result = getIndexByFamilyNameGivenNameEmailCozyUrl(contact)
-    expect(result).toEqual('Smithjohnjohn.smith@cozy.ccjohn.mycozy.cloud')
+    expect(result).toEqual('smithjohnjohn.smith@cozy.ccjohn.mycozy.cloud')
   })
 
   it('should returns only familyName if no givenName, email and cozy url', () => {
@@ -400,7 +400,7 @@ describe('getIndexByFamilyNameGivenNameEmailCozyUrl', () => {
       cozy: [{ url: '' }]
     }
     const result = getIndexByFamilyNameGivenNameEmailCozyUrl(contact)
-    expect(result).toEqual('Smith')
+    expect(result).toEqual('smith')
   })
 
   it('should returns only givenName if no familyName, email and cozy url', () => {
@@ -411,7 +411,7 @@ describe('getIndexByFamilyNameGivenNameEmailCozyUrl', () => {
       cozy: [{ url: '' }]
     }
     const result = getIndexByFamilyNameGivenNameEmailCozyUrl(contact)
-    expect(result).toEqual('John')
+    expect(result).toEqual('john')
   })
 
   it('should returns only cozy url if no givenName, familyName and email', () => {
@@ -422,10 +422,10 @@ describe('getIndexByFamilyNameGivenNameEmailCozyUrl', () => {
       cozy: [{ url: 'https://smith.mycozy.cloud' }]
     }
     const result = getIndexByFamilyNameGivenNameEmailCozyUrl(contact)
-    expect(result).toEqual('Smith.mycozy.cloud')
+    expect(result).toEqual('smith.mycozy.cloud')
   })
 
-  it('should returns empty object if no givenName, familyName, email and cozy url', () => {
+  it('should returns null if no givenName, familyName, email and cozy url', () => {
     const contact = {
       name: {},
       fullname: '',
@@ -433,7 +433,7 @@ describe('getIndexByFamilyNameGivenNameEmailCozyUrl', () => {
       cozy: []
     }
     const result = getIndexByFamilyNameGivenNameEmailCozyUrl(contact)
-    expect(result).toEqual({})
+    expect(result).toEqual(null)
   })
 
   it('should returns concatenated string of givenName and cozy url if no familyName and email', () => {
@@ -443,7 +443,7 @@ describe('getIndexByFamilyNameGivenNameEmailCozyUrl', () => {
       cozy: [{ url: 'https://smith.mycozy.cloud' }]
     }
     const result = getIndexByFamilyNameGivenNameEmailCozyUrl(contact)
-    expect(result).toEqual('Johnsmith.mycozy.cloud')
+    expect(result).toEqual('johnsmith.mycozy.cloud')
   })
 
   it('should returns only email if no name and cozy url', () => {
@@ -453,7 +453,22 @@ describe('getIndexByFamilyNameGivenNameEmailCozyUrl', () => {
       cozy: [{ url: '' }]
     }
     const result = getIndexByFamilyNameGivenNameEmailCozyUrl(contact)
-    expect(result).toEqual('John.smith@cozy.cc')
+    expect(result).toEqual('john.smith@cozy.cc')
+  })
+
+  it('should returns null if indexes.byFamilyNameGivenNameEmailCozyUrl was an empty object', () => {
+    const contact = {
+      indexes: { byFamilyNameGivenNameEmailCozyUrl: {} }
+    }
+    const result = getIndexByFamilyNameGivenNameEmailCozyUrl(contact)
+    expect(result).toEqual(null)
+  })
+  it('should returns indexes.byFamilyNameGivenNameEmailCozyUrl if already present', () => {
+    const contact = {
+      indexes: { byFamilyNameGivenNameEmailCozyUrl: 'john' }
+    }
+    const result = getIndexByFamilyNameGivenNameEmailCozyUrl(contact)
+    expect(result).toEqual('john')
   })
 })
 

--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -172,7 +172,7 @@ const getQueryDocumentsChecker = query => {
 }
 
 const makeCaseInsensitiveStringSorter = attrName => item => {
-  const attrValue = item[attrName]
+  const attrValue = get(item, attrName)
   return isString(attrValue) ? attrValue.toLowerCase() : attrValue
 }
 

--- a/packages/cozy-client/src/store/queries.spec.js
+++ b/packages/cozy-client/src/store/queries.spec.js
@@ -256,4 +256,18 @@ describe('makeSorterFromDefinition', () => {
     const sorted = sorter(files)
     expect(sorted.map(x => x._id)).toEqual(['4', '5', '3', '2', '1'])
   })
+
+  it('should handle objects with deep properties', () => {
+    const q = Q('io.cozy.files').sortBy([{ 'name.label': 'asc' }])
+    const sorter = makeSorterFromDefinition(q)
+    const files = [
+      { name: { label: 'C' } },
+      { name: { label: 'B' } },
+      { name: { label: 'a' } },
+      { name: { label: 'A' } },
+      { name: { label: 'b' } }
+    ]
+    const sorted = sorter(files)
+    expect(sorted.map(x => x.name.label)).toEqual(['a', 'A', 'B', 'b', 'C'])
+  })
 })


### PR DESCRIPTION
**Problem to solve :** 
Before that, if we used nested attributes in `sortBy()` it was ignored and no sorting was done in cozy-client. As a consequence, after editing a document, the sorting was not done again if a new request was not launched. The documents remained in their original position.

**Improvements :** 
- We can now use `sortBy()` with nested attributes like `sortBy([{ 'deep.property': 'asc' }])` as we do here https://github.com/cozy/cozy-contacts/blob/master/src/helpers/queries.js#L57
- getIndexByFamilyNameGivenNameEmailCozyUrl() now tranforms the index in lower case (not capitalize) to match this :  https://github.com/cozy/cozy-client/blob/fix/queries/packages/cozy-client/src/store/queries.js#L176
- getIndexByFamilyNameGivenNameEmailCozyUrl() now return `null` (instead of `empty object`) to have empty index at the end of the sort.

**Explanations for changing the `empty object` to `null` :** 
We thought using the sort order of couchDB (see https://docs.couchdb.org/en/2.3.1/ddocs/views/collation.html#collation-specification) during a `sortBy()` but in fine we sort the documents in cozy-client with an `Array.sort()`. Empty objects are at the end in couchDB but before not empty lowercase string with `Array.sort()`

**Details :** 
The entry point in cozy-client: https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/store/queries.js#L46
Then we use `orderBy()` from lodash (https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/store/queries.js#L202) which is based on `_baseOrderBy()` itself based on `_baseSortBy()`, which finally makes an `Array.sort()` https://github.com/lodash/lodash/blob/master/.internal/baseSortBy.js#L14

The sort order is therefore that of `Array.sort()` (see https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Array/sort and https://fr.wikipedia.org/wiki/Table_des_caract%C3%A8res_Unicode/U0000)

**Consequences :** 
Since couchDB and cozy-client do not sort the same way, paging will be a problem.

Edit : documentation about queries https://docs.cozy.io/en/tutorials/data/queries/ will be updated according to this