### PR TITLE
fix: Do not assign window to win if window is not defined

### DIFF
--- a/packages/cozy-client/src/authentication/mobile.js
+++ b/packages/cozy-client/src/authentication/mobile.js
@@ -11,7 +11,7 @@ import { CordovaWindow } from '../types'
  * @type {CordovaWindow}
  */
 // @ts-ignore
-const win = window
+const win = typeof window !== 'undefined' ? window : null
 
 const authenticateWithSafari = url => {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
In node environment, window is not defined.