### PR TITLE
feat: Can create tiny code (6 digits)

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -1031,7 +1031,8 @@ It can also associates one or more codes to it, via the codes parameter
 | --- | --- | --- |
 | permission | <code>object</code> |  |
 | permission.codes | <code>string</code> | A comma separed list of values (defaulted to code) |
-| permission.ttl | <code>string</code> | Make the codes expire after a delay (bigduration format) bigduration format: https://github.com/justincampbell/bigduration/blob/master/README.md |
+| permission.ttl | <code>string</code> | Make the codes expire after a delay (bigduration format) |
+| permission.tiny | <code>boolean</code> | If set to true then the generated shortcode will be 6 digits Cozy-Stack has a few conditions to be able to use this tiny shortcode ATM you have to specifiy a ttl < 1h, but it can change. see https://docs.cozy.io/en/cozy-stack/permissions/#post-permissions for exact informations bigduration format: https://github.com/justincampbell/bigduration/blob/master/README.md |
 
 <a name="PermissionCollection+add"></a>
 

--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -24,15 +24,20 @@ class PermissionCollection extends DocumentCollection {
    * @param {object} permission
    * @param {string} permission.codes A comma separed list of values (defaulted to code)
    * @param {string} permission.ttl Make the codes expire after a delay (bigduration format)
+   * @param {boolean} permission.tiny If set to true then the generated shortcode will be 6 digits
+   * Cozy-Stack has a few conditions to be able to use this tiny shortcode ATM you have to specifiy
+   * a ttl < 1h, but it can change.
+   * see https://docs.cozy.io/en/cozy-stack/permissions/#post-permissions for exact informations
    *
    * bigduration format: https://github.com/justincampbell/bigduration/blob/master/README.md
    * @see https://docs.cozy.io/en/cozy-stack/permissions/#post-permissions
    *
    */
-  async create({ _id, _type, codes = 'code', ttl, ...attributes }) {
+  async create({ _id, _type, codes = 'code', ttl, tiny, ...attributes }) {
     const searchParams = new URLSearchParams()
     searchParams.append('codes', codes)
     if (ttl) searchParams.append('ttl', ttl)
+    if (tiny) searchParams.append('tiny', true)
     const resp = await this.stackClient.fetchJSON(
       'POST',
       `/permissions?${searchParams}`,

--- a/packages/cozy-stack-client/src/PermissionCollection.spec.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.spec.js
@@ -55,6 +55,19 @@ describe('PermissionCollection', () => {
           '/permissions?codes=a%2Cb&ttl=1D',
           { data: { attributes: {}, type: 'io.cozy.permissions' } }
         )
+
+        await collection.create({
+          _type: 'io.cozy.permissions',
+          _id: 'a340d5e0d64711e6b66c5fc9ce1e17c6',
+          codes: 'a,b',
+          ttl: '1D',
+          tiny: 'true'
+        })
+        expect(client.fetchJSON).toHaveBeenCalledWith(
+          'POST',
+          '/permissions?codes=a%2Cb&ttl=1D&tiny=true',
+          { data: { attributes: {}, type: 'io.cozy.permissions' } }
+        )
       })
     })
     it('should fetch its own permissions', async () => {


### PR DESCRIPTION
By passing tiny=true in the Query String, we can now create a tiny
shortcode composed by only 6 digits.

Cozy-Stack has a few conditions to enable this tiny shortcode. ATM, we
have to specify a ttl < 1h to be able to do so.

I didn't want to "hardcode" these conditions here since they can change,
so I linked to the cozy-stack documentation

Added by https://github.com/cozy/cozy-stack/pull/2813