### PR TITLE
feat: Allow registry collection fetch to have a limit parameter

### DIFF
--- a/packages/cozy-client/src/registry.js
+++ b/packages/cozy-client/src/registry.js
@@ -72,13 +72,14 @@ class Registry {
    * @param  {string} params - Fetching parameters
    * @param  {string} params.type - "webapp" or "konnector"
    * @param  {string} params.channel - "dev"/"beta"/"stable"
+   * @param  {string} params.limit - maximum number of fetched apps - defaults to 200
    *
    * @returns {Array<RegistryApp>}
    */
   async fetchApps(params) {
-    const { channel, type } = params
+    const { channel, type, limit = 200 } = params
     const searchParams = {
-      limit: 200,
+      limit,
       versionsChannel: channel,
       latestChannelVersion: channel
     }

--- a/packages/cozy-client/src/registry.spec.js
+++ b/packages/cozy-client/src/registry.spec.js
@@ -105,6 +105,14 @@ describe('registry api', () => {
       )
     })
 
+    it('should handle the limit parameter', async () => {
+      await api.fetchApps({ channel: 'dev', limit: 400 })
+      expect(fetchJSON).toHaveBeenCalledWith(
+        'GET',
+        '/registry?limit=400&versionsChannel=dev&latestChannelVersion=dev'
+      )
+    })
+
     it('should call the correct route (filtering)', async () => {
       await api.fetchApps({ channel: 'beta', type: 'konnector' })
       expect(fetchJSON).toHaveBeenCalledWith(


### PR DESCRIPTION
This will allow a cleaner solution to the growing number of connectors
and apps in the store application.
The next step is to add proper pagination handling for this collection.

See https://github.com/cozy/cozy-store/pull/705#issuecomment-739244759
for more context
