### PR TITLE
fix: Do not filter on class

### DIFF
--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -214,7 +214,6 @@ export const fetchFilesByQualificationRules = async (client, docRules) => {
       ...rules
     })
     .partialIndex({
-      class: 'file',
       trashed: false
     })
     .indexFields(['cozyMetadata.updatedAt', 'metadata.qualification'])


### PR DESCRIPTION
The query was filtering 'file' to exclude directories, but it was on a wrong field: `class` is used to differentiate file type, e.g. 'pdf', 'image', etc, as stated [in the doc](https://github.com/cozy/cozy-doctypes/blob/master/docs/io.cozy.files.md#files).
And, in any case, this filtering is useless, as we index on the `metadata.qualification` field, which will exclude directories.