### PR TITLE
feat: Update cozy-device-helper

### DIFF
--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -17,7 +17,7 @@
     "@cozy/minilog": "1.0.0",
     "@types/jest": "^26.0.20",
     "btoa": "^1.2.1",
-    "cozy-device-helper": "^1.7.3",
+    "cozy-device-helper": "^1.12.0",
     "cozy-logger": "^1.6.0",
     "cozy-stack-client": "^20.0.0",
     "lodash": "^4.17.13",

--- a/packages/cozy-pouch-link/package.json
+++ b/packages/cozy-pouch-link/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@cozy/minilog": "1.0.0",
     "cozy-client": "^20.1.0",
-    "cozy-device-helper": "^1.7.3",
+    "cozy-device-helper": "^1.12.0",
     "pouchdb-browser": "^7.0.0",
     "pouchdb-find": "^7.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4296,10 +4296,10 @@ cosmiconfig@^5.0.0, cosmiconfig@^5.1.0, cosmiconfig@^5.2.0:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
-cozy-device-helper@^1.7.3:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-1.11.0.tgz#1dc9441b23c9bfd1f62b947f65334334a2f78cdc"
-  integrity sha512-Xw9Zah3ML8ORnKzOTFj8CPXVjLKOvFwwy1ue8KoHzrdkraHctyQ6pdm0Jm8qLuxV6oa0BexOilqnq849OR7ZdA==
+cozy-device-helper@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-1.12.0.tgz#619a24b0d3caf2d3f616a1524daef7c7b71eab7a"
+  integrity sha512-7pFbltgkD8rSO0PEf8pd6aBB37RUnNYH7fb3pkbcvo5rk4quCfSLREV94gZwXxowzP4vjZcAumTM09DfI42mJA==
   dependencies:
     lodash "^4.17.19"
 


### PR DESCRIPTION
This update will remove a pinned dependency on lodash from
cozy-device-helper.

This resulted in warnings like :

WARNING in lodash
  Multiple versions of lodash found:
    4.17.15 ./~/cozy-client/~/cozy-device-helper/~/lodash
    4.17.19 ./~/lodash