### PR TITLE
feat: GetOwnPermissions returns included

### DIFF
--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -197,7 +197,8 @@ class PermissionCollection extends DocumentCollection {
   async getOwnPermissions() {
     const resp = await this.stackClient.fetchJSON('GET', '/permissions/self')
     return {
-      data: normalizePermission(resp.data)
+      data: normalizePermission(resp.data),
+      included: resp.included ? resp.included.map(normalizePermission) : []
     }
   }
 }


### PR DESCRIPTION
CozyStack now includes the sharing member in
GET /permissions/self

This is used to have informations about the
member of the sharing. Specially if the
instance field is filled, it means that the
shortcut for this sharing has been created to
its cozy.