### PR TITLE
feat: Add helper to get files by qualification rules

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -194,6 +194,9 @@ example.</p>
 <dt><a href="#saveFileQualification">saveFileQualification</a> ⇒ <code>object</code></dt>
 <dd><p>Save the file with the given qualification</p>
 </dd>
+<dt><a href="#getFilesByQualificationRules">getFilesByQualificationRules</a> ⇒ <code>object</code></dt>
+<dd><p>Helper to query files based on qualification rules</p>
+</dd>
 <dt><a href="#ensureMagicFolder">ensureMagicFolder</a> ⇒ <code>object</code></dt>
 <dd><p>Returns a &quot;Magic Folder&quot;, given its id. See <a href="https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.apps/#special-iocozyapps-doctypes">https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.apps/#special-iocozyapps-doctypes</a></p>
 </dd>
@@ -2208,6 +2211,19 @@ Save the file with the given qualification
 | client | <code>object</code> | The CozyClient instance |
 | file | <code>object</code> | The file to qualify |
 | qualification | <code>object</code> | The file qualification |
+
+<a name="getFilesByQualificationRules"></a>
+
+## getFilesByQualificationRules ⇒ <code>object</code>
+Helper to query files based on qualification rules
+
+**Kind**: global constant  
+**Returns**: <code>object</code> - - The files found by the rules  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| client | <code>object</code> | The CozyClient instance |
+| docRules | <code>object</code> | the rules containing the searched qualification and the count |
 
 <a name="ensureMagicFolder"></a>
 

--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -194,7 +194,7 @@ example.</p>
 <dt><a href="#saveFileQualification">saveFileQualification</a> ⇒ <code>object</code></dt>
 <dd><p>Save the file with the given qualification</p>
 </dd>
-<dt><a href="#getFilesByQualificationRules">getFilesByQualificationRules</a> ⇒ <code>object</code></dt>
+<dt><a href="#fetchFilesByQualificationRules">fetchFilesByQualificationRules</a> ⇒ <code>object</code></dt>
 <dd><p>Helper to query files based on qualification rules</p>
 </dd>
 <dt><a href="#ensureMagicFolder">ensureMagicFolder</a> ⇒ <code>object</code></dt>
@@ -2212,9 +2212,9 @@ Save the file with the given qualification
 | file | <code>object</code> | The file to qualify |
 | qualification | <code>object</code> | The file qualification |
 
-<a name="getFilesByQualificationRules"></a>
+<a name="fetchFilesByQualificationRules"></a>
 
-## getFilesByQualificationRules ⇒ <code>object</code>
+## fetchFilesByQualificationRules ⇒ <code>object</code>
 Helper to query files based on qualification rules
 
 **Kind**: global constant  

--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -207,7 +207,7 @@ export const saveFileQualification = async (client, file, qualification) => {
  * @param {object} docRules - the rules containing the searched qualification and the count
  * @returns {object} - The files found by the rules
  */
-export const getFilesByQualificationRules = async (client, docRules) => {
+export const fetchFilesByQualificationRules = async (client, docRules) => {
   const { rules, count } = docRules
   const query = Q('io.cozy.files')
     .where({


### PR DESCRIPTION
This was previously done by cozy-doctypes, but seems more relevant in cozy-client that handles the qualification model: https://github.com/cozy/cozy-libs/blob/master/packages/cozy-doctypes/src/administrativeProcedures/AdministrativeProcedure.js#L57