### PR TITLE
fix: Add type to path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage
 .cache
 dist
 .eslintcache
+.idea

--- a/packages/cozy-stack-client/src/TriggerCollection.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.js
@@ -107,9 +107,9 @@ class TriggerCollection extends DocumentCollection {
    * @throws {FetchError}
    */
   async find(selector = {}, options = {}) {
-    if (Object.keys(selector).length === 1 && selector.worker) {
+    if (Object.keys(selector).length > 0 && selector.worker && selector.type) {
       // @see https://github.com/cozy/cozy-stack/blob/master/docs/jobs.md#get-jobstriggers
-      const url = `/jobs/triggers?Worker=${selector.worker}`
+      const url = `/jobs/triggers?Worker=${selector.worker}&Type=${selector.type}`
 
       try {
         const resp = await this.stackClient.fetchJSON('GET', url)

--- a/packages/cozy-stack-client/src/TriggerCollection.spec.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.spec.js
@@ -166,6 +166,41 @@ describe('TriggerCollection', () => {
       )
     })
 
+    it('should call /jobs/triggers route if only type selector is passed', async () => {
+      await collection.find({ type: '@cron' })
+      expect(stackClient.fetchJSON).toHaveBeenLastCalledWith(
+        'GET',
+        '/jobs/triggers?Type=%40cron'
+      )
+    })
+
+    it('should call /jobs/triggers route if only type selector is passed with multiple values', async () => {
+      await collection.find({ type: { $in: ['@cron', '@webhook'] } })
+      expect(stackClient.fetchJSON).toHaveBeenLastCalledWith(
+        'GET',
+        '/jobs/triggers?Type=%40cron%2C%40webhook'
+      )
+    })
+
+    it('should call /jobs/triggers route if only Worker and type selector is passed', async () => {
+      await collection.find({ worker: 'thumbnail', type: '@cron' })
+      expect(stackClient.fetchJSON).toHaveBeenLastCalledWith(
+        'GET',
+        '/jobs/triggers?Worker=thumbnail&Type=%40cron'
+      )
+    })
+
+    it('should call /jobs/triggers route if only Worker and type selector is passed with multiple type values', async () => {
+      await collection.find({
+        worker: 'thumbnail',
+        type: { $in: ['@cron', '@webhook'] }
+      })
+      expect(stackClient.fetchJSON).toHaveBeenLastCalledWith(
+        'GET',
+        '/jobs/triggers?Worker=thumbnail&Type=%40cron%2C%40webhook'
+      )
+    })
+
     it('should call /data/io.cozy.triggers/_find route if multiple arguments are passed', async () => {
       stackClient.fetchJSON.mockReturnValueOnce(
         Promise.resolve({


### PR DESCRIPTION
When query definition had a type, /data/io.cozy.triggers was fetched
instead of '/jobs/triggers'.