### PR TITLE
feat: Add receipt qualification

### DIFF
--- a/packages/cozy-client/src/assets/qualifications.json
+++ b/packages/cozy-client/src/assets/qualifications.json
@@ -351,6 +351,10 @@
     {
       "label": "other_bank_document",
       "sourceCategory": "bank"
+    },
+    {
+      "label": "receipt",
+      "purpose": "report"
     }
   ],
   "purposeKnownValues": [


### PR DESCRIPTION
This qualification is useful for receipt docs, for instance, coming from [the tax](https://github.com/konnectors/impots/blob/master/src/metadata.js#L71) 