### PR TITLE
Fix document creation with relationships

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -280,6 +280,10 @@ we have in the store.</p>
 <dl>
 <dt><a href="#QueryState">QueryState</a> : <code>object</code></dt>
 <dd></dd>
+<dt><a href="#Reference">Reference</a> : <code>object</code></dt>
+<dd><p>A reference to a document (special case of a relationship used between photos and albums)
+<a href="https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.files/#references">https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.files/#references</a></p>
+</dd>
 <dt><a href="#CozyAccount">CozyAccount</a> : <code>object</code></dt>
 <dd></dd>
 <dt><a href="#Document">Document</a> : <code>object</code></dt>
@@ -707,7 +711,8 @@ Responsible for
         * [.login(options)](#CozyClient+login) ⇒ <code>Promise</code>
         * [.logout()](#CozyClient+logout) ⇒ <code>Promise</code>
         * [.collection(doctype)](#CozyClient+collection) ⇒ <code>DocumentCollection</code>
-        * [.getDocumentSavePlan(document, relationships)](#CozyClient+getDocumentSavePlan) ⇒ <code>Array.&lt;Mutation&gt;</code>
+        * [.create(type, doc, references, options)](#CozyClient+create) ⇒ <code>Promise</code>
+        * [.getDocumentSavePlan(document, [referencesByName])](#CozyClient+getDocumentSavePlan) ⇒ <code>Array.&lt;Mutation&gt;</code>
         * [.destroy(document)](#CozyClient+destroy) ⇒ [<code>Document</code>](#Document)
         * [.query(queryDefinition, options)](#CozyClient+query) ⇒ <code>QueryResult</code>
         * [.queryAll(queryDefinition, options)](#CozyClient+queryAll) ⇒ <code>Array</code>
@@ -747,7 +752,7 @@ Responsible for
 | options.link | <code>Link</code> | Backward compatibility |
 | options.links | <code>Array.Link</code> | List of links |
 | options.schema | <code>object</code> | Schema description for each doctypes |
-| options.appMetadata | <code>object</code> | Metadata about the application that will be used in ensureCozyMetadata Cozy-Client will automatically call `this.login()` if provided with a token and an uri |
+| options.appMetadata | <code>object</code> | Metadata about the application that will be used in ensureCozyMetadata |
 
 <a name="CozyClient+registerPlugin"></a>
 
@@ -768,7 +773,7 @@ Two plugins with the same `pluginName` cannot co-exist.
 
 **Kind**: instance method of [<code>CozyClient</code>](#CozyClient)  
 **Example**  
-```
+```js
 class AlertPlugin {
   constructor(client, options) {
     this.client = client
@@ -845,9 +850,34 @@ a [DocumentCollection](https://docs.cozy.io/en/cozy-client/api/cozy-stack-client
 | --- | --- | --- |
 | doctype | <code>string</code> | The collection doctype. |
 
+<a name="CozyClient+create"></a>
+
+### cozyClient.create(type, doc, references, options) ⇒ <code>Promise</code>
+Creates a document and saves it on the server
+
+**Kind**: instance method of [<code>CozyClient</code>](#CozyClient)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| type | <code>string</code> | Doctype of the document |
+| doc | <code>object</code> | Document to save |
+| references | [<code>Array.&lt;Reference&gt;</code>](#Reference) | (Optional) References are a special kind of relationship that is not stored inside the referencer document, they are used for example between a photo and its album. You should not need to use it normally. |
+| options | <code>object</code> | Mutation options |
+
+**Example**  
+```js
+await client.create('io.cozy.todos', {
+  label: 'My todo',
+  relationships: {
+    authors: {
+      data: [{_id: 1, _type: 'io.cozy.persons'}]
+    }
+  }
+})
+```
 <a name="CozyClient+getDocumentSavePlan"></a>
 
-### cozyClient.getDocumentSavePlan(document, relationships) ⇒ <code>Array.&lt;Mutation&gt;</code>
+### cozyClient.getDocumentSavePlan(document, [referencesByName]) ⇒ <code>Array.&lt;Mutation&gt;</code>
 Creates a list of mutations to execute to create a document and its relationships.
 
 ```js
@@ -865,8 +895,8 @@ client.getDocumentSavePlan(baseDoc, relationships)
 
 | Param | Type | Description |
 | --- | --- | --- |
-| document | <code>object</code> | The base document to create |
-| relationships | <code>object</code> | The list of relationships to add, as a dictionnary. Keys should be relationship names and values the documents to link. |
+| document | <code>object</code> | Document to create |
+| [referencesByName] | <code>object.&lt;string, Array.&lt;Reference&gt;&gt;</code> | References to the created document. The relationship class associated to each reference list should support references, otherwise this method will throw. |
 
 <a name="CozyClient+destroy"></a>
 
@@ -2288,6 +2318,20 @@ HOC to provide mutations to components. Needs client in context or as prop.
 
 ## QueryState : <code>object</code>
 **Kind**: global typedef  
+<a name="Reference"></a>
+
+## Reference : <code>object</code>
+A reference to a document (special case of a relationship used between photos and albums)
+https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.files/#references
+
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| _id | <code>string</code> | id of the document |
+| _type | <code>string</code> | doctype of the document |
+
 <a name="CozyAccount"></a>
 
 ## CozyAccount : <code>object</code>

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -52,6 +52,19 @@ const deprecatedHandler = msg => ({
   }
 })
 
+const supportsReferences = relationshipClass => {
+  return (
+    relationshipClass.prototype.addReferences &&
+    relationshipClass.prototype.removeReferences
+  )
+}
+
+const referencesUnsupportedError = relationshipClassName => {
+  return new Error(
+    `The "${relationshipClassName}" relationship does not support references. If you need to add references to a document, its relationship class must have the methods {add,remove}References`
+  )
+}
+
 /**
  * @typedef {object} Link
  * @typedef {object} Mutation
@@ -60,6 +73,15 @@ const deprecatedHandler = msg => ({
  * @typedef {object} HydratedDocument
  * @typedef {object} ReduxStore
  * @typedef {object} QueryState
+ */
+
+/**
+ * A reference to a document (special case of a relationship used between photos and albums)
+ * https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.files/#references
+ *
+ * @typedef {object} Reference
+ * @property {string} _id - id of the document
+ * @property {string} _type - doctype of the document
  */
 
 const TRIGGER_CREATION = 'creation'
@@ -80,6 +102,23 @@ class CozyClient {
    * @param  {Array.Link}   options.links  - List of links
    * @param  {object}       options.schema - Schema description for each doctypes
    * @param  {object}       options.appMetadata - Metadata about the application that will be used in ensureCozyMetadata
+   *
+   * @example
+   * ```js
+   * const client = new CozyClient({
+   *   schema: {
+   *     todos: {
+   *       doctype: 'io.cozy.todos',
+   *       relationships: {
+   *         authors: {
+   *           type: 'has-many',
+   *           doctype: 'io.cozy.persons'
+   *         }
+   *       }
+   *     }
+   *   }
+   * })
+   * ```
    *
    * Cozy-Client will automatically call `this.login()` if provided with a token and an uri
    */
@@ -139,7 +178,7 @@ class CozyClient {
    * Two plugins with the same `pluginName` cannot co-exist.
    *
    * @example
-   * ```
+   * ```js
    * class AlertPlugin {
    *   constructor(client, options) {
    *     this.client = client
@@ -430,12 +469,37 @@ client.query(Q('io.cozy.bills'))`)
     return new QueryDefinition({ doctype, id })
   }
 
-  async create(type, { _type, ...attributes }, relationships, options = {}) {
-    const document = { _type: type, ...attributes }
+  /**
+   * Creates a document and saves it on the server
+   *
+   * @param  {string} type - Doctype of the document
+   * @param  {object} doc - Document to save
+   * @param  {Array.<Reference>} references - (Optional) References are a special kind of relationship
+   * that is not stored inside the referencer document, they are used for example between a photo
+   * and its album. You should not need to use it normally.
+   * @param  {object} options - Mutation options
+   *
+   * @example
+   * ```js
+   * await client.create('io.cozy.todos', {
+   *   label: 'My todo',
+   *   relationships: {
+   *     authors: {
+   *       data: [{_id: 1, _type: 'io.cozy.persons'}]
+   *     }
+   *   }
+   * })
+   * ```
+   *
+   * @returns {Promise}
+   */
+  async create(type, doc, references, options = {}) {
+    const { _type, ...attributes } = doc
+    const normalizedDoc = { _type: type, ...attributes }
     const ret = await this.schema.validate(document)
     if (ret !== true) throw new Error('Validation failed')
     return this.mutate(
-      this.getDocumentSavePlan(document, relationships),
+      this.getDocumentSavePlan(normalizedDoc, references),
       options
     )
   }
@@ -521,39 +585,58 @@ client.query(Q('io.cozy.bills'))`)
    * client.getDocumentSavePlan(baseDoc, relationships)
    * ```
    *
-   * @param  {object} document      The base document to create
-   * @param  {object} relationships The list of relationships to add, as a dictionnary. Keys should be relationship names and values the documents to link.
+   * @param  {object} document - Document to create
+   * @param  {object.<string, Array.<Reference>>} [referencesByName] - References to the created document. The
+   * relationship class associated to each reference list should support references, otherwise this
+   * method will throw.
+   *
    * @returns {Mutation[]}  One or more mutation to execute
    */
-  getDocumentSavePlan(document, relationships) {
-    const newDocument = !document._rev
+  getDocumentSavePlan(document, referencesByName) {
+    const isNewDoc = !document._rev
     const dehydratedDoc = this.ensureCozyMetadata(dehydrate(document), {
-      event: newDocument ? TRIGGER_CREATION : TRIGGER_UPDATE
+      event: isNewDoc ? TRIGGER_CREATION : TRIGGER_UPDATE
     })
 
-    const saveMutation = newDocument
+    const saveMutation = isNewDoc
       ? Mutations.createDocument(dehydratedDoc)
       : Mutations.updateDocument(dehydratedDoc)
-    const hasRelationships =
-      relationships &&
-      Object.values(relationships).filter(relations => {
-        return Array.isArray(relations) ? relations.length > 0 : relations
+
+    const hasReferences =
+      referencesByName &&
+      Object.values(referencesByName).filter(references => {
+        return Array.isArray(references) ? references.length > 0 : references
       }).length > 0
-    if (!hasRelationships) {
+
+    if (!hasReferences) {
       return saveMutation
+    } else {
+      for (let relName of Object.keys(referencesByName)) {
+        const doctype = document._type
+        const doctypeRelationship = this.schema.getRelationship(
+          doctype,
+          relName
+        )
+        const relationshipClass = doctypeRelationship.type
+        if (!supportsReferences(relationshipClass)) {
+          throw referencesUnsupportedError(doctypeRelationship.name)
+        }
+      }
     }
-    if (relationships && !newDocument) {
-      throw new Error('Unable to save relationships on a not-new document')
+
+    if (referencesByName && !isNewDoc) {
+      throw new Error(
+        'Unable to save external relationships on a not-new document'
+      )
     }
+
     return [
       saveMutation,
       response => {
         const document = this.hydrateDocument(response.data)
-        return Object.entries(relationships).map(([relName, relItem]) => {
+        return Object.entries(referencesByName).map(([relName, references]) => {
           const relationship = document[relName]
-          return Array.isArray(relItem)
-            ? relationship.insertDocuments(relItem)
-            : relationship.setDocument(relItem)
+          return relationship.addReferences(references)
         })
       }
     ]
@@ -837,11 +920,11 @@ client.query(Q('io.cozy.bills'))`)
       const [first, ...rest] = definition
       const firstResponse = await this.requestMutation(first)
       await Promise.all(
-        rest.map(def =>
-          typeof def === 'function'
-            ? this.requestMutation(def(firstResponse))
-            : this.requestMutation(def)
-        )
+        rest.map(def => {
+          const mutationDef =
+            typeof def === 'function' ? def(firstResponse) : def
+          return this.requestMutation(mutationDef)
+        })
       )
       return firstResponse
     }

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -549,11 +549,11 @@ client.query(Q('io.cozy.bills'))`)
       saveMutation,
       response => {
         const document = this.hydrateDocument(response.data)
-        return Object.keys(relationships).map(name => {
-          const val = relationships[name]
-          return Array.isArray(val)
-            ? document[name].insertDocuments(val)
-            : document[name].setDocument(val)
+        return Object.entries(relationships).map(([relName, relItem]) => {
+          const relationship = document[relName]
+          return Array.isArray(relItem)
+            ? relationship.insertDocuments(relItem)
+            : relationship.setDocument(relItem)
         })
       }
     ]

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -1383,19 +1383,21 @@ describe('CozyClient', () => {
 
 describe('file creation', () => {
   const setup = () => {
-    const client = new CozyClient({})
+    const client = new CozyClient({
+      schema: SCHEMA
+    })
     const fileCol = new FileCollection('io.cozy.files', client.stackClient)
     client.stackClient.collection.mockReturnValue(fileCol)
-    return { client }
-  }
-
-  it('should be possible to create a directory', async () => {
-    const { client } = setup()
     client.stackClient.fetchJSON = jest.fn().mockResolvedValue({
       data: {
         _id: '1337'
       }
     })
+    return { client }
+  }
+
+  it('should be possible to create a directory', async () => {
+    const { client } = setup()
     const { data: doc } = await client.create('io.cozy.files', {
       dirId: 'dirid1337',
       type: 'directory',
@@ -1412,11 +1414,6 @@ describe('file creation', () => {
 
   it('should be possible to create a file', async () => {
     const { client } = setup()
-    client.stackClient.fetchJSON = jest.fn().mockResolvedValue({
-      data: {
-        _id: '1337'
-      }
-    })
     jest.spyOn(client, 'dispatch')
     const data = 'file-content'
     const { data: doc } = await client.create('io.cozy.files', {

--- a/packages/cozy-client/src/Schema.js
+++ b/packages/cozy-client/src/Schema.js
@@ -123,7 +123,16 @@ class Schema {
    * Returns the relationship for a given doctype/name
    */
   getRelationship(doctype, relationshipName) {
+    if (!doctype) {
+      throw new TypeError(`Invalid doctype ${doctype}`)
+    }
     const schema = this.getDoctypeSchema(doctype)
+    if (!schema) {
+      throw new Error(`Cannot find doctype ${doctype} in schema`)
+    }
+    if (!schema.relationships) {
+      throw new Error(`Schema for doctype ${doctype} has no relationships`)
+    }
     return schema.relationships[relationshipName]
   }
 

--- a/packages/cozy-client/src/associations/HasManyFiles.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.js
@@ -47,23 +47,23 @@ export default class HasManyFiles extends HasMany {
       _id: id,
       _type: this.doctype
     }))
-    await this.mutate(this.insertDocuments(relations))
+    await this.mutate(this.addReferences(relations))
 
     await super.addById(ids)
   }
 
   async removeById(idsArg) {
     const ids = Array.isArray(idsArg) ? idsArg : [idsArg]
-    const relations = ids.map(id => ({
+    const references = ids.map(id => ({
       _id: id,
       _type: this.doctype
     }))
-    await this.mutate(this.removeDocuments(relations))
+    await this.mutate(this.removeReferences(references))
 
     await super.removeById(ids)
   }
 
-  insertDocuments(referencedDocs) {
+  addReferences(referencedDocs) {
     if (this.target._type === 'io.cozy.files') {
       return Mutations.addReferencedBy(this.target, referencedDocs)
     } else if (referencedDocs[0]._type === 'io.cozy.files') {
@@ -75,7 +75,7 @@ export default class HasManyFiles extends HasMany {
     }
   }
 
-  removeDocuments(referencedDocs) {
+  removeReferences(referencedDocs) {
     if (this.target._type === 'io.cozy.files') {
       return Mutations.removeReferencedBy(this.target, referencedDocs)
     } else if (referencedDocs[0]._type === 'io.cozy.files') {


### PR DESCRIPTION
- The relationships attribute in CozyClient::create should only be used
  for references. Here, it's made clearer by renaming the attribute to
  references and by adding documentation

- In the case of references, if the relationship class does not
  support them, we throw before creating the document, since the developer should probably use
  the relationship attribute directly in the document (probably managing the relationship attribute
  with helpers from HasMany)