### PR TITLE
fix: HasOneInPlace correctly gets its data

### DIFF
--- a/packages/cozy-client/src/associations/HasOneInPlace.js
+++ b/packages/cozy-client/src/associations/HasOneInPlace.js
@@ -10,7 +10,7 @@ export default class HasOneInPlace extends Association {
   }
 
   get data() {
-    return Q(this.doctype).getById(this.raw)
+    return this.get(this.doctype, this.raw)
   }
 
   static query(doc, client, assoc) {

--- a/packages/cozy-client/src/associations/HasOneInPlace.spec.js
+++ b/packages/cozy-client/src/associations/HasOneInPlace.spec.js
@@ -1,0 +1,65 @@
+import HasOneInPlace from './HasOneInPlace'
+import { dehydrate } from '../helpers'
+
+const fixtures = {
+  jediMaster: {
+    _id: 'obiwan',
+    _type: 'io.cozy.jedis',
+    name: 'Obiwan Kenobi',
+    padawan: 'anakin'
+  },
+  apprentice: {
+    _id: 'anakin',
+    _type: 'io.cozy.jedis',
+    name: 'Anakin Skywalker'
+  }
+}
+
+const hydratedMaster = {
+  ...fixtures.jediMaster,
+  padawan: new HasOneInPlace(fixtures.jediMaster, 'padawan', 'io.cozy.jedis', {
+    get: jest.fn().mockReturnValue(fixtures.apprentice)
+  })
+}
+
+const hydratedApprentice = {
+  ...fixtures.apprentice,
+  padawan: new HasOneInPlace(fixtures.apprentice, 'padawan', 'io.cozy.jedis', {
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}
+
+describe('HasOneInPlace', () => {
+  describe('raw', () => {
+    it('returns relationship raw data', () => {
+      expect(hydratedMaster.padawan.raw).toEqual('anakin')
+    })
+
+    it('returns null if the relationship has no data', () => {
+      expect(hydratedApprentice.padawan.raw).toEqual(undefined)
+    })
+  })
+
+  describe('dehydrate', () => {
+    it('should not create a relationship attribute if document has no relationship', () => {
+      const dehydrated = dehydrate(hydratedApprentice)
+      expect(dehydrated.padawan).toBe(undefined)
+    })
+
+    it('should dehydrate correctly', () => {
+      const dehydrated = dehydrate(hydratedMaster)
+      expect(dehydrated.padawan).toEqual('anakin')
+    })
+  })
+
+  describe('data', () => {
+    it('calls get method', () => {
+      const jedi = hydratedMaster.padawan.data
+      expect(hydratedMaster.padawan.get).toHaveBeenCalledWith(
+        'io.cozy.jedis',
+        'anakin'
+      )
+      expect(jedi).toEqual(fixtures.apprentice)
+    })
+  })
+})


### PR DESCRIPTION
A previous refactor broke the data() method from HasOneInPlace.
A test is added so that we do not make the same kind of mistake
in the future