### PR TITLE
feat: Add telecom invoice qualification

### DIFF
--- a/packages/cozy-client/src/assets/qualifications.json
+++ b/packages/cozy-client/src/assets/qualifications.json
@@ -268,6 +268,11 @@
       "subjects": ["subscription"]
     },
     {
+      "label": "telecom_invoice",
+      "purpose": "invoice",
+      "sourceCategory": "telecom"
+    },
+    {
       "label": "energy_invoice",
       "purpose": "invoice",
       "sourceCategory": "energy"
@@ -356,6 +361,6 @@
     "degree", "work", "employment", "revenues", "history", "insurance", "drugs",
     "medical_act", "car", "moto", "truck", "boat", "subscription", "buy/sale",
     "house", "compliance", "building", "food", "real_estate", "tax", "insurance",
-    "education", "statement", "course"
+    "education", "statement", "course", "internet", "phone"
   ]
 }


### PR DESCRIPTION
This qualification is useful for telecom bills grouping both mobile and box invoices. The konnector might specify "internet" and "phone" in the subjects