### PR TITLE
fix: Use index for PouchDB mango queries

### DIFF
--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -362,7 +362,11 @@ class PouchLink extends CozyLink {
         limit,
         skip
       }
-      await this.ensureIndex(doctype, { ...findOpts, indexedFields })
+      const index = await this.ensureIndex(doctype, {
+        ...findOpts,
+        indexedFields
+      })
+      findOpts.use_index = index.id
       res = await find(db, findOpts)
       res.offset = skip
       res.limit = limit


### PR DESCRIPTION
We need to pass the index to the query so pouch knows which index to use. As a side effect, it was creating each mrview 2 times, which is very costful for instances with many documents, e.g. thousands.
Note this was already done in [stack-client](https://github.com/cozy/cozy-client/blob/master/packages/cozy-stack-client/src/DocumentCollection.js#L359), which is again related to https://github.com/cozy/cozy-client/issues/786 ;)