### PR TITLE
feat: Add options.hydrated on client.query

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -719,20 +719,19 @@ client.query(Q('io.cozy.bills'))`)
    * @param  {string} options - Options
    * @param  {string} options.as - Names the query so it can be reused (by multiple components for example)
    * @param  {string} options.fetchPolicy - Fetch policy to bypass fetching based on what's already inside the state. See "Fetch policies"
+   * @param  {boolean} options.hydrated - Whether documents should be returned already hydrated (default: false)
    * @returns {QueryResult}
    */
   async query(queryDefinition, { update, ...options } = {}) {
     this.ensureStore()
     const queryId = options.as || this.generateId()
     this.ensureQueryExists(queryId, queryDefinition)
-
     if (options.fetchPolicy) {
       if (!options.as) {
         throw new Error(
           'Cannot use `fetchPolicy` without naming the query, please use `as` to name the query'
         )
       }
-
       const existingQuery = this.getQueryFromState(queryId)
       const shouldFetch = options.fetchPolicy(existingQuery)
       if (!shouldFetch) {
@@ -747,6 +746,9 @@ client.query(Q('io.cozy.bills'))`)
           update
         })
       )
+      if (options.hydrated) {
+        return this.getQueryFromState(queryId, { hydrated: options.hydrated })
+      }
       return response
     } catch (error) {
       this.dispatch(receiveQueryError(queryId, error))


### PR DESCRIPTION
It's currently a WIP (without test) because I'm not sure that using `getQueryFromState` to hydrate is the way to go. 

I can use directly `hydrateDocuments()` but I'm wondering if we should not add `singleDoc` also to `query()` to share the same API & behavior than `useQuery` or `ObservableQuery`

With that in mind, I think that we can remove `return response` and only do `return this.getQueryFromState(queryId,  options)`

What do you think @ptbrowne ?

(related to https://github.com/cozy/cozy-client/issues/493) 