### PR TITLE
feat: Support for perfs.execution_stats flag 

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -137,6 +137,11 @@ Both `create()` and `save()` will return a Promise with a `data` attribute conta
 
 You can check out our dedicated [query documentation](https://docs.cozy.io/en/tutorials/data/queries/) to know more about querying with cozy-client and avoid common traps that can dramatically impact your app performances.
 
+Note you can audit your queries performance by setting a `{ perfs.execution_stats: true }` flag. 
+This will add a log in the browser's development tools console for each query. This log provides  insights such as the query execution time taken on the database or the number of documents scanned. All the available stats are described [here](https://docs.couchdb.org/en/2.3.1/api/database/find.html#execution-statistics).
+
+See [cozy-flags](https://github.com/cozy/cozy-libs/tree/master/packages/cozy-flags) to know how to set flags.
+
 ## Connecting with you React components
 
 CozyClient comes with HOC and render props functions to connect to your data inside you own components. See the specific documentation for [React integration](./react-integration.md)

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -748,6 +748,13 @@ client.query(Q('io.cozy.bills'))`)
     try {
       this.dispatch(loadQuery(queryId))
       const response = await this.requestQuery(queryDefinition)
+      if (response.execution_stats) {
+        console.log(
+          `Execution stats for query ${queryId}: ${JSON.stringify(
+            response.execution_stats
+          )}`
+        )
+      }
       this.dispatch(
         receiveQueryResult(queryId, response, {
           update

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -955,6 +955,7 @@ describe('CozyClient', () => {
     })
 
     it('should first dispatch a INIT_QUERY action', async () => {
+      requestHandler.mockReturnValueOnce(Promise.resolve(fakeResponse))
       await client.query(query, { as: 'allTodos' })
       expect(client.store.dispatch.mock.calls[0][0]).toEqual(
         initQuery('allTodos', { doctype: 'io.cozy.todos' })
@@ -989,6 +990,7 @@ describe('CozyClient', () => {
     })
 
     it('should call the link with the query', async () => {
+      requestHandler.mockReturnValueOnce(Promise.resolve(fakeResponse))
       await client.query(query)
       expect(requestHandler).toHaveBeenCalledTimes(1)
       expect(requestHandler.mock.calls[0][0]).toBe(query)
@@ -1116,6 +1118,7 @@ describe('CozyClient', () => {
     })
 
     it('should dispatch a INIT_QUERY action if status is not loaded', async () => {
+      requestHandler.mockReturnValueOnce(Promise.resolve(fakeResponse))
       getQueryFromState.mockReturnValueOnce({
         fetchStatus: 'pending'
       })
@@ -1126,6 +1129,7 @@ describe('CozyClient', () => {
     })
 
     it('should dispatch a INIT_QUERY action if no skip and no bookmark', async () => {
+      requestHandler.mockReturnValueOnce(Promise.resolve(fakeResponse))
       getQueryFromState.mockReturnValueOnce({
         fetchStatus: 'loaded'
       })

--- a/packages/cozy-pouch-link/package.json
+++ b/packages/cozy-pouch-link/package.json
@@ -14,6 +14,7 @@
     "@cozy/minilog": "1.0.0",
     "cozy-client": "^16.10.2",
     "cozy-device-helper": "^1.7.3",
+    "cozy-flags": "^2.5.0",
     "pouchdb-browser": "^7.0.0",
     "pouchdb-find": "^7.0.0"
   },

--- a/packages/cozy-pouch-link/package.json
+++ b/packages/cozy-pouch-link/package.json
@@ -14,7 +14,6 @@
     "@cozy/minilog": "1.0.0",
     "cozy-client": "^16.10.2",
     "cozy-device-helper": "^1.7.3",
-    "cozy-flags": "^2.5.0",
     "pouchdb-browser": "^7.0.0",
     "pouchdb-find": "^7.0.0"
   },

--- a/packages/cozy-stack-client/package.json
+++ b/packages/cozy-stack-client/package.json
@@ -11,6 +11,7 @@
     "url": "git+https://github.com/cozy/cozy-client.git"
   },
   "dependencies": {
+    "cozy-flags": "^2.5.0",
     "detect-node": "^2.0.4",
     "mime": "^2.4.0",
     "qs": "^6.7.0"

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -1,3 +1,4 @@
+import flag from 'cozy-flags'
 import { uri, attempt, sleep } from './utils'
 import uniq from 'lodash/uniq'
 import transform from 'lodash/transform'
@@ -178,7 +179,8 @@ class DocumentCollection {
       data: resp.docs.map(doc => normalizeDoc(doc, this.doctype)),
       next: resp.next,
       skip,
-      bookmark: resp.bookmark
+      bookmark: resp.bookmark,
+      execution_stats: resp.execution_stats
     }
   }
 
@@ -364,7 +366,8 @@ class DocumentCollection {
       limit,
       skip,
       bookmark: options.bookmark || bookmark,
-      sort
+      sort,
+      execution_stats: flag('perfs.execution_stats') ? true : undefined
     }
     return opts
   }

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -1,5 +1,6 @@
 jest.mock('./CozyStackClient')
 
+import flag from 'cozy-flags'
 import CozyStackClient from './CozyStackClient'
 import DocumentCollection from './DocumentCollection'
 
@@ -534,6 +535,22 @@ describe('DocumentCollection', () => {
           selector: { done: { $exists: true } },
           sort: [{ label: 'desc' }],
           use_index: '_design/123456'
+        }
+      )
+    })
+
+    it('should set executions stats if flag is enabled', async () => {
+      const collection = new DocumentCollection('io.cozy.todos', client)
+      flag('perfs.execution_stats', true)
+      await collection.find({ done: false })
+      expect(client.fetchJSON).toHaveBeenLastCalledWith(
+        'POST',
+        '/data/io.cozy.todos/_find',
+        {
+          selector: { done: false },
+          skip: 0,
+          use_index: '_design/123456',
+          execution_stats: true
         }
       )
     })

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -126,7 +126,8 @@ class FileCollection extends DocumentCollection {
       meta: resp.meta,
       next: resp.meta.count > skip + resp.data.length,
       skip,
-      bookmark: nextBookmark || undefined
+      bookmark: nextBookmark || undefined,
+      execution_stats: resp.execution_stats
     }
   }
 

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -127,7 +127,7 @@ class FileCollection extends DocumentCollection {
       next: resp.meta.count > skip + resp.data.length,
       skip,
       bookmark: nextBookmark || undefined,
-      execution_stats: resp.execution_stats
+      execution_stats: resp.meta.execution_stats
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4290,6 +4290,13 @@ cozy-device-helper@^1.7.3:
   dependencies:
     lodash "^4.17.19"
 
+cozy-flags@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-2.5.0.tgz#f5ade2ceb636afb6151edf2dd9c5d1f34e35ab58"
+  integrity sha512-OluJtFAUSGeX13iPfpdVDQdNypGCTI2mVe8GVU+nY3z7m/lfkRprO3+rNKbOCGUAJJXkqCH+xO7RmqbUsbs9yA==
+  dependencies:
+    microee "^0.0.6"
+
 cozy-logger@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/cozy-logger/-/cozy-logger-1.6.0.tgz#51675e081e0a40baae6c38c64718cfaee5ee66ff"


### PR DESCRIPTION
Add  a `perfs.execution_stats` flag that enables an `execution_stats` flag for find queries, to get insights about query execution: https://docs.couchdb.org/en/2.3.1/api/database/find.html#execution-statistics 