### PR TITLE
feat: When an app/konnector is fetched by id, doctype should be present

### DIFF
--- a/packages/cozy-stack-client/src/AppCollection.js
+++ b/packages/cozy-stack-client/src/AppCollection.js
@@ -1,5 +1,6 @@
 import DocumentCollection, { normalizeDoc } from './DocumentCollection'
 import { FetchError } from './errors'
+import Collection from './Collection'
 
 export const APPS_DOCTYPE = 'io.cozy.apps'
 
@@ -14,6 +15,28 @@ class AppCollection extends DocumentCollection {
   constructor(stackClient) {
     super(APPS_DOCTYPE, stackClient)
     this.endpoint = '/apps/'
+  }
+
+  get(idArg) {
+    let id
+    if (idArg.indexOf('/') > -1) {
+      id = idArg.split('/')[1]
+    } else {
+      console.warn(
+        `Deprecated: in next versions of cozy-client, it will not be possible to query apps/konnectors only with id, please use the form ${this.doctype}/${idArg}
+
+- Q('io.cozy.apps').getById('banks')
++ Q('io.cozy.apps').getById('io.cozy.apps/banks')`
+      )
+      id = idArg
+    }
+    return Collection.get(
+      this.stackClient,
+      `${this.endpoint}${encodeURIComponent(id)}`,
+      {
+        normalize: this.constructor.normalizeDoctype(this.doctype)
+      }
+    )
   }
 
   /**

--- a/packages/cozy-stack-client/src/__tests__/AppCollection.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/AppCollection.spec.js
@@ -44,18 +44,33 @@ describe(`AppCollection`, () => {
         Promise.resolve(FIXTURES.GET_APPS_RESPONSE)
       )
     })
+
     it('should call the right route', async () => {
-      await collection.get('fakeid')
+      await collection.get('io.cozy.apps/fakeid')
       expect(client.fetchJSON).toHaveBeenCalledWith('GET', '/apps/fakeid')
     })
 
+    describe('deprecated get call without <doctype>/', () => {
+      beforeEach(() => {
+        jest.spyOn(console, 'warn').mockImplementation(() => {})
+      })
+
+      afterEach(() => {
+        console.warn.mockRestore()
+      })
+      it('should call the right route (deprecated call with <doctype>/)', async () => {
+        await collection.get('fakeid')
+        expect(client.fetchJSON).toHaveBeenCalledWith('GET', '/apps/fakeid')
+      })
+    })
+
     it('should return a correct JSON API response', async () => {
-      const resp = await collection.get('fakeid')
+      const resp = await collection.get('io.cozy.apps/fakeid')
       expect(resp).toConformToJSONAPI()
     })
 
     it('should return normalized document', async () => {
-      const resp = await collection.get('fakeid')
+      const resp = await collection.get('io.cozy.apps/fakeid')
       expect(resp.data).toHaveDocumentIdentity()
     })
   })


### PR DESCRIPTION
This is not breaking but this is deprecating the get with only the slug.

```patch
- Q('io.cozy.apps').getById('banks') // Deprecated
+ Q('io.cozy.apps').getById('io.cozy.apps/banks') // OK
```

This is because otherwise we have an erroneous behavior when loading
all konnectors then only one.

```js
await client.query(Q('io.cozy.konnectors').getById('konn'), { as: 'konn' })
await client.query(Q('io.cozy.konnectors'), { as: 'konnectors' })
```

At this point "konn" query will have nothing in its `data` since the doc
id was cleared out of the query by the filtering that cozy-client does
when receiving new documents, since the id "io.cozy.konnectors/konn"
does not correspond to the id in the queryDefinition "konn".

To prevent this behavior, we have to include the full id when doing the
query.
To prevent a breaking change, the old behavior is called out as
deprecated via a console.warn.