### PR TITLE
fix: Do not show singleDocData warning for non single doc queries

### DIFF
--- a/packages/cozy-client/src/hooks/useQuery.js
+++ b/packages/cozy-client/src/hooks/useQuery.js
@@ -49,7 +49,7 @@ const useQuery = (queryDefinition, options) => {
 
   const client = useClient()
   const queryState = useSelector(() => {
-    if (options.singleDocData === undefined) {
+    if (options.singleDocData === undefined && queryDefinition.id) {
       logger.warn(
         'useQuery options.singleDocData will pass to true in a next version of cozy-client, please add it now to prevent any problem in the future.'
       )


### PR DESCRIPTION
Otherwise we had warning for queries that were for multiple docs
and it makes no sense for them to add singleDocData in the options.