### PR TITLE
fix: Rename fetchFileContent to fetchFilecontentById

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -402,7 +402,7 @@ files associated to a specific document
     * [.create(attributes)](#FileCollection+create)
     * [.updateFile(data, params)](#FileCollection+updateFile) ⇒ <code>object</code>
     * [.download(file, versionId, filename)](#FileCollection+download)
-    * [.fetchFileContent(id)](#FileCollection+fetchFileContent)
+    * [.fetchFileContentById(id)](#FileCollection+fetchFileContentById)
     * [.getBeautifulSize(file, decimal)](#FileCollection+getBeautifulSize)
     * [.isChildOf(child, parent)](#FileCollection+isChildOf) ⇒ <code>boolean</code>
     * [.statById(id, [options])](#FileCollection+statById) ⇒ <code>object</code>
@@ -631,9 +631,9 @@ Download a file or a specific version of the file
 | versionId | <code>string</code> | <code>null</code> | Id of the io.cozy.files.version |
 | filename | <code>string</code> |  | The name you want for the downloaded file                            (by default the same as the file) |
 
-<a name="FileCollection+fetchFileContent"></a>
+<a name="FileCollection+fetchFileContentById"></a>
 
-### fileCollection.fetchFileContent(id)
+### fileCollection.fetchFileContentById(id)
 Fetch the binary of a file or a specific version of a file
 Useful for instance when you can't download the file directly
 (via a content-disposition attachement header) and need to store

--- a/packages/cozy-client/src/StackLink.js
+++ b/packages/cozy-client/src/StackLink.js
@@ -5,7 +5,7 @@ export default class StackLink extends CozyLink {
   constructor({ client, stackClient } = {}) {
     super()
     if (client) {
-      console.info(
+      console.warn(
         'Using options.client is deprecated, prefer options.stackClient'
       )
     }

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -494,6 +494,13 @@ class FileCollection extends DocumentCollection {
     forceFileDownload(`${href}?Dl=1`, filenameToUse)
   }
 
+  async fetchFileContent(id) {
+    console.warn(
+      'FileCollection.fetchFileContent() is deprecated. Use FileCollection.fetchFileContentById() instead'
+    )
+    return this.fetchFileContentById(id)
+  }
+
   /**
    * Fetch the binary of a file or a specific version of a file
    * Useful for instance when you can't download the file directly
@@ -503,9 +510,10 @@ class FileCollection extends DocumentCollection {
    * @param {string} id Id of the io.cozy.files or io.cozy.files.version
    *
    */
-  async fetchFileContent(id) {
+  async fetchFileContentById(id) {
     return this.stackClient.fetch('GET', `/files/download/${id}`)
   }
+
   /**
    * Get a beautified size for a given file
    * 1024B => 1KB

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -803,11 +803,11 @@ describe('FileCollection', () => {
     })
   })
 
-  describe('fetchFileContent', () => {
+  describe('fetchFileContentById', () => {
     it('should fetch the content of a file', async () => {
       const FILE_ID = 'd04ab491-2fc6'
 
-      await collection.fetchFileContent(FILE_ID)
+      await collection.fetchFileContentById(FILE_ID)
       expect(client.fetch).toHaveBeenCalledWith(
         'GET',
         '/files/download/d04ab491-2fc6'


### PR DESCRIPTION
Deprecate fetchFileContent and replace it by fetchFileContentById() 