### PR TITLE
refactor: Use new Q API to avoid warning on files relationships

### DIFF
--- a/packages/cozy-client/src/associations/HasManyFiles.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.js
@@ -1,6 +1,6 @@
 import omit from 'lodash/omit'
 import HasMany from './HasMany'
-import { QueryDefinition, Mutations } from '../queries/dsl'
+import { QueryDefinition, Mutations, Q } from '../queries/dsl'
 import { getDocumentFromState } from '../store'
 
 /**
@@ -95,7 +95,8 @@ export default class HasManyFiles extends HasMany {
   static query(document, client, assoc) {
     const key = [document._type, document._id]
     const cursor = [key, '']
-    const queryAll = client.find(assoc.doctype)
-    return queryAll.referencedBy(document).offsetCursor(cursor)
+    return Q(assoc.doctype)
+      .referencedBy(document)
+      .offsetCursor(cursor)
   }
 }


### PR DESCRIPTION
A depreciation warning was triggered each time a HasMany file was used