### PR TITLE
fix: Upgrade cozy-flags to avoid error in node env

### DIFF
--- a/packages/cozy-stack-client/package.json
+++ b/packages/cozy-stack-client/package.json
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/cozy/cozy-client.git"
   },
   "dependencies": {
-    "cozy-flags": "^2.5.0",
+    "cozy-flags": "^2.5.4",
     "detect-node": "^2.0.4",
     "mime": "^2.4.0",
     "qs": "^6.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4303,10 +4303,10 @@ cozy-device-helper@^1.7.3:
   dependencies:
     lodash "^4.17.19"
 
-cozy-flags@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-2.5.0.tgz#f5ade2ceb636afb6151edf2dd9c5d1f34e35ab58"
-  integrity sha512-OluJtFAUSGeX13iPfpdVDQdNypGCTI2mVe8GVU+nY3z7m/lfkRprO3+rNKbOCGUAJJXkqCH+xO7RmqbUsbs9yA==
+cozy-flags@^2.5.4:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-2.5.4.tgz#dc7155560b7dc91e59e02a5f4f1efebec7296073"
+  integrity sha512-BM3OB5+mTsX1EbC7qKpWjMWFyPKoCokXr6mPAXVeL5tUh9ld0plyB+8O8QDFV3T0fUl0XYhXIsKy63TSU/q2nA==
   dependencies:
     microee "^0.0.6"
 


### PR DESCRIPTION
When used in a node environment, an error was thrown because of
cozy-flags using react.

See https://github.com/cozy/cozy-libs/pull/1269