### PR TITLE
feat: Deprecate query helpers on the client

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,6 +5,9 @@
 - [Creating a client](#creating-a-client)
 - [How to query with Cozy Client](#how-to-query-with-cozy-client)
 - [How to mutate the data](#how-to-mutate-the-data)
+- [Learn more about queries](#learn-more-about-queries)
+- [Connecting with you React components](#connecting-with-you-react-components)
+- [Different entrypoints for node/browser](#different-entrypoints-for-nodebrowser)
 
 <!-- /MarkdownTOC -->
 
@@ -68,18 +71,19 @@ Every doctype accessed in `cozy-client` needs to be declared in the schema secti
 
 ## How to query with Cozy Client
 
-The two main methods to query data with cozyClient are `find()` and `get()`. Both take an doctype as first argument and return a `QueryDefinition` object: 
+To run a query, we first build a `QueryDefinition` with `Q`: 
 
 ```javascript
-client.find('io.cozy.todos')
+import { Q } from 'cozy-client'
 
-client.get('io.cozy.todos', '5fcbbf2cb171b1d5c3bc6df3d4affb32')
+const allTodosQuery = Q('io.cozy.todos')
+const singleTodoQuery = Q('io.cozy.todos').getById('5fcbbf2cb171b1d5c3bc6df3d4affb32')
 ```
 
 A `QueryDefinition` is a special object that describe a query to be sent to CouchDB. It uses a fluent interface:
 
 ```javascript
-client.find('io.cozy.todos')
+Q('io.cozy.todos')
   .select(['title', 'checked'])
   .where({checked: false})
   .include(['dependencies'])
@@ -101,11 +105,8 @@ const client = new CozyClient({
   /*...*/
 })
 
-client.query(
-  client.find('io.cozy.todos').where({ checked: false })
-).then(
-  ({ data }) => console.log(data)
-)
+const { data } = await client.query(Q('io.cozy.todos').where({ checked: false }))
+console.log(data)
 ```
 
 ## How to mutate the data
@@ -123,19 +124,11 @@ const client = new CozyClient({
 // create a new io.cozy.todo
 await client.create('io.cozy.todos', { label: 'Buy bread', checked: false })
 
-client.query(
-  client.find('io.cozy.todos').where({ checked: false })
-).then(
-  
-  ({ data }) => {
-
-    const doc = data[0]
-    // modify existing io.cozy.todo
-    await client.save({...doc, checked: true})
-
-  }
-
-)
+const qdef = Q('io.cozy.todos').where({ checked: false })
+const { data: todos } = await client.query(qdef)
+const doc = todos[0]
+// modify existing io.cozy.todo
+await client.save({...doc, checked: true})
 ```
 
 Both `create()` and `save()` will return a Promise with a `data` attribute containing the saved document.

--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -7,14 +7,15 @@ Once connected, your components will receive the requesting data and a fetch sta
 <!-- MarkdownTOC autolink=true -->
 
 - [1. Setup](#1-setup)
-    - [1.a Initialize a CozyClient provider](#1a-initialize-a-cozyclient-provider)
+  - [1.a Initialize a CozyClient provider](#1a-initialize-a-cozyclient-provider)
     - [1.b Use your own Redux store](#1b-use-your-own-redux-store)
 - [2. Usage](#2-usage)
-    - [2.a Requesting data with ``](#2a-requesting-data-with-)
-    - [2.b Requesting data with the `queryConnect` HOC](#2b-requesting-data-with-the-queryconnect-hoc)
-    - [2.c Using a fetch policy to decrease network requests](#2c-using-a-fetch-policy-to-decrease-network-requests)
-- [3. Mutating data](#3-mutating-data)
-- [4. Testing](#4-testing)
+  - [2.a Requesting data with ``](#2a-requesting-data-with-)
+  - [2.b Requesting data with the `queryConnect` HOC](#2b-requesting-data-with-the-queryconnect-hoc)
+  - [2.c Using a fetch policy to decrease network requests](#2c-using-a-fetch-policy-to-decrease-network-requests)
+  - [2.d Keeping data up to date in real time](#2d-keeping-data-up-to-date-in-real-time)
+  - [3. Mutating data](#3-mutating-data)
+  - [4. Testing](#4-testing)
 
 <!-- /MarkdownTOC -->
 
@@ -95,11 +96,13 @@ To make it easy to fetch data and make it available to your component, we provid
 
 
 ```jsx
-import { Query, isQueryLoading } from 'cozy-client'
+import { Query, isQueryLoading, Q } from 'cozy-client'
 
 const todos = 'io.cozy.todos'
 const checked = { checked: false }
-const query = client => client.find(todos).where(checked)
+
+// Use the Q helper to build queries
+const query = Q(todos).where(checked)
 
 function TodoList(props) {
   return <Query query={query}>
@@ -128,12 +131,12 @@ The following props will be given to your wrapped component:
 You can also pass a function instead of a direct query. Your function will be given the props of the component and should return the requested query:
 
 ```jsx
-import { Query } from 'cozy-client'
+import { Query, Q } from 'cozy-client'
 
 const query = function (props) {
   const todos = 'io.cozy.todos'
   const where = { checked: props.checked }
-  return client => client.find(todos).where(where)
+  return Q(todos).where(where)
 }
 
 function TodoList() {
@@ -168,15 +171,11 @@ function TodoList(props) {
   }
 }
 
-const dest = 'result'
-
-const todos = 'io.cozy.todos'
-const checked = { checked: false }
-const query = (client, props) => client.find('id', props.id).where(checked)
-
-const queryOpts = { [dest]: { query } }
-
-const ConnectedTodoList = queryConnect(queryOpts)(TodoList)
+const ConnectedTodoList = queryConnect({
+  result: {
+     query: Q('io.cozy.todos').where({ checked: false })
+  }
+})(TodoList)
 ```
 
 `queryConnect` will use `<Query />` internally so you will inherits the same behaviour.
@@ -196,8 +195,8 @@ function TodoList(props) {
 }
 
 const todos = 'io.cozy.todos'
-const checked = { query: client => client.find(todos).where({ checked: false }) }
-const archived = { query: client => client.find(todos).where({ archive: false }) }
+const checked = { query: Q(todos).where({ checked: false }) }
+const archived = { query: Q(todos).where({ archive: false }) }
 
 const queries = { checked, archived }
 
@@ -309,7 +308,7 @@ import { Query } from 'cozy-client'
 
 const todos = 'io.cozy.todos'
 const checked = { checked: false }
-const query = client => client.find(todos).where(checked)
+const query = Q(todos).where(checked)
 const mutations = client => ({ createDocument: client.create.bind(client) })
 
 function TodoList() {

--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -121,12 +121,13 @@ You may also see a special type named `'io.cozy.files:has-many'`. It's used for 
 Relations are not loaded eagerly by default. If you want your query to load your relations for you by default, you will have to name them in a `include()` request.
 
 ```javascript
-const query = client.find('io.cozy.books')
+const query = Q('io.cozy.books')
   .include(['authors'])
   .limitBy(20)
 ```
 
 You will then find your relations under the `data` attribute: 
+
 ```javascript 
 const response = await client.query(query)
 const docs = response.data

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -462,10 +462,16 @@ client.query(Q('io.cozy.bills'))`)
   }
 
   find(doctype, selector = undefined) {
+    console.warn(
+      'client.find(doctype, selector) is deprecated, please use Q(doctype).where(selector) to build the same query.'
+    )
     return new QueryDefinition({ doctype, selector })
   }
 
   get(doctype, id) {
+    console.warn(
+      'client.get(doctype, id) is deprecated, please use Q(doctype).getById(id) to build the same query.'
+    )
     return new QueryDefinition({ doctype, id })
   }
 

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -15,6 +15,7 @@ import {
 } from './__tests__/fixtures'
 
 import CozyClient from './CozyClient'
+import { Q } from './queries/dsl'
 import CozyStackClient, { OAuthClient } from 'cozy-stack-client'
 import CozyLink from './CozyLink'
 import { Mutations, QueryDefinition } from './queries/dsl'
@@ -30,7 +31,6 @@ import {
 import { HasManyFiles, Association, HasMany } from './associations'
 import mapValues from 'lodash/mapValues'
 import FileCollection from 'cozy-stack-client/dist/FileCollection'
-import { Q } from 'cozy-client'
 
 const normalizeData = data =>
   mapValues(data, (docs, doctype) => {
@@ -566,9 +566,7 @@ describe('CozyClient', () => {
 
   describe('find', () => {
     it('should return a QueryDefinition', () => {
-      expect(
-        client.find('io.cozy.todos').where({ done: { $eq: true } })
-      ).toEqual({
+      expect(Q('io.cozy.todos').where({ done: { $eq: true } })).toEqual({
         doctype: 'io.cozy.todos',
         selector: { done: { $eq: true } }
       })

--- a/packages/cozy-client/src/__tests__/ObservableQuery.spec.js
+++ b/packages/cozy-client/src/__tests__/ObservableQuery.spec.js
@@ -115,7 +115,7 @@ describe('ObservableQuery', () => {
     })
 
     it('should be able to return its results', async () => {
-      const def = client.get('io.cozy.todos', TODO_1._id)
+      const def = Q('io.cozy.todos').getById(TODO_1._id)
       await store.dispatch(initQuery('oneTodo', def))
       query = new ObservableQuery('oneTodo', def, client)
       await store.dispatch(
@@ -126,7 +126,7 @@ describe('ObservableQuery', () => {
 
     it('should return hydrated results even if fetch status != loaded', async () => {
       jest.spyOn(client, 'hydrateDocuments')
-      const def = client.get('io.cozy.todos', TODO_1._id)
+      const def = Q('io.cozy.todos').getById(TODO_1._id)
       await store.dispatch(initQuery('oneTodo', def))
       query = new ObservableQuery('oneTodo', def, client)
       await store.dispatch(

--- a/packages/cozy-client/src/__tests__/StackLink.spec.js
+++ b/packages/cozy-client/src/__tests__/StackLink.spec.js
@@ -24,7 +24,7 @@ describe('StackLink', () => {
     })
 
     it('should execute queries with a selector', async () => {
-      const query = client.find('io.cozy.todos').where({ checked: true })
+      const query = Q('io.cozy.todos').where({ checked: true })
       stackClient.collection().find.mockReset()
       await link.request(query)
       expect(stackClient.collection().find).toHaveBeenCalledWith(

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -226,7 +226,7 @@ describe('CozyPouchLink', () => {
         label: 'Make PouchDB link work',
         done: false
       })
-      const query = client.get(TODO_DOCTYPE, 'deadbeef')
+      const query = Q(TODO_DOCTYPE).getById('deadbeef')
       const resp = await link.request(query)
       expect(resp.data.label).toBe('Make PouchDB link work')
     })
@@ -237,8 +237,8 @@ describe('CozyPouchLink', () => {
       link.pouches.isSynced = jest.fn().mockReturnValue(true)
       const db = link.getPouch(TODO_DOCTYPE)
       await db.bulkDocs(docs.map(x => omit(x, '_type')))
-      const query = client
-        .find(TODO_DOCTYPE, { done: true, label: { $gt: null } })
+      const query = Q(TODO_DOCTYPE)
+        .where({ done: true, label: { $gt: null } })
         .indexFields(['label', 'done'])
       const resp = await link.request(query)
       expect(resp.data.length).toEqual(2)
@@ -267,8 +267,8 @@ describe('CozyPouchLink', () => {
       link.pouches.isSynced = jest.fn().mockReturnValue(true)
       const db = link.getPouch(TODO_DOCTYPE)
       await db.bulkDocs(docs.map(x => omit(x, '_type')))
-      const query = client
-        .find(TODO_DOCTYPE, { label: { $gt: null }, done: true })
+      const query = Q(TODO_DOCTYPE)
+        .where({ label: { $gt: null }, done: true })
         .indexFields(['done', 'label'])
         .sortBy([{ done: 'asc' }, { label: 'asc' }])
       const res = await link.request(query)

--- a/packages/cozy-stack-client/src/__tests__/KonnectorCollection.spec.js
+++ b/packages/cozy-stack-client/src/__tests__/KonnectorCollection.spec.js
@@ -69,17 +69,17 @@ describe(`KonnectorCollection`, () => {
       )
     })
     it('should call the right route', async () => {
-      await collection.get('fakeid')
+      await collection.get('io.cozy.konnectors/fakeid')
       expect(client.fetchJSON).toHaveBeenCalledWith('GET', '/konnectors/fakeid')
     })
 
     it('should return a correct JSON API response', async () => {
-      const resp = await collection.get('fakeid')
+      const resp = await collection.get('io.cozy.konnectors/fakeid')
       expect(resp).toConformToJSONAPI()
     })
 
     it('should return normalized document', async () => {
-      const resp = await collection.get('fakeid')
+      const resp = await collection.get('io.cozy.konnectors/fakeid')
       expect(resp.data).toHaveDocumentIdentity()
     })
   })


### PR DESCRIPTION
By separating query building and result fetching, it is clearer which
method build queries, and which methods retrieve results.

By deprecating those two methods, we make it clear that for query
building, Q is the recommended way, and for executing a query,
client.query is to be used.

- [x] Updated the documentation
- [x] Updated tests