### PR TITLE
fix: Do not sort fields for index name

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -1180,6 +1180,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 * [QueryDefinition](#QueryDefinition)
     * [new QueryDefinition(options)](#new_QueryDefinition_new)
+    * [.checkSortOrder(sort|selector|indexedFields)](#QueryDefinition+checkSortOrder)
     * [.getById(id)](#QueryDefinition+getById) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
     * [.getByIds(ids)](#QueryDefinition+getByIds) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
     * [.where(selector)](#QueryDefinition+where) ⇒ [<code>QueryDefinition</code>](#QueryDefinition)
@@ -1213,6 +1214,23 @@ from a Cozy. `QueryDefinition`s are sent to links.
 | options.skip | <code>number</code> | The number of docs to skip. |
 | options.cursor | <code>number</code> | The cursor to paginate views. |
 | options.bookmark | <code>number</code> | The bookmark to paginate mango queries. |
+
+<a name="QueryDefinition+checkSortOrder"></a>
+
+### queryDefinition.checkSortOrder(sort|selector|indexedFields)
+Check if the sort order matches the index' fields order.
+
+When sorting with CouchDB, it is required to:
+- use indexed fields
+- keep the same order than the indexed fields.
+
+See https://docs.cozy.io/en/tutorials/data/queries/#sort-data-with-mango
+
+**Kind**: instance method of [<code>QueryDefinition</code>](#QueryDefinition)  
+
+| Param | Type |
+| --- | --- |
+| sort|selector|indexedFields | <code>object</code> | 
 
 <a name="QueryDefinition+getById"></a>
 

--- a/packages/cozy-client/examples/complex-query.js
+++ b/packages/cozy-client/examples/complex-query.js
@@ -1,0 +1,43 @@
+const { default: CozyClient } = require('../dist')
+global.fetch = require('node-fetch') // in the browser we have native fetch
+
+const schema = {
+  contacts: {
+    doctype: 'io.cozy.contacts',
+    attributes: {
+      name: {
+        type: 'string'
+      }
+    }
+  }
+}
+
+const main = async _args => {
+  const uri = process.env.COZY_URL || 'http://cozy.tools:8080'
+  const token = process.env.COZY_TOKEN
+  if (!token) {
+    throw new Error('You should provide COZY_TOKEN as an environement variable')
+  }
+  const client = new CozyClient({ uri, token, schema })
+  const queryDef = client
+    .find('io.cozy.contacts')
+    .where({
+      $or: [
+        {
+          'cozyMetadata.doctypeVersion': { $exists: false }
+        },
+        {
+          'cozyMetadata.doctypeVersion': { $lt: 3 }
+        }
+      ]
+    })
+    .indexFields(['cozyMetadata.doctypeVersion'])
+    .sortBy([{ 'cozyMetadata.doctypeVersion': 'asc' }])
+
+  const resp = await client.query(queryDef)
+  const contacts = resp.data
+  console.log(contacts[0])
+  console.log('Number of contacts fetched : ', contacts.length)
+}
+
+main(process.argv).catch(e => console.error(e))

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -51,7 +51,7 @@ class QueryDefinition {
    *
    * See https://docs.cozy.io/en/tutorials/data/queries/#sort-data-with-mango
    *
-   * @param {sort|selector|indexedFields}
+   * @param {object} sort|selector|indexedFields
    */
   checkSortOrder({ sort, selector, indexedFields }) {
     const _sort = this.sort || sort

--- a/packages/cozy-pouch-link/src/mango.js
+++ b/packages/cozy-pouch-link/src/mango.js
@@ -2,10 +2,8 @@ import flatten from 'lodash/flatten'
 import isArray from 'lodash/isArray'
 import isObject from 'lodash/isObject'
 
-const fieldsComparator = (a, b) => a.localeCompare(b)
-
 export const getIndexNameFromFields = fields => {
-  return `by_${fields.sort(fieldsComparator).join('_and_')}`
+  return `by_${fields.join('_and_')}`
 }
 
 const getSortKeys = sort => {


### PR DESCRIPTION
BREAKING CHANGE: in the absence of an `indexFields` directive, the
attributes order in a `where` selector will matter to create the index.
To force an attributes order for an index, use `indexFields`.

We used to sort the index fields to build its name, e.g.
"by_date_and_type", which allows to keep the same order independently
from their position in the `where` selector.
However, this breaks the `indexedFields` behavior: because of the sort,
the fields might be indexed in a wrong order, e.g. `[type, date]` will
actually produce a `[date, type]` index. As the order is important
in Mango, this can break some queries.

We remove this sort to be consistent with
[cozy-stack-client](https://github.com/cozy/cozy-client/blob/ea768adecaf0dd1c52e9876bf68e86d099579a9b/packages/cozy-stack-client/src/DocumentCollection.js#L416-L418).

Eventually, this would be nice to refactor the code in a common lib, see https://github.com/cozy/cozy-client/issues/786