### PR TITLE
feat: Add fromDOM method

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -734,6 +734,7 @@ Responsible for
         * [.fromOldClient()](#CozyClient.fromOldClient)
         * [.fromOldOAuthClient()](#CozyClient.fromOldOAuthClient) ⇒ [<code>CozyClient</code>](#CozyClient)
         * [.fromEnv()](#CozyClient.fromEnv)
+        * [.fromDOM(selector, options)](#CozyClient.fromDOM) ⇒ <code>object</code>
         * [.registerHook(doctype, name, fn)](#CozyClient.registerHook)
 
 <a name="new_CozyClient_new"></a>
@@ -1147,6 +1148,20 @@ Warning: unlike other instantiators, this one needs to be awaited.
 In konnector/service context, CozyClient can be instantiated from environment variables
 
 **Kind**: static method of [<code>CozyClient</code>](#CozyClient)  
+<a name="CozyClient.fromDOM"></a>
+
+### CozyClient.fromDOM(selector, options) ⇒ <code>object</code>
+When used from an app, CozyClient can be instantiated from the data injected by the stack in
+the DOM.
+
+**Kind**: static method of [<code>CozyClient</code>](#CozyClient)  
+**Returns**: <code>object</code> - - CozyClient instance  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| selector | <code>string</code> | <code>&quot;[role&#x3D;application]&quot;</code> | Options |
+| options | <code>object</code> |  | CozyClient constructor options |
+
 <a name="CozyClient.registerHook"></a>
 
 ### CozyClient.registerHook(doctype, name, fn)

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -252,7 +252,11 @@ class CozyClient {
       throw new Error(`Found no data in ${selector} to instantiate cozyClient`)
     }
 
-    const { cozyDomain, cozyToken } = root.dataset
+    const data = root.dataset.cozy
+      ? JSON.parse(root.dataset.cozy)
+      : { ...root.dataset }
+
+    const { cozyDomain, cozyToken } = data
 
     if (!cozyDomain || !cozyToken) {
       throw new Error(

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -239,6 +239,34 @@ class CozyClient {
     })
   }
 
+  /**
+   * In cozy app context, CozyClient can be instantiated from data injected by the stack
+   *
+   * @param  {string}   selector - Options
+   * @param  {object}   options  - CozyClient constructor options
+   * @returns {object} - CozyClient instance
+   */
+  static fromDOM(selector = '[role=application]', options = {}) {
+    const root = document.querySelector(selector)
+    if (!root || !root.dataset) {
+      throw new Error(`Found no data in ${selector} to instantiate cozyClient`)
+    }
+
+    const { cozyDomain, cozyToken } = root.dataset
+
+    if (!cozyDomain || !cozyToken) {
+      throw new Error(
+        `Found no data in ${root.dataset} to instantiate cozyClient`
+      )
+    }
+
+    return new CozyClient({
+      uri: `${window.location.protocol}//${cozyDomain}`,
+      token: cozyToken,
+      ...options
+    })
+  }
+
   addSchema(schemaDefinition) {
     this.schema.add(schemaDefinition)
   }

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -240,7 +240,8 @@ class CozyClient {
   }
 
   /**
-   * In cozy app context, CozyClient can be instantiated from data injected by the stack
+   * When used from an app, CozyClient can be instantiated from the data injected by the stack in
+   * the DOM.
    *
    * @param  {string}   selector - Options
    * @param  {object}   options  - CozyClient constructor options

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -156,7 +156,20 @@ describe('CozyClient initialization', () => {
   it('can be instantiated from dataset injected by the Stack in DOM', async () => {
     const options = { cozyDomain: 'cozy.tools', cozyToken: 'abc123' }
     jest.spyOn(document, 'querySelector').mockReturnValue({ dataset: options })
-    document.querySelector = jest.fn().mockReturnValue({ dataset: options })
+    const client = CozyClient.fromDOM()
+    expect(client.stackClient.uri).toBe('http://cozy.tools')
+    expect(client.stackClient.token.token).toBe('abc123')
+    document.querySelector.mockRestore()
+  })
+
+  it('fromDOM should handle single DOM dataset', async () => {
+    const options = JSON.stringify({
+      cozyDomain: 'cozy.tools',
+      cozyToken: 'abc123'
+    })
+    jest
+      .spyOn(document, 'querySelector')
+      .mockReturnValue({ dataset: { cozy: options } })
     const client = CozyClient.fromDOM()
     expect(client.stackClient.uri).toBe('http://cozy.tools')
     expect(client.stackClient.token.token).toBe('abc123')

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -153,6 +153,16 @@ describe('CozyClient initialization', () => {
     expect(client.stackClient.token.token).toBe(token)
   })
 
+  it('can be instantiated from dataset injected by the Stack in DOM', async () => {
+    const options = { cozyDomain: 'cozy.tools', cozyToken: 'abc123' }
+    jest.spyOn(document, 'querySelector').mockReturnValue({ dataset: options })
+    document.querySelector = jest.fn().mockReturnValue({ dataset: options })
+    const client = CozyClient.fromDOM()
+    expect(client.stackClient.uri).toBe('http://cozy.tools')
+    expect(client.stackClient.token.token).toBe('abc123')
+    document.querySelector.mockRestore()
+  })
+
   describe('plugins', () => {
     it('can register a plugin', () => {
       expect.assertions(2)


### PR DESCRIPTION
To get a CozyClient instance from data injected by the stack in the DOM
in the main page

fixes issue #799