### PR TITLE
Fixes for optimist index

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -55,6 +55,9 @@ through OAuth.</p>
 <dt><a href="#isIndexConflictError">isIndexConflictError</a> ⇒ <code>boolean</code></dt>
 <dd><p>Helper to identify an index conflict</p>
 </dd>
+<dt><a href="#isNoUsableIndexError">isNoUsableIndexError</a> ⇒ <code>boolean</code></dt>
+<dd><p>Helper to identify a no usable index error</p>
+</dd>
 <dt><a href="#isDocumentUpdateConflict">isDocumentUpdateConflict</a> ⇒ <code>boolean</code></dt>
 <dd><p>Helper to identify a document conflict</p>
 </dd>
@@ -1428,6 +1431,18 @@ Helper to identify an index conflict
 | --- | --- |
 | error | <code>Error</code> | 
 
+<a name="isNoUsableIndexError"></a>
+
+## isNoUsableIndexError ⇒ <code>boolean</code>
+Helper to identify a no usable index error
+
+**Kind**: global constant  
+**Returns**: <code>boolean</code> - - Whether or not the error is a no usable index error  
+
+| Param | Type |
+| --- | --- |
+| error | <code>Error</code> | 
+
 <a name="isDocumentUpdateConflict"></a>
 
 ## isDocumentUpdateConflict ⇒ <code>boolean</code>
@@ -1464,7 +1479,7 @@ Get a matching index based on the given parameters
 | Param | Type | Description |
 | --- | --- | --- |
 | indexes | <code>Array</code> | The list of indexes to search |
-| fields | <code>object</code> | The index fields |
+| fields | <code>Array</code> | The index fields |
 | partialFilter | <code>object</code> | A partial filter selector |
 
 <a name="getPermissionsFor"></a>

--- a/packages/cozy-stack-client/src/Collection.js
+++ b/packages/cozy-stack-client/src/Collection.js
@@ -41,6 +41,16 @@ export const isIndexConflictError = error => {
 }
 
 /**
+ * Helper to identify a no usable index error
+ *
+ * @param {Error} error
+ * @returns {boolean} - Whether or not the error is a no usable index error
+ */
+export const isNoUsableIndexError = error => {
+  return error.message.match(/no_usable_index/)
+}
+
+/**
  * Helper to identify a document conflict
  *
  * @param {Error} error

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -10,6 +10,7 @@ import Collection, {
   dontThrowNotFoundError,
   isIndexNotFoundError,
   isIndexConflictError,
+  isNoUsableIndexError,
   isDocumentUpdateConflict
 } from './Collection'
 import {
@@ -241,7 +242,7 @@ class DocumentCollection {
     try {
       resp = await this.fetchDocumentsWithMango(path, selector, options)
     } catch (error) {
-      if (!isIndexNotFoundError(error)) {
+      if (!isIndexNotFoundError(error) && !isNoUsableIndexError(error)) {
         throw error
       } else {
         await this.handleMissingIndex(selector, options)

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -516,10 +516,10 @@ describe('DocumentCollection', () => {
       client.fetchJSON.mockRestore()
       client.fetchJSON
         .mockRejectedValueOnce(new Error('no_index'))
-        .mockReturnValueOnce(Promise.resolve({ rows: [] }))
-        .mockReturnValueOnce(Promise.resolve({}))
-        .mockReturnValueOnce(Promise.resolve(FIND_RESPONSE_FIXTURE))
-        .mockReturnValueOnce(Promise.resolve(FIND_RESPONSE_FIXTURE))
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce(FIND_RESPONSE_FIXTURE)
+        .mockResolvedValueOnce(FIND_RESPONSE_FIXTURE)
       const collection = new DocumentCollection('io.cozy.todos', client)
       await expect(
         collection.findWithMango(
@@ -530,10 +530,10 @@ describe('DocumentCollection', () => {
       ).resolves.toBe(FIND_RESPONSE_FIXTURE)
       client.fetchJSON
         .mockRejectedValueOnce(new Error('no_usable_index'))
-        .mockReturnValueOnce(Promise.resolve({ rows: [] }))
-        .mockReturnValueOnce(Promise.resolve({}))
-        .mockReturnValueOnce(Promise.resolve(FIND_RESPONSE_FIXTURE))
-        .mockReturnValueOnce(Promise.resolve(FIND_RESPONSE_FIXTURE))
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce(FIND_RESPONSE_FIXTURE)
+        .mockResolvedValueOnce(FIND_RESPONSE_FIXTURE)
 
       await expect(
         collection.findWithMango(

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -666,7 +666,7 @@ describe('DocumentCollection', () => {
         skip: 0,
         selector: { done: { $exists: true } },
         sort: [{ label: 'desc' }, { done: 'desc' }],
-        use_index: 'by_done_and_label'
+        use_index: 'by_label_and_done'
       }
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'POST',
@@ -683,7 +683,7 @@ describe('DocumentCollection', () => {
         'POST',
         '/data/io.cozy.todos/_design/123456/copy?rev=1-123',
         null,
-        { headers: { Destination: '_design/by_done_and_label' } }
+        { headers: { Destination: '_design/by_label_and_done' } }
       )
       expect(client.fetchJSON).toHaveBeenNthCalledWith(
         4,

--- a/packages/cozy-stack-client/src/mangoIndex.js
+++ b/packages/cozy-stack-client/src/mangoIndex.js
@@ -46,7 +46,7 @@ export const getIndexFields = ({ selector, sort = [] }) => {
  * Get a matching index based on the given parameters
  *
  * @param {Array} indexes - The list of indexes to search
- * @param {object} fields  - The index fields
+ * @param {Array} fields  - The index fields
  * @param {object} partialFilter - A partial filter selector
  * @returns {object} A matching index
  */
@@ -54,7 +54,7 @@ export const getMatchingIndex = (indexes, fields, partialFilter) => {
   return indexes.find(index => {
     const viewId = Object.keys(get(index, `views`))[0]
     const fieldsInIndex = get(index, `views.${viewId}.map.fields`)
-    const sortedFields = fields.sort()
+    const sortedFields = [...fields].sort()
     const sortedFieldsInIndex = Object.keys(fieldsInIndex).sort()
     if (isEqual(sortedFieldsInIndex, sortedFields)) {
       if (!partialFilter) {


### PR DESCRIPTION
This fixes 2 things introduced with #857

* For some queries, CouchDB returns a `no_usable_index` error, instead of a `no_index` error when the index is missing. 
Therefore, we handle this case to create the index after this error 
* For indexes with a partial index, we sort the fields to ease the comparison when looking for existing indexes. This sort was changing the original `indexedFields`, leading to potentially wrong index definition 