### PR TITLE
feat: Use Q instead of client.get

### DIFF
--- a/packages/cozy-client/src/associations/HasOne.js
+++ b/packages/cozy-client/src/associations/HasOne.js
@@ -1,6 +1,7 @@
 import get from 'lodash/get'
 import set from 'lodash/set'
 import Association from './Association'
+import { Q } from '../queries/dsl'
 
 export default class HasOne extends Association {
   get raw() {
@@ -20,7 +21,7 @@ export default class HasOne extends Association {
     if (!relationship || !relationship._id) {
       return null
     }
-    return client.get(assoc.doctype, relationship._id)
+    return Q(assoc.doctype).getById(relationship._id)
   }
 
   set(doc) {

--- a/packages/cozy-client/src/associations/HasOneInPlace.js
+++ b/packages/cozy-client/src/associations/HasOneInPlace.js
@@ -1,5 +1,5 @@
 import Association from './Association'
-
+import { Q } from '../queries/dsl'
 /**
  * Here the id of the document is directly set in the attribute
  * of the document, not in the relationships attribute
@@ -10,7 +10,7 @@ export default class HasOneInPlace extends Association {
   }
 
   get data() {
-    return this.get(this.doctype, this.raw)
+    return Q(this.doctype).getById(this.raw)
   }
 
   static query(doc, client, assoc) {

--- a/packages/cozy-client/src/hooks/useCapabilities.jsx
+++ b/packages/cozy-client/src/hooks/useCapabilities.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { Q } from '../queries/dsl'
 
 const useCapabilities = client => {
   const [capabilities, setCapabilities] = useState()
@@ -8,7 +9,7 @@ const useCapabilities = client => {
       setFetchStatus('loading')
       try {
         const capabilitiesResult = await client.query(
-          client.get('io.cozy.settings', 'capabilities')
+          Q('io.cozy.settings').getById('capabilities')
         )
 
         setCapabilities(capabilitiesResult)


### PR DESCRIPTION
client.get is deprecated. Q is preferred as it can be used statically (no
need for a cozy-client) and more versatile as you can build any query
with it (with client.find and client.get, you are limited, to Q::where()
and Q::getById()).