### PR TITLE
Test improvements

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,6 +1,9 @@
 import Enzyme from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import fetch from 'whatwg-fetch'
+import { setupConsoleToThrow } from './packages/cozy-client/src/__tests__/console'
+
+setupConsoleToThrow()
 
 global.fetch = fetch
 

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -13,6 +13,7 @@ import {
   SOURCE_ACCOUNT_ID,
   FILE_1
 } from './__tests__/fixtures'
+import { withIgnoreConsoleWarn } from './__tests__/console'
 
 import CozyClient from './CozyClient'
 import { Q } from './queries/dsl'
@@ -471,8 +472,10 @@ describe('CozyClient login', () => {
     expect(links[0].onLogin).toHaveBeenCalledTimes(1)
     expect(links[2].onLogin).toHaveBeenCalledTimes(1)
 
-    // test if we launch twice login, it doesn't launch twice onLogin.
-    await client.login()
+    await withIgnoreConsoleWarn(async () => {
+      // test if we launch twice login, it doesn't launch twice onLogin.
+      await client.login()
+    })
 
     expect(links[0].onLogin).toHaveBeenCalledTimes(1)
     expect(links[2].onLogin).toHaveBeenCalledTimes(1)

--- a/packages/cozy-client/src/ObservableQuery.spec.js
+++ b/packages/cozy-client/src/ObservableQuery.spec.js
@@ -1,14 +1,13 @@
 import { createStore, combineReducers } from 'redux'
-import CozyClient from '../CozyClient'
-import CozyLink from '../CozyLink'
-import ObservableQuery from '../ObservableQuery'
-import { initQuery, receiveQueryResult } from '../store'
-
-import { queryResultFromData } from './utils'
-import { SCHEMA, TODO_1, TODO_2 } from './fixtures'
 import omit from 'lodash/omit'
-
 import { Q } from 'cozy-client'
+
+import CozyClient from './CozyClient'
+import CozyLink from './CozyLink'
+import ObservableQuery from './ObservableQuery'
+import { initQuery, receiveQueryResult } from './store'
+import { queryResultFromData } from './__tests__/utils'
+import { SCHEMA, TODO_1, TODO_2 } from './__tests__/fixtures'
 
 const AUTHORS = [
   {

--- a/packages/cozy-client/src/Provider.spec.jsx
+++ b/packages/cozy-client/src/Provider.spec.jsx
@@ -1,12 +1,12 @@
-jest.mock('../CozyClient')
+jest.mock('./CozyClient')
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import configureStore from 'redux-mock-store'
 import { mount, shallow } from 'enzyme'
 
-import Provider from '../Provider'
-import CozyClient from '../CozyClient'
+import Provider from './Provider'
+import CozyClient from './CozyClient'
 
 describe('Provider', () => {
   const client = new CozyClient()

--- a/packages/cozy-client/src/StackLink.spec.js
+++ b/packages/cozy-client/src/StackLink.spec.js
@@ -1,9 +1,8 @@
-import CozyClient from '../CozyClient'
-import StackLink from '../StackLink'
-
-import { SCHEMA } from './fixtures'
-
 import { Q } from 'cozy-client'
+
+import CozyClient from './CozyClient'
+import StackLink from './StackLink'
+import { SCHEMA } from './__tests__/fixtures'
 
 describe('StackLink', () => {
   let stackClient, link, client

--- a/packages/cozy-client/src/__tests__/console.js
+++ b/packages/cozy-client/src/__tests__/console.js
@@ -1,0 +1,38 @@
+/**
+ * Calls callback while ignoring console[type] calls
+ *
+ * Useful for tests that we know will use console[type] but we do not
+ * want to them to trigger an exception during tests.
+ */
+const withIgnoreConsole = type => async callback => {
+  let original = console[type]
+  console[type] = () => {}
+  try {
+    const res = callback()
+    if (res.then) {
+      await res
+    }
+  } finally {
+    console[type] = original
+  }
+}
+
+export const withIgnoreConsoleWarn = withIgnoreConsole('warn')
+export const withIgnoreConsoleError = withIgnoreConsole('error')
+
+/**
+ * Override console.warn and error to throw
+ */
+export const setupConsoleToThrow = () => {
+  let originalWarn = console.warn
+  console.warn = function() {
+    originalWarn.apply(this, arguments)
+    throw new Error('console.warn should not be called during tests')
+  }
+
+  let originalError = console.error
+  console.error = function() {
+    originalError.apply(this, arguments)
+    throw new Error('console.error should not be called during tests')
+  }
+}

--- a/packages/cozy-client/src/associations.spec.js
+++ b/packages/cozy-client/src/associations.spec.js
@@ -1,9 +1,9 @@
-import CozyClient from '../CozyClient'
-import CozyLink from '../CozyLink'
+import CozyClient from './CozyClient'
+import CozyLink from './CozyLink'
+import { createStore, getQueryFromStore } from './store'
+import { receiveQueryResult, initQuery } from './store/queries'
 
-import { createStore, getQueryFromStore } from '../store'
-import { SCHEMA, TODO_1, TODO_2 } from './fixtures'
-import { receiveQueryResult, initQuery } from '../store/queries'
+import { SCHEMA, TODO_1, TODO_2 } from './__tests__/fixtures'
 
 describe('Associations', () => {
   const requestHandler = jest.fn()

--- a/packages/cozy-client/src/store.spec.js
+++ b/packages/cozy-client/src/store.spec.js
@@ -10,8 +10,8 @@ import reducer, {
   receiveQueryError,
   receiveMutationResult,
   StoreProxy
-} from '../store'
-import { QueryDefinition as Q } from '../queries/dsl'
+} from './store'
+import { QueryDefinition as Q } from './queries/dsl'
 import {
   TODO_1,
   TODO_2,
@@ -20,7 +20,7 @@ import {
   TODO_WITH_RELATION,
   FILE_1,
   FILE_2
-} from './fixtures'
+} from './__tests__/fixtures'
 
 describe('Store', () => {
   let store

--- a/packages/cozy-client/src/withMutation.spec.jsx
+++ b/packages/cozy-client/src/withMutation.spec.jsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
-import CozyClient from '../CozyClient'
-import CozyLink from '../CozyLink'
-import withMutation from '../withMutation'
+import CozyClient from './CozyClient'
+import CozyLink from './CozyLink'
+import withMutation from './withMutation'
 
 describe('withMutation', () => {
   const NEW_TODO = {

--- a/packages/cozy-client/src/withMutations.spec.jsx
+++ b/packages/cozy-client/src/withMutations.spec.jsx
@@ -4,6 +4,17 @@ import { shallow } from 'enzyme'
 import withMutations from './withMutations'
 
 describe('withMutations', () => {
+  beforeEach(() => {
+    let originalWarn = console.warn
+    // eslint-disable-next-line no-console
+    jest.spyOn(console, 'warn').mockImplementation(function(msg) {
+      if (msg.includes && msg.includes('withMutations will be removed')) {
+        return
+      }
+      return originalWarn.apply(this, arguments)
+    })
+  })
+
   const clientMock = {
     create: jest.fn(),
     destroy: jest.fn(),

--- a/packages/cozy-stack-client/src/utils.spec.js
+++ b/packages/cozy-stack-client/src/utils.spec.js
@@ -1,4 +1,4 @@
-import { uri } from '../utils'
+import { uri } from './utils'
 
 describe('uri template tag function', () => {
   it('should encode URI components', () => {


### PR DESCRIPTION
- Move spec files near implementation

Test files are easier to find and imports from the spec file match
imports from the implementation file.

- Make console warn and errors fail during tests

This makes it easier to enforce a no-warning-during-tests policy.