### PR TITLE
Feat/warmed up queries

### DIFF
--- a/docs/api/cozy-pouch-link.md
+++ b/docs/api/cozy-pouch-link.md
@@ -26,6 +26,13 @@ and on demand immediately.</p>
 </dd>
 </dl>
 
+## Functions
+
+<dl>
+<dt><a href="#getQueryAlias">getQueryAlias(query)</a> ⇒ <code>string</code></dt>
+<dd></dd>
+</dl>
+
 <a name="PouchLink"></a>
 
 ## PouchLink
@@ -40,6 +47,7 @@ to respond to queries and mutations.
     * [.handleOnSync()](#PouchLink+handleOnSync)
     * [.startReplication()](#PouchLink+startReplication) ⇒ <code>void</code>
     * [.stopReplication()](#PouchLink+stopReplication) ⇒ <code>void</code>
+    * [.needsToWaitWarmup(doctype)](#PouchLink+needsToWaitWarmup) ⇒ <code>boolean</code>
 
 <a name="new_PouchLink_new"></a>
 
@@ -84,6 +92,18 @@ Emits pouchlink:sync:stop event
 
 **Kind**: instance method of [<code>PouchLink</code>](#PouchLink)  
 **Access**: public  
+<a name="PouchLink+needsToWaitWarmup"></a>
+
+### pouchLink.needsToWaitWarmup(doctype) ⇒ <code>boolean</code>
+**Kind**: instance method of [<code>PouchLink</code>](#PouchLink)  
+**Returns**: <code>boolean</code> - the need to wait for the warmup
+Check if there is warmup queries for this doctype
+and return if those queries are already warmedup or not  
+
+| Param | Type |
+| --- | --- |
+| doctype | <code>string</code> | 
+
 <a name="Loop"></a>
 
 ## Loop
@@ -207,3 +227,13 @@ immediately
 Starts replication
 
 **Kind**: instance method of [<code>PouchManager</code>](#PouchManager)  
+<a name="getQueryAlias"></a>
+
+## getQueryAlias(query) ⇒ <code>string</code>
+**Kind**: global function  
+**Returns**: <code>string</code> - alias  
+
+| Param | Type |
+| --- | --- |
+| query | <code>QueryDefinition</code> | 
+

--- a/docs/api/cozy-pouch-link.md
+++ b/docs/api/cozy-pouch-link.md
@@ -95,10 +95,11 @@ Emits pouchlink:sync:stop event
 <a name="PouchLink+needsToWaitWarmup"></a>
 
 ### pouchLink.needsToWaitWarmup(doctype) ⇒ <code>boolean</code>
-**Kind**: instance method of [<code>PouchLink</code>](#PouchLink)  
-**Returns**: <code>boolean</code> - the need to wait for the warmup
 Check if there is warmup queries for this doctype
-and return if those queries are already warmedup or not  
+and return if those queries are already warmedup or not
+
+**Kind**: instance method of [<code>PouchLink</code>](#PouchLink)  
+**Returns**: <code>boolean</code> - the need to wait for the warmup  
 
 | Param | Type |
 | --- | --- |

--- a/docs/mobile-guide.md
+++ b/docs/mobile-guide.md
@@ -185,6 +185,11 @@ example, the `StackLink`).
 
 Additionally, it is possible to replicate some doctypes only in a specific direction:
 
+Since making the first query can be long (PouchDB will create the index first), you can 
+specify the queries you want to be "warmed up". It means that, those queries will be 
+executed by CozyClient during the PouchLink's instanciation, but CozyClient will use 
+PouchDB only if those queries have been resolved at least one time.
+
 ```js
 
 const pouchLink = new PouchLink({

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -298,7 +298,7 @@ class PouchLink extends CozyLink {
       this.doctypesReplicationOptions[doctype] &&
       this.doctypesReplicationOptions[doctype].warmupQueries
     ) {
-      return !this.pouches.areWarmedUpQueries(
+      return !this.pouches.areQueriesWarmedUp(
         doctype,
         this.doctypesReplicationOptions[doctype].warmupQueries
       )

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -287,10 +287,11 @@ class PouchLink extends CozyLink {
   }
   /**
    *
-   * @param {string} doctype
-   * @returns {boolean} the need to wait for the warmup
    * Check if there is warmup queries for this doctype
    * and return if those queries are already warmedup or not
+   *
+   * @param {string} doctype
+   * @returns {boolean} the need to wait for the warmup
    */
   needsToWaitWarmup(doctype) {
     if (

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -311,7 +311,7 @@ class PouchLink extends CozyLink {
   }
 
   async ensureIndex(doctype, query) {
-    const fields = getIndexFields(query)
+    const fields = query.indexedFields || getIndexFields(query)
     const name = getIndexNameFromFields(fields)
     const absName = `${doctype}/${name}`
     const db = this.pouches.getPouch(doctype)
@@ -336,7 +336,8 @@ class PouchLink extends CozyLink {
     limit,
     id,
     ids,
-    skip
+    skip,
+    indexedFields
   }) {
     const db = this.getPouch(doctype)
     let res, withRows
@@ -360,7 +361,7 @@ class PouchLink extends CozyLink {
         limit,
         skip
       }
-      await this.ensureIndex(doctype, findOpts)
+      await this.ensureIndex(doctype, { ...findOpts, indexedFields })
       res = await find(db, findOpts)
       res.offset = skip
       res.limit = limit

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -98,7 +98,7 @@ describe('CozyPouchLink', () => {
       })
     })
 
-    it('test if the pouch is synced and no warmup queries for this doctype, it should not forward', async () => {
+    it('should not forward if the pouch is synced and there is no warmup queries for this doctype', async () => {
       await setup({
         doctypesReplicationOptions: {
           'io.cozy.files': { warmupQueries: [query1(), query2()] }
@@ -371,7 +371,7 @@ describe('CozyPouchLink', () => {
       spy.mockRestore()
     })
 
-    it('uses the default index aka the from the sort', async () => {
+    it('uses the default index, the one from the sort', async () => {
       spy = jest.spyOn(PouchDB.prototype, 'createIndex')
       await setup()
       link.pouches.isSynced = jest.fn().mockReturnValue(true)

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -177,15 +177,7 @@ class PouchManager {
       ).then(res => {
         this.addSyncedDoctype(doctype)
         logger.log('PouchManager: Replication for ' + doctype + ' ended', res)
-        //We want to warmupQueries only once by "start". aka we want to warmup
-        //every time we launch the client (app) but not every time a replication
-        //is done (aka every 30s at least)
-        if (
-          !this.warmedUpQueries[doctype] &&
-          replicationOptions.warmupQueries
-        ) {
-          this.warmupQueries(doctype, replicationOptions.warmupQueries)
-        }
+        this.checkToWarmupDoctype(doctype, replicationOptions)
         return res
       })
     })
@@ -299,6 +291,13 @@ class PouchManager {
     )
     this.persistwarmedUpQueries()
     logger.log('PouchManager: warmupQueries for ' + doctype + ' are done')
+  // Queries are warmed up only once per instantiation of the PouchManager. Since
+  // the PouchManager lives during the complete lifecycle of the app, warm up
+  // happens only on app start / restart.
+  checkToWarmupDoctype(doctype, replicationOptions) {
+    if (!this.warmedUpQueries[doctype] && replicationOptions.warmupQueries) {
+      this.warmupQueries(doctype, replicationOptions.warmupQueries)
+    }
   }
 
   persistWarmedUpQueries() {

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -84,7 +84,7 @@ class PouchManager {
     this.stopReplicationLoop()
     this.removeListeners()
     this.destroySyncedDoctypes()
-    this.destroyWarmedUpQueries()
+    this.clearWarmedUpQueries()
 
     return Promise.all(
       Object.values(this.pouches).map(pouch => pouch.destroy())
@@ -301,19 +301,19 @@ class PouchManager {
     logger.log('PouchManager: warmupQueries for ' + doctype + ' are done')
   }
 
-  persistwarmedUpQueries() {
+  persistWarmedUpQueries() {
     window.localStorage.setItem(
       LOCALSTORAGE_WARMUPEDQUERIES_KEY,
       JSON.stringify(this.warmedUpQueries)
     )
   }
 
-  areWarmedUpQueries(doctype, queries) {
-    const persistwarmedUpQueries = this.getPersistedWarmedUpQueries()
+  areQueriesWarmedUp(doctype, queries) {
+    const persistWarmedUpQueries = this.getPersistedWarmedUpQueries()
     return queries.every(
       query =>
-        persistwarmedUpQueries[doctype] &&
-        persistwarmedUpQueries[doctype].includes(getQueryAlias(query))
+        persistWarmedUpQueries[doctype] &&
+        persistWarmedUpQueries[doctype].includes(getQueryAlias(query))
     )
   }
 
@@ -325,7 +325,7 @@ class PouchManager {
     return JSON.parse(item)
   }
 
-  destroyWarmedUpQueries() {
+  clearWarmedUpQueries() {
     this.warmedUpQueries = {}
     window.localStorage.removeItem(LOCALSTORAGE_WARMUPEDQUERIES_KEY)
   }

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -5,102 +5,14 @@ import get from 'lodash/get'
 import map from 'lodash/map'
 import zip from 'lodash/zip'
 import Loop from './loop'
-import { default as helpers } from './helpers'
 import { isMobileApp } from 'cozy-device-helper'
 import logger from './logger'
-
-const { isDesignDocument, isDeletedDocument } = helpers
+import { startReplication } from './startReplication'
 const DEFAULT_DELAY = 30 * 1000
 
-const TIME_UNITS = [['ms', 1000], ['s', 60], ['m', 60], ['h', 24]]
-const humanTimeDelta = timeMs => {
-  let cur = timeMs
-  let unitIndex = 0
-  let str = ''
-  while (cur >= TIME_UNITS[unitIndex][1]) {
-    let unit = TIME_UNITS[unitIndex]
-    const int = Math.round(cur / unit[1])
-    const rest = cur % unit[1]
-    str = `${rest}${unit[0]}` + str
-    cur = int
-    unitIndex++
-  }
-  const lastUnit = TIME_UNITS[unitIndex]
-  str = `${cur}${lastUnit[0]}` + str
-  return str
-}
-
-/**
- * startReplication - Create a cancellable promise for replication with default options
- *
- * @private
- * @param {object} pouch                 Pouch database instance
- * @param {object} replicationOptions Any option supported by the Pouch replication API (https://pouchdb.com/api.html#replication)
- * @param {string} replicationOptions.strategy The direction of the replication. Can be "fromRemote",  "toRemote" or "sync"
- * @param {Function} getReplicationURL A function that should return the remote replication URL
- *
- * @returns {Promise} A cancelable promise that resolves at the end of the replication
- */
-const startReplication = (pouch, replicationOptions, getReplicationURL) => {
-  let replication
-  const start = new Date()
-  const promise = new Promise((resolve, reject) => {
-    const url = getReplicationURL()
-    const { strategy, ...customReplicationOptions } = replicationOptions
-    const options = {
-      batch_size: 1000, // we have mostly small documents
-      ...customReplicationOptions
-    }
-    let replication
-
-    if (strategy === 'fromRemote')
-      replication = pouch.replicate.from(url, options)
-    else if (strategy === 'toRemote')
-      replication = pouch.replicate.to(url, options)
-    else replication = pouch.sync(url, options)
-
-    const docs = {}
-
-    replication.on('change', infos => {
-      //! Since we introduced the concept of strategy we can use
-      // PouchDB.replicate or PouchDB.sync. But both don't share the
-      // same API for the change's event.
-      // See https://pouchdb.com/api.html#replication
-      // and https://pouchdb.com/api.html#sync (see example response)
-      const change = infos.change ? infos.change : infos
-
-      if (change.docs) {
-        change.docs
-          .filter(doc => !isDesignDocument(doc) && !isDeletedDocument(doc))
-          .forEach(doc => {
-            docs[doc._id] = doc
-          })
-      }
-    })
-    replication.on('error', reject).on('complete', () => {
-      const end = new Date()
-      if (process.env.NODE_ENV !== 'production') {
-        logger.info(
-          `PouchManager: replication for ${url} took ${humanTimeDelta(
-            end - start
-          )}`
-        )
-      }
-      resolve(Object.values(docs))
-    })
-  })
-
-  const cancel = () => {
-    if (replication) {
-      replication.cancel()
-    }
-  }
-
-  promise.cancel = cancel
-  return promise
-}
-
 export const LOCALSTORAGE_SYNCED_KEY = 'cozy-client-pouch-link-synced'
+export const LOCALSTORAGE_WARMUPEDQUERIES_KEY =
+  'cozy-client-pouch-link-warmupedqueries'
 
 /**
  * Handles the lifecycle of several pouches

--- a/packages/cozy-pouch-link/src/PouchManager.spec.js
+++ b/packages/cozy-pouch-link/src/PouchManager.spec.js
@@ -517,5 +517,17 @@ describe('PouchManager', () => {
       await sleep(10)
       expect(executeMock).toHaveBeenCalledTimes(2)
     })
+
+    it('should not persist or cache warmedup queries if one have failled', async () => {
+      jest
+        .spyOn(rep, 'startReplication')
+        .mockImplementation(() => Promise.resolve({}))
+      executeMock.mockRejectedValueOnce('error').mockResolvedValue({})
+
+      await manager.replicateOnce()
+      await sleep(10)
+      expect(manager.getPersistedWarmedUpQueries()).toEqual({})
+      expect(manager.warmedUpQueries['io.cozy.todos']).toBeUndefined()
+    })
   })
 })

--- a/packages/cozy-pouch-link/src/PouchManager.spec.js
+++ b/packages/cozy-pouch-link/src/PouchManager.spec.js
@@ -4,12 +4,21 @@
 // See https://github.com/cozy/cozy-client/pull/239 for example
 // on how to use fake timers with setTimeout created in promises.
 
-import PouchManager, { LOCALSTORAGE_SYNCED_KEY } from './PouchManager'
+import PouchManager, {
+  LOCALSTORAGE_SYNCED_KEY,
+  LOCALSTORAGE_WARMUPEDQUERIES_KEY
+} from './PouchManager'
 import * as mocks from './__tests__/mocks'
+
+import CozyClient, { Q } from 'cozy-client'
+
 import { isMobileApp } from 'cozy-device-helper'
 
 jest.mock('pouchdb-browser')
 jest.mock('cozy-device-helper')
+
+import * as rep from './startReplication'
+
 import PouchDB from 'pouchdb-browser'
 
 const sleep = delay => {
@@ -18,6 +27,34 @@ const sleep = delay => {
   })
 }
 
+const query = () => ({
+  definition: () =>
+    Q('io.cozy.files')
+      .where({
+        trashed: false,
+        type: 'file',
+        updated_at: { $gt: null }
+      })
+      .indexFields(['updated_at', 'type', 'trashed'])
+      .sortBy([{ updated_at: 'desc' }])
+      .limitBy(100),
+  options: {
+    as: 'recent-view-query'
+  }
+})
+
+const query1 = () => ({
+  definition: () => Q('io.cozy.todos').limitBy(100),
+  options: {
+    as: 'query1'
+  }
+})
+const query2 = () => ({
+  definition: () => Q('io.cozy.todos').limitBy(100),
+  options: {
+    as: 'query2'
+  }
+})
 describe('PouchManager', () => {
   let manager,
     managerOptions,
@@ -266,6 +303,106 @@ describe('PouchManager', () => {
     })
   })
 
+  describe('getPersistedWarmedUpQueriess', () => {
+    it('Should return an empty object if local storage is empty', () => {
+      const manager = new PouchManager(['io.cozy.todos'], managerOptions)
+
+      expect(manager.getPersistedWarmedUpQueries()).toEqual({})
+    })
+
+    it('Should return the list of queries if local storage contains ones', () => {
+      const persistedQueries = [query().options.as]
+      localStorage.__STORE__[LOCALSTORAGE_WARMUPEDQUERIES_KEY] = JSON.stringify(
+        persistedQueries
+      )
+      const manager = new PouchManager(['io.cozy.todos'], managerOptions)
+
+      expect(manager.getPersistedWarmedUpQueries()).toEqual(persistedQueries)
+    })
+  })
+
+  describe('persistwarmedUpQueries', () => {
+    it('Should put the list of warmedUpQueries in localStorage', () => {
+      const manager = new PouchManager(['io.cozy.todos'], managerOptions)
+      manager.warmedUpQueries = { 'io.cozy.todos': ['query1', 'query2'] }
+      manager.persistwarmedUpQueries()
+
+      expect(localStorage.__STORE__[LOCALSTORAGE_WARMUPEDQUERIES_KEY]).toEqual(
+        JSON.stringify(manager.warmedUpQueries)
+      )
+    })
+  })
+
+  describe('warmupQueries', () => {
+    /* it('Should add the doctype to synced doctypes', () => {
+      const manager = new PouchManager(['io.cozy.todos'], managerOptions)
+      manager.addSyncedDoctype('io.cozy.todos')
+
+      expect(manager.syncedDoctypes).toEqual(['io.cozy.todos'])
+    })
+
+    it('Should persist the new synced doctypes list', () => {
+      const manager = new PouchManager(['io.cozy.todos'], managerOptions)
+      manager.persistSyncedDoctypes = jest.fn()
+      manager.addSyncedDoctype('io.cozy.todos')
+
+      expect(manager.persistSyncedDoctypes).toHaveBeenCalledTimes(1)
+    }) */
+  })
+
+  describe('areWarmedUpQueries', () => {
+    let manager
+
+    beforeEach(() => {
+      manager = new PouchManager(['io.cozy.todos'], managerOptions)
+    })
+
+    it('Should return true if all the queries are warmuped', () => {
+      manager.warmedUpQueries = {
+        'io.cozy.todos': [query1().options.as, query2().options.as]
+      }
+      manager.persistwarmedUpQueries()
+
+      expect(
+        manager.areWarmedUpQueries('io.cozy.todos', [query1(), query2()])
+      ).toBe(true)
+    })
+
+    it('Should return false if at least one query is not warmuped', () => {
+      manager.warmedUpQueries = {
+        'io.cozy.todos': [query2().options.as]
+      }
+      manager.persistwarmedUpQueries()
+
+      expect(
+        manager.areWarmedUpQueries('io.cozy.todos', [query1(), query2()])
+      ).toBe(false)
+    })
+
+    it('Should return false if the queries are not been done', () => {
+      expect(
+        manager.areWarmedUpQueries('io.cozy.todos', [query1(), query2()])
+      ).toBe(false)
+    })
+  })
+
+  describe('destroyWarmedupQueries', () => {
+    it('Should destroy the local storage item', () => {
+      manager.destroyWarmedUpQueries()
+
+      expect(localStorage.removeItem).toHaveBeenLastCalledWith(
+        LOCALSTORAGE_WARMUPEDQUERIES_KEY
+      )
+    })
+    it('Should reset warmedupQueries', () => {
+      manager.warmedUpQueries = {
+        'io.cozy.todos': [query2().options.as]
+      }
+      manager.destroyWarmedUpQueries()
+      expect(manager.warmedUpQueries).toEqual({})
+    })
+  })
+
   describe('Events Listeners', () => {
     describe('Add/Remove Listeners', () => {
       beforeEach(() => {
@@ -332,6 +469,53 @@ describe('PouchManager', () => {
           expect(stopReplicationLoop).toHaveBeenCalled()
         })
       }
+    })
+  })
+
+  describe('warmupQueries', () => {
+    let manager
+    const executeMock = jest.fn()
+    beforeEach(() => {
+      let newManagerOptions = {
+        ...managerOptions,
+        executeQuery: executeMock,
+        doctypesReplicationOptions: {
+          'io.cozy.todos': {
+            strategy: 'fromRemote',
+            warmupQueries: [query1(), query2()]
+          }
+        }
+      }
+      manager = new PouchManager(['io.cozy.todos'], newManagerOptions)
+    })
+
+    it('should executes warmeupQueries on the first replicationLoop only', async () => {
+      jest
+        .spyOn(rep, 'startReplication')
+        .mockImplementation(() => Promise.resolve({}))
+      await manager.replicateOnce()
+      await sleep(10)
+      executeMock.mockResolvedValue({})
+      expect(executeMock).toHaveBeenCalledTimes(2)
+      expect(executeMock).toHaveBeenNthCalledWith(
+        1,
+        query1()
+          .definition()
+          .toDefinition()
+      )
+      expect(executeMock).toHaveBeenNthCalledWith(
+        2,
+        query2()
+          .definition()
+          .toDefinition()
+      )
+      expect(manager.getPersistedWarmedUpQueries()).toEqual({
+        'io.cozy.todos': ['query1', 'query2']
+      })
+      //Simulation of a loop. Let's replicate again
+      await manager.replicateOnce()
+      await sleep(10)
+      expect(executeMock).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/packages/cozy-pouch-link/src/PouchManager.spec.js
+++ b/packages/cozy-pouch-link/src/PouchManager.spec.js
@@ -10,7 +10,7 @@ import PouchManager, {
 } from './PouchManager'
 import * as mocks from './__tests__/mocks'
 
-import CozyClient, { Q } from 'cozy-client'
+import { Q } from 'cozy-client'
 
 import { isMobileApp } from 'cozy-device-helper'
 

--- a/packages/cozy-pouch-link/src/PouchManager.spec.js
+++ b/packages/cozy-pouch-link/src/PouchManager.spec.js
@@ -321,11 +321,11 @@ describe('PouchManager', () => {
     })
   })
 
-  describe('persistwarmedUpQueries', () => {
+  describe('persistWarmedUpQueries', () => {
     it('Should put the list of warmedUpQueries in localStorage', () => {
       const manager = new PouchManager(['io.cozy.todos'], managerOptions)
       manager.warmedUpQueries = { 'io.cozy.todos': ['query1', 'query2'] }
-      manager.persistwarmedUpQueries()
+      manager.persistWarmedUpQueries()
 
       expect(localStorage.__STORE__[LOCALSTORAGE_WARMUPEDQUERIES_KEY]).toEqual(
         JSON.stringify(manager.warmedUpQueries)
@@ -350,7 +350,7 @@ describe('PouchManager', () => {
     }) */
   })
 
-  describe('areWarmedUpQueries', () => {
+  describe('areQueriesWarmedUp', () => {
     let manager
 
     beforeEach(() => {
@@ -361,10 +361,10 @@ describe('PouchManager', () => {
       manager.warmedUpQueries = {
         'io.cozy.todos': [query1().options.as, query2().options.as]
       }
-      manager.persistwarmedUpQueries()
+      manager.persistWarmedUpQueries()
 
       expect(
-        manager.areWarmedUpQueries('io.cozy.todos', [query1(), query2()])
+        manager.areQueriesWarmedUp('io.cozy.todos', [query1(), query2()])
       ).toBe(true)
     })
 
@@ -372,23 +372,23 @@ describe('PouchManager', () => {
       manager.warmedUpQueries = {
         'io.cozy.todos': [query2().options.as]
       }
-      manager.persistwarmedUpQueries()
+      manager.persistWarmedUpQueries()
 
       expect(
-        manager.areWarmedUpQueries('io.cozy.todos', [query1(), query2()])
+        manager.areQueriesWarmedUp('io.cozy.todos', [query1(), query2()])
       ).toBe(false)
     })
 
     it('Should return false if the queries are not been done', () => {
       expect(
-        manager.areWarmedUpQueries('io.cozy.todos', [query1(), query2()])
+        manager.areQueriesWarmedUp('io.cozy.todos', [query1(), query2()])
       ).toBe(false)
     })
   })
 
-  describe('destroyWarmedupQueries', () => {
-    it('Should destroy the local storage item', () => {
-      manager.destroyWarmedUpQueries()
+  describe('clearWarmedupQueries', () => {
+    it('Should clear the local storage item', () => {
+      manager.clearWarmedUpQueries()
 
       expect(localStorage.removeItem).toHaveBeenLastCalledWith(
         LOCALSTORAGE_WARMUPEDQUERIES_KEY
@@ -398,7 +398,7 @@ describe('PouchManager', () => {
       manager.warmedUpQueries = {
         'io.cozy.todos': [query2().options.as]
       }
-      manager.destroyWarmedUpQueries()
+      manager.clearWarmedUpQueries()
       expect(manager.warmedUpQueries).toEqual({})
     })
   })

--- a/packages/cozy-pouch-link/src/PouchManager.spec.js
+++ b/packages/cozy-pouch-link/src/PouchManager.spec.js
@@ -333,23 +333,6 @@ describe('PouchManager', () => {
     })
   })
 
-  describe('warmupQueries', () => {
-    /* it('Should add the doctype to synced doctypes', () => {
-      const manager = new PouchManager(['io.cozy.todos'], managerOptions)
-      manager.addSyncedDoctype('io.cozy.todos')
-
-      expect(manager.syncedDoctypes).toEqual(['io.cozy.todos'])
-    })
-
-    it('Should persist the new synced doctypes list', () => {
-      const manager = new PouchManager(['io.cozy.todos'], managerOptions)
-      manager.persistSyncedDoctypes = jest.fn()
-      manager.addSyncedDoctype('io.cozy.todos')
-
-      expect(manager.persistSyncedDoctypes).toHaveBeenCalledTimes(1)
-    }) */
-  })
-
   describe('areQueriesWarmedUp', () => {
     let manager
 

--- a/packages/cozy-pouch-link/src/PouchManager.spec.js
+++ b/packages/cozy-pouch-link/src/PouchManager.spec.js
@@ -501,7 +501,7 @@ describe('PouchManager', () => {
       expect(executeMock).toHaveBeenCalledTimes(2)
     })
 
-    it('should not persist or cache warmedup queries if one have failled', async () => {
+    it('should not persist or cache warmedup queries if one has failed', async () => {
       jest
         .spyOn(rep, 'startReplication')
         .mockImplementation(() => Promise.resolve({}))

--- a/packages/cozy-pouch-link/src/startReplication.js
+++ b/packages/cozy-pouch-link/src/startReplication.js
@@ -1,0 +1,99 @@
+import { default as helpers } from './helpers'
+import logger from './logger'
+
+const { isDesignDocument, isDeletedDocument } = helpers
+const humanTimeDelta = timeMs => {
+  let cur = timeMs
+  let unitIndex = 0
+  let str = ''
+  while (cur >= TIME_UNITS[unitIndex][1]) {
+    let unit = TIME_UNITS[unitIndex]
+    const int = Math.round(cur / unit[1])
+    const rest = cur % unit[1]
+    str = `${rest}${unit[0]}` + str
+    cur = int
+    unitIndex++
+  }
+  const lastUnit = TIME_UNITS[unitIndex]
+  str = `${cur}${lastUnit[0]}` + str
+  return str
+}
+const TIME_UNITS = [['ms', 1000], ['s', 60], ['m', 60], ['h', 24]]
+
+/**
+ * startReplication - Create a cancellable promise for replication with default options
+ *
+ * @private
+ * @param {object} pouch                 Pouch database instance
+ * @param {object} replicationOptions Any option supported by the Pouch replication API (https://pouchdb.com/api.html#replication)
+ * @param {string} replicationOptions.strategy The direction of the replication. Can be "fromRemote",  "toRemote" or "sync"
+ * @param {Function} getReplicationURL A function that should return the remote replication URL
+ *
+ * @returns {Promise} A cancelable promise that resolves at the end of the replication
+ */
+export const startReplication = (
+  pouch,
+  replicationOptions,
+  getReplicationURL
+) => {
+  let replication
+  const start = new Date()
+  const promise = new Promise((resolve, reject) => {
+    const url = getReplicationURL()
+    const {
+      strategy,
+      warmupQueries,
+      ...customReplicationOptions
+    } = replicationOptions
+    const options = {
+      batch_size: 1000, // we have mostly small documents
+      ...customReplicationOptions
+    }
+    let replication
+    if (strategy === 'fromRemote')
+      replication = pouch.replicate.from(url, options)
+    else if (strategy === 'toRemote')
+      replication = pouch.replicate.to(url, options)
+    else replication = pouch.sync(url, options)
+
+    // console.log('replication', replication)
+    const docs = {}
+
+    replication.on('change', infos => {
+      //! Since we introduced the concept of strategy we can use
+      // PouchDB.replicate or PouchDB.sync. But both don't share the
+      // same API for the change's event.
+      // See https://pouchdb.com/api.html#replication
+      // and https://pouchdb.com/api.html#sync (see example response)
+      const change = infos.change ? infos.change : infos
+
+      if (change.docs) {
+        change.docs
+          .filter(doc => !isDesignDocument(doc) && !isDeletedDocument(doc))
+          .forEach(doc => {
+            docs[doc._id] = doc
+          })
+      }
+    })
+    replication.on('error', reject).on('complete', () => {
+      const end = new Date()
+      if (process.env.NODE_ENV !== 'production') {
+        logger.info(
+          `PouchManager: replication for ${url} took ${humanTimeDelta(
+            end - start
+          )}`
+        )
+      }
+      resolve(Object.values(docs))
+    })
+  })
+
+  const cancel = () => {
+    if (replication) {
+      replication.cancel()
+    }
+  }
+
+  promise.cancel = cancel
+  return promise
+}


### PR DESCRIPTION
Since first Pouch request can be slow (Pouch creates and populates the
index before returning the result), we need in a some cases (
like the first sync), to be able to warmed up a few queries to
create the index before making the real call.

Until those warmupQueries are done, we forward the request to the next link. 