### PR TITLE
feat: Sharing get & permission check shortcut

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -326,6 +326,16 @@ we have in the store.</p>
 <dd></dd>
 <dt><a href="#PermissionItem">PermissionItem</a> : <code>object</code></dt>
 <dd></dd>
+<dt><a href="#Permission">Permission</a> : <code>object</code></dt>
+<dd><p>When a cozy to cozy sharing is created Cozy&#39;s stack creates a
+shortcut in <code>/Inbox of sharing</code> on the recipient&#39;s cozy to have a
+quick access even when the sharing is not accepted yet.</p>
+<p>However, this file is created only if the stack knows the URL of the cozy.
+This is not always the case.</p>
+<p>This method is here to tell us if the shortcut&#39;s file is created
+on the recipient&#39;s cozy. It can be used to make an UI distinction between the
+both situation.</p>
+</dd>
 <dt><a href="#HydratedQueryState">HydratedQueryState</a> ⇒ <code><a href="#HydratedQueryState">HydratedQueryState</a></code></dt>
 <dd><p>Returns the query from the store with hydrated documents.</p>
 </dd>
@@ -2732,6 +2742,33 @@ Couchdb document like an io.cozy.files
 | selector | <code>string</code> | defaults to `id` |
 | values | <code>Array.&lt;string&gt;</code> |  |
 | type | <code>string</code> | a couch db database like 'io.cozy.files' |
+
+<a name="Permission"></a>
+
+## Permission : <code>object</code>
+When a cozy to cozy sharing is created Cozy's stack creates a
+shortcut in `/Inbox of sharing` on the recipient's cozy to have a
+quick access even when the sharing is not accepted yet.
+
+However, this file is created only if the stack knows the URL of the cozy.
+This is not always the case.
+
+This method is here to tell us if the shortcut's file is created
+on the recipient's cozy. It can be used to make an UI distinction between the
+both situation.
+
+**Kind**: global typedef  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| permission | [<code>Permission</code>](#Permission) | From getOwnPermissions mainly |
+
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| data | <code>object</code> | Permission document |
+| included | <code>Array</code> | Member information from the sharing |
 
 <a name="HydratedQueryState"></a>
 

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -89,6 +89,9 @@ through OAuth.</p>
 <dt><a href="#Stream">Stream</a> : <code>object</code></dt>
 <dd><p>Stream is not defined in a browser, but is on NodeJS environment</p>
 </dd>
+<dt><a href="#Permission">Permission</a> ⇒ <code><a href="#Permission">Permission</a></code></dt>
+<dd><p>async getOwnPermissions - Gets the permission for the current token</p>
+</dd>
 <dt><a href="#Rule">Rule</a> : <code>object</code></dt>
 <dd><p>A sharing rule</p>
 </dd>
@@ -1014,7 +1017,6 @@ Implements `DocumentCollection` API along with specific methods for `io.cozy.per
     * [.fetchPermissionsByLink(permissions)](#PermissionCollection+fetchPermissionsByLink)
     * [.fetchAllLinks(document)](#PermissionCollection+fetchAllLinks) ⇒ <code>object</code>
     * [.revokeSharingLink(document)](#PermissionCollection+revokeSharingLink)
-    * [.getOwnPermissions()](#PermissionCollection+getOwnPermissions) ⇒ <code>object</code>
 
 <a name="PermissionCollection+create"></a>
 
@@ -1101,12 +1103,6 @@ Destroy a sharing link and the related permissions
 | --- | --- |
 | document | <code>object</code> | 
 
-<a name="PermissionCollection+getOwnPermissions"></a>
-
-### permissionCollection.getOwnPermissions() ⇒ <code>object</code>
-async getOwnPermissions - Gets the permission for the current token
-
-**Kind**: instance method of [<code>PermissionCollection</code>](#PermissionCollection)  
 <a name="SettingsCollection"></a>
 
 ## SettingsCollection
@@ -1134,6 +1130,7 @@ Implements the `DocumentCollection` API along with specific methods for
 **Kind**: global class  
 
 * [SharingCollection](#SharingCollection)
+    * [.get(id)](#SharingCollection+get) ⇒ [<code>Sharing</code>](#Sharing)
     * [.create(params)](#SharingCollection+create)
     * ~~[.share(document, recipients, sharingType, description, [previewPath])](#SharingCollection+share)~~
     * [.getDiscoveryLink(sharingId, sharecode)](#SharingCollection+getDiscoveryLink) ⇒ <code>string</code>
@@ -1141,6 +1138,16 @@ Implements the `DocumentCollection` API along with specific methods for
     * [.revokeRecipient(sharing, recipientIndex)](#SharingCollection+revokeRecipient)
     * [.revokeSelf(sharing)](#SharingCollection+revokeSelf)
     * [.revokeAllRecipients(sharing)](#SharingCollection+revokeAllRecipients)
+
+<a name="SharingCollection+get"></a>
+
+### sharingCollection.get(id) ⇒ [<code>Sharing</code>](#Sharing)
+**Kind**: instance method of [<code>SharingCollection</code>](#SharingCollection)  
+**Returns**: [<code>Sharing</code>](#Sharing) - sharing  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| id | <code>string</code> | Sharing's id |
 
 <a name="SharingCollection+create"></a>
 
@@ -1436,6 +1443,13 @@ Document representing a io.cozy.files
 Stream is not defined in a browser, but is on NodeJS environment
 
 **Kind**: global typedef  
+<a name="Permission"></a>
+
+## Permission ⇒ [<code>Permission</code>](#Permission)
+async getOwnPermissions - Gets the permission for the current token
+
+**Kind**: global typedef  
+**Returns**: [<code>Permission</code>](#Permission) - permission  
 <a name="Rule"></a>
 
 ## Rule : <code>object</code>

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -90,7 +90,7 @@ through OAuth.</p>
 <dd><p>Stream is not defined in a browser, but is on NodeJS environment</p>
 </dd>
 <dt><a href="#Permission">Permission</a> ⇒ <code><a href="#Permission">Permission</a></code></dt>
-<dd><p>async getOwnPermissions - Gets the permission for the current token</p>
+<dd><p>async fetchOwnPermissions - Fetches permissions</p>
 </dd>
 <dt><a href="#Rule">Rule</a> : <code>object</code></dt>
 <dd><p>A sharing rule</p>
@@ -1446,7 +1446,7 @@ Stream is not defined in a browser, but is on NodeJS environment
 <a name="Permission"></a>
 
 ## Permission ⇒ [<code>Permission</code>](#Permission)
-async getOwnPermissions - Gets the permission for the current token
+async fetchOwnPermissions - Fetches permissions
 
 **Kind**: global typedef  
 **Returns**: [<code>Permission</code>](#Permission) - permission  

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -1142,6 +1142,8 @@ Implements the `DocumentCollection` API along with specific methods for
 <a name="SharingCollection+get"></a>
 
 ### sharingCollection.get(id) ⇒ [<code>Sharing</code>](#Sharing)
+Fetches a sharing by id
+
 **Kind**: instance method of [<code>SharingCollection</code>](#SharingCollection)  
 **Returns**: [<code>Sharing</code>](#Sharing) - sharing  
 

--- a/packages/cozy-client/src/models/permission.js
+++ b/packages/cozy-client/src/models/permission.js
@@ -139,3 +139,32 @@ export async function isDocumentReadOnly(args) {
     return undefined
   }
 }
+
+/**
+ * When a cozy to cozy sharing is created Cozy's stack creates a
+ * shortcut in `/Inbox of sharing` on the recipient's cozy to have a
+ * quick access even when the sharing is not accepted yet.
+ *
+ * However, this file is created only if the stack knows the URL of the cozy.
+ * This is not always the case.
+ *
+ * This method is here to tell us if the shortcut's file is created
+ * on the recipient's cozy. It can be used to make an UI distinction between the
+ * both situation.
+ *
+ * @typedef  {object} Permission
+ * @property {object} data Permission document
+ * @property {Array} included Member information from the sharing
+ *
+ * @param {Permission} permission From getOwnPermissions mainly
+ */
+export const isShortcutCreatedOnTheRecipientCozy = permission => {
+  if (!permission.included) return false
+  const sharingMember = permission.included.find(
+    item => item.type === 'io.cozy.sharings.members'
+  )
+  if (sharingMember && sharingMember.attributes.instance) {
+    return true
+  }
+  return false
+}

--- a/packages/cozy-client/src/models/permission.spec.js
+++ b/packages/cozy-client/src/models/permission.spec.js
@@ -1,4 +1,9 @@
-import { isReadOnly, isDocumentReadOnly, fetchOwn } from './permission'
+import {
+  isReadOnly,
+  isDocumentReadOnly,
+  fetchOwn,
+  isShortcutCreatedOnTheRecipientCozy
+} from './permission'
 
 function getById(id, doctype) {
   const parents = {
@@ -159,5 +164,40 @@ describe('fetchOwn', () => {
       { type: 'io.cozy.files', values: ['first', 'other'], verbs: [] },
       { type: 'io.cozy.photo.albums', values: ['third'], verbs: [] }
     ])
+  })
+})
+
+describe('isShortcutCreatedOnTheRecipientCozy', () => {
+  it('tests the return ', () => {
+    const includedWithInstance = [
+      {
+        type: 'io.cozy.sharings.members',
+        id: '',
+        attributes: {
+          status: 'seen',
+          name: 'alice@cozy.tools',
+          email: 'alice@cozy.tools',
+          instance: 'http://q2.cozy.tools:8080'
+        }
+      }
+    ]
+    expect(
+      isShortcutCreatedOnTheRecipientCozy({ included: includedWithInstance })
+    ).toBeTruthy()
+
+    const includedWithoutInstance = [
+      {
+        type: 'io.cozy.sharings.members',
+        id: '',
+        attributes: {
+          status: 'seen',
+          name: 'alice@cozy.tools',
+          email: 'alice@cozy.tools'
+        }
+      }
+    ]
+    expect(
+      isShortcutCreatedOnTheRecipientCozy({ included: includedWithoutInstance })
+    ).toBeFalsy()
   })
 })

--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -189,14 +189,20 @@ class PermissionCollection extends DocumentCollection {
     }
   }
 
+  async getOwnPermissions() {
+    console.warn(
+      'getOwnPermissions is deprecated, please use fetchOwnPermissions instead'
+    )
+    return this.fetchOwnPermissions()
+  }
   /**
-   * async getOwnPermissions - Gets the permission for the current token
+   * async fetchOwnPermissions - Fetches permissions
    *
    * @typedef {object} Permission
    *
    * @returns {Permission} permission
    */
-  async getOwnPermissions() {
+  async fetchOwnPermissions() {
     const resp = await this.stackClient.fetchJSON('GET', '/permissions/self')
     return {
       data: normalizePermission(resp.data),

--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -192,7 +192,9 @@ class PermissionCollection extends DocumentCollection {
   /**
    * async getOwnPermissions - Gets the permission for the current token
    *
-   * @returns {object}
+   * @typedef {object} Permission
+   *
+   * @returns {Permission} permission
    */
   async getOwnPermissions() {
     const resp = await this.stackClient.fetchJSON('GET', '/permissions/self')

--- a/packages/cozy-stack-client/src/PermissionCollection.spec.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.spec.js
@@ -57,8 +57,8 @@ describe('PermissionCollection', () => {
         )
       })
     })
-    it('should get its own permissions', async () => {
-      await collection.getOwnPermissions()
+    it('should fetch its own permissions', async () => {
+      await collection.fetchOwnPermissions()
       expect(client.fetchJSON).toHaveBeenCalledWith('GET', '/permissions/self')
     })
 

--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -37,6 +37,7 @@ class SharingCollection extends DocumentCollection {
     }
   }
   /**
+   * Fetches a sharing by id
    *
    * @param {string} id Sharing's id
    * @returns {Sharing} sharing

--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -1,8 +1,9 @@
 import DocumentCollection, { normalizeDoc } from './DocumentCollection'
 import { isFile, isDirectory } from './FileCollection'
 import { uri } from './utils'
+export const SHARING_DOCTYPE = 'io.cozy.sharings'
 
-const normalizeSharing = sharing => normalizeDoc(sharing, 'io.cozy.sharings')
+const normalizeSharing = sharing => normalizeDoc(sharing, SHARING_DOCTYPE)
 
 /**
  * @typedef {object} Rule A sharing rule
@@ -35,6 +36,19 @@ class SharingCollection extends DocumentCollection {
       data: resp.data.map(normalizeSharing)
     }
   }
+  /**
+   *
+   * @param {string} id Sharing's id
+   * @returns {Sharing} sharing
+   */
+  async get(id) {
+    const path = uri`/sharings/${id}`
+    const resp = await this.stackClient.fetchJSON('GET', path)
+    return {
+      data: normalizeSharing(resp.data)
+    }
+  }
+
   /**
    *
    * Creates a new Sharing. See https://docs.cozy.io/en/cozy-stack/sharing/#post-sharings

--- a/packages/cozy-stack-client/src/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/SharingCollection.spec.js
@@ -32,7 +32,7 @@ describe('SharingCollection', () => {
   const collection = new SharingCollection('io.cozy.sharings', client)
 
   describe('get', () => {
-    it('tests if it calls the right route', async () => {
+    it('should call the right route', async () => {
       client.fetchJSON.mockReturnValue(Promise.resolve({ data: [] }))
       await collection.get('1')
       expect(client.fetchJSON).toHaveBeenCalledWith('GET', '/sharings/1')

--- a/packages/cozy-stack-client/src/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/SharingCollection.spec.js
@@ -31,6 +31,13 @@ describe('SharingCollection', () => {
   const client = new CozyStackClient()
   const collection = new SharingCollection('io.cozy.sharings', client)
 
+  describe('get', () => {
+    it('tests if it calls the right route', async () => {
+      client.fetchJSON.mockReturnValue(Promise.resolve({ data: [] }))
+      await collection.get('1')
+      expect(client.fetchJSON).toHaveBeenCalledWith('GET', '/sharings/1')
+    })
+  })
   describe('findByDoctype', () => {
     beforeEach(() => {
       client.fetch.mockReset()


### PR DESCRIPTION
- Add get on sharing doctype to be able to client.query(client.get('io.cozy.sharings', sharingId))
- Add isShortcutCreatedOnTheRecipientCozy (from Drive, but we'll need it in Notes and others apps using sharing / permission) 