### PR TITLE
feat: Optimistic index creation

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -55,6 +55,16 @@ through OAuth.</p>
 <dt><a href="#isIndexConflictError">isIndexConflictError</a> ⇒ <code>boolean</code></dt>
 <dd><p>Helper to identify an index conflict</p>
 </dd>
+<dt><a href="#isDocumentUpdateConflict">isDocumentUpdateConflict</a> ⇒ <code>boolean</code></dt>
+<dd><p>Helper to identify a document conflict</p>
+</dd>
+<dt><a href="#getIndexFields">getIndexFields</a> ⇒ <code>Array</code></dt>
+<dd><p>Compute fields that should be indexed for a mango
+query to work</p>
+</dd>
+<dt><a href="#getMatchingIndex">getMatchingIndex</a> ⇒ <code>object</code></dt>
+<dd><p>Get a matching index based on the given parameters</p>
+</dd>
 <dt><a href="#getPermissionsFor">getPermissionsFor</a> ⇒ <code>object</code></dt>
 <dd><p>Build a permission set</p>
 </dd>
@@ -260,7 +270,6 @@ Abstracts a collection of documents of the same doctype, providing CRUD methods 
 
 * [DocumentCollection](#DocumentCollection)
     * [.all(options)](#DocumentCollection+all) ⇒ <code>Object</code>
-    * [.findWithMango(path, selector, options)](#DocumentCollection+findWithMango) ⇒ <code>object</code>
     * [.find(selector, options)](#DocumentCollection+find) ⇒ <code>Object</code>
     * [.get(id)](#DocumentCollection+get) ⇒ <code>object</code>
     * [.getAll()](#DocumentCollection+getAll)
@@ -269,6 +278,9 @@ Abstracts a collection of documents of the same doctype, providing CRUD methods 
     * [.destroy(doc)](#DocumentCollection+destroy)
     * [.updateAll(docs)](#DocumentCollection+updateAll)
     * [.destroyAll(docs)](#DocumentCollection+destroyAll)
+    * [.fetchAllMangoIndexes()](#DocumentCollection+fetchAllMangoIndexes) ⇒ <code>Array</code>
+    * [.destroyIndex(index)](#DocumentCollection+destroyIndex) ⇒ <code>object</code>
+    * [.copyIndex(existingIndex, newIndexName)](#DocumentCollection+copyIndex) ⇒ <code>object</code>
     * [.fetchChanges(couchOptions, options)](#DocumentCollection+fetchChanges)
 
 <a name="DocumentCollection+all"></a>
@@ -288,26 +300,6 @@ The returned documents are paginated by the stack.
 | Param | Type | Description |
 | --- | --- | --- |
 | options | <code>Object</code> | The fetch options: pagination & fetch of specific docs. |
-
-<a name="DocumentCollection+findWithMango"></a>
-
-### documentCollection.findWithMango(path, selector, options) ⇒ <code>object</code>
-Find documents with the mango selector and create index
-if missing.
-
-We adopt an optimistic approach for index creation:
-we run the query first, and only if an index missing
-error is returned, the index is created and
-the query run again.
-
-**Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
-**Returns**: <code>object</code> - - The find response  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| path | <code>string</code> | The route path |
-| selector | <code>object</code> | The mango selector |
-| options | <code>object</code> | The find options |
 
 <a name="DocumentCollection+find"></a>
 
@@ -400,6 +392,41 @@ Deletes several documents in one batch
 | Param | Type | Description |
 | --- | --- | --- |
 | docs | <code>Array.&lt;Document&gt;</code> | Documents to delete |
+
+<a name="DocumentCollection+fetchAllMangoIndexes"></a>
+
+### documentCollection.fetchAllMangoIndexes() ⇒ <code>Array</code>
+Retrieve all design docs of mango indexes
+
+**Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
+**Returns**: <code>Array</code> - The design docs  
+<a name="DocumentCollection+destroyIndex"></a>
+
+### documentCollection.destroyIndex(index) ⇒ <code>object</code>
+Delete the specified design doc
+
+**Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
+**Returns**: <code>object</code> - The delete response  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| index | <code>object</code> | The design doc to remove |
+
+<a name="DocumentCollection+copyIndex"></a>
+
+### documentCollection.copyIndex(existingIndex, newIndexName) ⇒ <code>object</code>
+Copy an existing design doc.
+
+This is useful to create a new design doc without
+having to recompute the existing index.
+
+**Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
+**Returns**: <code>object</code> - The copy response  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| existingIndex | <code>object</code> | The design doc to copy |
+| newIndexName | <code>string</code> | The name of the copy |
 
 <a name="DocumentCollection+fetchChanges"></a>
 
@@ -1400,6 +1427,45 @@ Helper to identify an index conflict
 | Param | Type |
 | --- | --- |
 | error | <code>Error</code> | 
+
+<a name="isDocumentUpdateConflict"></a>
+
+## isDocumentUpdateConflict ⇒ <code>boolean</code>
+Helper to identify a document conflict
+
+**Kind**: global constant  
+**Returns**: <code>boolean</code> - - Whether or not the error is a document conflict error  
+
+| Param | Type |
+| --- | --- |
+| error | <code>Error</code> | 
+
+<a name="getIndexFields"></a>
+
+## getIndexFields ⇒ <code>Array</code>
+Compute fields that should be indexed for a mango
+query to work
+
+**Kind**: global constant  
+**Returns**: <code>Array</code> - - Fields to index  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | <code>object</code> | Mango query options |
+
+<a name="getMatchingIndex"></a>
+
+## getMatchingIndex ⇒ <code>object</code>
+Get a matching index based on the given parameters
+
+**Kind**: global constant  
+**Returns**: <code>object</code> - A matching index  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| indexes | <code>Array</code> | The list of indexes to search |
+| fields | <code>object</code> | The index fields |
+| partialFilter | <code>object</code> | A partial filter selector |
 
 <a name="getPermissionsFor"></a>
 

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -49,6 +49,9 @@ through OAuth.</p>
 <dt><a href="#dontThrowNotFoundError">dontThrowNotFoundError</a> ⇒ <code>object</code></dt>
 <dd><p>Handler for error response which return a empty value for &quot;not found&quot; error</p>
 </dd>
+<dt><a href="#isIndexNotFoundError">isIndexNotFoundError</a> ⇒ <code>boolean</code></dt>
+<dd><p>Helper to identify an index not found error</p>
+</dd>
 <dt><a href="#isIndexConflictError">isIndexConflictError</a> ⇒ <code>boolean</code></dt>
 <dd><p>Helper to identify an index conflict</p>
 </dd>
@@ -257,6 +260,7 @@ Abstracts a collection of documents of the same doctype, providing CRUD methods 
 
 * [DocumentCollection](#DocumentCollection)
     * [.all(options)](#DocumentCollection+all) ⇒ <code>Object</code>
+    * [.findWithMango(path, selector, options)](#DocumentCollection+findWithMango) ⇒ <code>object</code>
     * [.find(selector, options)](#DocumentCollection+find) ⇒ <code>Object</code>
     * [.get(id)](#DocumentCollection+get) ⇒ <code>object</code>
     * [.getAll()](#DocumentCollection+getAll)
@@ -284,6 +288,26 @@ The returned documents are paginated by the stack.
 | Param | Type | Description |
 | --- | --- | --- |
 | options | <code>Object</code> | The fetch options: pagination & fetch of specific docs. |
+
+<a name="DocumentCollection+findWithMango"></a>
+
+### documentCollection.findWithMango(path, selector, options) ⇒ <code>object</code>
+Find documents with the mango selector and create index
+if missing.
+
+We adopt an optimistic approach for index creation:
+we run the query first, and only if an index missing
+error is returned, the index is created and
+the query run again.
+
+**Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
+**Returns**: <code>object</code> - - The find response  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| path | <code>string</code> | The route path |
+| selector | <code>object</code> | The mango selector |
+| options | <code>object</code> | The find options |
 
 <a name="DocumentCollection+find"></a>
 
@@ -1352,6 +1376,18 @@ found" error.
 | --- | --- | --- |
 | error | <code>Error</code> |  |
 | data | <code>Array</code> \| <code>object</code> | Data to return in case of "not found" error |
+
+<a name="isIndexNotFoundError"></a>
+
+## isIndexNotFoundError ⇒ <code>boolean</code>
+Helper to identify an index not found error
+
+**Kind**: global constant  
+**Returns**: <code>boolean</code> - - Whether or not the error is an index not found error  
+
+| Param | Type |
+| --- | --- |
+| error | <code>Error</code> | 
 
 <a name="isIndexConflictError"></a>
 

--- a/packages/cozy-stack-client/src/Collection.js
+++ b/packages/cozy-stack-client/src/Collection.js
@@ -41,6 +41,16 @@ export const isIndexConflictError = error => {
 }
 
 /**
+ * Helper to identify a document conflict
+ *
+ * @param {Error} error
+ * @returns {boolean} - Whether or not the error is a document conflict error
+ */
+export const isDocumentUpdateConflict = error => {
+  return error.message.match(/Document update conflict/)
+}
+
+/**
  * Utility class to abstract an regroup identical methods and logics for
  * specific collections.
  */

--- a/packages/cozy-stack-client/src/Collection.js
+++ b/packages/cozy-stack-client/src/Collection.js
@@ -21,6 +21,16 @@ export const dontThrowNotFoundError = (error, data = []) => {
 }
 
 /**
+ * Helper to identify an index not found error
+ *
+ * @param {Error} error
+ * @returns {boolean} - Whether or not the error is an index not found error
+ */
+export const isIndexNotFoundError = error => {
+  return error.message.match(/no_index/)
+}
+
+/**
  * Helper to identify an index conflict
  *
  * @param {Error} error

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -414,8 +414,6 @@ class DocumentCollection {
       : getIndexFields({ sort, selector })
     const indexId = options.indexId || getIndexNameFromFields(indexedFields)
 
-    const indexId =
-      options.indexId || this.getIndexNameFromFields(indexedFields)
     if (sort) {
       const sortOrders = uniq(
         sort.map(sortOption => head(Object.values(sortOption)))
@@ -509,8 +507,8 @@ class DocumentCollection {
       if (!isIndexConflictError(error)) {
         throw error
       } else {
-        // This error much probably comes from 2 parallel index creation,
-        // so there is nothing to do here.
+        // This error much probably comes from 2 parallel index creation, so
+        // there is nothing to do here as the index will eventually be created
         return
       }
     }
@@ -522,7 +520,7 @@ class DocumentCollection {
 
     // indexes might not be usable right after being created; so we delay the resolving until they are
     const selector = { [fields[0]]: { $gt: null } }
-    const options = { indexId: indexResp.id }
+    const options = { indexId: indexResp.id, limit: 1 }
 
     if (await attempt(this.find(selector, options))) return indexResp
     // one retry

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -666,7 +666,7 @@ describe('DocumentCollection', () => {
         skip: 0,
         selector: { done: { $exists: true } },
         sort: [{ label: 'desc' }, { done: 'desc' }],
-        use_index: 'by_label_and_done'
+        use_index: 'by_done_and_label'
       }
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'POST',
@@ -683,7 +683,7 @@ describe('DocumentCollection', () => {
         'POST',
         '/data/io.cozy.todos/_design/123456/copy?rev=1-123',
         null,
-        { headers: { Destination: '_design/by_label_and_done' } }
+        { headers: { Destination: '_design/by_done_and_label' } }
       )
       expect(client.fetchJSON).toHaveBeenNthCalledWith(
         4,

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -104,7 +104,7 @@ class FileCollection extends DocumentCollection {
     return this.stackClient.fetchJSON(
       'POST',
       '/files/_find',
-      await this.toMangoOptions(selector, options)
+      this.toMangoOptions(selector, options)
     )
   }
 

--- a/packages/cozy-stack-client/src/TriggerCollection.spec.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.spec.js
@@ -202,13 +202,6 @@ describe('TriggerCollection', () => {
     })
 
     it('should call /data/io.cozy.triggers/_find route if multiple arguments are passed', async () => {
-      stackClient.fetchJSON.mockReturnValueOnce(
-        Promise.resolve({
-          id: '_design/123456',
-          name: '123456',
-          result: 'exists'
-        })
-      )
       stackClient.fetchJSON.mockReturnValue(FIND_RESPONSE_FIXTURES)
       await collection.find({
         worker: 'thumbnail',
@@ -225,7 +218,7 @@ describe('TriggerCollection', () => {
             worker: 'thumbnail'
           },
           skip: 0,
-          use_index: '_design/123456'
+          use_index: 'by_worker_and_message'
         }
       )
     })

--- a/packages/cozy-stack-client/src/mangoIndex.js
+++ b/packages/cozy-stack-client/src/mangoIndex.js
@@ -1,0 +1,39 @@
+import { transform } from './utils'
+import head from 'lodash/head'
+import get from 'lodash/get'
+import difference from 'lodash/difference'
+import isEqual from 'lodash/difference'
+
+export const getIndexNameFromFields = fields => {
+  return `by_${fields.join('_and_')}`
+}
+
+export const transformSort = sort => {
+  if (!sort || Array.isArray(sort)) {
+    return sort
+  }
+  console.warn(
+    'Passing an object to the "sort" is deprecated, please use an array instead.'
+  )
+  return transform(
+    sort,
+    (acc, order, field) => acc.push({ [field]: order }),
+    []
+  )
+}
+
+/**
+ * Compute fields that should be indexed for a mango
+ * query to work
+ *
+ * @param  {object} options - Mango query options
+ * @returns {Array} - Fields to index
+ */
+export const getIndexFields = ({ selector, sort = [] }) => {
+  return Array.from(
+    new Set([
+      ...sort.map(sortOption => head(Object.keys(sortOption))),
+      ...(selector ? Object.keys(selector) : [])
+    ])
+  )
+}

--- a/packages/cozy-stack-client/src/mangoIndex.js
+++ b/packages/cozy-stack-client/src/mangoIndex.js
@@ -1,8 +1,7 @@
 import { transform } from './utils'
 import head from 'lodash/head'
 import get from 'lodash/get'
-import difference from 'lodash/difference'
-import isEqual from 'lodash/difference'
+import isEqual from 'lodash/isEqual'
 
 export const normalizeDesignDoc = designDoc => {
   const id = designDoc._id || designDoc.id
@@ -53,16 +52,17 @@ export const getIndexFields = ({ selector, sort = [] }) => {
  */
 export const getMatchingIndex = (indexes, fields, partialFilter) => {
   return indexes.find(index => {
-    const ddoc = index.id.split('/')[1]
     const viewId = Object.keys(get(index, `views`))[0]
     const fieldsInIndex = get(index, `views.${viewId}.map.fields`)
-    if (difference(Object.keys(fieldsInIndex), fields).length === 0) {
+    const sortedFields = fields.sort()
+    const sortedFieldsInIndex = Object.keys(fieldsInIndex).sort()
+    if (isEqual(sortedFieldsInIndex, sortedFields)) {
       if (!partialFilter) {
         return true
       }
       const partialFilterInIndex = get(
         index,
-        `views.${ddoc}.map.partial_filter_selector`
+        `views.${viewId}.map.partial_filter_selector`
       )
       if (isEqual(partialFilter, partialFilterInIndex)) {
         return true

--- a/packages/cozy-stack-client/src/mangoIndex.spec.js
+++ b/packages/cozy-stack-client/src/mangoIndex.spec.js
@@ -1,0 +1,87 @@
+import { getMatchingIndex } from './mangoIndex'
+
+const buildDesignDoc = (fields, partialFilter = {}) => {
+  return {
+    views: {
+      123: {
+        map: {
+          fields,
+          partial_filter_selector: partialFilter
+        }
+      }
+    }
+  }
+}
+
+describe('matching index', () => {
+  it('should match index with same fields', () => {
+    const nonMatchingIndex = buildDesignDoc({ baz: 'asc' })
+    const matchingIndex = buildDesignDoc({
+      foo: 'asc',
+      bar: 'asc'
+    })
+    const indexes = [nonMatchingIndex, matchingIndex]
+
+    expect(getMatchingIndex(indexes, ['foo', 'bar'])).toEqual(matchingIndex)
+    expect(getMatchingIndex(indexes, ['bar', 'foo'])).toEqual(matchingIndex)
+  })
+
+  it('should match index with same fields and same partial filter', () => {
+    const partialFilter = {
+      baz: {
+        $ne: 'xyz'
+      }
+    }
+    const matchingIndex = buildDesignDoc(
+      {
+        foo: 'asc',
+        bar: 'asc'
+      },
+      partialFilter
+    )
+    const indexes = [matchingIndex]
+
+    expect(getMatchingIndex(indexes, ['foo', 'bar'], partialFilter)).toEqual(
+      matchingIndex
+    )
+  })
+
+  it('should not match index with different fields ', () => {
+    const designDoc1 = buildDesignDoc({ foo: 'asc' })
+    const designDoc2 = buildDesignDoc({})
+    const designDoc3 = buildDesignDoc({
+      foo: 'asc',
+      bar: 'asc',
+      baz: 'asc'
+    })
+    const indexes = [designDoc1, designDoc2, designDoc3]
+    const fields = ['foo', 'bar']
+
+    expect(getMatchingIndex(indexes, fields)).toEqual(undefined)
+  })
+
+  it('should not match index with same fields and different partial filter', () => {
+    const partialFilter = {
+      baz: {
+        $ne: 'xyz',
+        $exists: true
+      }
+    }
+    const matchingIndex = buildDesignDoc(
+      {
+        foo: 'asc',
+        bar: 'asc'
+      },
+      partialFilter
+    )
+    const indexes = [matchingIndex]
+
+    expect(
+      getMatchingIndex(indexes, ['foo', 'bar'], {
+        baz: {
+          $ne: 'xyz'
+        }
+      })
+    ).toEqual(undefined)
+  })
+})


### PR DESCRIPTION
We used to have a pessimistic index creation strategy: for each find
query, a index creation query was sent to the database, and ignored if
the index was already created.
Most of the time, these index creation queries are useless, as the index
is created when the app is first used.
Therefore, we now adopt an optimistic strategy, that is, running the
find query, and create the index afterwards only if a missing index is
returned.
It also now creates a named index, i.e. `_design/by_selector_field` and
catch index creation conflicts.

This fixes  https://github.com/cozy/cozy-client/issues/719

EDIT 04/02/20
As mentioned [here](https://github.com/cozy/cozy-client/pull/857#issuecomment-766918762), the first draft of this PR had the drawback to force the re-creation of all existing indexes. So, to overcome this, we implemented this behaviour:

- If the index is missing, query the existing design_docs and check if there is one with the same index definition
- If there is one, [copy this design doc](https://github.com/cozy/cozy-stack/blob/master/docs/data-system.md#copy-a-design-document) with the new index name. The actual index (the b-tree) won't be re-computed.
  - Delete the old design doc
- If there is none, creat the index


