### PR TITLE
feat: Do not polyfill at the module level

### DIFF
--- a/packages/cozy-client/src/cli/index.js
+++ b/packages/cozy-client/src/cli/index.js
@@ -10,8 +10,8 @@ import logger from 'cozy-logger'
 
 const log = logger.namespace('create-cli-client')
 
-global.fetch = require('node-fetch')
-global.btoa = require('btoa')
+const nodeFetch = require('node-fetch')
+const btoa = require('btoa')
 
 /**
  * Creates and starts and HTTP server suitable for OAuth authentication
@@ -225,6 +225,9 @@ const createClientInteractive = (clientOptions, serverOpts) => {
 }
 
 const main = async () => {
+  global.fetch = nodeFetch
+  global.btoa = btoa
+
   const client = await createClientInteractive({
     scope: ['io.cozy.files'],
     uri: 'http://cozy.tools:8080',


### PR DESCRIPTION
Saw this when trying to resolve a "fetch" is not a function in a service
from the home.

After investigation:

- Home services try do their polyfill if global.fetch is not yet defined
- global.fetch is already defined
- this because cozy-client/dist/cli.js is exported from index.node.js
- global.fetch was assigned at the module level in cli.js

When doing this fix, global.fetch is not polyfilled here and is
polyfilled directly by the service of the home.

I think we should improve how we polyfill, it is still a bit unclear but
right now, we expect the service to polyfill fetch themselves.
It is in the documentation: docs/node.md.

With this fix, there is no surprise, since the assignment to global is
done in the main, and no more at import level : if you do not use the
cli.js main, global.fetch is not polyfilled, it seems clearer to me.