### PR TITLE
Fix failing index

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -112,6 +112,9 @@ contains the indexed attributes which are not in correct order.</p>
 <dt><a href="#Stream">Stream</a> : <code>object</code></dt>
 <dd><p>Stream is not defined in a browser, but is on NodeJS environment</p>
 </dd>
+<dt><a href="#DesignDoc">DesignDoc</a> : <code>object</code></dt>
+<dd><p>Attributes representing a design doc</p>
+</dd>
 <dt><a href="#Permission">Permission</a> ⇒ <code><a href="#Permission">Permission</a></code></dt>
 <dd><p>async fetchOwnPermissions - Fetches permissions</p>
 </dd>
@@ -1484,7 +1487,7 @@ contains the indexed attributes which are not in correct order.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| index | <code>object</code> | The index to check |
+| index | [<code>DesignDoc</code>](#DesignDoc) | The index to check |
 
 <a name="isMatchingIndex"></a>
 
@@ -1496,7 +1499,7 @@ Check if an index is matching the given fields
 
 | Param | Type | Description |
 | --- | --- | --- |
-| index | <code>object</code> | The index to check |
+| index | [<code>DesignDoc</code>](#DesignDoc) | The index to check |
 | fields | <code>Array</code> | The fields that the index must have |
 | partialFilter | <code>object</code> | An optional partial filter |
 
@@ -1596,6 +1599,20 @@ Document representing a io.cozy.files
 Stream is not defined in a browser, but is on NodeJS environment
 
 **Kind**: global typedef  
+<a name="DesignDoc"></a>
+
+## DesignDoc : <code>object</code>
+Attributes representing a design doc
+
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| _id | <code>string</code> | Id of the design doc. Can be named, e.g. '_design/by_indexed_attribute' or not, e.g. '_design/12345' |
+| language | <code>string</code> | The index language. Can be 'query' for mango index or 'javascript' for views. |
+| views | <code>object</code> | Views definition, i.e. the index. |
+
 <a name="Permission"></a>
 
 ## Permission ⇒ [<code>Permission</code>](#Permission)

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -65,8 +65,12 @@ through OAuth.</p>
 <dd><p>Compute fields that should be indexed for a mango
 query to work</p>
 </dd>
-<dt><a href="#getMatchingIndex">getMatchingIndex</a> ⇒ <code>object</code></dt>
-<dd><p>Get a matching index based on the given parameters</p>
+<dt><a href="#isInconsistentIndex">isInconsistentIndex</a> ⇒ <code>boolean</code></dt>
+<dd><p>Check if an index is in an inconsistent state, i.e. its name
+contains the indexed attributes which are not in correct order.</p>
+</dd>
+<dt><a href="#isMatchingIndex">isMatchingIndex</a> ⇒ <code>boolean</code></dt>
+<dd><p>Check if an index is matching the given fields</p>
 </dd>
 <dt><a href="#getPermissionsFor">getPermissionsFor</a> ⇒ <code>object</code></dt>
 <dd><p>Build a permission set</p>
@@ -1469,19 +1473,32 @@ query to work
 | --- | --- | --- |
 | options | <code>object</code> | Mango query options |
 
-<a name="getMatchingIndex"></a>
+<a name="isInconsistentIndex"></a>
 
-## getMatchingIndex ⇒ <code>object</code>
-Get a matching index based on the given parameters
+## isInconsistentIndex ⇒ <code>boolean</code>
+Check if an index is in an inconsistent state, i.e. its name
+contains the indexed attributes which are not in correct order.
 
 **Kind**: global constant  
-**Returns**: <code>object</code> - A matching index  
+**Returns**: <code>boolean</code> - True if the index is inconsistent  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| indexes | <code>Array</code> | The list of indexes to search |
-| fields | <code>Array</code> | The index fields |
-| partialFilter | <code>object</code> | A partial filter selector |
+| index | <code>object</code> | The index to check |
+
+<a name="isMatchingIndex"></a>
+
+## isMatchingIndex ⇒ <code>boolean</code>
+Check if an index is matching the given fields
+
+**Kind**: global constant  
+**Returns**: <code>boolean</code> - True if the index is matches the given fields  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| index | <code>object</code> | The index to check |
+| fields | <code>Array</code> | The fields that the index must have |
+| partialFilter | <code>object</code> | An optional partial filter |
 
 <a name="getPermissionsFor"></a>
 

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -57,7 +57,7 @@ class PouchLink extends CozyLink {
    * @param {string[]} opts.doctypes Doctypes to replicate
    * @param {object[]} opts.doctypesReplicationOptions A mapping from doctypes to replication options. All pouch replication options can be used, as well as the "strategy" option that determines which way the replication is done (can be "sync", "fromRemote" or "toRemote")
    *
-   * @return {object} The PouchLink instance
+   * @returns {object} The PouchLink instance
    */
 
   constructor(opts = {}) {

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -214,7 +214,6 @@ class DocumentCollection {
     if (!indexedFields) {
       indexedFields = getIndexFields({ sort: options.sort, selector })
     }
-
     const existingIndex = await this.findExistingIndex(selector, options)
     const indexName = getIndexNameFromFields(indexedFields)
     if (!existingIndex) {
@@ -431,8 +430,8 @@ class DocumentCollection {
     indexedFields = indexedFields
       ? indexedFields
       : getIndexFields({ sort, selector })
-    const indexId = options.indexId || getIndexNameFromFields(indexedFields)
-
+    const indexName =
+      options.indexId || `_design/${getIndexNameFromFields(indexedFields)}`
     if (sort) {
       const sortOrders = uniq(
         sort.map(sortOption => head(Object.values(sortOption)))

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -448,7 +448,7 @@ class DocumentCollection {
 
     const opts = {
       selector,
-      use_index: indexId,
+      use_index: indexName,
       // TODO: type and class should not be necessary, it's just a temp fix for a stack bug
       fields: fields ? [...fields, '_id', '_type', 'class'] : undefined,
       limit,
@@ -537,7 +537,8 @@ class DocumentCollection {
     if (resp.result === 'exists') return indexResp
 
     // indexes might not be usable right after being created; so we delay the resolving until they are
-    const selector = { [fields[0]]: { $gt: null } }
+    const selector = {}
+    fields.forEach(f => (selector[f] = { $gt: null }))
     const options = { indexId: indexResp.id, limit: 1 }
 
     if (await attempt(this.find(selector, options))) return indexResp

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -318,6 +318,7 @@ describe('DocumentCollection', () => {
 
     describe('existing index', () => {
       beforeAll(() => {
+        jest.resetAllMocks()
         jest.spyOn(client, 'fetchJSON').mockResolvedValue({
           id: '_design/123456',
           name: '123456',
@@ -401,7 +402,7 @@ describe('DocumentCollection', () => {
         {
           selector: { done: false },
           skip: 0,
-          use_index: 'by_done'
+          use_index: '_design/by_done'
         }
       )
     })
@@ -416,7 +417,7 @@ describe('DocumentCollection', () => {
           limit: 200,
           selector: { done: false },
           skip: 50,
-          use_index: 'by_done'
+          use_index: '_design/by_done'
         }
       )
     })
@@ -432,7 +433,7 @@ describe('DocumentCollection', () => {
           selector: { done: false },
           skip: 0,
           bookmark: 'himark',
-          use_index: 'by_done'
+          use_index: '_design/by_done'
         }
       )
     })
@@ -447,7 +448,7 @@ describe('DocumentCollection', () => {
           skip: 0,
           selector: { done: false },
           sort: [{ label: 'desc' }, { done: 'desc' }],
-          use_index: 'by_label_and_done'
+          use_index: '_design/by_label_and_done'
         }
       )
     })
@@ -462,7 +463,7 @@ describe('DocumentCollection', () => {
           skip: 0,
           selector: { done: false },
           sort: [{ label: 'asc' }, { done: 'asc' }],
-          use_index: 'by_label_and_done'
+          use_index: '_design/by_label_and_done'
         }
       )
       await collection.find({ done: false }, { sort: [{ label: 'desc' }] })
@@ -473,7 +474,7 @@ describe('DocumentCollection', () => {
           skip: 0,
           selector: { done: false },
           sort: [{ label: 'desc' }, { done: 'desc' }],
-          use_index: 'by_label_and_done'
+          use_index: '_design/by_label_and_done'
         }
       )
     })
@@ -501,7 +502,7 @@ describe('DocumentCollection', () => {
           skip: 0,
           selector: { done: false },
           sort: [{ label: 'desc' }, { _id: 'desc' }, { done: 'desc' }],
-          use_index: 'by_label_and__id_and_done'
+          use_index: '_design/by_label_and__id_and_done'
         }
       )
     })
@@ -591,7 +592,7 @@ describe('DocumentCollection', () => {
         skip: 0,
         selector: { done: { $exists: true } },
         sort: [{ label: 'desc' }],
-        use_index: 'by_label'
+        use_index: '_design/by_label'
       }
 
       expect(client.fetchJSON).toHaveBeenCalledWith(
@@ -634,7 +635,7 @@ describe('DocumentCollection', () => {
         skip: 0,
         selector: { done: { $exists: true } },
         sort: [{ label: 'desc' }],
-        use_index: 'by_label'
+        use_index: '_design/by_label'
       }
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'POST',
@@ -682,7 +683,7 @@ describe('DocumentCollection', () => {
         }
       }
       getMatchingIndex.mockReturnValue(index.doc)
-
+      
       client.fetchJSON.mockRestore()
       client.fetchJSON
         .mockRejectedValueOnce(new Error('no_index'))
@@ -719,7 +720,7 @@ describe('DocumentCollection', () => {
         skip: 0,
         selector: { done: { $exists: true } },
         sort: [{ label: 'desc' }, { done: 'desc' }],
-        use_index: 'by_label_and_done'
+        use_index: '_design/by_label_and_done'
       }
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'POST',
@@ -760,7 +761,7 @@ describe('DocumentCollection', () => {
         {
           selector: { done: false },
           skip: 0,
-          use_index: 'by_done',
+          use_index: '_design/by_done',
           execution_stats: true
         }
       )

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -3,11 +3,11 @@ jest.mock('./CozyStackClient')
 import flag from 'cozy-flags'
 import CozyStackClient from './CozyStackClient'
 import DocumentCollection from './DocumentCollection'
-import { getMatchingIndex } from './mangoIndex'
+import { isMatchingIndex } from './mangoIndex'
 
 jest.mock('./mangoIndex', () => ({
   ...jest.requireActual('./mangoIndex'),
-  getMatchingIndex: jest.fn()
+  isMatchingIndex: jest.fn()
 }))
 
 const ALL_RESPONSE_FIXTURE = {
@@ -704,7 +704,7 @@ describe('DocumentCollection', () => {
           }
         }
       }
-      getMatchingIndex.mockReturnValue(index.doc)
+      isMatchingIndex.mockReturnValue(index.doc)
 
       client.fetchJSON.mockRestore()
       client.fetchJSON
@@ -1091,6 +1091,18 @@ describe('DocumentCollection', () => {
     const selector = {
       'message.account': 'ca7b7f1'
     }
+    const index = {
+      _id: '_design/123',
+      views: {
+        '123': {
+          map: {
+            fields: {
+              'cozyMetadata.createdAt': 'desc'
+            }
+          }
+        }
+      }
+    }
 
     beforeEach(() => {
       collection.fetchAllMangoIndexes = jest.fn()
@@ -1105,32 +1117,26 @@ describe('DocumentCollection', () => {
     })
 
     it('should get matching index with correct arguments with indexed field', async () => {
-      const index = {
-        _id: '123'
-      }
       collection.fetchAllMangoIndexes.mockResolvedValue([index])
 
       await collection.findExistingIndex(selector, {
         indexedFields: ['message.account']
       })
-      expect(getMatchingIndex).toHaveBeenCalledWith(
-        [index],
+      expect(isMatchingIndex).toHaveBeenCalledWith(
+        index,
         ['message.account'],
         undefined
       )
     })
 
     it('should get matching index with correct arguments without indexed field', async () => {
-      const index = {
-        _id: '123'
-      }
       collection.fetchAllMangoIndexes.mockResolvedValue([index])
 
       await collection.findExistingIndex(selector, {
         sort: [{ 'cozyMetadata.createdAt': 'desc' }]
       })
-      expect(getMatchingIndex).toHaveBeenCalledWith(
-        [index],
+      expect(isMatchingIndex).toHaveBeenCalledWith(
+        index,
         ['cozyMetadata.createdAt', 'message.account'],
         undefined
       )

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -330,12 +330,34 @@ describe('DocumentCollection', () => {
         jest.resetAllMocks()
       })
 
-      it('should call the right route with the right payload', async () => {
+      it('should call the right routes with the right payload', async () => {
+        client.fetchJSON.mockResolvedValueOnce({
+          id: '_design/123456',
+          name: '123456'
+        })
+        client.fetchJSON.mockResolvedValueOnce({
+          data: []
+        })
         await collection.createIndex(['label', 'done'])
-        expect(client.fetchJSON).toHaveBeenCalledWith(
+        expect(client.fetchJSON).toHaveBeenNthCalledWith(
+          1,
           'POST',
           '/data/io.cozy.todos/_index',
           { index: { fields: ['label', 'done'] } }
+        )
+        expect(client.fetchJSON).toHaveBeenNthCalledWith(
+          2,
+          'POST',
+          '/data/io.cozy.todos/_find',
+          {
+            selector: {
+              label: { $gt: null },
+              done: { $gt: null }
+            },
+            limit: 1,
+            skip: 0,
+            use_index: '_design/123456'
+          }
         )
       })
 
@@ -683,7 +705,7 @@ describe('DocumentCollection', () => {
         }
       }
       getMatchingIndex.mockReturnValue(index.doc)
-      
+
       client.fetchJSON.mockRestore()
       client.fetchJSON
         .mockRejectedValueOnce(new Error('no_index'))

--- a/packages/cozy-stack-client/src/TriggerCollection.spec.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.spec.js
@@ -218,7 +218,7 @@ describe('TriggerCollection', () => {
             worker: 'thumbnail'
           },
           skip: 0,
-          use_index: 'by_worker_and_message'
+          use_index: '_design/by_worker_and_message'
         }
       )
     })

--- a/packages/cozy-stack-client/src/mangoIndex.js
+++ b/packages/cozy-stack-client/src/mangoIndex.js
@@ -3,6 +3,15 @@ import head from 'lodash/head'
 import get from 'lodash/get'
 import isEqual from 'lodash/isEqual'
 
+/**
+ * Attributes representing a design doc
+ *
+ * @typedef {object} DesignDoc
+ * @property {string} _id - Id of the design doc. Can be named, e.g. '_design/by_indexed_attribute' or not, e.g. '_design/12345'
+ * @property {string} language - The index language. Can be 'query' for mango index or 'javascript' for views.
+ * @property {object} views - Views definition, i.e. the index.
+ */
+
 export const normalizeDesignDoc = designDoc => {
   const id = designDoc._id || designDoc.id
   return { id, _id: id, ...designDoc.doc }
@@ -46,7 +55,7 @@ export const getIndexFields = ({ selector, sort = [] }) => {
  * Check if an index is in an inconsistent state, i.e. its name
  * contains the indexed attributes which are not in correct order.
  *
- * @param {object} index - The index to check
+ * @param {DesignDoc} index - The index to check
  * @returns {boolean} True if the index is inconsistent
  */
 export const isInconsistentIndex = index => {
@@ -63,7 +72,7 @@ export const isInconsistentIndex = index => {
 /**
  * Check if an index is matching the given fields
  *
- * @param {object} index - The index to check
+ * @param {DesignDoc} index - The index to check
  * @param {Array} fields - The fields that the index must have
  * @param {object} partialFilter - An optional partial filter
  * @returns {boolean} True if the index is matches the given fields


### PR DESCRIPTION
This fixes two things: 

- queries missing the `_design/` prefix on index name
- new index wrongly created after a creation (see description of 154728f )
- old indexes with inconsistent states (see 0bbbd9d and its description)