### PR TITLE
Fix/travis check

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -20,5 +20,16 @@ else
 fi
 set -e
 
+set +e # The following command relies on exit 1
 cd packages/cozy-client
 yarn typecheck
+git diff --exit-code
+types_status=$?
+set -e
+if [[ $types_status == 0 ]]; then
+  echo "Types are up to date"
+else
+  echo "Types are not up-to-date, please run cd packages/cozy-client && yarn typecheck and repush"
+  exit 1
+fi
+set -e


### PR DESCRIPTION
Now, if yarn typecheck returns an error, we exit 1 telling to travis that something is wrong with the commit. 

Previously, the error was not catch resulting of merging PR with types issue. And since `typecheck` changes the files, we had a git diff before publishing and we failed to publish. 

This fix should avoid that situation 