### PR TITLE
feat: Add possibility to use sources props to a get query

### DIFF
--- a/packages/cozy-client/src/StackLink.js
+++ b/packages/cozy-client/src/StackLink.js
@@ -35,7 +35,7 @@ export default class StackLink extends CozyLink {
     }
     const collection = this.stackClient.collection(doctype)
     if (id) {
-      return collection.get(id)
+      return collection.get(id, query)
     }
     if (ids) {
       return collection.getAll(ids)

--- a/packages/cozy-client/src/registry.js
+++ b/packages/cozy-client/src/registry.js
@@ -1,6 +1,16 @@
+import get from 'lodash/get'
 import 'url-search-params-polyfill'
+
 import termUtils from './terms'
 import { APP_TYPE } from './constants'
+
+export const transformRegistryFormatToStackFormat = doc => ({
+  id: get(doc, 'latest_version.manifest.source'),
+  attributes: get(doc, 'latest_version.manifest'),
+  ...doc
+})
+
+export const registryEndpoint = '/registry/'
 
 const queryPartFromOptions = options => {
   const query = new URLSearchParams(options).toString()

--- a/packages/cozy-client/src/registry.spec.js
+++ b/packages/cozy-client/src/registry.spec.js
@@ -1,6 +1,6 @@
 import CozyClient from 'cozy-client'
 import termUtils from './terms'
-import Registry from './registry'
+import Registry, { transformRegistryFormatToStackFormat } from './registry'
 
 jest.mock('./terms', () => ({
   save: jest.fn()
@@ -120,5 +120,24 @@ describe('registry api', () => {
         '/registry?limit=200&versionsChannel=beta&latestChannelVersion=beta&filter[type]=konnector'
       )
     })
+  })
+})
+
+describe('transformRegistryFormatToStackFormat', () => {
+  it('should add "id" and "attributes" properties', () => {
+    const registryRes = {
+      latest_version: { manifest: { name: 'name', source: 'source' } },
+      type: 'konnector'
+    }
+    const stackFormat = {
+      id: 'source',
+      attributes: { name: 'name', source: 'source' },
+      latest_version: { manifest: { name: 'name', source: 'source' } },
+      type: 'konnector'
+    }
+
+    expect(transformRegistryFormatToStackFormat(registryRes)).toEqual(
+      stackFormat
+    )
   })
 })

--- a/packages/cozy-stack-client/src/AppCollection.js
+++ b/packages/cozy-stack-client/src/AppCollection.js
@@ -17,7 +17,7 @@ class AppCollection extends DocumentCollection {
     this.endpoint = '/apps/'
   }
 
-  get(idArg) {
+  get(idArg, query) {
     let id
     if (idArg.indexOf('/') > -1) {
       id = idArg.split('/')[1]

--- a/packages/cozy-stack-client/src/KonnectorCollection.js
+++ b/packages/cozy-stack-client/src/KonnectorCollection.js
@@ -1,10 +1,11 @@
+import pick from 'lodash/pick'
+
 import AppCollection from './AppCollection'
 import TriggerCollection, {
   isForKonnector,
   isForAccount
 } from './TriggerCollection'
 import { normalizeDoc } from './DocumentCollection'
-import pick from 'lodash/pick'
 
 export const KONNECTORS_DOCTYPE = 'io.cozy.konnectors'
 


### PR DESCRIPTION
**Besoin :** On souhaite pouvoir récupérer depuis la stack les données d'un connecteur grâce à son id (slug), prioritairement depuis la `stack`, ou depuis la `registry` si la `stack` renvoie une erreur.

**Modifications :** Ajout de la possibilité de définir une ou des sources lors d'une requête d'une app par son id, en passant un tableau en valeur de l'attribut `sources` d'une requête : 
```
qDef = Q('io.cozy.konnectors').getById('io.cozy.konnectors/slug')
qDef.sources = ['stack', 'registry']
```

Cet exemple retourne le connecteur selon son `slug`, depuis la première source (ici la `stack`) si possible, sinon depuis la deuxième (ici la `registry`).

Cette modification n'est pas dans le DSL pour le moment mais directement dans l'`AppCollection`.