### PR TITLE
feat: Send uploaded file size via querystring

### DIFF
--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -1511,14 +1511,18 @@ describe('file creation', () => {
       type: 'file',
       data: data,
       dirId: 'folder-id',
-      name: 'toto.pdf'
+      name: 'toto.pdf',
+      contentLength: data.length
     })
     expect(doc._id).toEqual('1337')
     expect(client.stackClient.fetchJSON).toHaveBeenCalledWith(
       'POST',
-      '/files/folder-id?Name=toto.pdf&Type=file&Executable=false&MetadataID=',
+      '/files/folder-id?Name=toto.pdf&Type=file&Executable=false&MetadataID=&Size=12',
       'file-content',
-      { headers: { 'Content-Type': 'text/plain' }, onUploadProgress: undefined }
+      {
+        headers: { 'Content-Type': 'text/plain', 'Content-Length': '12' },
+        onUploadProgress: undefined
+      }
     )
     expect(client.dispatch.mock.calls.map(x => x[0].type)).toEqual([
       'INIT_MUTATION',

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -400,7 +400,11 @@ class FileCollection extends DocumentCollection {
       const meta = await this.createFileMetadata(metadata)
       metadataId = meta.data.id
     }
-    const path = uri`/files/${dirId}?Name=${name}&Type=file&Executable=${executable}&MetadataID=${metadataId}`
+    let size = ''
+    if (options.contentLength) {
+      size = String(options.contentLength)
+    }
+    const path = uri`/files/${dirId}?Name=${name}&Type=file&Executable=${executable}&MetadataID=${metadataId}&Size=${size}`
     return this.doUpload(data, path, options)
   }
 
@@ -447,6 +451,11 @@ class FileCollection extends DocumentCollection {
       const meta = await this.createFileMetadata(metadata)
       metadataId = meta.data.id
       path = path + `&MetadataID=${metadataId}`
+    }
+    let size = ''
+    if (options.contentLength) {
+      size = String(options.contentLength)
+      path = path + `&Size=${size}`
     }
 
     return this.doUpload(data, path, options, 'PUT')


### PR DESCRIPTION
Some `fetch` implementations like the one used in the Cozy Desktop
client (i.e. using Chromium's network stack) don't allow setting the
`Content-Length` header when sending stream bodies.
With this limitation, the remote `cozy-stack` cannot run size checks
until the whole file has been uploaded. If the file is large and too
large for the available space or the file size limit, the uploading
client can spend quite some time uploading it to end up receiving an
error response.

`cozy-stack` now allows passing the file size via the querystring
parameter `Size` so those clients will get the benefits of early size
checks.