### PR TITLE
Fix/operation on doctypes

### DIFF
--- a/docs/mobile-guide.md
+++ b/docs/mobile-guide.md
@@ -185,11 +185,6 @@ example, the `StackLink`).
 
 Additionally, it is possible to replicate some doctypes only in a specific direction:
 
-Since making the first query can be long (PouchDB will create the index first), you can 
-specify the queries you want to be "warmed up". It means that, those queries will be 
-executed by CozyClient during the PouchLink's instanciation, but CozyClient will use 
-PouchDB only if those queries have been resolved at least one time.
-
 ```js
 
 const pouchLink = new PouchLink({
@@ -211,3 +206,40 @@ const pouchLink = new PouchLink({
 
 If you choose the `fromRemote` strategy, the cozy-client mutation will not be executed 
 on the PouchLink but rather on the StackLink. 
+
+Since making the first query can be long (PouchDB will create the index first), you can 
+specify the queries you want to be "warmed up". It means that, those queries will be 
+executed by CozyClient during the PouchLink's instanciation, but CozyClient will use 
+PouchDB only if those queries have been resolved at least one time.
+
+```js
+
+const buildRecentQuery = () => ({
+  definition: () =>
+    Q('io.cozy.files')
+      .where({
+        type: 'file',
+        trashed: false,
+        updated_at: {
+          $gt: null
+        }
+      })
+  options: {
+    as: 'recent-view-query',
+    fetchPolicy: defaultFetchPolicy,
+  }
+})
+
+const pouchLink = new PouchLink({
+  doctypes: ['io.cozy.todos', 'io.cozy.files', 'io.cozy.localtype'],
+  doctypesReplicationOptions: {
+    'io.cozy.files': {
+      warmupQueries: [
+        buildRecentQuery()
+      ]
+    }
+  }
+  initialSync: true
+})
+```
+

--- a/docs/mobile-guide.md
+++ b/docs/mobile-guide.md
@@ -208,3 +208,6 @@ const pouchLink = new PouchLink({
   initialSync: true
 })
 ```
+
+If you choose the `fromRemote` strategy, the cozy-client mutation will not be executed 
+on the PouchLink but rather on the StackLink. 

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -235,6 +235,15 @@ class PouchLink extends CozyLink {
 
   supportsOperation(operation) {
     const impactedDoctype = getDoctypeFromOperation(operation)
+    // If the Pouch is configured only to replicate from the remote,
+    // we don't want to apply the mutation on it, but to forward
+    // to the next link
+    if (
+      this.doctypesReplicationOptions &&
+      this.doctypesReplicationOptions[impactedDoctype] &&
+      this.doctypesReplicationOptions[impactedDoctype].strategy === 'fromRemote'
+    )
+      return false
     return !!this.getPouch(impactedDoctype)
   }
 

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -124,6 +124,42 @@ describe('CozyPouchLink', () => {
         expect(true).toBe(true)
       })
     })
+
+    test('supportsOperation returns false if the doctype is sync with a read only strategy', async () => {
+      const operationTODO = {
+        doctype: TODO_DOCTYPE
+      }
+
+      await setup({
+        doctypesReplicationOptions: {
+          'io.cozy.todos': { strategy: 'fromRemote' }
+        }
+      })
+
+      expect(link.supportsOperation(operationTODO)).toBe(false)
+    })
+
+    test('supportsOperation with a synchronized doctype', async () => {
+      const operationTODO = {
+        doctype: TODO_DOCTYPE
+      }
+
+      await setup()
+      expect(link.supportsOperation(operationTODO)).toBe(true)
+    })
+
+    it('should forward if the doctype is sync only for read access', async () => {
+      await setup({
+        doctypesReplicationOptions: {
+          'io.cozy.todos': { strategy: 'fromRemote' }
+        }
+      })
+      const query = Q(TODO_DOCTYPE)
+      expect.assertions(1)
+      await link.request(query, null, () => {
+        expect(true).toBe(true)
+      })
+    })
   })
 
   describe('queries', () => {


### PR DESCRIPTION
Since fromRemote is a readOnly strategy, we don't want to apply
current mutation on it since this mutation will never be synched.

So, we forward it to the next link