### PR TITLE
feat: Can use app_slug when creating a sharing

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -1226,6 +1226,7 @@ Creates a new Sharing. See https://docs.cozy.io/en/cozy-stack/sharing/#post-shar
 | [params.recipients] | [<code>Array.&lt;Recipient&gt;</code>](#Recipient) | Recipients to add to the sharings (will have the same permissions given by the rules defined by the sharing ) |
 | [params.readOnlyRecipients] | [<code>Array.&lt;Recipient&gt;</code>](#Recipient) | Recipients to add to the sharings with only read only access |
 | [params.openSharing] | <code>boolean</code> | If someone else than the owner can add a recipient to the sharing |
+| [params.appSlug] | <code>string</code> | Slug of the targeted app |
 
 <a name="SharingCollection+share"></a>
 

--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -62,6 +62,7 @@ class SharingCollection extends DocumentCollection {
    * @param {Array<Recipient>=} params.recipients Recipients to add to the sharings (will have the same permissions given by the rules defined by the sharing )
    * @param {Array<Recipient>=} params.readOnlyRecipients Recipients to add to the sharings with only read only access
    * @param {boolean=} params.openSharing If someone else than the owner can add a recipient to the sharing
+   * @param {string=} params.appSlug Slug of the targeted app
    */
   async create({
     document,
@@ -70,17 +71,26 @@ class SharingCollection extends DocumentCollection {
     rules,
     recipients = [],
     readOnlyRecipients = [],
-    openSharing
+    openSharing,
+    appSlug
   }) {
+    const attributes = {
+      description,
+      preview_path: previewPath,
+      open_sharing: openSharing,
+      rules: rules ? rules : getSharingRules(document)
+    }
+    let optionalAttributes = {}
+    if (appSlug) {
+      optionalAttributes = {
+        app_slug: appSlug
+      }
+    }
+
     const resp = await this.stackClient.fetchJSON('POST', '/sharings/', {
       data: {
         type: 'io.cozy.sharings',
-        attributes: {
-          description,
-          preview_path: previewPath,
-          open_sharing: openSharing,
-          rules: rules ? rules : getSharingRules(document)
-        },
+        attributes: { ...attributes, ...optionalAttributes },
         relationships: {
           ...(recipients.length > 0 && {
             recipients: { data: recipients.map(toRelationshipItem) }

--- a/packages/cozy-stack-client/src/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/SharingCollection.spec.js
@@ -339,6 +339,46 @@ describe('SharingCollection', () => {
         }
       })
     })
+    it('should creates a sharing with the appSlug', async () => {
+      const sharingDesc = 'foo'
+      const openSharing = true
+      const previewPath = '/preview'
+      const appSlug = 'mySlugApp'
+      await collection.create({
+        document: FILE,
+        recipients: [RECIPIENT],
+        openSharing,
+        previewPath,
+        description: sharingDesc,
+        appSlug
+      })
+
+      expect(client.fetchJSON).toHaveBeenCalledWith('POST', '/sharings/', {
+        data: {
+          attributes: {
+            description: sharingDesc,
+            open_sharing: openSharing,
+            preview_path: previewPath,
+            app_slug: appSlug,
+            rules: [
+              {
+                doctype: 'io.cozy.files',
+                remove: 'revoke',
+                title: FILE.name,
+                update: 'sync',
+                values: [FILE._id]
+              }
+            ]
+          },
+          relationships: {
+            recipients: {
+              data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
+            }
+          },
+          type: 'io.cozy.sharings'
+        }
+      })
+    })
   })
 
   describe('revokeAllRecipients', () => {


### PR DESCRIPTION
By default, Cozy-Stack gets the app_slug from the token.
But we can define the app_slug when creating the sharing. In that case
the cozy-stack will use this slug in the mail sent for a cozy-to-cozy
sharing.
It enables the fact, that the app1, can generate a link to an app2.