### PR TITLE
Feat/autoname query

### DIFF
--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -1095,6 +1095,34 @@ describe('CozyClient', () => {
       })
     })
 
+    it('should set the correct name to the query', async () => {
+      requestHandler.mockReturnValueOnce(Promise.resolve(fakeResponse))
+      const getById = Q('io.cozy.files').getById('1')
+      await client.query(getById)
+      expect(client.store.dispatch.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          queryId: 'io.cozy.files/1'
+        })
+      )
+    })
+    it('should use the name passed as an argument', async () => {
+      requestHandler.mockReturnValueOnce(Promise.resolve(fakeResponse))
+      const getById = Q('io.cozy.files').getById('1')
+      await client.query(getById, { as: 'toto' })
+      expect(client.store.dispatch.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          queryId: 'toto'
+        })
+      )
+    })
+    it('should name corretly the query', async () => {
+      requestHandler.mockReturnValueOnce(Promise.resolve(fakeResponse))
+      await client.query(query, { as: 'allTodos' })
+      expect(client.store.dispatch.mock.calls[0][0]).toEqual(
+        initQuery('allTodos', { doctype: 'io.cozy.todos' })
+      )
+    })
+
     describe('relationship with query failure', () => {
       beforeEach(() => {
         jest.spyOn(HasManyFiles, 'query').mockImplementation(() => {

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -337,6 +337,20 @@ class QueryDefinition {
  */
 export const Q = doctype => new QueryDefinition({ doctype })
 
+/**
+ * Check if the query is a getById() query
+ *
+ * @param {QueryDefinition} queryDefinition The query definition
+ *
+ * @returns {boolean}
+ */
+export const isAGetByIdQuery = queryDefinition => {
+  // 2 attrs because we check if id and doctype are not undefined
+  return (
+    Object.values(queryDefinition).filter(attr => attr !== undefined).length ===
+      2 && queryDefinition.id !== undefined
+  )
+}
 // Mutations
 const CREATE_DOCUMENT = 'CREATE_DOCUMENT'
 const UPDATE_DOCUMENT = 'UPDATE_DOCUMENT'

--- a/packages/cozy-client/types/CozyClient.d.ts
+++ b/packages/cozy-client/types/CozyClient.d.ts
@@ -581,11 +581,20 @@ declare class CozyClient {
     };
     dispatch(action: any): any;
     /**
-     * Generates a random id for queries
+     * Generates an id for queries
+     * If the query is a getById only query,
+     * we can generate a name for it.
      *
+     * If not, let's generate a random id
+     *
+     * @param {QueryDefinition} queryDefinition The query definition
      * @returns {string}
      */
-    generateId(): string;
+    generateId(queryDefinition: QueryDefinition): string;
+    /**
+     * Generates a random id for unamed querie
+     */
+    generateRandomId(): string;
     /**
      * getInstanceOptions - Returns current instance options, such as domain or app slug
      *

--- a/packages/cozy-client/types/queries/dsl.d.ts
+++ b/packages/cozy-client/types/queries/dsl.d.ts
@@ -1,4 +1,5 @@
 export function Q(doctype: Doctype): QueryDefinition;
+export function isAGetByIdQuery(queryDefinition: QueryDefinition): boolean;
 export function createDocument(document: any): {
     mutationType: string;
     document: any;


### PR DESCRIPTION
Since the new dev tools, we can see unnamed queries. Let's fix what we can. 

The idea is the generate the `as` for a `getById()` query 

Should fix #782