### PR TITLE
fix: HasMany helpers

### DIFF
--- a/packages/cozy-client/src/associations/HasMany.js
+++ b/packages/cozy-client/src/associations/HasMany.js
@@ -290,8 +290,8 @@ export const updateRelationship = (HasMany.updateRelationship = (
     relationships: {
       ...doc.relationships,
       [relName]: {
-        ...doc.relationships[relName],
-        ...updateFn(doc.relationships[name])
+        ...(doc.relationships ? doc.relationships[relName] : {}),
+        ...updateFn(doc.relationships ? doc.relationships[relName] : {})
       }
     }
   }

--- a/packages/cozy-client/src/associations/HasMany.spec.js
+++ b/packages/cozy-client/src/associations/HasMany.spec.js
@@ -150,7 +150,7 @@ describe('HasMany', () => {
 })
 
 describe('HasMany static helpers', () => {
-  it('should work', () => {
+  it('should work with a doc that already have setted relationships', () => {
     const doc = {
       _id: 'doc-1',
       label: 'Document 1',
@@ -176,5 +176,23 @@ describe('HasMany static helpers', () => {
 
     expect(doc2).toMatchSnapshot()
     expect(doc3).toMatchSnapshot()
+  })
+
+  it(`should work with a doc that don't have relationships yet`, () => {
+    const docWithoutRelationships = {
+      _id: 'doc-1',
+      label: 'Document 1'
+    }
+
+    const docWithRelationships = HasMany.setHasManyItem(
+      docWithoutRelationships,
+      'books',
+      'book-1',
+      {
+        _id: 'book-1',
+        _type: 'io.cozy.books'
+      }
+    )
+    expect(docWithRelationships).toMatchSnapshot()
   })
 })

--- a/packages/cozy-client/src/associations/__snapshots__/HasMany.spec.js.snap
+++ b/packages/cozy-client/src/associations/__snapshots__/HasMany.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HasMany static helpers should work 1`] = `
+exports[`HasMany static helpers should work with a doc that already have setted relationships 1`] = `
 Object {
   "_id": "doc-1",
   "label": "Document 1",
@@ -34,7 +34,7 @@ Object {
 }
 `;
 
-exports[`HasMany static helpers should work 2`] = `
+exports[`HasMany static helpers should work with a doc that already have setted relationships 2`] = `
 Object {
   "_id": "doc-1",
   "label": "Document 1",
@@ -64,6 +64,23 @@ Object {
           "metadata": Object {
             "read": true,
           },
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`HasMany static helpers should work with a doc that don't have relationships yet 1`] = `
+Object {
+  "_id": "doc-1",
+  "label": "Document 1",
+  "relationships": Object {
+    "books": Object {
+      "data": Array [
+        Object {
+          "_id": "book-1",
+          "_type": "io.cozy.books",
         },
       ],
     },


### PR DESCRIPTION
We can setHasManyItem on a document that don't
have relationships yet.