### PR TITLE
Add capabilities inside cozy-client

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -487,6 +487,11 @@ both situation.</p>
 <dd></dd>
 <dt><a href="#InAppBrowser">InAppBrowser</a></dt>
 <dd></dd>
+<dt><a href="#AppMetadata">AppMetadata</a> : <code>object</code></dt>
+<dd></dd>
+<dt><a href="#ClientCapabilities">ClientCapabilities</a> : <code>object</code></dt>
+<dd><p>Read more about client capabilities here <a href="https://docs.cozy.io/en/cozy-stack/settings/#get-settingscapabilities">https://docs.cozy.io/en/cozy-stack/settings/#get-settingscapabilities</a>.</p>
+</dd>
 <dt><a href="#Cordova">Cordova</a></dt>
 <dd></dd>
 <dt><a href="#CordovaWindow">CordovaWindow</a></dt>
@@ -985,6 +990,7 @@ Responsible for
 * [CozyClient](#CozyClient)
     * [new CozyClient(rawOptions)](#new_CozyClient_new)
     * _instance_
+        * [.capabilities](#CozyClient+capabilities) : [<code>ClientCapabilities</code>](#ClientCapabilities)
         * [.storeAccesors](#CozyClient+storeAccesors) : <code>object</code>
         * [.fetchQueryAndGetFromState](#CozyClient+fetchQueryAndGetFromState) ⇒ [<code>Promise.&lt;QueryState&gt;</code>](#QueryState)
         * [.emit()](#CozyClient+emit)
@@ -1001,6 +1007,7 @@ Responsible for
         * [.hydrateDocuments(doctype, documents)](#CozyClient+hydrateDocuments) ⇒ <code>Array.&lt;HydratedDocument&gt;</code>
         * [.hydrateDocument(document, [schemaArg])](#CozyClient+hydrateDocument) ⇒ <code>HydratedDocument</code>
         * [.makeNewDocument()](#CozyClient+makeNewDocument)
+        * [.getAssociation()](#CozyClient+getAssociation)
         * [.getRelationshipStoreAccessors()](#CozyClient+getRelationshipStoreAccessors)
         * [.getCollectionFromState(type)](#CozyClient+getCollectionFromState) ⇒ [<code>Array.&lt;CozyClientDocument&gt;</code>](#CozyClientDocument)
         * [.getDocumentFromState(type, id)](#CozyClient+getDocumentFromState) ⇒ [<code>CozyClientDocument</code>](#CozyClientDocument)
@@ -1021,7 +1028,7 @@ Responsible for
         * [.fromOldClient(oldClient)](#CozyClient.fromOldClient) ⇒ [<code>CozyClient</code>](#CozyClient)
         * [.fromOldOAuthClient(oldClient)](#CozyClient.fromOldOAuthClient) ⇒ [<code>Promise.&lt;CozyClient&gt;</code>](#CozyClient)
         * [.fromEnv([envArg], options)](#CozyClient.fromEnv) ⇒ [<code>CozyClient</code>](#CozyClient)
-        * [.fromDOM(selector, options)](#CozyClient.fromDOM) ⇒ <code>object</code>
+        * [.fromDOM(options, selector)](#CozyClient.fromDOM) ⇒ <code>object</code>
         * [.registerHook(doctype, name, fn)](#CozyClient.registerHook)
 
 <a name="new_CozyClient_new"></a>
@@ -1050,6 +1057,10 @@ const client = new CozyClient({
 ```
 
 Cozy-Client will automatically call `this.login()` if provided with a token and an uri
+<a name="CozyClient+capabilities"></a>
+
+### cozyClient.capabilities : [<code>ClientCapabilities</code>](#ClientCapabilities)
+**Kind**: instance property of [<code>CozyClient</code>](#CozyClient)  
 <a name="CozyClient+storeAccesors"></a>
 
 ### cozyClient.storeAccesors : <code>object</code>
@@ -1321,6 +1332,12 @@ This document is hydrated : its relationships are there
 and working.
 
 **Kind**: instance method of [<code>CozyClient</code>](#CozyClient)  
+<a name="CozyClient+getAssociation"></a>
+
+### cozyClient.getAssociation()
+Creates an association that is linked to the store.
+
+**Kind**: instance method of [<code>CozyClient</code>](#CozyClient)  
 <a name="CozyClient+getRelationshipStoreAccessors"></a>
 
 ### cozyClient.getRelationshipStoreAccessors()
@@ -1539,7 +1556,7 @@ environment variables
 
 <a name="CozyClient.fromDOM"></a>
 
-### CozyClient.fromDOM(selector, options) ⇒ <code>object</code>
+### CozyClient.fromDOM(options, selector) ⇒ <code>object</code>
 When used from an app, CozyClient can be instantiated from the data injected by the stack in
 the DOM.
 
@@ -1548,8 +1565,8 @@ the DOM.
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| selector | <code>string</code> | <code>&quot;[role&#x3D;application]&quot;</code> | Options |
 | options | <code>object</code> |  | CozyClient constructor options |
+| selector | <code>string</code> | <code>&quot;[role&#x3D;application]&quot;</code> | Options |
 
 <a name="CozyClient.registerHook"></a>
 
@@ -3129,10 +3146,11 @@ HOC to provide mutations to components. Needs client in context or as prop.
 | [oauth] | <code>object</code> |  |
 | [onTokenRefresh] | <code>function</code> |  |
 | [onTokenRefresh] | <code>function</code> |  |
-| [options.link] | <code>Link</code> | Backward compatibility |
-| [options.links] | <code>Array.&lt;Link&gt;</code> | List of links |
-| [options.schema] | <code>object</code> | Schema description for each doctypes |
-| [options.appMetadata] | <code>object</code> | Metadata about the application that will be used in ensureCozyMetadata |
+| [link] | <code>Link</code> | Backward compatibility |
+| [links] | <code>Array.&lt;Link&gt;</code> | List of links |
+| [schema] | <code>object</code> | Schema description for each doctypes |
+| [appMetadata] | [<code>AppMetadata</code>](#AppMetadata) | Metadata about the application that will be used in ensureCozyMetadata |
+| [capabilities] | [<code>ClientCapabilities</code>](#ClientCapabilities) | Capabilities sent by the stack |
 
 <a name="CozyAccount"></a>
 
@@ -3476,6 +3494,25 @@ An io.cozy.files document
 | Name | Type |
 | --- | --- |
 | open | <code>function</code> | 
+
+<a name="AppMetadata"></a>
+
+## AppMetadata : <code>object</code>
+**Kind**: global typedef  
+<a name="ClientCapabilities"></a>
+
+## ClientCapabilities : <code>object</code>
+Read more about client capabilities here https://docs.cozy.io/en/cozy-stack/settings/#get-settingscapabilities.
+
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| can_auth_with_oidc | <code>boolean</code> | Whether OIDC login is possible with this Cozy |
+| can_auth_with_password | <code>boolean</code> | Whether  password login is possible with this Cozy |
+| file_versioning | <code>boolean</code> | Whether file versioning is active on this Cozy |
+| flat_subdomains | <code>boolean</code> | Whether the stack has been configured to use flat subdomains |
 
 <a name="Cordova"></a>
 

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -1102,7 +1102,7 @@ client.query(Q('io.cozy.bills'))`)
   getAssociation(document, associationName) {
     return createAssociation(
       document,
-      this.schema.getAssociation(document._type, associationName),
+      this.schema.getRelationship(document._type, associationName),
       this.getRelationshipStoreAccessors()
     )
   }

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -1097,6 +1097,17 @@ client.query(Q('io.cozy.bills'))`)
   }
 
   /**
+   * Creates an association that is linked to the store.
+   */
+  getAssociation(document, associationName) {
+    return createAssociation(
+      document,
+      this.schema.getAssociation(document._type, associationName),
+      this.getRelationshipStoreAccessors()
+    )
+  }
+
+  /**
    * Returns the accessors that are given to the relationships for them
    * to deal with the stores.
    *

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -359,17 +359,22 @@ class CozyClient {
       ? JSON.parse(root.dataset.cozy)
       : { ...root.dataset }
 
-    const { cozyDomain, cozyToken } = data
+    let { domain, token } = data
+    if (!domain || !token) {
+      domain = domain || data.cozyDomain
+      token = token || data.cozyToken
+    }
 
-    if (!cozyDomain || !cozyToken) {
+    if (!domain || !token) {
       throw new Error(
         `Found no data in ${root.dataset} to instantiate cozyClient`
       )
     }
 
     return new CozyClient({
-      uri: `${window.location.protocol}//${cozyDomain}`,
-      token: cozyToken,
+      uri: `${window.location.protocol}//${domain}`,
+      token: token,
+      capabilities: data.capabilities,
       ...options
     })
   }

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -56,7 +56,8 @@ import {
   ReferenceMap,
   OldCozyClient,
   NodeEnvironment,
-  AppMetadata
+  AppMetadata,
+  ClientCapabilities
 } from './types'
 
 const ensureArray = arr => (Array.isArray(arr) ? arr : [arr])
@@ -101,6 +102,7 @@ const DOC_UPDATE = 'update'
  * @property  {Array<Link>}  [links]  - List of links
  * @property  {object}       [schema] - Schema description for each doctypes
  * @property  {AppMetadata}  [appMetadata] - Metadata about the application that will be used in ensureCozyMetadata
+ * @property  {ClientCapabilities} [capabilities] - Capabilities sent by the stack
  */
 
 /**
@@ -140,6 +142,7 @@ class CozyClient {
       links,
       schema = {},
       appMetadata = {},
+      capabilities,
       ...options
     } = rawOptions
     if (link) {
@@ -168,6 +171,11 @@ class CozyClient {
     this.chain = chain(this.links)
 
     this.schema = new Schema(schema, stackClient)
+
+    /**
+     * @type {ClientCapabilities}
+     */
+    this.capabilities = capabilities || null
 
     // Instances of plugins registered with registerPlugin
     this.plugins = {}

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -334,11 +334,11 @@ class CozyClient {
    * When used from an app, CozyClient can be instantiated from the data injected by the stack in
    * the DOM.
    *
-   * @param  {string}   selector - Options
    * @param  {object}   options  - CozyClient constructor options
+   * @param  {string}   selector - Options
    * @returns {object} - CozyClient instance
    */
-  static fromDOM(selector = '[role=application]', options = {}) {
+  static fromDOM(options = {}, selector = '[role=application]') {
     const root = document.querySelector(selector)
     if (!(root instanceof HTMLElement)) {
       return

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -55,7 +55,8 @@ import {
   ClientResponse,
   ReferenceMap,
   OldCozyClient,
-  NodeEnvironment
+  NodeEnvironment,
+  AppMetadata
 } from './types'
 
 const ensureArray = arr => (Array.isArray(arr) ? arr : [arr])
@@ -96,10 +97,10 @@ const DOC_UPDATE = 'update'
  * @property {object} [oauth]
  * @property {Function} [onTokenRefresh]
  * @property {Function} [onTokenRefresh]
- * @property  {Link}         [options.link]   - Backward compatibility
- * @property  {Array<Link>}  [options.links]  - List of links
- * @property  {object}       [options.schema] - Schema description for each doctypes
- * @property  {object}       [options.appMetadata] - Metadata about the application that will be used in ensureCozyMetadata
+ * @property  {Link}         [link]   - Backward compatibility
+ * @property  {Array<Link>}  [links]  - List of links
+ * @property  {object}       [schema] - Schema description for each doctypes
+ * @property  {AppMetadata}  [appMetadata] - Metadata about the application that will be used in ensureCozyMetadata
  */
 
 /**

--- a/packages/cozy-client/src/Query.jsx
+++ b/packages/cozy-client/src/Query.jsx
@@ -24,6 +24,7 @@ const getQueryAttributes = (client, props) => {
   const createDocument = client.create.bind(client)
   const saveDocument = client.save.bind(client)
   const deleteDocument = client.destroy.bind(client)
+  const getAssociation = client.getAssociation.bind(client)
 
   // Methods on ObservableQuery
   const queryDefinition =
@@ -52,6 +53,7 @@ const getQueryAttributes = (client, props) => {
     createDocument,
     saveDocument,
     deleteDocument,
+    getAssociation,
     fetchMore,
     fetch,
     mutations
@@ -66,6 +68,7 @@ const computeChildrenArgs = queryAttributes => {
     createDocument,
     saveDocument,
     deleteDocument,
+    getAssociation,
     mutations
   } = queryAttributes
 
@@ -79,6 +82,7 @@ const computeChildrenArgs = queryAttributes => {
       createDocument: createDocument,
       saveDocument: saveDocument,
       deleteDocument: deleteDocument,
+      getAssociation: getAssociation,
       ...mutations
     }
   ]

--- a/packages/cozy-client/src/__tests__/mocks.js
+++ b/packages/cozy-client/src/__tests__/mocks.js
@@ -18,6 +18,7 @@ export const client = implementations => {
     create: jest.fn(),
     save: jest.fn(),
     destroy: jest.fn(),
+    getAssociation: jest.fn(),
     makeObservableQuery: jest.fn(),
     requestQuery: jest.fn(),
     all: jest.fn(),

--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -125,6 +125,17 @@ import { QueryDefinition } from './queries/dsl'
  */
 
 /**
+ * @typedef {object} ClientCapabilities
+ *
+ * @description Read more about client capabilities here https://docs.cozy.io/en/cozy-stack/settings/#get-settingscapabilities.
+ *
+ * @property {boolean} can_auth_with_oidc - Whether OIDC login is possible with this Cozy
+ * @property {boolean} can_auth_with_password - Whether  password login is possible with this Cozy
+ * @property {boolean} file_versioning - Whether file versioning is active on this Cozy
+ * @property {boolean} flat_subdomains - Whether the stack has been configured to use flat subdomains
+ */
+
+/**
  * @typedef Cordova
  * @property {FilePlugin} file
  * @property {InAppBrowser} InAppBrowser

--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -121,6 +121,10 @@ import { QueryDefinition } from './queries/dsl'
  */
 
 /**
+ * @typedef {object} AppMetadata
+ */
+
+/**
  * @typedef Cordova
  * @property {FilePlugin} file
  * @property {InAppBrowser} InAppBrowser

--- a/packages/cozy-client/types/CozyClient.d.ts
+++ b/packages/cozy-client/types/CozyClient.d.ts
@@ -77,11 +77,11 @@ declare class CozyClient {
      * When used from an app, CozyClient can be instantiated from the data injected by the stack in
      * the DOM.
      *
-     * @param  {string}   selector - Options
      * @param  {object}   options  - CozyClient constructor options
+     * @param  {string}   selector - Options
      * @returns {object} - CozyClient instance
      */
-    static fromDOM(selector?: string, options?: object): object;
+    static fromDOM(options?: object, selector?: string): object;
     /**
      * Hooks are an observable system for events on documents.
      * There are at the moment only 2 hooks available.

--- a/packages/cozy-client/types/CozyClient.d.ts
+++ b/packages/cozy-client/types/CozyClient.d.ts
@@ -424,6 +424,10 @@ declare class CozyClient {
      */
     makeNewDocument(doctype: any): any;
     /**
+     * Creates an association that is linked to the store.
+     */
+    getAssociation(document: any, associationName: any): any;
+    /**
      * Returns the accessors that are given to the relationships for them
      * to deal with the stores.
      *

--- a/packages/cozy-client/types/CozyClient.d.ts
+++ b/packages/cozy-client/types/CozyClient.d.ts
@@ -18,6 +18,10 @@ export type ClientOptions = {
      * - Metadata about the application that will be used in ensureCozyMetadata
      */
     appMetadata?: AppMetadata;
+    /**
+     * - Capabilities sent by the stack
+     */
+    capabilities?: ClientCapabilities;
 };
 /**
  * @typedef {object} ClientOptions
@@ -36,6 +40,7 @@ export type ClientOptions = {
  * @property  {Array<Link>}  [links]  - List of links
  * @property  {object}       [schema] - Schema description for each doctypes
  * @property  {AppMetadata}  [appMetadata] - Metadata about the application that will be used in ensureCozyMetadata
+ * @property  {ClientCapabilities} [capabilities] - Capabilities sent by the stack
  */
 /**
  * Responsible for
@@ -145,6 +150,10 @@ declare class CozyClient {
     links: any[];
     chain: any;
     schema: Schema;
+    /**
+     * @type {ClientCapabilities}
+     */
+    capabilities: ClientCapabilities;
     plugins: {};
     /**
      * @type {object}
@@ -595,6 +604,7 @@ declare namespace CozyClient {
 }
 import { Token } from "./types";
 import { AppMetadata } from "./types";
+import { ClientCapabilities } from "./types";
 import Schema from "./Schema";
 import { DocumentCollection } from "./types";
 import { QueryDefinition } from "./queries/dsl";

--- a/packages/cozy-client/types/CozyClient.d.ts
+++ b/packages/cozy-client/types/CozyClient.d.ts
@@ -17,7 +17,7 @@ export type ClientOptions = {
     /**
      * - Metadata about the application that will be used in ensureCozyMetadata
      */
-    appMetadata?: object;
+    appMetadata?: AppMetadata;
 };
 /**
  * @typedef {object} ClientOptions
@@ -32,10 +32,10 @@ export type ClientOptions = {
  * @property {object} [oauth]
  * @property {Function} [onTokenRefresh]
  * @property {Function} [onTokenRefresh]
- * @property  {Link}         [options.link]   - Backward compatibility
- * @property  {Array<Link>}  [options.links]  - List of links
- * @property  {object}       [options.schema] - Schema description for each doctypes
- * @property  {object}       [options.appMetadata] - Metadata about the application that will be used in ensureCozyMetadata
+ * @property  {Link}         [link]   - Backward compatibility
+ * @property  {Array<Link>}  [links]  - List of links
+ * @property  {object}       [schema] - Schema description for each doctypes
+ * @property  {AppMetadata}  [appMetadata] - Metadata about the application that will be used in ensureCozyMetadata
  */
 /**
  * Responsible for
@@ -594,6 +594,7 @@ declare namespace CozyClient {
     export const version: string;
 }
 import { Token } from "./types";
+import { AppMetadata } from "./types";
 import Schema from "./Schema";
 import { DocumentCollection } from "./types";
 import { QueryDefinition } from "./queries/dsl";

--- a/packages/cozy-client/types/Query.d.ts
+++ b/packages/cozy-client/types/Query.d.ts
@@ -50,6 +50,7 @@ export function getQueryAttributes(client: any, props: any): {
     createDocument: any;
     saveDocument: any;
     deleteDocument: any;
+    getAssociation: any;
     fetchMore: any;
     fetch: any;
     mutations: any;

--- a/packages/cozy-client/types/__tests__/mocks.d.ts
+++ b/packages/cozy-client/types/__tests__/mocks.d.ts
@@ -3,6 +3,7 @@ export function client(implementations: any): {
     create: jest.Mock<any, any>;
     save: jest.Mock<any, any>;
     destroy: jest.Mock<any, any>;
+    getAssociation: jest.Mock<any, any>;
     makeObservableQuery: jest.Mock<any, any>;
     requestQuery: jest.Mock<any, any>;
     all: jest.Mock<any, any>;

--- a/packages/cozy-client/types/cli/index.d.ts
+++ b/packages/cozy-client/types/cli/index.d.ts
@@ -23,5 +23,5 @@ export type DestroyableServer = any;
  * })
  * ```
  */
-export function createClientInteractive(clientOptions: object, serverOpts: any): Promise<any> | CozyClient;
+export function createClientInteractive(clientOptions: object, serverOpts: any): CozyClient | Promise<any>;
 import CozyClient from "../CozyClient";

--- a/packages/cozy-client/types/cli/index.d.ts
+++ b/packages/cozy-client/types/cli/index.d.ts
@@ -23,5 +23,5 @@ export type DestroyableServer = any;
  * })
  * ```
  */
-export function createClientInteractive(clientOptions: object, serverOpts: any): CozyClient | Promise<any>;
+export function createClientInteractive(clientOptions: object, serverOpts: any): Promise<any> | CozyClient;
 import CozyClient from "../CozyClient";

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -17,11 +17,8 @@ export type ReduxStore = any;
 export type Token = any;
 export type ClientResponse = any;
 export type Manifest = any;
-<<<<<<< HEAD
 export type OldCozyClient = any;
 export type NodeEnvironment = any;
-=======
->>>>>>> f712c244 (fix: Correct types)
 export type QueryFetchStatus = "loading" | "loaded" | "pending" | "failed";
 export type QueryState = {
     id: string;
@@ -137,6 +134,7 @@ export type InAppBrowser = {
     open: Function;
 };
 export type AppMetadata = any;
+export type ClientCapabilities = any;
 export type Cordova = {
     file: FilePlugin;
     InAppBrowser: InAppBrowser;

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -17,8 +17,11 @@ export type ReduxStore = any;
 export type Token = any;
 export type ClientResponse = any;
 export type Manifest = any;
+<<<<<<< HEAD
 export type OldCozyClient = any;
 export type NodeEnvironment = any;
+=======
+>>>>>>> f712c244 (fix: Correct types)
 export type QueryFetchStatus = "loading" | "loaded" | "pending" | "failed";
 export type QueryState = {
     id: string;
@@ -133,6 +136,7 @@ export type FilePlugin = {
 export type InAppBrowser = {
     open: Function;
 };
+export type AppMetadata = any;
 export type Cordova = {
     file: FilePlugin;
     InAppBrowser: InAppBrowser;


### PR DESCRIPTION
When instantiating a client from the DOM, the client has
the "capabilities" attributes filled.

I also changed the signature of the fromDOM call, to have
the selector in second, it is a breaking change but I checked and we do not use fromDOM much yet:

```
notes
libs
contacts
drive
store
banks
  src/ducks/client/web.js
settings
  src/lib/client.js
home
```

I'll take care of changing the call in Banks.