### PR TITLE
fix: Use cozy's fork of minilog

### DIFF
--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -12,6 +12,7 @@
     "url": "git+https://github.com/cozy/cozy-client.git"
   },
   "dependencies": {
+    "@cozy/minilog": "1.0.0",
     "btoa": "^1.2.1",
     "cozy-device-helper": "^1.7.3",
     "cozy-logger": "^1.6.0",
@@ -19,7 +20,6 @@
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.13",
     "microee": "^0.0.6",
-    "minilog": "https://github.com/cozy/minilog.git#master",
     "open": "^7.0.2",
     "prop-types": "^15.6.2",
     "react-redux": "^7.2.0",

--- a/packages/cozy-client/src/logger.js
+++ b/packages/cozy-client/src/logger.js
@@ -1,4 +1,4 @@
-import minilog from 'minilog'
+import minilog from '@cozy/minilog'
 
 const logger = minilog('cozy-client')
 minilog.suggest.deny('cozy-client', 'info')

--- a/packages/cozy-pouch-link/package.json
+++ b/packages/cozy-pouch-link/package.json
@@ -11,9 +11,9 @@
     "url": "git+https://github.com/cozy/cozy-client.git"
   },
   "dependencies": {
+    "@cozy/minilog": "1.0.0",
     "cozy-client": "^15.4.1",
     "cozy-device-helper": "^1.7.3",
-    "minilog": "^3.1.0",
     "pouchdb-browser": "^7.0.0",
     "pouchdb-find": "^7.0.0"
   },

--- a/packages/cozy-pouch-link/src/logger.js
+++ b/packages/cozy-pouch-link/src/logger.js
@@ -1,4 +1,4 @@
-import minilog from 'minilog'
+import minilog from '@cozy/minilog'
 
 const logger = minilog('cozy-pouch-link')
 minilog.suggest.deny('cozy-pouch-link', 'info')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1759,6 +1759,13 @@
   dependencies:
     eslint-config-cozy-app "^1.5.0"
 
+"@cozy/minilog@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@cozy/minilog/-/minilog-1.0.0.tgz#1acc1aad849261e931e255a5f181b638315f7b84"
+  integrity sha512-IkDHF9CLh0kQeSEVsou59ar/VehvenpbEUjLfwhckJyOUqZnKAWmXy8qrBgMT5Loxr8Xjs2wmMnj0D67wP00eQ==
+  dependencies:
+    microee "0.0.6"
+
 "@emotion/cache@^10.0.27":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
@@ -9589,12 +9596,6 @@ min-document@^2.19.0:
   integrity sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
   dependencies:
     dom-walk "^0.1.0"
-
-minilog@^3.1.0, "minilog@https://github.com/cozy/minilog.git#master":
-  version "3.1.0"
-  resolved "https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
-  dependencies:
-    microee "0.0.6"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Let's use the cozy's fork of minilog to support `octal literals in strict mode`