### PR TITLE
Remove need for Redux provider

### DIFF
--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -92,8 +92,9 @@ ReactDOM.render(<MyCozyApp />,
 
 ### 2.a Requesting data with `useQuery`
 
-⚠️  You need to have a redux provider connected to the store of cozy-client for useQuery
-to work correctly.
+`useQuery` is the most straightforward to fetch data from the Cozy.
+Query results are cached and can be reused across components, you just
+have to name the query results ("checked-todos") below.
 
 ```jsx
 import CozyClient, { Query, isQueryLoading, Q } from 'cozy-client'
@@ -107,7 +108,10 @@ const checked = { checked: false }
 const query = Q(todos).where(checked)
 
 function TodoList(props) {
-  const queryResult = useQuery(query, { as: 'checked-todos' })
+  const queryResult = useQuery(query, {
+    as: 'checked-todos',
+    fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000)
+  })
   return <>
     {
       queryResult => isQueryLoading(queryResult)
@@ -119,9 +123,7 @@ function TodoList(props) {
 
 function App() {
   return <CozyProvider client={client}>
-    <ReduxProvider store={client.store}>
-      <TodoList />
-    </ReduxProvider>
+    <TodoList />
   </CozyProvider>
 }
 ```

--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -90,9 +90,46 @@ ReactDOM.render(<MyCozyApp />,
 
 ## 2. Usage
 
-### 2.a Requesting data with `<Query />`
+### 2.a Requesting data with `useQuery`
 
-To make it easy to fetch data and make it available to your component, we provide a Render Props component called `Query`. Basic example of usage:
+⚠️  You need to have a redux provider connected to the store of cozy-client for useQuery
+to work correctly.
+
+```jsx
+import CozyClient, { Query, isQueryLoading, Q } from 'cozy-client'
+
+const client = CozyClient.fromDOM()
+client.ensureStore()
+const todos = 'io.cozy.todos'
+const checked = { checked: false }
+
+// Use the Q helper to build queries
+const query = Q(todos).where(checked)
+
+function TodoList(props) {
+  const queryResult = useQuery(query, { as: 'checked-todos' })
+  return <>
+    {
+      queryResult => isQueryLoading(queryResult)
+        ? <h1>Loading...</h1>
+        : <ul>{queryResult.data.map(todo => <li>{todo.label}</li>)}</ul>
+    }
+  </>
+}
+
+function App() {
+  return <CozyProvider client={client}>
+    <ReduxProvider store={client.store}>
+      <TodoList />
+    </ReduxProvider>
+  </CozyProvider>
+}
+```
+
+
+### 2.b Requesting data with `<Query />`
+
+If you cannot use a hook, you can use the `Query` render-prop component. Basic example of usage:
 
 
 ```jsx
@@ -155,7 +192,7 @@ function TodoList() {
 
 Note: Your query will be bound when the `<Query/>` component mounts. Future changes in props will not modify the query.
 
-### 2.b Requesting data with the `queryConnect` HOC
+### 2.c Requesting data with the `queryConnect` HOC
 
 At your preference, you can use an higher-order component. `queryConnect` will take the name of the props field where it should send the result of the query and the actual query:
 
@@ -203,7 +240,7 @@ const queries = { checked, archived }
 const ConnectedTodoList = queryConnect(queries)(TodoList)
 ```
 
-### 2.c Using a fetch policy to decrease network requests
+### 2.d Using a fetch policy to decrease network requests
 
 When multiple components share the same data, you might want to share the data between the two
 components. In this case, you do not want to execute 2 network requests for the same data, the
@@ -252,7 +289,7 @@ queryConnect({
 See [CozyClient::fetchPolicies](../api/cozy-client/#fetchpolicies)
 for the API documentation.
 
-### 2.d Keeping data up to date in real time
+### 2.e Keeping data up to date in real time
 
 Sometimes the data you are displaying will be changed from other places than your app. Maybe the data is shared and someone else has updated it, or maybe it simply changes over time.
 

--- a/packages/cozy-client/src/hooks/useQuery.js
+++ b/packages/cozy-client/src/hooks/useQuery.js
@@ -1,9 +1,12 @@
 import { useEffect, useCallback } from 'react'
-import { useSelector } from 'react-redux'
+import { createSelectorHook } from 'react-redux'
 import get from 'lodash/get'
 import useClient from './useClient'
 import logger from '../logger'
 import { UseQueryReturnValue } from '../types'
+import { clientContext } from '../context'
+
+const useSelector = createSelectorHook(clientContext)
 
 const resolveToValue = fnOrValue => {
   return typeof fnOrValue === 'function' ? fnOrValue() : fnOrValue

--- a/packages/cozy-client/src/testing/utils.js
+++ b/packages/cozy-client/src/testing/utils.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { createMockClient } from '../mock'
 import simpsonsFixture from '../testing/simpsons.json'
 import ClientProvider from '../Provider'
-import { Provider as ReduxProvider } from 'react-redux'
 import CozyClient from '../CozyClient'
 
 /**
@@ -42,9 +41,7 @@ const setupClient = ({ queries } = {}) => {
 
 const makeWrapper = client => {
   const Wrapper = ({ children }) => (
-    <ReduxProvider store={client.store}>
-      <ClientProvider client={client}>{children}</ClientProvider>
-    </ReduxProvider>
+    <ClientProvider client={client}>{children}</ClientProvider>
   )
   return Wrapper
 }


### PR DESCRIPTION
The original issue is https://github.com/cozy/cozy-client/issues/910, drazik found out that without ReduxProvider, useQuery failed : it uses the default useSelector from redux that expects to have the redux context provided by redux provider.

Here, the useSelector used in useQuery is created from the client context, meaning that it works by getting the store from the cozy-client context instead of the redux context. An app is no longer required to wrap its app with ReduxProvider to use `useQuery`.