### PR TITLE
feat: Make interval query consistent on operators

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -409,8 +409,6 @@ both situation.</p>
 </dd>
 <dt><a href="#TimeSeriesJSONAPI">TimeSeriesJSONAPI</a> ⇒ <code><a href="#TimeSeriesJSONAPI">TimeSeriesJSONAPI</a></code></dt>
 <dd><p>Helper to retrieve time series by their date interval and source.</p>
-<p>The starting date must be greater or equal while the ending date must
-be stricly less than the given startDate and endDate parameters.</p>
 </dd>
 <dt><a href="#HydratedQueryState">HydratedQueryState</a> ⇒ <code><a href="#HydratedQueryState">HydratedQueryState</a></code></dt>
 <dd><p>Returns the query from the store with hydrated documents.</p>
@@ -3174,9 +3172,6 @@ Helper to save a time series document.
 
 ## TimeSeriesJSONAPI ⇒ [<code>TimeSeriesJSONAPI</code>](#TimeSeriesJSONAPI)
 Helper to retrieve time series by their date interval and source.
-
-The starting date must be greater or equal while the ending date must
-be stricly less than the given startDate and endDate parameters.
 
 **Kind**: global typedef  
 **Returns**: [<code>TimeSeriesJSONAPI</code>](#TimeSeriesJSONAPI) - The TimeSeries found by the query in JSON-API format  

--- a/packages/cozy-client/src/models/timeseries.js
+++ b/packages/cozy-client/src/models/timeseries.js
@@ -52,9 +52,6 @@ export const saveTimeSeries = async (
 /**
  * Helper to retrieve time series by their date interval and source.
  *
- * The starting date must be greater or equal while the ending date must
- * be stricly less than the given startDate and endDate parameters.
- *
  * @param {object} client - The CozyClient instance
  * @param {{ startDate, endDate, dataType, source, limit }} The query params.
  *
@@ -74,7 +71,7 @@ export const fetchTimeSeriesByIntervalAndSource = async (
         $gte: startDate
       },
       endDate: {
-        $lt: endDate
+        $lte: endDate
       }
     })
     .indexFields(['source', 'startDate', 'endDate'])


### PR DESCRIPTION
It probably makes more sense to have an interval query with symmetric operators, i.e. `$gte` and `$lte`, to avoid confusion