### PR TITLE
fix: Use correct var in create

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -496,7 +496,7 @@ client.query(Q('io.cozy.bills'))`)
   async create(type, doc, references, options = {}) {
     const { _type, ...attributes } = doc
     const normalizedDoc = { _type: type, ...attributes }
-    const ret = await this.schema.validate(document)
+    const ret = await this.schema.validate(normalizedDoc)
     if (ret !== true) throw new Error('Validation failed')
     return this.mutate(
       this.getDocumentSavePlan(normalizedDoc, references),

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -49,6 +49,7 @@ jest.mock('./store', () => ({
   getQueryFromState: jest.fn().mockReturnValue({})
 }))
 
+
 describe('CozyClient initialization', () => {
   let client, links
 
@@ -1382,9 +1383,9 @@ describe('CozyClient', () => {
 })
 
 describe('file creation', () => {
-  const setup = () => {
+  const setup = (options = {}) => {
     const client = new CozyClient({
-      schema: SCHEMA
+      schema: options.schema || SCHEMA
     })
     const fileCol = new FileCollection('io.cozy.files', client.stackClient)
     client.stackClient.collection.mockReturnValue(fileCol)
@@ -1410,6 +1411,23 @@ describe('file creation', () => {
       undefined,
       { headers: { Date: '' } }
     )
+  })
+
+  it('should not be possible to create a document with a wrong schema', async () => {
+    const customSchema = {
+      validated: {
+        doctype: 'io.cozy.validated',
+        attributes: {
+          dummy: 'dummy'
+        }
+      }
+    }
+    const { client } = setup({ schema: customSchema })
+    jest
+      .spyOn(client.schema, 'validateAttribute')
+      .mockResolvedValue('must be unique')
+    const res = client.create('io.cozy.validated', {})
+    await expect(res).rejects.toEqual(new Error('Validation failed'))
   })
 
   it('should be possible to create a file', async () => {

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -49,7 +49,6 @@ jest.mock('./store', () => ({
   getQueryFromState: jest.fn().mockReturnValue({})
 }))
 
-
 describe('CozyClient initialization', () => {
   let client, links
 


### PR DESCRIPTION
https://github.com/cozy/cozy-client/commit/03e46d12574b897a76af925917b8d944fec4d929 introduced a bug that makes any call to `client.create` fails with `ReferenceError: document is not defined`