### PR TITLE
feat: Add openFileWith in fsnative

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -246,6 +246,9 @@ example.</p>
 <dd></dd>
 <dt><a href="#openOfflineFile">openOfflineFile</a></dt>
 <dd></dd>
+<dt><a href="#openFileWith">openFileWith</a></dt>
+<dd><p>openFileWith - Opens a file on a mobile device</p>
+</dd>
 <dt><a href="#shouldDisplayOffers">shouldDisplayOffers</a></dt>
 <dd><p>Returns whether an instance is concerned by our offers</p>
 </dd>
@@ -2471,6 +2474,18 @@ Save the document in the temporary folder and open it in an other app
 
 | Param | Type | Description |
 | --- | --- | --- |
+| file | <code>object</code> | io.cozy.files document |
+
+<a name="openFileWith"></a>
+
+## openFileWith
+openFileWith - Opens a file on a mobile device
+
+**Kind**: global constant  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| client | [<code>CozyClient</code>](#CozyClient) | The CozyClient instance |
 | file | <code>object</code> | io.cozy.files document |
 
 <a name="shouldDisplayOffers"></a>

--- a/packages/cozy-client/src/models/fsnative.spec.js
+++ b/packages/cozy-client/src/models/fsnative.spec.js
@@ -1,11 +1,30 @@
-import * as fsnative from './fsnative'
+import { isMobileApp } from 'cozy-device-helper'
+
+import { createMockClient } from '../mock'
+
+import fsnative, { getRootPath, openFileWith } from './fsnative'
+
+jest.spyOn(fsnative, 'saveAndOpenWithCordova').mockReturnValue()
+
+jest.mock('cozy-device-helper', () => ({
+  ...jest.requireActual('cozy-device-helper'),
+  isMobileApp: jest.fn()
+}))
+
+jest.mock('cozy-ui/transpiled/react/Alerter', () => ({
+  success: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn()
+}))
 
 const ANDROID_ROOT_DIRECTORY = 'externalRootDirectory'
 const IOS_ROOT_DIRECTORY = 'dataDirectory'
+const EXTERNAL_CACHE_DIRECTORY = 'externalCacheDirectory'
+const CACHE_DIRECTORY = 'cacheDirectory'
 const ANDROID = 'android'
 const IOS = 'ios'
 
-describe('fsnative', () => {
+describe('getRootPath', () => {
   beforeEach(() => {
     window.cordova = {
       file: {
@@ -18,8 +37,88 @@ describe('fsnative', () => {
 
   it('should get root path', () => {
     window.cordova.platformId = ANDROID
-    expect(fsnative.getRootPath()).toEqual(ANDROID_ROOT_DIRECTORY)
+    expect(getRootPath()).toEqual(ANDROID_ROOT_DIRECTORY)
     window.cordova.platformId = IOS
-    expect(fsnative.getRootPath()).toEqual(IOS_ROOT_DIRECTORY)
+    expect(getRootPath()).toEqual(IOS_ROOT_DIRECTORY)
+  })
+})
+
+describe('openFileWith', () => {
+  const mockClient = createMockClient({})
+  const blobMock = jest.fn()
+  const file = { id: 'fileId' }
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    isMobileApp.mockReturnValue(true)
+
+    mockClient.collection = jest.fn().mockReturnValue(mockClient)
+    mockClient.fetchFileContent = jest.fn().mockReturnValue({
+      blob: blobMock
+    })
+
+    window.cordova = {
+      file: {
+        externalCacheDirectory: EXTERNAL_CACHE_DIRECTORY,
+        cacheDirectory: CACHE_DIRECTORY
+      },
+      plugins: { fileOpener2: {} }
+    }
+  })
+
+  it('opens the file with cordova', async () => {
+    blobMock.mockReturnValue('fake file blob')
+    await openFileWith(mockClient, file)
+    expect(mockClient.fetchFileContent).toHaveBeenCalledWith(file.id)
+    expect(fsnative.saveAndOpenWithCordova).toHaveBeenCalledWith(
+      'fake file blob',
+      file
+    )
+  })
+
+  it('errors when it fails to download the file without 404', async () => {
+    expect.assertions(1)
+    mockClient.fetchFileContent = jest.fn().mockRejectedValue(new Error())
+
+    try {
+      await openFileWith(mockClient, file)
+    } catch (e) {
+      expect(e).toMatch('offline')
+    }
+  })
+
+  it('errors when it fails to download the file with 404', async () => {
+    expect.assertions(1)
+    const error = new Error('Not Found')
+    error.status = 404
+    mockClient.fetchFileContent = jest.fn().mockRejectedValue(error)
+
+    try {
+      await openFileWith(mockClient, file)
+    } catch (e) {
+      expect(e).toMatch('missing')
+    }
+  })
+
+  it('errors when opening the filewith cordova fails', async () => {
+    expect.assertions(1)
+    fsnative.saveAndOpenWithCordova.mockRejectedValue(new Error())
+
+    try {
+      await openFileWith(mockClient, file)
+    } catch (e) {
+      expect(e).toMatch('noapp')
+    }
+  })
+
+  it('errors when the plugin is not present', async () => {
+    expect.assertions(1)
+    window.cordova.plugins.fileOpener2 = null
+
+    try {
+      await openFileWith(mockClient, file)
+    } catch (e) {
+      expect(e).toMatch('noapp')
+    }
   })
 })


### PR DESCRIPTION
to easily open a file on mobile devices in an external app

Méthode rapatriée de Drive https://github.com/cozy/cozy-drive/blob/master/src/drive/web/modules/actions/utils.js#L178

Les throw ont été ajustés pour que l'`Alerter` soit exécuté dans l'app et non dans cozy-client, de la manière : 
```
    try {
      await openFileWith(client, file)
    } catch (error) {
      Alerter.info(`Viewer.error.${error}`, { fileMime: file.mime })
    }
```