### PR TITLE
Feat/create sharing

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -89,8 +89,14 @@ through OAuth.</p>
 <dt><a href="#Stream">Stream</a> : <code>object</code></dt>
 <dd><p>Stream is not defined in a browser, but is on NodeJS environment</p>
 </dd>
-<dt><a href="#Recipient">Recipient</a> : <code>object</code></dt>
+<dt><a href="#Rule">Rule</a> : <code>object</code></dt>
 <dd><p>A sharing rule</p>
+</dd>
+<dt><a href="#Recipient">Recipient</a> : <code>object</code></dt>
+<dd><p>An io.cozy.contact</p>
+</dd>
+<dt><a href="#Sharing">Sharing</a> : <code>object</code></dt>
+<dd><p>An io.cozy.sharings document</p>
 </dd>
 </dl>
 
@@ -1131,7 +1137,7 @@ Implements the `DocumentCollection` API along with specific methods for
     * [.create(params)](#SharingCollection+create)
     * ~~[.share(document, recipients, sharingType, description, [previewPath])](#SharingCollection+share)~~
     * [.getDiscoveryLink(sharingId, sharecode)](#SharingCollection+getDiscoveryLink) ⇒ <code>string</code>
-    * [.addRecipients(sharing, [recipients], [sharingType])](#SharingCollection+addRecipients)
+    * [.addRecipients(options)](#SharingCollection+addRecipients)
     * [.revokeRecipient(sharing, recipientIndex)](#SharingCollection+revokeRecipient)
     * [.revokeSelf(sharing)](#SharingCollection+revokeSelf)
     * [.revokeAllRecipients(sharing)](#SharingCollection+revokeAllRecipients)
@@ -1146,10 +1152,10 @@ Creates a new Sharing. See https://docs.cozy.io/en/cozy-stack/sharing/#post-shar
 | Param | Type | Description |
 | --- | --- | --- |
 | params | <code>object</code> | Sharing  params |
-| params.document | <code>object</code> | The document to share |
+| params.document | [<code>Sharing</code>](#Sharing) | The document to share |
 | params.description | <code>string</code> | Description of the sharing |
 | [params.previewPath] | <code>string</code> | The preview path |
-| [params.rules] | <code>Array.&lt;Rule&gt;</code> | The rules defined to the sharing. See https://docs.cozy.io/en/cozy-stack/sharing-design/#description-of-a-sharing |
+| [params.rules] | [<code>Array.&lt;Rule&gt;</code>](#Rule) | The rules defined to the sharing. See https://docs.cozy.io/en/cozy-stack/sharing-design/#description-of-a-sharing |
 | [params.recipients] | [<code>Array.&lt;Recipient&gt;</code>](#Recipient) | Recipients to add to the sharings (will have the same permissions given by the rules defined by the sharing ) |
 | [params.readOnlyRecipients] | [<code>Array.&lt;Recipient&gt;</code>](#Recipient) | Recipients to add to the sharings with only read only access |
 | [params.openSharing] | <code>boolean</code> | If someone else than the owner can add a recipient to the sharing |
@@ -1163,7 +1169,7 @@ Creates a new Sharing. See https://docs.cozy.io/en/cozy-stack/sharing/#post-shar
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| document | <code>object</code> |  | The document to share. Should have and _id and a name. |
+| document | [<code>Sharing</code>](#Sharing) |  | The document to share. Should have and _id and a name. |
 | recipients | <code>Array</code> |  | A list of io.cozy.contacts |
 | sharingType | <code>string</code> |  | If "two-way", will set the open_sharing attribute to true |
 | description | <code>string</code> |  | Describes the sharing |
@@ -1183,16 +1189,17 @@ getDiscoveryLink - Returns the URL of the page that can be used to accept a shar
 
 <a name="SharingCollection+addRecipients"></a>
 
-### sharingCollection.addRecipients(sharing, [recipients], [sharingType])
+### sharingCollection.addRecipients(options)
 Add an array of contacts to the Sharing
 
 **Kind**: instance method of [<code>SharingCollection</code>](#SharingCollection)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| sharing | <code>object</code> | Sharing Object |
-| [recipients] | <code>Array</code> | Array of {id:1, type:"io.cozy.contacts"} |
-| [sharingType] | <code>string</code> | Read and write: two-way. Other only read |
+| options | <code>object</code> | Object |
+| options.document | [<code>Sharing</code>](#Sharing) | Sharing Object |
+| [options.recipients] | [<code>Array.&lt;Recipient&gt;</code>](#Recipient) | Recipients to add to the sharing |
+| [options.readOnlyRecipients] | [<code>Array.&lt;Recipient&gt;</code>](#Recipient) | Recipients to add to the sharings with only read only access |
 
 <a name="SharingCollection+revokeRecipient"></a>
 
@@ -1429,9 +1436,9 @@ Document representing a io.cozy.files
 Stream is not defined in a browser, but is on NodeJS environment
 
 **Kind**: global typedef  
-<a name="Recipient"></a>
+<a name="Rule"></a>
 
-## Recipient : <code>object</code>
+## Rule : <code>object</code>
 A sharing rule
 
 **Kind**: global typedef  
@@ -1446,3 +1453,15 @@ A sharing rule
 | [update] | <code>string</code> | 
 | [remove] | <code>string</code> | 
 
+<a name="Recipient"></a>
+
+## Recipient : <code>object</code>
+An io.cozy.contact
+
+**Kind**: global typedef  
+<a name="Sharing"></a>
+
+## Sharing : <code>object</code>
+An io.cozy.sharings document
+
+**Kind**: global typedef  

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -1131,7 +1131,7 @@ Implements the `DocumentCollection` API along with specific methods for
     * [.create(params)](#SharingCollection+create)
     * ~~[.share(document, recipients, sharingType, description, [previewPath])](#SharingCollection+share)~~
     * [.getDiscoveryLink(sharingId, sharecode)](#SharingCollection+getDiscoveryLink) ⇒ <code>string</code>
-    * [.addRecipients(sharing, recipients, sharingType)](#SharingCollection+addRecipients)
+    * [.addRecipients(sharing, [recipients], [sharingType])](#SharingCollection+addRecipients)
     * [.revokeRecipient(sharing, recipientIndex)](#SharingCollection+revokeRecipient)
     * [.revokeSelf(sharing)](#SharingCollection+revokeSelf)
     * [.revokeAllRecipients(sharing)](#SharingCollection+revokeAllRecipients)
@@ -1183,7 +1183,7 @@ getDiscoveryLink - Returns the URL of the page that can be used to accept a shar
 
 <a name="SharingCollection+addRecipients"></a>
 
-### sharingCollection.addRecipients(sharing, recipients, sharingType)
+### sharingCollection.addRecipients(sharing, [recipients], [sharingType])
 Add an array of contacts to the Sharing
 
 **Kind**: instance method of [<code>SharingCollection</code>](#SharingCollection)  
@@ -1191,8 +1191,8 @@ Add an array of contacts to the Sharing
 | Param | Type | Description |
 | --- | --- | --- |
 | sharing | <code>object</code> | Sharing Object |
-| recipients | <code>Array</code> | Array of {id:1, type:"io.cozy.contacts"} |
-| sharingType | <code>string</code> | Read and write: two-way. Other only read |
+| [recipients] | <code>Array</code> | Array of {id:1, type:"io.cozy.contacts"} |
+| [sharingType] | <code>string</code> | Read and write: two-way. Other only read |
 
 <a name="SharingCollection+revokeRecipient"></a>
 

--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -193,12 +193,12 @@ SharingCollection.normalizeDoctype = DocumentCollection.normalizeDoctypeJsonApi
 export const getSharingRules = (document, sharingType) => {
   if (sharingType) {
     console.warn(
-      `sharingType is deprecated and will be removed. We now set this default policy : ${
+      `sharingType is deprecated and will be removed. We now set this default rules: ${
         isFile(document)
           ? getSharingRulesForFile(document)
           : getSharingRulesForPhotosAlbum(document)
       }} \n      
-      If this default policy doesn't follow your need, please set custom rules 
+      If this default rules do not fill your need, please set custom rules 
       by using the 'rules' object of the SharingCollection.create() method`
     )
   }

--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -67,10 +67,14 @@ class SharingCollection extends DocumentCollection {
           rules: rules ? rules : getSharingRules(document)
         },
         relationships: {
-          recipients: { data: recipients.map(toRelationshipItem) },
-          read_only_recipients: {
-            data: readOnlyRecipients.map(toRelationshipItem)
-          }
+          ...(recipients.length > 0 && {
+            recipients: { data: recipients.map(toRelationshipItem) }
+          }),
+          ...(readOnlyRecipients.length > 0 && {
+            read_only_recipients: {
+              data: readOnlyRecipients.map(toRelationshipItem)
+            }
+          })
         }
       }
     })

--- a/packages/cozy-stack-client/src/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/SharingCollection.spec.js
@@ -415,7 +415,7 @@ describe('SharingCollection', () => {
       client.fetchJSON.mockReturnValue(Promise.resolve({ data: [] }))
     })
 
-    it('should accept recipient API', async () => {
+    it('handle the recipients option', async () => {
       await collection.addRecipients({
         document: SHARING,
         recipients: [RECIPIENT]
@@ -437,7 +437,7 @@ describe('SharingCollection', () => {
         }
       )
     })
-    it('should accept read only', async () => {
+    it('should accept the readOnlyRecipients option', async () => {
       await collection.addRecipients({
         document: SHARING,
         readOnlyRecipients: [RECIPIENT]
@@ -459,7 +459,7 @@ describe('SharingCollection', () => {
         }
       )
     })
-    it('should accept both', async () => {
+    it('should accept both options', async () => {
       await collection.addRecipients({
         document: SHARING,
         readOnlyRecipients: [RECIPIENT],

--- a/packages/cozy-stack-client/src/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/SharingCollection.spec.js
@@ -366,49 +366,6 @@ describe('SharingCollection', () => {
     })
   })
 
-  describe('addRecipients Old API', () => {
-    beforeEach(() => {
-      jest.spyOn(console, 'warn').mockImplementation(() => {})
-      client.fetch.mockReset()
-      client.fetchJSON.mockReturnValue(Promise.resolve({ data: [] }))
-    })
-
-    it('should accept old API', async () => {
-      await collection.addRecipients(SHARING, [RECIPIENT], 'two-way')
-      expect(client.fetchJSON).toHaveBeenCalledWith(
-        'POST',
-        `/sharings/${SHARING._id}/recipients`,
-        {
-          data: {
-            id: SHARING._id,
-            relationships: {
-              recipients: {
-                data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
-              }
-            },
-            type: 'io.cozy.sharings'
-          }
-        }
-      )
-      await collection.addRecipients(SHARING, [RECIPIENT], 'one-way')
-      expect(client.fetchJSON).toHaveBeenCalledWith(
-        'POST',
-        `/sharings/${SHARING._id}/recipients`,
-        {
-          data: {
-            id: SHARING._id,
-            relationships: {
-              read_only_recipients: {
-                data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
-              }
-            },
-            type: 'io.cozy.sharings'
-          }
-        }
-      )
-    })
-  })
-
   describe('addRecipients', () => {
     beforeEach(() => {
       client.fetch.mockReset()
@@ -429,8 +386,7 @@ describe('SharingCollection', () => {
             relationships: {
               recipients: {
                 data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
-              },
-              read_only_recipients: { data: [] }
+              }
             },
             type: 'io.cozy.sharings'
           }
@@ -449,7 +405,6 @@ describe('SharingCollection', () => {
           data: {
             id: SHARING._id,
             relationships: {
-              recipients: { data: [] },
               read_only_recipients: {
                 data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
               }

--- a/packages/cozy-stack-client/src/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/SharingCollection.spec.js
@@ -365,4 +365,124 @@ describe('SharingCollection', () => {
       )
     })
   })
+
+  describe('addRecipients Old API', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'warn').mockImplementation(() => {})
+      client.fetch.mockReset()
+      client.fetchJSON.mockReturnValue(Promise.resolve({ data: [] }))
+    })
+
+    it('should accept old API', async () => {
+      await collection.addRecipients(SHARING, [RECIPIENT], 'two-way')
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        `/sharings/${SHARING._id}/recipients`,
+        {
+          data: {
+            id: SHARING._id,
+            relationships: {
+              recipients: {
+                data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
+              }
+            },
+            type: 'io.cozy.sharings'
+          }
+        }
+      )
+      await collection.addRecipients(SHARING, [RECIPIENT], 'one-way')
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        `/sharings/${SHARING._id}/recipients`,
+        {
+          data: {
+            id: SHARING._id,
+            relationships: {
+              read_only_recipients: {
+                data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
+              }
+            },
+            type: 'io.cozy.sharings'
+          }
+        }
+      )
+    })
+  })
+
+  describe('addRecipients', () => {
+    beforeEach(() => {
+      client.fetch.mockReset()
+      client.fetchJSON.mockReturnValue(Promise.resolve({ data: [] }))
+    })
+
+    it('should accept recipient API', async () => {
+      await collection.addRecipients({
+        document: SHARING,
+        recipients: [RECIPIENT]
+      })
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        `/sharings/${SHARING._id}/recipients`,
+        {
+          data: {
+            id: SHARING._id,
+            relationships: {
+              recipients: {
+                data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
+              },
+              read_only_recipients: { data: [] }
+            },
+            type: 'io.cozy.sharings'
+          }
+        }
+      )
+    })
+    it('should accept read only', async () => {
+      await collection.addRecipients({
+        document: SHARING,
+        readOnlyRecipients: [RECIPIENT]
+      })
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        `/sharings/${SHARING._id}/recipients`,
+        {
+          data: {
+            id: SHARING._id,
+            relationships: {
+              recipients: { data: [] },
+              read_only_recipients: {
+                data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
+              }
+            },
+            type: 'io.cozy.sharings'
+          }
+        }
+      )
+    })
+    it('should accept both', async () => {
+      await collection.addRecipients({
+        document: SHARING,
+        readOnlyRecipients: [RECIPIENT],
+        recipients: [RECIPIENT]
+      })
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        `/sharings/${SHARING._id}/recipients`,
+        {
+          data: {
+            id: SHARING._id,
+            relationships: {
+              read_only_recipients: {
+                data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
+              },
+              recipients: {
+                data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
+              }
+            },
+            type: 'io.cozy.sharings'
+          }
+        }
+      )
+    })
+  })
 })

--- a/packages/cozy-stack-client/src/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/SharingCollection.spec.js
@@ -86,8 +86,7 @@ describe('SharingCollection', () => {
           relationships: {
             read_only_recipients: {
               data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
-            },
-            recipients: { data: [] }
+            }
           },
           type: 'io.cozy.sharings'
         }
@@ -126,8 +125,7 @@ describe('SharingCollection', () => {
           relationships: {
             read_only_recipients: {
               data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
-            },
-            recipients: { data: [] }
+            }
           },
           type: 'io.cozy.sharings'
         }
@@ -164,9 +162,6 @@ describe('SharingCollection', () => {
             ]
           },
           relationships: {
-            read_only_recipients: {
-              data: []
-            },
             recipients: {
               data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
             }
@@ -207,9 +202,6 @@ describe('SharingCollection', () => {
             ]
           },
           relationships: {
-            read_only_recipients: {
-              data: []
-            },
             recipients: {
               data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
             }
@@ -258,9 +250,6 @@ describe('SharingCollection', () => {
           relationships: {
             read_only_recipients: {
               data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
-            },
-            recipients: {
-              data: []
             }
           },
           type: 'io.cozy.sharings'
@@ -299,9 +288,6 @@ describe('SharingCollection', () => {
           relationships: {
             read_only_recipients: {
               data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
-            },
-            recipients: {
-              data: []
             }
           },
           type: 'io.cozy.sharings'
@@ -338,9 +324,6 @@ describe('SharingCollection', () => {
             ]
           },
           relationships: {
-            read_only_recipients: {
-              data: []
-            },
             recipients: {
               data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
             }


### PR DESCRIPTION
- BREAKING CHANGE: remove addRecipients(document, recipients, sharingType) in favor of addRecipients({document, recipients, readOnlyRecipients)

- Fix: don't send empty params (recipients / readOnlyRecipients) 
