### PR TITLE
fix: PouchLink should not forward if this is a read only operation

### DIFF
--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -239,6 +239,7 @@ class PouchLink extends CozyLink {
     // we don't want to apply the mutation on it, but to forward
     // to the next link
     if (
+      operation.mutationType &&
       this.doctypesReplicationOptions &&
       this.doctypesReplicationOptions[impactedDoctype] &&
       this.doctypesReplicationOptions[impactedDoctype].strategy === 'fromRemote'


### PR DESCRIPTION
PouchLink should not forward if this is a read only operation when the
sync strategy is read only.