### PR TITLE
fix: HandleMissingIndex can now deal with undefined indexedFields

### DIFF
--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -209,7 +209,12 @@ class DocumentCollection {
    * @private
    */
   async handleMissingIndex(selector, options) {
-    const { indexedFields, partialFilter } = options
+    let { indexedFields, partialFilter } = options
+
+    if (!indexedFields) {
+      indexedFields = getIndexFields({ sort: options.sort, selector })
+    }
+
     const existingIndex = await this.findExistingIndex(selector, options)
     const indexName = getIndexNameFromFields(indexedFields)
     if (!existingIndex) {

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -986,4 +986,41 @@ describe('DocumentCollection', () => {
       })
     })
   })
+
+  describe('handleMissingIndex', () => {
+    const collection = new DocumentCollection('io.cozy.triggers', client)
+    const selector = {
+      'message.account': 'ca7b7f1'
+    }
+    const response = {
+      rows: [
+        {
+          doc: {
+            _id: '123',
+            language: 'query',
+            views: {
+              123456: {
+                map: {
+                  fields: {
+                    'message.account': 'asc'
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      total_rows: 1
+    }
+
+    it('should work with undefined indexedFields', async () => {
+      client.fetchJSON.mockResolvedValue(response)
+      expect(
+        await collection.handleMissingIndex(selector, {
+          indexedFields: undefined,
+          sort: undefined
+        })
+      )
+    })
+  })
 })


### PR DESCRIPTION
Lors d'une toute première requête sans option sur un index inexistant, donc avec un indexedFields undefined, la fonction plantait au moment de la création du nom de l'index, la méthode utilisée `getIndexNameFromFields` prend indexedFields comme argument