### PR TITLE
Document qualification

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-babel --root-mode upward src/ -d dist/ --verbose --ignore '**/*.spec.js','**/*.spec.jsx' "$@"
+babel --root-mode upward src/ -d dist/ --copy-files --verbose --ignore '**/*.spec.js','**/*.spec.jsx' "$@" 

--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -32,6 +32,15 @@ only the ids.</p>
 <li>Associations</li>
 </ul>
 </dd>
+<dt><a href="#Qualification">Qualification</a></dt>
+<dd><p>This class is used to create document Qualification, i.e. metadata
+attributes used to describe the document.
+The qualifications model is stored in the assets, associating
+labels to attributes, namely: purpose, sourceCategory, sourceSubCategory
+and subjects.
+Only subjects can be customized: see the checkQualification for more
+details about the qualification rules.</p>
+</dd>
 <dt><a href="#QueryDefinition">QueryDefinition</a></dt>
 <dd><p>Chainable API to create query definitions to retrieve documents
 from a Cozy. <code>QueryDefinition</code>s are sent to links.</p>
@@ -141,6 +150,15 @@ example.</p>
 <dt><del><a href="#getIndexByFamilyNameGivenNameEmailCozyUrl">getIndexByFamilyNameGivenNameEmailCozyUrl</a> ⇒ <code>string</code></del></dt>
 <dd><p>Returns &#39;byFamilyNameGivenNameEmailCozyUrl&#39; index of a contact</p>
 </dd>
+<dt><a href="#getQualificationByLabel">getQualificationByLabel</a> ⇒ <code>object</code></dt>
+<dd><p>Returns the qualification associated to a label.</p>
+</dd>
+<dt><a href="#setQualification">setQualification</a> ⇒ <code>object</code></dt>
+<dd><p>Set the qualification to the document metadata</p>
+</dd>
+<dt><a href="#getQualification">getQualification</a> ⇒ <code>object</code></dt>
+<dd><p>Helper to get the qualification from a document</p>
+</dd>
 <dt><a href="#splitFilename">splitFilename</a> ⇒ <code>object</code></dt>
 <dd><p>Returns base filename and extension</p>
 </dd>
@@ -166,6 +184,9 @@ example.</p>
 </dd>
 <dt><a href="#isSharingShorcutNew">isSharingShorcutNew</a> ⇒ <code>boolean</code></dt>
 <dd><p>Returns whether the sharing shortcut is new</p>
+</dd>
+<dt><a href="#saveFileQualification">saveFileQualification</a> ⇒ <code>object</code></dt>
+<dd><p>Save the file with the given qualification</p>
 </dd>
 <dt><a href="#ensureMagicFolder">ensureMagicFolder</a> ⇒ <code>object</code></dt>
 <dd><p>Returns a &quot;Magic Folder&quot;, given its id. See <a href="https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.apps/#special-iocozyapps-doctypes">https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.apps/#special-iocozyapps-doctypes</a></p>
@@ -1228,6 +1249,115 @@ CozyClient.registerHook('io.cozy.bank.accounts', 'before:destroy', () => {
   console.log('A io.cozy.bank.accounts is being destroyed')
 })
 ```
+<a name="Qualification"></a>
+
+## Qualification
+This class is used to create document Qualification, i.e. metadata
+attributes used to describe the document.
+The qualifications model is stored in the assets, associating
+labels to attributes, namely: purpose, sourceCategory, sourceSubCategory
+and subjects.
+Only subjects can be customized: see the checkQualification for more
+details about the qualification rules.
+
+**Kind**: global class  
+
+* [Qualification](#Qualification)
+    * [new Qualification(label, attributes)](#new_Qualification_new)
+    * [.checkQualification(qualification)](#Qualification+checkQualification)
+    * [.setPurpose(purpose)](#Qualification+setPurpose) ⇒ [<code>Qualification</code>](#Qualification)
+    * [.setSourceCategory(sourceCategory)](#Qualification+setSourceCategory) ⇒ [<code>Qualification</code>](#Qualification)
+    * [.setSourceSubCategory(sourceSubCategory)](#Qualification+setSourceSubCategory) ⇒ [<code>Qualification</code>](#Qualification)
+    * [.setSubjects(subjects)](#Qualification+setSubjects) ⇒ [<code>Qualification</code>](#Qualification)
+    * [.toQualification()](#Qualification+toQualification) ⇒ <code>object</code>
+
+<a name="new_Qualification_new"></a>
+
+### new Qualification(label, attributes)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| label | <code>string</code> | The qualification label. |
+| attributes | <code>object</code> | Qualification attributes. |
+| attributes.purpose | <code>string</code> | The document purpose. |
+| attributes.sourceCategory | <code>string</code> | The activity field of the document source. |
+| attributes.sourceSubCategory | <code>string</code> | The sub-activity field of the document source. |
+| attributes.subjects | <code>Array</code> | On what is about the document. |
+
+<a name="Qualification+checkQualification"></a>
+
+### qualification.checkQualification(qualification)
+Check the given qualification respects the following rules:
+  - For the given label, if a purpose, sourceCategory or sourceSubCategory
+    attribute is defined in the model, it must match the given qualification.
+  - If not defined in the model for the label, a custom purpose, sourceCategory or
+    sourceSubCategory value can be defined, if it exist in their respective
+    authorized values list.
+  - For the given label, if subjects are defined in the model, they must be included
+    in the given qualification.
+  - If extra subjects are set, they should exist in the authorized values.
+
+**Kind**: instance method of [<code>Qualification</code>](#Qualification)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| qualification | <code>object</code> | The qualification to check |
+
+<a name="Qualification+setPurpose"></a>
+
+### qualification.setPurpose(purpose) ⇒ [<code>Qualification</code>](#Qualification)
+Set purpose to the qualification.
+
+**Kind**: instance method of [<code>Qualification</code>](#Qualification)  
+**Returns**: [<code>Qualification</code>](#Qualification) - The Qualification object.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| purpose | <code>Array</code> | The purpose to set. |
+
+<a name="Qualification+setSourceCategory"></a>
+
+### qualification.setSourceCategory(sourceCategory) ⇒ [<code>Qualification</code>](#Qualification)
+Set sourceCategory to the qualification.
+
+**Kind**: instance method of [<code>Qualification</code>](#Qualification)  
+**Returns**: [<code>Qualification</code>](#Qualification) - The Qualification object.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| sourceCategory | <code>Array</code> | The sourceCategory to set. |
+
+<a name="Qualification+setSourceSubCategory"></a>
+
+### qualification.setSourceSubCategory(sourceSubCategory) ⇒ [<code>Qualification</code>](#Qualification)
+Set sourceSubCategory to the qualification.
+
+**Kind**: instance method of [<code>Qualification</code>](#Qualification)  
+**Returns**: [<code>Qualification</code>](#Qualification) - The Qualification object.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| sourceSubCategory | <code>Array</code> | The sourceSubCategory to set. |
+
+<a name="Qualification+setSubjects"></a>
+
+### qualification.setSubjects(subjects) ⇒ [<code>Qualification</code>](#Qualification)
+Set subjects to the qualification.
+
+**Kind**: instance method of [<code>Qualification</code>](#Qualification)  
+**Returns**: [<code>Qualification</code>](#Qualification) - The Qualification object.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| subjects | <code>Array</code> | The subjects to set. |
+
+<a name="Qualification+toQualification"></a>
+
+### qualification.toQualification() ⇒ <code>object</code>
+Returns the qualification attributes
+
+**Kind**: instance method of [<code>Qualification</code>](#Qualification)  
+**Returns**: <code>object</code> - The qualification attributes  
 <a name="QueryDefinition"></a>
 
 ## QueryDefinition
@@ -1826,6 +1956,43 @@ Returns 'byFamilyNameGivenNameEmailCozyUrl' index of a contact
 | --- | --- | --- |
 | contact | <code>object</code> | A contact |
 
+<a name="getQualificationByLabel"></a>
+
+## getQualificationByLabel ⇒ <code>object</code>
+Returns the qualification associated to a label.
+
+**Kind**: global constant  
+**Returns**: <code>object</code> - - The qualification  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| label | <code>string</code> | The label to qualify |
+
+<a name="setQualification"></a>
+
+## setQualification ⇒ <code>object</code>
+Set the qualification to the document metadata
+
+**Kind**: global constant  
+**Returns**: <code>object</code> - - The qualified document  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | <code>object</code> | The document to set the qualification |
+| qualification | <code>object</code> | The qualification to set |
+
+<a name="getQualification"></a>
+
+## getQualification ⇒ <code>object</code>
+Helper to get the qualification from a document
+
+**Kind**: global constant  
+**Returns**: <code>object</code> - - The document qualification  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | <code>object</code> | The document |
+
 <a name="splitFilename"></a>
 
 ## splitFilename ⇒ <code>object</code>
@@ -1932,6 +2099,20 @@ Returns whether the sharing shortcut is new
 | Param | Type | Description |
 | --- | --- | --- |
 | file | <code>object</code> | io.cozy.files document |
+
+<a name="saveFileQualification"></a>
+
+## saveFileQualification ⇒ <code>object</code>
+Save the file with the given qualification
+
+**Kind**: global constant  
+**Returns**: <code>object</code> - - The saved file  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| client | <code>object</code> | The CozyClient instance |
+| file | <code>object</code> | The file to qualify |
+| qualification | <code>object</code> | The file qualification |
 
 <a name="ensureMagicFolder"></a>
 

--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -150,13 +150,13 @@ example.</p>
 <dt><del><a href="#getIndexByFamilyNameGivenNameEmailCozyUrl">getIndexByFamilyNameGivenNameEmailCozyUrl</a> ⇒ <code>string</code></del></dt>
 <dd><p>Returns &#39;byFamilyNameGivenNameEmailCozyUrl&#39; index of a contact</p>
 </dd>
-<dt><a href="#getQualificationByLabel">getQualificationByLabel</a> ⇒ <code>object</code></dt>
+<dt><a href="#getQualificationByLabel">getQualificationByLabel</a> ⇒ <code><a href="#Qualification">Qualification</a></code></dt>
 <dd><p>Returns the qualification associated to a label.</p>
 </dd>
 <dt><a href="#setQualification">setQualification</a> ⇒ <code>object</code></dt>
 <dd><p>Set the qualification to the document metadata</p>
 </dd>
-<dt><a href="#getQualification">getQualification</a> ⇒ <code>object</code></dt>
+<dt><a href="#getQualification">getQualification</a> ⇒ <code><a href="#Qualification">Qualification</a></code></dt>
 <dd><p>Helper to get the qualification from a document</p>
 </dd>
 <dt><a href="#splitFilename">splitFilename</a> ⇒ <code>object</code></dt>
@@ -319,6 +319,9 @@ we have in the store.</p>
 </dd>
 <dt><a href="#CozyAccount">CozyAccount</a> : <code>object</code></dt>
 <dd></dd>
+<dt><a href="#Qualification">Qualification</a> : <code>object</code></dt>
+<dd><p>Qualification&#39;s object.</p>
+</dd>
 <dt><a href="#Document">Document</a> : <code>object</code></dt>
 <dd><p>Couchdb document like an io.cozy.files</p>
 </dd>
@@ -1277,12 +1280,8 @@ details about the qualification rules.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| label | <code>string</code> | The qualification label. |
-| attributes | <code>object</code> | Qualification attributes. |
-| attributes.purpose | <code>string</code> | The document purpose. |
-| attributes.sourceCategory | <code>string</code> | The activity field of the document source. |
-| attributes.sourceSubCategory | <code>string</code> | The sub-activity field of the document source. |
-| attributes.subjects | <code>Array</code> | On what is about the document. |
+| label | <code>string</code> | The qualification label |
+| attributes | [<code>Qualification</code>](#Qualification) | Qualification's attributes |
 
 <a name="Qualification+checkQualification"></a>
 
@@ -1301,7 +1300,7 @@ Check the given qualification respects the following rules:
 
 | Param | Type | Description |
 | --- | --- | --- |
-| qualification | <code>object</code> | The qualification to check |
+| qualification | [<code>Qualification</code>](#Qualification) | The qualification to check |
 
 <a name="Qualification+setPurpose"></a>
 
@@ -1958,11 +1957,11 @@ Returns 'byFamilyNameGivenNameEmailCozyUrl' index of a contact
 
 <a name="getQualificationByLabel"></a>
 
-## getQualificationByLabel ⇒ <code>object</code>
+## getQualificationByLabel ⇒ [<code>Qualification</code>](#Qualification)
 Returns the qualification associated to a label.
 
 **Kind**: global constant  
-**Returns**: <code>object</code> - - The qualification  
+**Returns**: [<code>Qualification</code>](#Qualification) - - The qualification  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1979,15 +1978,15 @@ Set the qualification to the document metadata
 | Param | Type | Description |
 | --- | --- | --- |
 | document | <code>object</code> | The document to set the qualification |
-| qualification | <code>object</code> | The qualification to set |
+| qualification | [<code>Qualification</code>](#Qualification) | The qualification to set |
 
 <a name="getQualification"></a>
 
-## getQualification ⇒ <code>object</code>
+## getQualification ⇒ [<code>Qualification</code>](#Qualification)
 Helper to get the qualification from a document
 
 **Kind**: global constant  
-**Returns**: <code>object</code> - - The document qualification  
+**Returns**: [<code>Qualification</code>](#Qualification) - - The document qualification  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -2580,6 +2579,115 @@ https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.files/#references
 
 ## CozyAccount : <code>object</code>
 **Kind**: global typedef  
+<a name="Qualification"></a>
+
+## Qualification : <code>object</code>
+Qualification's object.
+
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| label | <code>string</code> | The qualification label. |
+| purpose | <code>string</code> | The document purpose. |
+| sourceCategory | <code>string</code> | The activity field of the document source. |
+| sourceSubCategory | <code>string</code> | The sub-activity field of the document source. |
+| subjects | <code>Array</code> | On what is about the document. |
+
+
+* [Qualification](#Qualification) : <code>object</code>
+    * [new Qualification(label, attributes)](#new_Qualification_new)
+    * [.checkQualification(qualification)](#Qualification+checkQualification)
+    * [.setPurpose(purpose)](#Qualification+setPurpose) ⇒ [<code>Qualification</code>](#Qualification)
+    * [.setSourceCategory(sourceCategory)](#Qualification+setSourceCategory) ⇒ [<code>Qualification</code>](#Qualification)
+    * [.setSourceSubCategory(sourceSubCategory)](#Qualification+setSourceSubCategory) ⇒ [<code>Qualification</code>](#Qualification)
+    * [.setSubjects(subjects)](#Qualification+setSubjects) ⇒ [<code>Qualification</code>](#Qualification)
+    * [.toQualification()](#Qualification+toQualification) ⇒ <code>object</code>
+
+<a name="new_Qualification_new"></a>
+
+### new Qualification(label, attributes)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| label | <code>string</code> | The qualification label |
+| attributes | [<code>Qualification</code>](#Qualification) | Qualification's attributes |
+
+<a name="Qualification+checkQualification"></a>
+
+### qualification.checkQualification(qualification)
+Check the given qualification respects the following rules:
+  - For the given label, if a purpose, sourceCategory or sourceSubCategory
+    attribute is defined in the model, it must match the given qualification.
+  - If not defined in the model for the label, a custom purpose, sourceCategory or
+    sourceSubCategory value can be defined, if it exist in their respective
+    authorized values list.
+  - For the given label, if subjects are defined in the model, they must be included
+    in the given qualification.
+  - If extra subjects are set, they should exist in the authorized values.
+
+**Kind**: instance method of [<code>Qualification</code>](#Qualification)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| qualification | [<code>Qualification</code>](#Qualification) | The qualification to check |
+
+<a name="Qualification+setPurpose"></a>
+
+### qualification.setPurpose(purpose) ⇒ [<code>Qualification</code>](#Qualification)
+Set purpose to the qualification.
+
+**Kind**: instance method of [<code>Qualification</code>](#Qualification)  
+**Returns**: [<code>Qualification</code>](#Qualification) - The Qualification object.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| purpose | <code>Array</code> | The purpose to set. |
+
+<a name="Qualification+setSourceCategory"></a>
+
+### qualification.setSourceCategory(sourceCategory) ⇒ [<code>Qualification</code>](#Qualification)
+Set sourceCategory to the qualification.
+
+**Kind**: instance method of [<code>Qualification</code>](#Qualification)  
+**Returns**: [<code>Qualification</code>](#Qualification) - The Qualification object.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| sourceCategory | <code>Array</code> | The sourceCategory to set. |
+
+<a name="Qualification+setSourceSubCategory"></a>
+
+### qualification.setSourceSubCategory(sourceSubCategory) ⇒ [<code>Qualification</code>](#Qualification)
+Set sourceSubCategory to the qualification.
+
+**Kind**: instance method of [<code>Qualification</code>](#Qualification)  
+**Returns**: [<code>Qualification</code>](#Qualification) - The Qualification object.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| sourceSubCategory | <code>Array</code> | The sourceSubCategory to set. |
+
+<a name="Qualification+setSubjects"></a>
+
+### qualification.setSubjects(subjects) ⇒ [<code>Qualification</code>](#Qualification)
+Set subjects to the qualification.
+
+**Kind**: instance method of [<code>Qualification</code>](#Qualification)  
+**Returns**: [<code>Qualification</code>](#Qualification) - The Qualification object.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| subjects | <code>Array</code> | The subjects to set. |
+
+<a name="Qualification+toQualification"></a>
+
+### qualification.toQualification() ⇒ <code>object</code>
+Returns the qualification attributes
+
+**Kind**: instance method of [<code>Qualification</code>](#Qualification)  
+**Returns**: <code>object</code> - The qualification attributes  
 <a name="Document"></a>
 
 ## Document : <code>object</code>

--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -38,8 +38,8 @@ attributes used to describe the document.
 The qualifications model is stored in the assets, associating
 labels to attributes, namely: purpose, sourceCategory, sourceSubCategory
 and subjects.
-Only subjects can be customized: see the checkQualification for more
-details about the qualification rules.</p>
+A qualification can be customized accordingly to rules detailed in
+the checkValueAttributes method.</p>
 </dd>
 <dt><a href="#QueryDefinition">QueryDefinition</a></dt>
 <dd><p>Chainable API to create query definitions to retrieve documents
@@ -149,9 +149,6 @@ example.</p>
 </dd>
 <dt><del><a href="#getIndexByFamilyNameGivenNameEmailCozyUrl">getIndexByFamilyNameGivenNameEmailCozyUrl</a> ⇒ <code>string</code></del></dt>
 <dd><p>Returns &#39;byFamilyNameGivenNameEmailCozyUrl&#39; index of a contact</p>
-</dd>
-<dt><a href="#getQualificationByLabel">getQualificationByLabel</a> ⇒ <code><a href="#Qualification">Qualification</a></code></dt>
-<dd><p>Returns the qualification associated to a label.</p>
 </dd>
 <dt><a href="#setQualification">setQualification</a> ⇒ <code>object</code></dt>
 <dd><p>Set the qualification to the document metadata</p>
@@ -1260,47 +1257,50 @@ attributes used to describe the document.
 The qualifications model is stored in the assets, associating
 labels to attributes, namely: purpose, sourceCategory, sourceSubCategory
 and subjects.
-Only subjects can be customized: see the checkQualification for more
-details about the qualification rules.
+A qualification can be customized accordingly to rules detailed in
+the checkValueAttributes method.
 
 **Kind**: global class  
 
 * [Qualification](#Qualification)
-    * [new Qualification(label, attributes)](#new_Qualification_new)
-    * [.checkQualification(qualification)](#Qualification+checkQualification)
-    * [.setPurpose(purpose)](#Qualification+setPurpose) ⇒ [<code>Qualification</code>](#Qualification)
-    * [.setSourceCategory(sourceCategory)](#Qualification+setSourceCategory) ⇒ [<code>Qualification</code>](#Qualification)
-    * [.setSourceSubCategory(sourceSubCategory)](#Qualification+setSourceSubCategory) ⇒ [<code>Qualification</code>](#Qualification)
-    * [.setSubjects(subjects)](#Qualification+setSubjects) ⇒ [<code>Qualification</code>](#Qualification)
-    * [.toQualification()](#Qualification+toQualification) ⇒ <code>object</code>
+    * [new exports.Qualification(label, attributes)](#new_Qualification_new)
+    * _instance_
+        * [.checkValueAttributes(attributes)](#Qualification+checkValueAttributes)
+        * [.setPurpose(purpose)](#Qualification+setPurpose) ⇒ [<code>Qualification</code>](#Qualification)
+        * [.setSourceCategory(sourceCategory)](#Qualification+setSourceCategory) ⇒ [<code>Qualification</code>](#Qualification)
+        * [.setSourceSubCategory(sourceSubCategory)](#Qualification+setSourceSubCategory) ⇒ [<code>Qualification</code>](#Qualification)
+        * [.setSubjects(subjects)](#Qualification+setSubjects) ⇒ [<code>Qualification</code>](#Qualification)
+        * [.toQualification()](#Qualification+toQualification) ⇒ <code>object</code>
+    * _static_
+        * [.getQualificationByLabel(label)](#Qualification.getQualificationByLabel) ⇒ [<code>Qualification</code>](#Qualification)
 
 <a name="new_Qualification_new"></a>
 
-### new Qualification(label, attributes)
+### new exports.Qualification(label, attributes)
 
 | Param | Type | Description |
 | --- | --- | --- |
 | label | <code>string</code> | The qualification label |
 | attributes | [<code>Qualification</code>](#Qualification) | Qualification's attributes |
 
-<a name="Qualification+checkQualification"></a>
+<a name="Qualification+checkValueAttributes"></a>
 
-### qualification.checkQualification(qualification)
-Check the given qualification respects the following rules:
+### qualification.checkValueAttributes(attributes)
+Check the given qualification attributes respects the following rules:
   - For the given label, if a purpose, sourceCategory or sourceSubCategory
     attribute is defined in the model, it must match the given qualification.
   - If not defined in the model for the label, a custom purpose, sourceCategory or
     sourceSubCategory value can be defined, if it exist in their respective
-    authorized values list.
+    known values list.
   - For the given label, if subjects are defined in the model, they must be included
     in the given qualification.
-  - If extra subjects are set, they should exist in the authorized values.
+  - If extra subjects are set, they should exist in the known values.
 
 **Kind**: instance method of [<code>Qualification</code>](#Qualification)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| qualification | [<code>Qualification</code>](#Qualification) | The qualification to check |
+| attributes | <code>object</code> | The qualification attributes to check |
 
 <a name="Qualification+setPurpose"></a>
 
@@ -1357,6 +1357,18 @@ Returns the qualification attributes
 
 **Kind**: instance method of [<code>Qualification</code>](#Qualification)  
 **Returns**: <code>object</code> - The qualification attributes  
+<a name="Qualification.getQualificationByLabel"></a>
+
+### Qualification.getQualificationByLabel(label) ⇒ [<code>Qualification</code>](#Qualification)
+Returns the qualification associated to a label.
+
+**Kind**: static method of [<code>Qualification</code>](#Qualification)  
+**Returns**: [<code>Qualification</code>](#Qualification) - - The qualification  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| label | <code>string</code> | The label to qualify |
+
 <a name="QueryDefinition"></a>
 
 ## QueryDefinition
@@ -1954,18 +1966,6 @@ Returns 'byFamilyNameGivenNameEmailCozyUrl' index of a contact
 | Param | Type | Description |
 | --- | --- | --- |
 | contact | <code>object</code> | A contact |
-
-<a name="getQualificationByLabel"></a>
-
-## getQualificationByLabel ⇒ [<code>Qualification</code>](#Qualification)
-Returns the qualification associated to a label.
-
-**Kind**: global constant  
-**Returns**: [<code>Qualification</code>](#Qualification) - - The qualification  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| label | <code>string</code> | The label to qualify |
 
 <a name="setQualification"></a>
 
@@ -2597,41 +2597,44 @@ Qualification's object.
 
 
 * [Qualification](#Qualification) : <code>object</code>
-    * [new Qualification(label, attributes)](#new_Qualification_new)
-    * [.checkQualification(qualification)](#Qualification+checkQualification)
-    * [.setPurpose(purpose)](#Qualification+setPurpose) ⇒ [<code>Qualification</code>](#Qualification)
-    * [.setSourceCategory(sourceCategory)](#Qualification+setSourceCategory) ⇒ [<code>Qualification</code>](#Qualification)
-    * [.setSourceSubCategory(sourceSubCategory)](#Qualification+setSourceSubCategory) ⇒ [<code>Qualification</code>](#Qualification)
-    * [.setSubjects(subjects)](#Qualification+setSubjects) ⇒ [<code>Qualification</code>](#Qualification)
-    * [.toQualification()](#Qualification+toQualification) ⇒ <code>object</code>
+    * [new exports.Qualification(label, attributes)](#new_Qualification_new)
+    * _instance_
+        * [.checkValueAttributes(attributes)](#Qualification+checkValueAttributes)
+        * [.setPurpose(purpose)](#Qualification+setPurpose) ⇒ [<code>Qualification</code>](#Qualification)
+        * [.setSourceCategory(sourceCategory)](#Qualification+setSourceCategory) ⇒ [<code>Qualification</code>](#Qualification)
+        * [.setSourceSubCategory(sourceSubCategory)](#Qualification+setSourceSubCategory) ⇒ [<code>Qualification</code>](#Qualification)
+        * [.setSubjects(subjects)](#Qualification+setSubjects) ⇒ [<code>Qualification</code>](#Qualification)
+        * [.toQualification()](#Qualification+toQualification) ⇒ <code>object</code>
+    * _static_
+        * [.getQualificationByLabel(label)](#Qualification.getQualificationByLabel) ⇒ [<code>Qualification</code>](#Qualification)
 
 <a name="new_Qualification_new"></a>
 
-### new Qualification(label, attributes)
+### new exports.Qualification(label, attributes)
 
 | Param | Type | Description |
 | --- | --- | --- |
 | label | <code>string</code> | The qualification label |
 | attributes | [<code>Qualification</code>](#Qualification) | Qualification's attributes |
 
-<a name="Qualification+checkQualification"></a>
+<a name="Qualification+checkValueAttributes"></a>
 
-### qualification.checkQualification(qualification)
-Check the given qualification respects the following rules:
+### qualification.checkValueAttributes(attributes)
+Check the given qualification attributes respects the following rules:
   - For the given label, if a purpose, sourceCategory or sourceSubCategory
     attribute is defined in the model, it must match the given qualification.
   - If not defined in the model for the label, a custom purpose, sourceCategory or
     sourceSubCategory value can be defined, if it exist in their respective
-    authorized values list.
+    known values list.
   - For the given label, if subjects are defined in the model, they must be included
     in the given qualification.
-  - If extra subjects are set, they should exist in the authorized values.
+  - If extra subjects are set, they should exist in the known values.
 
 **Kind**: instance method of [<code>Qualification</code>](#Qualification)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| qualification | [<code>Qualification</code>](#Qualification) | The qualification to check |
+| attributes | <code>object</code> | The qualification attributes to check |
 
 <a name="Qualification+setPurpose"></a>
 
@@ -2688,6 +2691,18 @@ Returns the qualification attributes
 
 **Kind**: instance method of [<code>Qualification</code>](#Qualification)  
 **Returns**: <code>object</code> - The qualification attributes  
+<a name="Qualification.getQualificationByLabel"></a>
+
+### Qualification.getQualificationByLabel(label) ⇒ [<code>Qualification</code>](#Qualification)
+Returns the qualification associated to a label.
+
+**Kind**: static method of [<code>Qualification</code>](#Qualification)  
+**Returns**: [<code>Qualification</code>](#Qualification) - - The qualification  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| label | <code>string</code> | The label to qualify |
+
 <a name="Document"></a>
 
 ## Document : <code>object</code>

--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -1265,14 +1265,14 @@ the checkValueAttributes method.
 * [Qualification](#Qualification)
     * [new exports.Qualification(label, attributes)](#new_Qualification_new)
     * _instance_
-        * [.checkValueAttributes(attributes)](#Qualification+checkValueAttributes)
+        * [.checkAttributes(attributes)](#Qualification+checkAttributes)
         * [.setPurpose(purpose)](#Qualification+setPurpose) ⇒ [<code>Qualification</code>](#Qualification)
         * [.setSourceCategory(sourceCategory)](#Qualification+setSourceCategory) ⇒ [<code>Qualification</code>](#Qualification)
         * [.setSourceSubCategory(sourceSubCategory)](#Qualification+setSourceSubCategory) ⇒ [<code>Qualification</code>](#Qualification)
         * [.setSubjects(subjects)](#Qualification+setSubjects) ⇒ [<code>Qualification</code>](#Qualification)
         * [.toQualification()](#Qualification+toQualification) ⇒ <code>object</code>
     * _static_
-        * [.getQualificationByLabel(label)](#Qualification.getQualificationByLabel) ⇒ [<code>Qualification</code>](#Qualification)
+        * [.getByLabel(label)](#Qualification.getByLabel) ⇒ [<code>Qualification</code>](#Qualification)
 
 <a name="new_Qualification_new"></a>
 
@@ -1283,9 +1283,9 @@ the checkValueAttributes method.
 | label | <code>string</code> | The qualification label |
 | attributes | [<code>Qualification</code>](#Qualification) | Qualification's attributes |
 
-<a name="Qualification+checkValueAttributes"></a>
+<a name="Qualification+checkAttributes"></a>
 
-### qualification.checkValueAttributes(attributes)
+### qualification.checkAttributes(attributes)
 Check the given qualification attributes respects the following rules:
   - For the given label, if a purpose, sourceCategory or sourceSubCategory
     attribute is defined in the model, it must match the given qualification.
@@ -1357,9 +1357,9 @@ Returns the qualification attributes
 
 **Kind**: instance method of [<code>Qualification</code>](#Qualification)  
 **Returns**: <code>object</code> - The qualification attributes  
-<a name="Qualification.getQualificationByLabel"></a>
+<a name="Qualification.getByLabel"></a>
 
-### Qualification.getQualificationByLabel(label) ⇒ [<code>Qualification</code>](#Qualification)
+### Qualification.getByLabel(label) ⇒ [<code>Qualification</code>](#Qualification)
 Returns the qualification associated to a label.
 
 **Kind**: static method of [<code>Qualification</code>](#Qualification)  
@@ -2599,14 +2599,14 @@ Qualification's object.
 * [Qualification](#Qualification) : <code>object</code>
     * [new exports.Qualification(label, attributes)](#new_Qualification_new)
     * _instance_
-        * [.checkValueAttributes(attributes)](#Qualification+checkValueAttributes)
+        * [.checkAttributes(attributes)](#Qualification+checkAttributes)
         * [.setPurpose(purpose)](#Qualification+setPurpose) ⇒ [<code>Qualification</code>](#Qualification)
         * [.setSourceCategory(sourceCategory)](#Qualification+setSourceCategory) ⇒ [<code>Qualification</code>](#Qualification)
         * [.setSourceSubCategory(sourceSubCategory)](#Qualification+setSourceSubCategory) ⇒ [<code>Qualification</code>](#Qualification)
         * [.setSubjects(subjects)](#Qualification+setSubjects) ⇒ [<code>Qualification</code>](#Qualification)
         * [.toQualification()](#Qualification+toQualification) ⇒ <code>object</code>
     * _static_
-        * [.getQualificationByLabel(label)](#Qualification.getQualificationByLabel) ⇒ [<code>Qualification</code>](#Qualification)
+        * [.getByLabel(label)](#Qualification.getByLabel) ⇒ [<code>Qualification</code>](#Qualification)
 
 <a name="new_Qualification_new"></a>
 
@@ -2617,9 +2617,9 @@ Qualification's object.
 | label | <code>string</code> | The qualification label |
 | attributes | [<code>Qualification</code>](#Qualification) | Qualification's attributes |
 
-<a name="Qualification+checkValueAttributes"></a>
+<a name="Qualification+checkAttributes"></a>
 
-### qualification.checkValueAttributes(attributes)
+### qualification.checkAttributes(attributes)
 Check the given qualification attributes respects the following rules:
   - For the given label, if a purpose, sourceCategory or sourceSubCategory
     attribute is defined in the model, it must match the given qualification.
@@ -2691,9 +2691,9 @@ Returns the qualification attributes
 
 **Kind**: instance method of [<code>Qualification</code>](#Qualification)  
 **Returns**: <code>object</code> - The qualification attributes  
-<a name="Qualification.getQualificationByLabel"></a>
+<a name="Qualification.getByLabel"></a>
 
-### Qualification.getQualificationByLabel(label) ⇒ [<code>Qualification</code>](#Qualification)
+### Qualification.getByLabel(label) ⇒ [<code>Qualification</code>](#Qualification)
 Returns the qualification associated to a label.
 
 **Kind**: static method of [<code>Qualification</code>](#Qualification)  

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,8 @@ const commonConfig = {
   ],
   modulePathIgnorePatterns: ['<rootDir>/packages/.*/dist/'],
   transformIgnorePatterns: ['node_modules/(?!(cozy-ui))'],
-  testEnvironment: 'jest-environment-jsdom-sixteen'
+  testEnvironment: 'jest-environment-jsdom-sixteen',
+  moduleFileExtensions: ['js', 'jsx', 'json']
 }
 
 module.exports = {

--- a/packages/cozy-client/src/assets/qualifications.json
+++ b/packages/cozy-client/src/assets/qualifications.json
@@ -1,0 +1,361 @@
+{
+  "qualifications": [
+    {
+      "label": "national_id_card",
+      "purpose": "attestation",
+      "sourceCategory": "gov",
+      "sourceSubCategory": "civil_registration",
+      "subjects": ["identity"]
+    },
+    {
+      "label": "passport",
+      "purpose": "attestation",
+      "sourceCategory": "gov",
+      "sourceSubCategory": "civil_registration",
+      "subjects": ["identity"]
+    },
+    {
+      "label": "residence_permit",
+      "purpose": "attestation",
+      "sourceCategory": "gov",
+      "sourceSubCategory": "immigration",
+      "subjects": ["permit", "identity"]
+    },
+    {
+      "label": "family_record_book",
+      "purpose": "attestation",
+      "sourceCategory": "gov",
+      "sourceSubCategory": "civil_registration",
+      "subjects": ["family"]
+    },
+    {
+      "label": "birth_certificate",
+      "purpose": "attestation",
+      "sourceCategory": "gov",
+      "sourceSubCategory": "civil_registration",
+      "subjects": ["identity", "family"]
+    },
+    {
+      "label": "driver_license",
+      "purpose": "attestation",
+      "sourceCategory": "gov",
+      "sourceSubCategory": "transport",
+      "subjects": ["permit", "driving"]
+    },
+    {
+      "label": "other_identity_document",
+      "purpose": "attestation"
+    },
+    {
+      "label": "wedding",
+      "purpose": "contract",
+      "sourceCategory": "gov",
+      "sourceSubCategory": "civil_registration",
+      "subjects": ["family"]
+    },
+    {
+      "label": "pacs",
+      "purpose": "contract",
+      "sourceCategory": "gov",
+      "sourceSubCategory": "civil_registration",
+      "subjects": ["family"]
+    },
+    {
+      "label": "divorce",
+      "purpose": "contract",
+      "sourceCategory": "gov",
+      "sourceSubCategory": "civil_registration",
+      "subjects": ["family"]
+    },
+    {
+      "label": "large_family_card",
+      "purpose": "attestation",
+      "sourceCategory": "transport",
+      "subjects": ["right"]
+    },
+    {
+      "label": "caf",
+      "purpose": "attestation",
+      "sourceCategory": "gov",
+      "sourceSubCategory": "family",
+      "subjects": ["right"]
+    },
+    {
+      "label": "other_family_document"
+    },
+    {
+      "label": "diploma",
+      "purpose": "attestation",
+      "sourceCategory": "education",
+      "subjects": ["achievement"]
+    },
+    {
+      "label": "work_contract",
+      "purpose": "contract",
+      "sourceCategory": "employer",
+      "subjects": ["work", "employment"]
+    },
+    {
+      "label": "pay_sheet",
+      "purpose": "attestation",
+      "sourceCategory": "employer",
+      "subjects": ["work", "revenues"]
+    },
+    {
+      "label": "unemployment_benefit",
+      "purpose": "attestation",
+      "sourceCategory": "gov",
+      "subjects": ["revenues"]
+    },
+    {
+      "label": "pension",
+      "purpose": "attestation",
+      "sourceCategory": "gov",
+      "subjects": ["revenues"]
+    },
+    {
+      "label": "other_revenue",
+      "purpose": "attestation",
+      "subjects": ["revenues"]
+    },
+    {
+      "label": "gradebook",
+      "purpose": "report",
+      "sourceCategory": "education",
+      "subjects": ["history"]
+    },
+    {
+      "label": "student_card",
+      "purpose": "attestation",
+      "sourceCategory": "education",
+      "subjects": ["identity"]
+    },
+    {
+      "label": "resume",
+      "purpose": "description",
+      "subjects": ["employment"]
+    },
+    {
+      "label": "motivation_letter",
+      "purpose": "description",
+      "subjects": ["employment"]
+    },
+    {
+      "label": "other_work_document"
+    },
+    {
+      "label": "health_book",
+      "purpose": "report",
+      "sourceCategory": "health",
+      "subjects": ["history"]
+    },
+    {
+      "label": "national_insurance_card",
+      "purpose": "attestation",
+      "sourceCategory": "gov",
+      "sourceSubCategory": "health",
+      "subjects": ["insurance"]
+    },
+    {
+      "label": "health_insurance_card",
+      "purpose": "attestation",
+      "sourceCategory": "insurance",
+      "sourceSubCategory": "health",
+      "subjects": ["insurance"]
+    },
+    {
+      "label": "prescription",
+      "purpose": "attestation",
+      "sourceCategory": "health",
+      "subjects": ["right"]
+    },
+    {
+      "label": "health_invoice",
+      "purpose": "invoice",
+      "sourceCategory": "health"
+    },
+    {
+      "label": "vehicle_registration",
+      "purpose": "attestation",
+      "sourceCategory": "gov",
+      "sourceSubCategory": "transport",
+      "subjects": ["right", "identity"]
+    },
+    {
+      "label": "car_insurance",
+      "purpose": "attestation",
+      "sourceCategory": "insurance",
+      "sourceSubCategory": "transport",
+      "subjects": ["insurance", "car"]
+    },
+    {
+      "label": "mechanic_invoice",
+      "purpose": "invoice",
+      "sourceCategory": "transport"
+    },
+    {
+      "label": "transport_invoice",
+      "purpose": "invoice",
+      "sourceCategory": "transport"
+    },
+    {
+      "label": "other_transport_document"
+    },
+    {
+      "label": "house_sale_agreeement",
+      "purpose": "contract",
+      "sourceCategory": "real_estate",
+      "subjects": ["house"]
+    },
+    {
+      "label": "building_permit",
+      "purpose": "attestation",
+      "sourceCategory": "gov",
+      "sourceSubCategory": "real_estate",
+      "subjects": ["permit", "house"]
+    },
+    {
+      "label": "technical_diagnostic_record",
+      "purpose": "report",
+      "sourceCategory": "real_estate",
+      "subjects": ["compliance", "house"]
+    },
+    {
+      "label": "lease",
+      "purpose": "contract",
+      "sourceCategory": "real_estate",
+      "subjects": ["house"]
+    },
+    {
+      "label": "rent_receipt",
+      "purpose": "invoice",
+      "sourceCategory": "real_estate",
+      "subjects": ["house"]
+    },
+    {
+      "label": "house_insurance",
+      "purpose": "contract",
+      "sourceCategory": "insurance",
+      "sourceSubCategory": "real_estate",
+      "subjects": ["insurance", "house"]
+    },
+    {
+      "label": "work_quote",
+      "purpose": "description",
+      "sourceCategory": "building",
+      "subjects": ["building", "house"]
+    },
+    {
+      "label": "work_invoice",
+      "purpose": "invoice",
+      "sourceCategory": "building",
+      "subjects": ["building", "house"]
+    },
+    {
+      "label": "other_house_document"
+    },
+    {
+      "label": "phone_invoice",
+      "purpose": "invoice",
+      "sourceCategory": "telecom",
+      "sourceSubCategory": "mobile"
+    },
+    {
+      "label": "isp_invoice",
+      "purpose": "invoice",
+      "sourceCategory": "telecom",
+      "sourceSubCategory": "internet",
+      "subjects": ["subscription"]
+    },
+    {
+      "label": "energy_invoice",
+      "purpose": "invoice",
+      "sourceCategory": "energy"
+    },
+    {
+      "label": "water_invoice",
+      "purpose": "invoice",
+      "sourceCategory": "water"
+    },
+    {
+      "label": "appliance_invoice",
+      "purpose": "invoice",
+      "sourceCategory": "retail"
+    },
+    {
+      "label": "web_service_invoice",
+      "purpose": "invoice",
+      "sourceCategory": "web"
+    },
+    {
+      "label": "restaurant_invoice",
+      "purpose": "invoice",
+      "sourceCategory": "alimentation"
+    },
+    {
+      "label": "other_invoice",
+      "purpose": "invoice"
+    },
+    {
+      "label": "tax_return",
+      "purpose": "report",
+      "sourceCategory": "gov",
+      "sourceSubCategory": "tax",
+      "subjects": ["tax"]
+    },
+    {
+      "label": "tax_notice",
+      "purpose": "invoice",
+      "sourceCategory": "gov",
+      "sourceSubCategory": "tax",
+      "subjects": ["tax"]
+    },
+    {
+      "label": "tax_timetable",
+      "purpose": "report",
+      "sourceCategory": "gov",
+      "sourceSubCategory": "tax",
+      "subjects": ["tax"]
+    },
+    {
+      "label": "bank_details",
+      "purpose": "attestation",
+      "sourceCategory": "bank",
+      "subjects": ["identity"]
+    },
+    {
+      "label": "bank_statement",
+      "purpose": "report",
+      "sourceCategory": "bank",
+      "subjects": ["history"]
+    },
+    {
+      "label": "loan_agreement",
+      "purpose": "contract",
+      "sourceCategory": "bank"
+    },
+    {
+      "label": "other_bank_document",
+      "sourceCategory": "bank"
+    }
+  ],
+  "purposeAuthorizedValues": [
+    "attestation", "contract", "invoice", "report", "description", "evaluation"
+  ],
+  "sourceCategoryAuthorizedValues": [
+    "bank", "insurance", "retail", "telecom", "energy", "water", "health", "gov",
+    "education", "employer", "transport", "goods", "alimentation", "building",
+    "real_estate", "web"
+  ],
+  "sourceSubCategoryAuthorizedValues": [
+    "civil_registration", "immigration", "transport", "family", "tax", "health", 
+    "real_estate", "mobile", "internet"
+  ],
+  "subjectsAuthorizedValues": [
+    "identity", "permit", "family", "driving", "right", "subvention", "achievement",
+    "degree", "work", "employment", "revenues", "history", "insurance", "drugs",
+    "medical_act", "car", "moto", "truck", "boat", "subscription", "buy/sale",
+    "house", "compliance", "building", "food", "real_estate", "tax", "insurance",
+    "education", "statement", "course"
+  ]
+}

--- a/packages/cozy-client/src/assets/qualifications.json
+++ b/packages/cozy-client/src/assets/qualifications.json
@@ -339,19 +339,19 @@
       "sourceCategory": "bank"
     }
   ],
-  "purposeAuthorizedValues": [
+  "purposeKnownValues": [
     "attestation", "contract", "invoice", "report", "description", "evaluation"
   ],
-  "sourceCategoryAuthorizedValues": [
+  "sourceCategoryKnownValues": [
     "bank", "insurance", "retail", "telecom", "energy", "water", "health", "gov",
     "education", "employer", "transport", "goods", "alimentation", "building",
     "real_estate", "web"
   ],
-  "sourceSubCategoryAuthorizedValues": [
+  "sourceSubCategoryKnownValues": [
     "civil_registration", "immigration", "transport", "family", "tax", "health", 
     "real_estate", "mobile", "internet"
   ],
-  "subjectsAuthorizedValues": [
+  "subjectsKnownValues": [
     "identity", "permit", "family", "driving", "right", "subvention", "achievement",
     "degree", "work", "employment", "revenues", "history", "insurance", "drugs",
     "medical_act", "car", "moto", "truck", "boat", "subscription", "buy/sale",

--- a/packages/cozy-client/src/models/document.js
+++ b/packages/cozy-client/src/models/document.js
@@ -42,27 +42,27 @@ export class Qualification {
   }
 
   /**
-   * Check the given qualification respects the following rules:
+   * Check the given qualification attributes respects the following rules:
    *   - For the given label, if a purpose, sourceCategory or sourceSubCategory
    *     attribute is defined in the model, it must match the given qualification.
    *   - If not defined in the model for the label, a custom purpose, sourceCategory or
    *     sourceSubCategory value can be defined, if it exist in their respective
-   *     authorized values list.
+   *     known values list.
    *   - For the given label, if subjects are defined in the model, they must be included
    *     in the given qualification.
-   *   - If extra subjects are set, they should exist in the authorized values.
+   *   - If extra subjects are set, they should exist in the known values.
    *
-   * @param {Qualification} qualification - The qualification to check
+   * @param {object} attributes - The qualification attributes to check
    */
-  checkQualification(qualification) {
-    if (this.purpose !== qualification.purpose) {
+  checkValueAttributes(attributes) {
+    if (this.purpose !== attributes.purpose) {
       if (!this.purpose) {
-        const isListedValue = qualificationModel.purposeAuthorizedValues.includes(
-          qualification.purpose
+        const isKnownValue = qualificationModel.purposeKnownValues.includes(
+          attributes.purpose
         )
-        if (!isListedValue) {
+        if (!isKnownValue) {
           console.info(
-            `This purpose is not listed among the possible values: ${qualification.purpose}. ` +
+            `This purpose is not listed among the known values: ${attributes.purpose}. ` +
               `Please open an issue on https://github.com/cozy/cozy-client/issues`
           )
         }
@@ -73,14 +73,14 @@ export class Qualification {
         )
       }
     }
-    if (this.sourceCategory !== qualification.sourceCategory) {
+    if (this.sourceCategory !== attributes.sourceCategory) {
       if (!this.sourceCategory) {
-        const isListedValue = qualificationModel.sourceCategoryAuthorizedValues.includes(
-          qualification.sourceCategory
+        const isKnownValue = qualificationModel.sourceCategoryKnownValues.includes(
+          attributes.sourceCategory
         )
-        if (!isListedValue) {
+        if (!isKnownValue) {
           console.info(
-            `This sourceCategory is not listed among the possible values: ${qualification.sourceCategory}. ` +
+            `This sourceCategory is not listed among the known values: ${attributes.sourceCategory}. ` +
               `Please open an issue on https://github.com/cozy/cozy-client/issues`
           )
         }
@@ -91,14 +91,14 @@ export class Qualification {
         )
       }
     }
-    if (this.sourceSubCategory !== qualification.sourceSubCategory) {
+    if (this.sourceSubCategory !== attributes.sourceSubCategory) {
       if (!this.sourceSubCategory) {
-        const isListedValue = qualificationModel.sourceSubCategoryAuthorizedValues.includes(
-          qualification.sourceSubCategory
+        const isKnownValue = qualificationModel.sourceSubCategoryKnownValues.includes(
+          attributes.sourceSubCategory
         )
-        if (!isListedValue) {
+        if (!isKnownValue) {
           console.info(
-            `This sourceSubCategory is not listed among the possible values: ${qualification.sourceSubCategory}. ` +
+            `This sourceSubCategory is not listed among the known values: ${attributes.sourceSubCategory}. ` +
               `Please open an issue on https://github.com/cozy/cozy-client/issues`
           )
         }
@@ -110,22 +110,22 @@ export class Qualification {
       }
     }
 
-    const missingSubjects = difference(this.subjects, qualification.subjects)
+    const missingSubjects = difference(this.subjects, attributes.subjects)
     if (missingSubjects.length > 0) {
       throw new Error(
         `The subjects for the label ${this.label} should include ${this.subjects}. ` +
           `Please use this or open an issue on https://github.com/cozy/cozy-client/issues`
       )
     }
-    const extraSubjects = difference(qualification.subjects, this.subjects)
+    const extraSubjects = difference(attributes.subjects, this.subjects)
     if (extraSubjects.length > 0) {
       const unknownSubjects = difference(
         extraSubjects,
-        qualificationModel.subjectsAuthorizedValues
+        qualificationModel.subjectsKnownValues
       )
       if (unknownSubjects.length > 0)
         console.info(
-          `These subjects are not listed among the possible values: ${unknownSubjects}. ` +
+          `These subjects are not listed among the known values: ${unknownSubjects}. ` +
             `Please open an issue on https://github.com/cozy/cozy-client/issues`
         )
     }
@@ -215,7 +215,7 @@ Qualification.getQualificationByLabel = label => {
  */
 export const setQualification = (document, qualification) => {
   if (qualification.label) {
-    new Qualification(qualification.label).checkQualification(qualification)
+    new Qualification(qualification.label).checkValueAttributes(qualification)
   } else {
     throw new Error('You must set a label to qualify')
   }

--- a/packages/cozy-client/src/models/document.js
+++ b/packages/cozy-client/src/models/document.js
@@ -54,7 +54,7 @@ export class Qualification {
    *
    * @param {object} attributes - The qualification attributes to check
    */
-  checkValueAttributes(attributes) {
+  checkAttributes(attributes) {
     if (this.purpose !== attributes.purpose) {
       if (!this.purpose) {
         const isKnownValue = qualificationModel.purposeKnownValues.includes(
@@ -202,7 +202,7 @@ export class Qualification {
  * @param {string} label - The label to qualify
  * @returns {Qualification} - The qualification
  */
-Qualification.getQualificationByLabel = label => {
+Qualification.getByLabel = label => {
   return new Qualification(label)
 }
 
@@ -215,7 +215,7 @@ Qualification.getQualificationByLabel = label => {
  */
 export const setQualification = (document, qualification) => {
   if (qualification.label) {
-    new Qualification(qualification.label).checkValueAttributes(qualification)
+    new Qualification(qualification.label).checkAttributes(qualification)
   } else {
     throw new Error('You must set a label to qualify')
   }

--- a/packages/cozy-client/src/models/document.js
+++ b/packages/cozy-client/src/models/document.js
@@ -7,10 +7,10 @@ import * as qualificationModel from '../assets/qualifications.json'
  * The qualifications model is stored in the assets, associating
  * labels to attributes, namely: purpose, sourceCategory, sourceSubCategory
  * and subjects.
- * Only subjects can be customized: see the checkQualification for more
- * details about the qualification rules.
+ * A qualification can be customized accordingly to rules detailed in
+ * the checkValueAttributes method.
  */
-class Qualification {
+export class Qualification {
   /**
    * @typedef {object} Qualification Qualification's object.
    * @property {string} label - The qualification label.
@@ -202,7 +202,7 @@ class Qualification {
  * @param {string} label - The label to qualify
  * @returns {Qualification} - The qualification
  */
-export const getQualificationByLabel = label => {
+Qualification.getQualificationByLabel = label => {
   return new Qualification(label)
 }
 

--- a/packages/cozy-client/src/models/document.js
+++ b/packages/cozy-client/src/models/document.js
@@ -227,17 +227,14 @@ export const setQualification = (document, qualification) => {
  * Helper to get the qualification from a document
  *
  * @param {object} document - The document
- * @returns {object} - The document qualification
+ * @returns {Qualification} - The document qualification
  *
  */
 export const getQualification = document => {
-  return {
-    purpose: get(document, 'metadata.qualification.purpose'),
-    sourceCategory: get(document, 'metadata.qualification.sourceCategory'),
-    sourceSubCategory: get(
-      document,
-      'metadata.qualification.sourceSubCategory'
-    ),
-    subjects: get(document, 'metadata.qualification.subjects')
-  }
+  const docQualification = get(document, 'metadata.qualification')
+  const qualification = new Qualification(
+    docQualification.label,
+    docQualification.qualification
+  )
+  return qualification.toQualification()
 }

--- a/packages/cozy-client/src/models/document.js
+++ b/packages/cozy-client/src/models/document.js
@@ -12,13 +12,17 @@ import * as qualificationModel from '../assets/qualifications.json'
  */
 class Qualification {
   /**
-   * @class
-   * @param {string} label - The qualification label.
-   * @param {object} attributes - Qualification attributes.
-   * @param {string} attributes.purpose - The document purpose.
-   * @param {string} attributes.sourceCategory - The activity field of the document source.
-   * @param {string} attributes.sourceSubCategory - The sub-activity field of the document source.
-   * @param {Array} attributes.subjects - On what is about the document.
+   * @typedef {object} Qualification Qualification's object.
+   * @property {string} label - The qualification label.
+   * @property {string} purpose - The document purpose.
+   * @property {string} sourceCategory - The activity field of the document source.
+   * @property {string} sourceSubCategory - The sub-activity field of the document source.
+   * @property {Array} subjects - On what is about the document.
+   */
+
+  /**
+   * @param {string} label - The qualification label
+   * @param {Qualification} attributes - Qualification's attributes
    */
   constructor(label, attributes = {}) {
     const qualification = qualificationModel.qualifications.find(
@@ -196,7 +200,7 @@ class Qualification {
  * Returns the qualification associated to a label.
  *
  * @param {string} label - The label to qualify
- * @returns {object} - The qualification
+ * @returns {Qualification} - The qualification
  */
 export const getQualificationByLabel = label => {
   return new Qualification(label)
@@ -206,7 +210,7 @@ export const getQualificationByLabel = label => {
  * Set the qualification to the document metadata
  *
  * @param {object} document - The document to set the qualification
- * @param {object} qualification - The qualification to set
+ * @param {Qualification} qualification - The qualification to set
  * @returns {object} - The qualified document
  */
 export const setQualification = (document, qualification) => {

--- a/packages/cozy-client/src/models/document.js
+++ b/packages/cozy-client/src/models/document.js
@@ -52,15 +52,15 @@ class Qualification {
    *     in the given qualification.
    *   - If extra subjects are set, they should exist in the authorized values.
    *
-   * @param {object} qualification - The qualification to check
+   * @param {Qualification} qualification - The qualification to check
    */
   checkQualification(qualification) {
     if (this.purpose !== qualification.purpose) {
       if (!this.purpose) {
-        const allowedValue = qualificationModel.purposeAuthorizedValues.includes(
+        const isListedValue = qualificationModel.purposeAuthorizedValues.includes(
           qualification.purpose
         )
-        if (!allowedValue) {
+        if (!isListedValue) {
           console.info(
             `This purpose is not listed among the possible values: ${qualification.purpose}. ` +
               `Please open an issue on https://github.com/cozy/cozy-client/issues`
@@ -75,10 +75,10 @@ class Qualification {
     }
     if (this.sourceCategory !== qualification.sourceCategory) {
       if (!this.sourceCategory) {
-        const allowedValue = qualificationModel.sourceCategoryAuthorizedValues.includes(
+        const isListedValue = qualificationModel.sourceCategoryAuthorizedValues.includes(
           qualification.sourceCategory
         )
-        if (!allowedValue) {
+        if (!isListedValue) {
           console.info(
             `This sourceCategory is not listed among the possible values: ${qualification.sourceCategory}. ` +
               `Please open an issue on https://github.com/cozy/cozy-client/issues`
@@ -93,10 +93,10 @@ class Qualification {
     }
     if (this.sourceSubCategory !== qualification.sourceSubCategory) {
       if (!this.sourceSubCategory) {
-        const allowedValue = qualificationModel.sourceSubCategoryAuthorizedValues.includes(
+        const isListedValue = qualificationModel.sourceSubCategoryAuthorizedValues.includes(
           qualification.sourceSubCategory
         )
-        if (!allowedValue) {
+        if (!isListedValue) {
           console.info(
             `This sourceSubCategory is not listed among the possible values: ${qualification.sourceSubCategory}. ` +
               `Please open an issue on https://github.com/cozy/cozy-client/issues`

--- a/packages/cozy-client/src/models/document.js
+++ b/packages/cozy-client/src/models/document.js
@@ -1,0 +1,239 @@
+import { get, set, difference } from 'lodash'
+import * as qualificationModel from '../assets/qualifications.json'
+
+/**
+ * This class is used to create document Qualification, i.e. metadata
+ * attributes used to describe the document.
+ * The qualifications model is stored in the assets, associating
+ * labels to attributes, namely: purpose, sourceCategory, sourceSubCategory
+ * and subjects.
+ * Only subjects can be customized: see the checkQualification for more
+ * details about the qualification rules.
+ */
+class Qualification {
+  /**
+   * @class
+   * @param {string} label - The qualification label.
+   * @param {object} attributes - Qualification attributes.
+   * @param {string} attributes.purpose - The document purpose.
+   * @param {string} attributes.sourceCategory - The activity field of the document source.
+   * @param {string} attributes.sourceSubCategory - The sub-activity field of the document source.
+   * @param {Array} attributes.subjects - On what is about the document.
+   */
+  constructor(label, attributes = {}) {
+    const qualification = qualificationModel.qualifications.find(
+      qualif => qualif.label === label
+    )
+    if (qualification) {
+      this.label = qualification.label
+      this.purpose = attributes.purpose || qualification.purpose
+      this.sourceCategory =
+        attributes.sourceCategory || qualification.sourceCategory
+      this.sourceSubCategory =
+        attributes.sourceSubCategory || qualification.sourceSubCategory
+      this.subjects = attributes.subjects || qualification.subjects
+    } else {
+      throw new Error('No qualification found for the label ', label)
+    }
+  }
+
+  /**
+   * Check the given qualification respects the following rules:
+   *   - For the given label, if a purpose, sourceCategory or sourceSubCategory
+   *     attribute is defined in the model, it must match the given qualification.
+   *   - If not defined in the model for the label, a custom purpose, sourceCategory or
+   *     sourceSubCategory value can be defined, if it exist in their respective
+   *     authorized values list.
+   *   - For the given label, if subjects are defined in the model, they must be included
+   *     in the given qualification.
+   *   - If extra subjects are set, they should exist in the authorized values.
+   *
+   * @param {object} qualification - The qualification to check
+   */
+  checkQualification(qualification) {
+    if (this.purpose !== qualification.purpose) {
+      if (!this.purpose) {
+        const allowedValue = qualificationModel.purposeAuthorizedValues.includes(
+          qualification.purpose
+        )
+        if (!allowedValue) {
+          console.info(
+            `This purpose is not listed among the possible values: ${qualification.purpose}. ` +
+              `Please open an issue on https://github.com/cozy/cozy-client/issues`
+          )
+        }
+      } else {
+        throw new Error(
+          `The purpose for the label ${this.label} should be ${this.purpose}. ` +
+            `Please use this or open an issue on https://github.com/cozy/cozy-client/issues`
+        )
+      }
+    }
+    if (this.sourceCategory !== qualification.sourceCategory) {
+      if (!this.sourceCategory) {
+        const allowedValue = qualificationModel.sourceCategoryAuthorizedValues.includes(
+          qualification.sourceCategory
+        )
+        if (!allowedValue) {
+          console.info(
+            `This sourceCategory is not listed among the possible values: ${qualification.sourceCategory}. ` +
+              `Please open an issue on https://github.com/cozy/cozy-client/issues`
+          )
+        }
+      } else {
+        throw new Error(
+          `The sourceCategory for the label ${this.label} should be ${this.sourceCategory}. ` +
+            `Please use this or open an issue on https://github.com/cozy/cozy-client/issues`
+        )
+      }
+    }
+    if (this.sourceSubCategory !== qualification.sourceSubCategory) {
+      if (!this.sourceSubCategory) {
+        const allowedValue = qualificationModel.sourceSubCategoryAuthorizedValues.includes(
+          qualification.sourceSubCategory
+        )
+        if (!allowedValue) {
+          console.info(
+            `This sourceSubCategory is not listed among the possible values: ${qualification.sourceSubCategory}. ` +
+              `Please open an issue on https://github.com/cozy/cozy-client/issues`
+          )
+        }
+      } else {
+        throw new Error(
+          `The sourceSubCategory for the label ${this.label} should be ${this.sourceSubCategory}. ` +
+            `Please use this or open an issue on https://github.com/cozy/cozy-client/issues`
+        )
+      }
+    }
+
+    const missingSubjects = difference(this.subjects, qualification.subjects)
+    if (missingSubjects.length > 0) {
+      throw new Error(
+        `The subjects for the label ${this.label} should include ${this.subjects}. ` +
+          `Please use this or open an issue on https://github.com/cozy/cozy-client/issues`
+      )
+    }
+    const extraSubjects = difference(qualification.subjects, this.subjects)
+    if (extraSubjects.length > 0) {
+      const unknownSubjects = difference(
+        extraSubjects,
+        qualificationModel.subjectsAuthorizedValues
+      )
+      if (unknownSubjects.length > 0)
+        console.info(
+          `These subjects are not listed among the possible values: ${unknownSubjects}. ` +
+            `Please open an issue on https://github.com/cozy/cozy-client/issues`
+        )
+    }
+  }
+
+  /**
+   * Set purpose to the qualification.
+   *
+   * @param {Array} purpose - The purpose to set.
+   * @returns {Qualification} The Qualification object.
+   */
+  setPurpose(purpose) {
+    return new Qualification(this.label, { ...this.toQualification(), purpose })
+  }
+
+  /**
+   * Set sourceCategory to the qualification.
+   *
+   * @param {Array} sourceCategory - The sourceCategory to set.
+   * @returns {Qualification} The Qualification object.
+   */
+  setSourceCategory(sourceCategory) {
+    return new Qualification(this.label, {
+      ...this.toQualification(),
+      sourceCategory
+    })
+  }
+
+  /**
+   * Set sourceSubCategory to the qualification.
+   *
+   * @param {Array} sourceSubCategory - The sourceSubCategory to set.
+   * @returns {Qualification} The Qualification object.
+   */
+  setSourceSubCategory(sourceSubCategory) {
+    return new Qualification(this.label, {
+      ...this.toQualification(),
+      sourceSubCategory
+    })
+  }
+
+  /**
+   * Set subjects to the qualification.
+   *
+   * @param {Array} subjects - The subjects to set.
+   * @returns {Qualification} The Qualification object.
+   */
+  setSubjects(subjects) {
+    return new Qualification(this.label, {
+      ...this.toQualification(),
+      subjects
+    })
+  }
+
+  /**
+   * Returns the qualification attributes
+   *
+   * @returns {object} The qualification attributes
+   */
+  toQualification() {
+    return {
+      label: this.label,
+      purpose: this.purpose,
+      sourceCategory: this.sourceCategory,
+      sourceSubCategory: this.sourceSubCategory,
+      subjects: this.subjects
+    }
+  }
+}
+
+/**
+ * Returns the qualification associated to a label.
+ *
+ * @param {string} label - The label to qualify
+ * @returns {object} - The qualification
+ */
+export const getQualificationByLabel = label => {
+  return new Qualification(label)
+}
+
+/**
+ * Set the qualification to the document metadata
+ *
+ * @param {object} document - The document to set the qualification
+ * @param {object} qualification - The qualification to set
+ * @returns {object} - The qualified document
+ */
+export const setQualification = (document, qualification) => {
+  if (qualification.label) {
+    new Qualification(qualification.label).checkQualification(qualification)
+  } else {
+    throw new Error('You must set a label to qualify')
+  }
+
+  return set(document, 'metadata.qualification', qualification)
+}
+
+/**
+ * Helper to get the qualification from a document
+ *
+ * @param {object} document - The document
+ * @returns {object} - The document qualification
+ *
+ */
+export const getQualification = document => {
+  return {
+    purpose: get(document, 'metadata.qualification.purpose'),
+    sourceCategory: get(document, 'metadata.qualification.sourceCategory'),
+    sourceSubCategory: get(
+      document,
+      'metadata.qualification.sourceSubCategory'
+    ),
+    subjects: get(document, 'metadata.qualification.subjects')
+  }
+}

--- a/packages/cozy-client/src/models/document.spec.js
+++ b/packages/cozy-client/src/models/document.spec.js
@@ -1,0 +1,158 @@
+import * as Document from './document'
+import * as qualificationModel from '../assets/qualifications.json'
+
+describe('document qualification', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn')
+    jest.spyOn(console, 'info')
+  })
+
+  afterEach(() => {
+    console.warn.mockRestore()
+    console.info.mockRestore()
+  })
+
+  it('should get the correct qualification by the label', () => {
+    const qualification = Document.getQualificationByLabel(
+      'national_id_card'
+    ).toQualification()
+    expect(qualification.label).toEqual('national_id_card')
+    expect(qualification.sourceCategory).toEqual('gov')
+    expect(qualification.sourceSubCategory).toEqual('civil_registration')
+    expect(qualification.subjects).toEqual(['identity'])
+  })
+  it('should get the file qualification', () => {
+    const qualification = {
+      purpose: 'invoice',
+      subjects: ['subscription']
+    }
+    const fileDoc = {
+      _id: '123',
+      metadata: { qualification }
+    }
+    const fileQualification = Document.getQualification(fileDoc)
+    expect(fileQualification).toEqual(qualification)
+  })
+
+  it('should set the correct qualification', () => {
+    const fileDoc = {
+      _id: '123',
+      metadata: {
+        datetime: '2020-01-01T20:38:04Z'
+      }
+    }
+    let qualification = {
+      label: 'health_invoice',
+      purpose: 'invoice',
+      sourceCategory: 'health'
+    }
+    Document.setQualification(fileDoc, qualification)
+    expect(fileDoc).toEqual({
+      _id: '123',
+      metadata: {
+        datetime: '2020-01-01T20:38:04Z',
+        qualification: {
+          label: 'health_invoice',
+          purpose: 'invoice',
+          sourceCategory: 'health'
+        }
+      }
+    })
+
+    qualification = Document.getQualificationByLabel('other_identity_document')
+      .setPurpose('attestation')
+      .setSourceCategory('gov')
+      .setSourceSubCategory('civil_registration')
+      .setSubjects(['identity'])
+    Document.setQualification(fileDoc, qualification)
+    expect(fileDoc).toEqual({
+      _id: '123',
+      metadata: {
+        datetime: '2020-01-01T20:38:04Z',
+        qualification: {
+          label: 'other_identity_document',
+          purpose: 'attestation',
+          sourceCategory: 'gov',
+          sourceSubCategory: 'civil_registration',
+          subjects: ['identity']
+        }
+      }
+    })
+  })
+
+  it('should throw an error when setting a qualification with no label', () => {
+    expect(() =>
+      Document.setQualification({}, { purpose: 'invoice' })
+    ).toThrow()
+  })
+
+  it('should throw an error when setting a qualification with an unknown label', () => {
+    expect(() =>
+      Document.setQualification({}, { label: 'dummy', purpose: 'invoice' })
+    ).toThrow()
+  })
+
+  it('should throw an error when setting a qualification with missing attributes', () => {
+    const qualification = {
+      label: 'health_invoice'
+    }
+    expect(() => Document.setQualification({}, qualification)).toThrow()
+  })
+
+  it('should inform when setting an unknown subject', () => {
+    const qualification = {
+      label: 'health_invoice',
+      purpose: 'invoice',
+      sourceCategory: 'health',
+      subjects: ['very_hard_drugs']
+    }
+    Document.setQualification({}, qualification)
+    expect(console.info).toHaveBeenCalledTimes(1)
+  })
+})
+describe('qualifications items', () => {
+  const isAttributeValueAuthorized = (attributeVal, authorizedValues) => {
+    let isAuthorized
+    if (Array.isArray(attributeVal)) {
+      isAuthorized = attributeVal.some(s => authorizedValues.includes(s))
+    } else {
+      isAuthorized = authorizedValues.includes(attributeVal)
+    }
+    expect(isAuthorized).toBe(true)
+  }
+
+  it('should always define a label', () => {
+    qualificationModel.qualifications.forEach(q => {
+      expect(q).toHaveProperty('label')
+    })
+  })
+
+  it('should define authorized attributes', () => {
+    qualificationModel.qualifications.forEach(q => {
+      if (q.purpose) {
+        isAttributeValueAuthorized(
+          q.purpose,
+          qualificationModel.purposeAuthorizedValues
+        )
+      }
+      if (q.sourceCategory) {
+        isAttributeValueAuthorized(
+          q.sourceCategory,
+          qualificationModel.sourceCategoryAuthorizedValues
+        )
+      }
+      if (q.sourceSubCategory) {
+        isAttributeValueAuthorized(
+          q.sourceSubCategory,
+          qualificationModel.sourceSubCategoryAuthorizedValues
+        )
+      }
+      if (q.subjects) {
+        isAttributeValueAuthorized(
+          q.subjects,
+          qualificationModel.subjectsAuthorizedValues
+        )
+      }
+    })
+  })
+})

--- a/packages/cozy-client/src/models/document.spec.js
+++ b/packages/cozy-client/src/models/document.spec.js
@@ -1,4 +1,4 @@
-import * as Document from './document'
+import { Qualification, setQualification, getQualification } from './document'
 import * as qualificationModel from '../assets/qualifications.json'
 
 describe('document qualification', () => {
@@ -13,7 +13,7 @@ describe('document qualification', () => {
   })
 
   it('should get the correct qualification by the label', () => {
-    const qualification = Document.getQualificationByLabel(
+    const qualification = Qualification.getQualificationByLabel(
       'national_id_card'
     ).toQualification()
     expect(qualification.label).toEqual('national_id_card')
@@ -33,7 +33,7 @@ describe('document qualification', () => {
       _id: '123',
       metadata: { qualification }
     }
-    const fileQualification = Document.getQualification(fileDoc)
+    const fileQualification = getQualification(fileDoc)
     expect(fileQualification).toEqual(qualification)
   })
 
@@ -49,7 +49,7 @@ describe('document qualification', () => {
       purpose: 'invoice',
       sourceCategory: 'health'
     }
-    Document.setQualification(fileDoc, qualification)
+    setQualification(fileDoc, qualification)
     expect(fileDoc).toEqual({
       _id: '123',
       metadata: {
@@ -62,12 +62,14 @@ describe('document qualification', () => {
       }
     })
 
-    qualification = Document.getQualificationByLabel('other_identity_document')
+    qualification = Qualification.getQualificationByLabel(
+      'other_identity_document'
+    )
       .setPurpose('attestation')
       .setSourceCategory('gov')
       .setSourceSubCategory('civil_registration')
       .setSubjects(['identity'])
-    Document.setQualification(fileDoc, qualification)
+    setQualification(fileDoc, qualification)
     expect(fileDoc).toEqual({
       _id: '123',
       metadata: {
@@ -84,14 +86,12 @@ describe('document qualification', () => {
   })
 
   it('should throw an error when setting a qualification with no label', () => {
-    expect(() =>
-      Document.setQualification({}, { purpose: 'invoice' })
-    ).toThrow()
+    expect(() => setQualification({}, { purpose: 'invoice' })).toThrow()
   })
 
   it('should throw an error when setting a qualification with an unknown label', () => {
     expect(() =>
-      Document.setQualification({}, { label: 'dummy', purpose: 'invoice' })
+      setQualification({}, { label: 'dummy', purpose: 'invoice' })
     ).toThrow()
   })
 
@@ -99,7 +99,7 @@ describe('document qualification', () => {
     const qualification = {
       label: 'health_invoice'
     }
-    expect(() => Document.setQualification({}, qualification)).toThrow()
+    expect(() => setQualification({}, qualification)).toThrow()
   })
 
   it('should inform when setting an unknown subject', () => {
@@ -109,7 +109,7 @@ describe('document qualification', () => {
       sourceCategory: 'health',
       subjects: ['very_hard_drugs']
     }
-    Document.setQualification({}, qualification)
+    setQualification({}, qualification)
     expect(console.info).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/cozy-client/src/models/document.spec.js
+++ b/packages/cozy-client/src/models/document.spec.js
@@ -13,7 +13,7 @@ describe('document qualification', () => {
   })
 
   it('should get the correct qualification by the label', () => {
-    const qualification = Qualification.getQualificationByLabel(
+    const qualification = Qualification.getByLabel(
       'national_id_card'
     ).toQualification()
     expect(qualification.label).toEqual('national_id_card')
@@ -62,9 +62,7 @@ describe('document qualification', () => {
       }
     })
 
-    qualification = Qualification.getQualificationByLabel(
-      'other_identity_document'
-    )
+    qualification = Qualification.getByLabel('other_identity_document')
       .setPurpose('attestation')
       .setSourceCategory('gov')
       .setSourceSubCategory('civil_registration')

--- a/packages/cozy-client/src/models/document.spec.js
+++ b/packages/cozy-client/src/models/document.spec.js
@@ -114,14 +114,14 @@ describe('document qualification', () => {
   })
 })
 describe('qualifications items', () => {
-  const isAttributeValueAuthorized = (attributeVal, authorizedValues) => {
-    let isAuthorized
+  const isAttributeValueKnown = (attributeVal, authorizedValues) => {
+    let isKnown
     if (Array.isArray(attributeVal)) {
-      isAuthorized = attributeVal.some(s => authorizedValues.includes(s))
+      isKnown = attributeVal.some(s => authorizedValues.includes(s))
     } else {
-      isAuthorized = authorizedValues.includes(attributeVal)
+      isKnown = authorizedValues.includes(attributeVal)
     }
-    expect(isAuthorized).toBe(true)
+    expect(isKnown).toBe(true)
   }
 
   it('should always define a label', () => {
@@ -133,27 +133,24 @@ describe('qualifications items', () => {
   it('should define authorized attributes', () => {
     qualificationModel.qualifications.forEach(q => {
       if (q.purpose) {
-        isAttributeValueAuthorized(
-          q.purpose,
-          qualificationModel.purposeAuthorizedValues
-        )
+        isAttributeValueKnown(q.purpose, qualificationModel.purposeKnownValues)
       }
       if (q.sourceCategory) {
-        isAttributeValueAuthorized(
+        isAttributeValueKnown(
           q.sourceCategory,
-          qualificationModel.sourceCategoryAuthorizedValues
+          qualificationModel.sourceCategoryKnownValues
         )
       }
       if (q.sourceSubCategory) {
-        isAttributeValueAuthorized(
+        isAttributeValueKnown(
           q.sourceSubCategory,
-          qualificationModel.sourceSubCategoryAuthorizedValues
+          qualificationModel.sourceSubCategoryKnownValues
         )
       }
       if (q.subjects) {
-        isAttributeValueAuthorized(
+        isAttributeValueKnown(
           q.subjects,
-          qualificationModel.subjectsAuthorizedValues
+          qualificationModel.subjectsKnownValues
         )
       }
     })

--- a/packages/cozy-client/src/models/document.spec.js
+++ b/packages/cozy-client/src/models/document.spec.js
@@ -23,7 +23,10 @@ describe('document qualification', () => {
   })
   it('should get the file qualification', () => {
     const qualification = {
+      label: 'isp_invoice',
       purpose: 'invoice',
+      sourceCategory: 'telecom',
+      sourceSubCategory: 'internet',
       subjects: ['subscription']
     }
     const fileDoc = {

--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -1,5 +1,6 @@
 import get from 'lodash/get'
 import isString from 'lodash/isString'
+import { setQualification } from './document'
 
 const FILE_TYPE = 'file'
 const DIR_TYPE = 'directory'
@@ -152,3 +153,18 @@ export const isSharingShorcut = file => Boolean(getSharingShortcutStatus(file))
  */
 export const isSharingShorcutNew = file =>
   getSharingShortcutStatus(file) === 'new'
+
+/**
+ * Save the file with the given qualification
+ *
+ * @param {object} client - The CozyClient instance
+ * @param {object} file - The file to qualify
+ * @param {object} qualification - The file qualification
+ * @returns {object} - The saved file
+ */
+export const saveFileQualification = async (client, file, qualification) => {
+  const qualifiedFile = setQualification(file, qualification)
+  return client
+    .collection('io.cozy.files')
+    .updateMetadataAttribute(file._id, qualifiedFile.metadata)
+}

--- a/packages/cozy-client/src/models/file.spec.js
+++ b/packages/cozy-client/src/models/file.spec.js
@@ -1,5 +1,5 @@
 import * as file from './file'
-import { getQualificationByLabel } from './document'
+import { Qualification } from './document'
 
 describe('File Model', () => {
   it('should test if a file is a note or not', () => {
@@ -240,7 +240,9 @@ describe('File qualification', () => {
         datetime: '2020-01-01T20:38:04Z'
       }
     }
-    const qualification = getQualificationByLabel('health_invoice')
+    const qualification = Qualification.getQualificationByLabel(
+      'health_invoice'
+    )
     const updFile = await file.saveFileQualification(
       mockedClient,
       fileDoc,

--- a/packages/cozy-client/src/models/file.spec.js
+++ b/packages/cozy-client/src/models/file.spec.js
@@ -240,9 +240,7 @@ describe('File qualification', () => {
         datetime: '2020-01-01T20:38:04Z'
       }
     }
-    const qualification = Qualification.getQualificationByLabel(
-      'health_invoice'
-    )
+    const qualification = Qualification.getByLabel('health_invoice')
     const updFile = await file.saveFileQualification(
       mockedClient,
       fileDoc,

--- a/packages/cozy-client/src/models/file.spec.js
+++ b/packages/cozy-client/src/models/file.spec.js
@@ -1,4 +1,5 @@
 import * as file from './file'
+import { getQualificationByLabel } from './document'
 
 describe('File Model', () => {
   it('should test if a file is a note or not', () => {
@@ -213,6 +214,48 @@ describe('File Model', () => {
       expect(
         file.getSharingShortcutTargetMime(nonSharingShortcutDocument)
       ).toBeUndefined()
+    })
+  })
+})
+
+describe('File qualification', () => {
+  let mockedClient
+  let updateMetadataAttribute
+  beforeEach(() => {
+    updateMetadataAttribute = jest.fn()
+    mockedClient = {
+      collection: name => ({
+        updateMetadataAttribute
+      })
+    }
+  })
+
+  it('should save the qualification', async () => {
+    updateMetadataAttribute.mockImplementation((_id, attributes) => {
+      return { _id, metadata: { ...attributes } }
+    })
+    const fileDoc = {
+      _id: '123',
+      metadata: {
+        datetime: '2020-01-01T20:38:04Z'
+      }
+    }
+    const qualification = getQualificationByLabel('health_invoice')
+    const updFile = await file.saveFileQualification(
+      mockedClient,
+      fileDoc,
+      qualification
+    )
+    expect(updFile).toEqual({
+      _id: '123',
+      metadata: {
+        datetime: '2020-01-01T20:38:04Z',
+        qualification: {
+          label: 'health_invoice',
+          sourceCategory: 'health',
+          purpose: 'invoice'
+        }
+      }
     })
   })
 })

--- a/packages/cozy-client/src/models/index.js
+++ b/packages/cozy-client/src/models/index.js
@@ -8,6 +8,7 @@ import * as note from './note'
 import * as permission from './permission'
 import * as utils from './utils'
 import * as contact from './contact'
+import * as document from './document'
 
 // For backward compatibility before 9.0.0
 const triggers = trigger
@@ -25,5 +26,6 @@ export {
   accounts,
   permission,
   utils,
-  contact
+  contact,
+  document
 }


### PR DESCRIPTION
This PR:
* Add the new qualification.json model
* Implement helpers so apps/konnectors can automatically qualify documents based on their labels
* Implement setters to customize the qualification
* Implement integrity checks on the qualification
* Add tests
* Add doc

Next steps:
* Update the documentation [here](https://github.com/cozy/cozy-doctypes/blob/master/docs/io.cozy.files_metadata.md#administrative-documents) and maybe add a how-to in cozy-client.
* Develop a migration service in Cozy Drive to requalify files having the old qualification
* Use the new qualification in cozy-scanner
* Use the new qualification in the concerned konnectors