### PR TITLE
feat: Handle index conflicts

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -49,6 +49,9 @@ through OAuth.</p>
 <dt><a href="#dontThrowNotFoundError">dontThrowNotFoundError</a> ⇒ <code>object</code></dt>
 <dd><p>Handler for error response which return a empty value for &quot;not found&quot; error</p>
 </dd>
+<dt><a href="#isIndexConflictError">isIndexConflictError</a> ⇒ <code>boolean</code></dt>
+<dd><p>Helper to identify an index conflict</p>
+</dd>
 <dt><a href="#getPermissionsFor">getPermissionsFor</a> ⇒ <code>object</code></dt>
 <dd><p>Build a permission set</p>
 </dd>
@@ -1349,6 +1352,18 @@ found" error.
 | --- | --- | --- |
 | error | <code>Error</code> |  |
 | data | <code>Array</code> \| <code>object</code> | Data to return in case of "not found" error |
+
+<a name="isIndexConflictError"></a>
+
+## isIndexConflictError ⇒ <code>boolean</code>
+Helper to identify an index conflict
+
+**Kind**: global constant  
+**Returns**: <code>boolean</code> - - Whether or not the error is an index conflict error  
+
+| Param | Type |
+| --- | --- |
+| error | <code>Error</code> | 
 
 <a name="getPermissionsFor"></a>
 

--- a/packages/cozy-stack-client/src/Collection.js
+++ b/packages/cozy-stack-client/src/Collection.js
@@ -21,6 +21,16 @@ export const dontThrowNotFoundError = (error, data = []) => {
 }
 
 /**
+ * Helper to identify an index conflict
+ *
+ * @param {Error} error
+ * @returns {boolean} - Whether or not the error is an index conflict error
+ */
+export const isIndexConflictError = error => {
+  return error.message.match(/error_saving_ddoc/)
+}
+
+/**
  * Utility class to abstract an regroup identical methods and logics for
  * specific collections.
  */


### PR DESCRIPTION
Note this is temporary workaround as we realized that https://github.com/cozy/cozy-client/pull/857 might require extra work to avoid recomputing all indexes.

Sometimes, an app might run 2 concurrent queries on the same index. If
this index happens to be not created yet, it might result into a
creation conflict. In cozy-drive, this was causing an interface error,
which is a pity as this only occur for new users leading to a bad
first impression.
Here, we fix this by simply retrying the index creation when a
conflict is detected.
Furthermore, we plan to improve the index creation in a nearby
future to avoid unecessary index creation requests.