### PR TITLE
Init replication

### DIFF
--- a/docs/api/cozy-pouch-link.md
+++ b/docs/api/cozy-pouch-link.md
@@ -26,6 +26,23 @@ and on demand immediately.</p>
 </dd>
 </dl>
 
+## Constants
+
+<dl>
+<dt><a href="#fetchRemoteInstance">fetchRemoteInstance</a> ⇒ <code>object</code></dt>
+<dd><p>Fetch remote instance</p>
+</dd>
+<dt><a href="#fetchRemoteLastSequence">fetchRemoteLastSequence</a> ⇒ <code>string</code></dt>
+<dd><p>Fetch last sequence from remote instance</p>
+</dd>
+<dt><a href="#replicateAllDocs">replicateAllDocs</a> ⇒ <code>Array</code></dt>
+<dd><p>Replicate all docs locally from a remote URL.</p>
+<p>It uses the _all_docs view, and bulk insert the docs.
+Note it saves the last replicated _id for each run and
+starts from there in case the process stops before the end.</p>
+</dd>
+</dl>
+
 ## Functions
 
 <dl>
@@ -229,6 +246,48 @@ immediately
 Starts replication
 
 **Kind**: instance method of [<code>PouchManager</code>](#PouchManager)  
+<a name="fetchRemoteInstance"></a>
+
+## fetchRemoteInstance ⇒ <code>object</code>
+Fetch remote instance
+
+**Kind**: global constant  
+**Returns**: <code>object</code> - The instance response  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| url | <code>URL</code> | The remote instance URL, including the credentials |
+| params | <code>object</code> | The params to query the remote instance |
+
+<a name="fetchRemoteLastSequence"></a>
+
+## fetchRemoteLastSequence ⇒ <code>string</code>
+Fetch last sequence from remote instance
+
+**Kind**: global constant  
+**Returns**: <code>string</code> - The last sequence  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| baseUrl | <code>string</code> | The base URL of the remote instance |
+
+<a name="replicateAllDocs"></a>
+
+## replicateAllDocs ⇒ <code>Array</code>
+Replicate all docs locally from a remote URL.
+
+It uses the _all_docs view, and bulk insert the docs.
+Note it saves the last replicated _id for each run and
+starts from there in case the process stops before the end.
+
+**Kind**: global constant  
+**Returns**: <code>Array</code> - The retrieved documents  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| db | <code>object</code> | Pouch instance |
+| baseUrl | <code>string</code> | The remote instance |
+
 <a name="getQueryAlias"></a>
 
 ## getQueryAlias(query) ⇒ <code>string</code>

--- a/docs/api/cozy-pouch-link.md
+++ b/docs/api/cozy-pouch-link.md
@@ -29,6 +29,45 @@ and on demand immediately.</p>
 ## Constants
 
 <dl>
+<dt><a href="#persistLastReplicatedDocID">persistLastReplicatedDocID</a></dt>
+<dd><p>Persist the last replicated doc id for a doctype</p>
+</dd>
+<dt><a href="#getLastReplicatedDocID">getLastReplicatedDocID</a> ⇒ <code>string</code></dt>
+<dd><p>Get the last replicated doc id for a doctype</p>
+</dd>
+<dt><a href="#destroyAllLastReplicatedDocID">destroyAllLastReplicatedDocID</a></dt>
+<dd><p>Destroy all the replicated doc id</p>
+</dd>
+<dt><a href="#persistSyncedDoctypes">persistSyncedDoctypes</a></dt>
+<dd><p>Persist the synchronized doctypes</p>
+</dd>
+<dt><a href="#getPersistedSyncedDoctypes">getPersistedSyncedDoctypes</a> ⇒ <code>object</code></dt>
+<dd><p>Get the persisted doctypes</p>
+</dd>
+<dt><a href="#destroySyncedDoctypes">destroySyncedDoctypes</a></dt>
+<dd><p>Destroy the synced doctypes</p>
+</dd>
+<dt><a href="#persistDoctypeLastSequence">persistDoctypeLastSequence</a></dt>
+<dd><p>Persist the last CouchDB sequence for a synced doctype</p>
+</dd>
+<dt><a href="#getDoctypeLastSequence">getDoctypeLastSequence</a> ⇒ <code>string</code></dt>
+<dd><p>Get the last CouchDB sequence for a doctype</p>
+</dd>
+<dt><a href="#destroyAllDoctypeLastSequence">destroyAllDoctypeLastSequence</a></dt>
+<dd><p>Destroy all the last sequence</p>
+</dd>
+<dt><a href="#destroyDoctypeLastSequence">destroyDoctypeLastSequence</a></dt>
+<dd><p>Destroy the last sequence for a doctype</p>
+</dd>
+<dt><a href="#persistWarmedUpQueries">persistWarmedUpQueries</a></dt>
+<dd><p>Persist the warmed up queries</p>
+</dd>
+<dt><a href="#getPersistedWarmedUpQueries">getPersistedWarmedUpQueries</a> ⇒ <code>object</code></dt>
+<dd><p>Get the warmed up queries</p>
+</dd>
+<dt><a href="#destroyWarmedUpQueries">destroyWarmedUpQueries</a></dt>
+<dd><p>Destroy the warmed queries</p>
+</dd>
 <dt><a href="#fetchRemoteInstance">fetchRemoteInstance</a> ⇒ <code>object</code></dt>
 <dd><p>Fetch remote instance</p>
 </dd>
@@ -246,6 +285,125 @@ immediately
 Starts replication
 
 **Kind**: instance method of [<code>PouchManager</code>](#PouchManager)  
+<a name="persistLastReplicatedDocID"></a>
+
+## persistLastReplicatedDocID
+Persist the last replicated doc id for a doctype
+
+**Kind**: global constant  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| doctype | <code>string</code> | The replicated doctype |
+| id | <code>string</code> | The docid |
+
+<a name="getLastReplicatedDocID"></a>
+
+## getLastReplicatedDocID ⇒ <code>string</code>
+Get the last replicated doc id for a doctype
+
+**Kind**: global constant  
+**Returns**: <code>string</code> - The last replicated docid  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| doctype | <code>string</code> | The doctype |
+
+<a name="destroyAllLastReplicatedDocID"></a>
+
+## destroyAllLastReplicatedDocID
+Destroy all the replicated doc id
+
+**Kind**: global constant  
+<a name="persistSyncedDoctypes"></a>
+
+## persistSyncedDoctypes
+Persist the synchronized doctypes
+
+**Kind**: global constant  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| syncedDoctypes | <code>object</code> | The sync doctypes |
+
+<a name="getPersistedSyncedDoctypes"></a>
+
+## getPersistedSyncedDoctypes ⇒ <code>object</code>
+Get the persisted doctypes
+
+**Kind**: global constant  
+**Returns**: <code>object</code> - The synced doctypes  
+<a name="destroySyncedDoctypes"></a>
+
+## destroySyncedDoctypes
+Destroy the synced doctypes
+
+**Kind**: global constant  
+<a name="persistDoctypeLastSequence"></a>
+
+## persistDoctypeLastSequence
+Persist the last CouchDB sequence for a synced doctype
+
+**Kind**: global constant  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| doctype | <code>string</code> | The synced doctype |
+| sequence | <code>string</code> | The sequence hash |
+
+<a name="getDoctypeLastSequence"></a>
+
+## getDoctypeLastSequence ⇒ <code>string</code>
+Get the last CouchDB sequence for a doctype
+
+**Kind**: global constant  
+**Returns**: <code>string</code> - the last sequence  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| doctype | <code>string</code> | The doctype |
+
+<a name="destroyAllDoctypeLastSequence"></a>
+
+## destroyAllDoctypeLastSequence
+Destroy all the last sequence
+
+**Kind**: global constant  
+<a name="destroyDoctypeLastSequence"></a>
+
+## destroyDoctypeLastSequence
+Destroy the last sequence for a doctype
+
+**Kind**: global constant  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| doctype | <code>string</code> | The doctype |
+
+<a name="persistWarmedUpQueries"></a>
+
+## persistWarmedUpQueries
+Persist the warmed up queries
+
+**Kind**: global constant  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| warmedUpQueries | <code>object</code> | The warmedup queries |
+
+<a name="getPersistedWarmedUpQueries"></a>
+
+## getPersistedWarmedUpQueries ⇒ <code>object</code>
+Get the warmed up queries
+
+**Kind**: global constant  
+**Returns**: <code>object</code> - the warmed up queries  
+<a name="destroyWarmedUpQueries"></a>
+
+## destroyWarmedUpQueries
+Destroy the warmed queries
+
+**Kind**: global constant  
 <a name="fetchRemoteInstance"></a>
 
 ## fetchRemoteInstance ⇒ <code>object</code>
@@ -287,6 +445,7 @@ starts from there in case the process stops before the end.
 | --- | --- | --- |
 | db | <code>object</code> | Pouch instance |
 | baseUrl | <code>string</code> | The remote instance |
+| doctype | <code>string</code> | The doctype to replicate |
 
 <a name="getQueryAlias"></a>
 

--- a/packages/cozy-pouch-link/package.json
+++ b/packages/cozy-pouch-link/package.json
@@ -15,7 +15,7 @@
     "cozy-client": "^22.1.0",
     "cozy-device-helper": "^1.12.0",
     "pouchdb-browser": "^7.0.0",
-    "pouchdb-find": "^7.0.0"
+    "pouchdb-find": "7.2.2"
   },
   "devDependencies": {
     "@babel/cli": "7.12.8",

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -41,7 +41,6 @@ class PouchManager {
         new PouchDB(this.getDatabaseName(doctype), pouchOptions)
       ])
     )
-    window.pouch = this.pouches
     this.syncedDoctypes = localStorage.getPersistedSyncedDoctypes()
     this.warmedUpQueries = localStorage.getPersistedWarmedUpQueries()
     this.getReplicationURL = options.getReplicationURL

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -86,8 +86,8 @@ class PouchManager {
     this.removeListeners()
     this.clearSyncedDoctypes()
     this.clearWarmedUpQueries()
-    localStorage.destroyDoctypeLastSequence()
-    localStorage.destroyLastReplicatedDocID()
+    localStorage.destroyAllDoctypeLastSequence()
+    localStorage.destroyAllLastReplicatedDocID()
 
     return Promise.all(
       Object.values(this.pouches).map(pouch => pouch.destroy())
@@ -191,6 +191,7 @@ class PouchManager {
       replicationOptions.initialReplication = initialReplication
       replicationOptions.filter = replicationFilter
       replicationOptions.since = seq
+      replicationOptions.doctype = doctype
 
       const res = await startReplication(
         pouch,

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -204,10 +204,6 @@ class PouchManager {
         localStorage.destroyDoctypeLastSequence(doctype)
       }
 
-      console.log(
-        'PouchManager: Replication for ' + doctype + ' ended with: ',
-        res.length
-      )
       this.addSyncedDoctype(doctype)
       this.checkToWarmupDoctype(doctype, replicationOptions)
       return res

--- a/packages/cozy-pouch-link/src/helpers.js
+++ b/packages/cozy-pouch-link/src/helpers.js
@@ -57,4 +57,8 @@ helpers.isDesignDocument = doc => startsWith(doc._id, '_design')
 
 helpers.isDeletedDocument = doc => doc._deleted
 
+helpers.insertBulkDocs = async (db, docs) => {
+  return db.bulkDocs(docs, { new_edits: false })
+}
+
 export default helpers

--- a/packages/cozy-pouch-link/src/localStorage.js
+++ b/packages/cozy-pouch-link/src/localStorage.js
@@ -11,7 +11,6 @@ export const persistLastReplicatedDocID = id => {
 }
 
 export const getLastReplicatedDocID = () => {
-  console.log('enter get last')
   return window.localStorage.getItem(LOCALSTORAGE_LASTREPLICATEDDOCID_KEY)
 }
 

--- a/packages/cozy-pouch-link/src/localStorage.js
+++ b/packages/cozy-pouch-link/src/localStorage.js
@@ -6,15 +6,33 @@ export const LOCALSTORAGE_LASTSEQUENCES_KEY =
 export const LOCALSTORAGE_LASTREPLICATEDDOCID_KEY =
   'cozy-client-pouch-link-lastreplicateddocid'
 
-export const persistLastReplicatedDocID = id => {
-  window.localStorage.setItem(LOCALSTORAGE_LASTREPLICATEDDOCID_KEY, id)
+/**
+ * Persist the last replicated doc id
+ *
+ * @param {string} doctype - The replicated doctype
+ * @param {string} id - The docid
+ */
+export const persistLastReplicatedDocID = (doctype, id) => {
+  const docids = getAllLastReplicatedDocID()
+  docids[doctype] = id
+
+  window.localStorage.setItem(
+    LOCALSTORAGE_LASTREPLICATEDDOCID_KEY,
+    JSON.stringify(docids)
+  )
 }
 
-export const getLastReplicatedDocID = () => {
-  return window.localStorage.getItem(LOCALSTORAGE_LASTREPLICATEDDOCID_KEY)
+export const getAllLastReplicatedDocID = () => {
+  const item = window.localStorage.getItem(LOCALSTORAGE_LASTREPLICATEDDOCID_KEY)
+  return item ? JSON.parse(item) : {}
 }
 
-export const destroyLastReplicatedDocID = () => {
+export const getLastReplicatedDocID = doctype => {
+  const docids = getAllLastSequences()
+  return docids[doctype]
+}
+
+export const destroyAllLastReplicatedDocID = () => {
   window.localStorage.removeItem(LOCALSTORAGE_LASTREPLICATEDDOCID_KEY)
 }
 
@@ -58,6 +76,10 @@ export const getAllLastSequences = () => {
 export const getDoctypeLastSequence = doctype => {
   const seqs = getAllLastSequences()
   return seqs[doctype]
+}
+
+export const destroyAllDoctypeLastSequence = () => {
+  window.localStorage.removeItem(LOCALSTORAGE_LASTSEQUENCES_KEY)
 }
 
 export const destroyDoctypeLastSequence = doctype => {

--- a/packages/cozy-pouch-link/src/localStorage.js
+++ b/packages/cozy-pouch-link/src/localStorage.js
@@ -7,7 +7,7 @@ export const LOCALSTORAGE_LASTREPLICATEDDOCID_KEY =
   'cozy-client-pouch-link-lastreplicateddocid'
 
 /**
- * Persist the last replicated doc id
+ * Persist the last replicated doc id for a doctype
  *
  * @param {string} doctype - The replicated doctype
  * @param {string} id - The docid
@@ -27,15 +27,41 @@ export const getAllLastReplicatedDocID = () => {
   return item ? JSON.parse(item) : {}
 }
 
+/**
+ * Get the last replicated doc id for a doctype
+ *
+ * @param {string} doctype - The doctype
+ * @returns {string} The last replicated docid
+ */
 export const getLastReplicatedDocID = doctype => {
   const docids = getAllLastSequences()
   return docids[doctype]
 }
 
+/**
+ * Destroy all the replicated doc id
+ */
 export const destroyAllLastReplicatedDocID = () => {
   window.localStorage.removeItem(LOCALSTORAGE_LASTREPLICATEDDOCID_KEY)
 }
 
+/**
+ * Persist the synchronized doctypes
+ *
+ * @param {object} syncedDoctypes - The sync doctypes
+ */
+export const persistSyncedDoctypes = syncedDoctypes => {
+  window.localStorage.setItem(
+    LOCALSTORAGE_SYNCED_KEY,
+    JSON.stringify(syncedDoctypes)
+  )
+}
+
+/**
+ * Get the persisted doctypes
+ *
+ * @returns {object} The synced doctypes
+ */
 export const getPersistedSyncedDoctypes = () => {
   const item = window.localStorage.getItem(LOCALSTORAGE_SYNCED_KEY)
 
@@ -47,17 +73,20 @@ export const getPersistedSyncedDoctypes = () => {
   return JSON.parse(item)
 }
 
-export const persistSyncedDoctypes = syncedDoctypes => {
-  window.localStorage.setItem(
-    LOCALSTORAGE_SYNCED_KEY,
-    JSON.stringify(syncedDoctypes)
-  )
-}
-
+/**
+ * Destroy the synced doctypes
+ *
+ */
 export const destroySyncedDoctypes = () => {
   window.localStorage.removeItem(LOCALSTORAGE_SYNCED_KEY)
 }
 
+/**
+ * Persist the last CouchDB sequence for a synced doctype
+ *
+ * @param {string} doctype - The synced doctype
+ * @param {string} sequence - The sequence hash
+ */
 export const persistDoctypeLastSequence = (doctype, sequence) => {
   const seqs = getAllLastSequences()
   seqs[doctype] = sequence
@@ -73,15 +102,29 @@ export const getAllLastSequences = () => {
   return item ? JSON.parse(item) : {}
 }
 
+/**
+ * Get the last CouchDB sequence for a doctype
+ *
+ * @param {string} doctype - The doctype
+ * @returns {string} the last sequence
+ */
 export const getDoctypeLastSequence = doctype => {
   const seqs = getAllLastSequences()
   return seqs[doctype]
 }
 
+/**
+ * Destroy all the last sequence
+ */
 export const destroyAllDoctypeLastSequence = () => {
   window.localStorage.removeItem(LOCALSTORAGE_LASTSEQUENCES_KEY)
 }
 
+/**
+ * Destroy the last sequence for a doctype
+ *
+ * @param {string} doctype - The doctype
+ */
 export const destroyDoctypeLastSequence = doctype => {
   const seqs = getAllLastSequences()
   delete seqs[doctype]
@@ -91,6 +134,11 @@ export const destroyDoctypeLastSequence = doctype => {
   )
 }
 
+/**
+ * Persist the warmed up queries
+ *
+ * @param {object} warmedUpQueries - The warmedup queries
+ */
 export const persistWarmedUpQueries = warmedUpQueries => {
   window.localStorage.setItem(
     LOCALSTORAGE_WARMUPEDQUERIES_KEY,
@@ -98,6 +146,11 @@ export const persistWarmedUpQueries = warmedUpQueries => {
   )
 }
 
+/**
+ * Get the warmed up queries
+ *
+ * @returns {object} the warmed up queries
+ */
 export const getPersistedWarmedUpQueries = () => {
   const item = window.localStorage.getItem(LOCALSTORAGE_WARMUPEDQUERIES_KEY)
   if (!item) {
@@ -106,6 +159,10 @@ export const getPersistedWarmedUpQueries = () => {
   return JSON.parse(item)
 }
 
+/**
+ * Destroy the warmed queries
+ *
+ */
 export const destroyWarmedUpQueries = () => {
   window.localStorage.removeItem(LOCALSTORAGE_WARMUPEDQUERIES_KEY)
 }

--- a/packages/cozy-pouch-link/src/localStorage.js
+++ b/packages/cozy-pouch-link/src/localStorage.js
@@ -1,0 +1,90 @@
+export const LOCALSTORAGE_SYNCED_KEY = 'cozy-client-pouch-link-synced'
+export const LOCALSTORAGE_WARMUPEDQUERIES_KEY =
+  'cozy-client-pouch-link-warmupedqueries'
+export const LOCALSTORAGE_LASTSEQUENCES_KEY =
+  'cozy-client-pouch-link-lastreplicationsequence'
+export const LOCALSTORAGE_LASTREPLICATEDDOCID_KEY =
+  'cozy-client-pouch-link-lastreplicateddocid'
+
+export const persistLastReplicatedDocID = id => {
+  window.localStorage.setItem(LOCALSTORAGE_LASTREPLICATEDDOCID_KEY, id)
+}
+
+export const getLastReplicatedDocID = () => {
+  console.log('enter get last')
+  return window.localStorage.getItem(LOCALSTORAGE_LASTREPLICATEDDOCID_KEY)
+}
+
+export const destroyLastReplicatedDocID = () => {
+  window.localStorage.removeItem(LOCALSTORAGE_LASTREPLICATEDDOCID_KEY)
+}
+
+export const getPersistedSyncedDoctypes = () => {
+  const item = window.localStorage.getItem(LOCALSTORAGE_SYNCED_KEY)
+
+  // We check if the item in local storage is an array because we previously stored a boolean
+  if (!item || !Array.isArray(JSON.parse(item))) {
+    return []
+  }
+
+  return JSON.parse(item)
+}
+
+export const persistSyncedDoctypes = syncedDoctypes => {
+  window.localStorage.setItem(
+    LOCALSTORAGE_SYNCED_KEY,
+    JSON.stringify(syncedDoctypes)
+  )
+}
+
+export const destroySyncedDoctypes = () => {
+  window.localStorage.removeItem(LOCALSTORAGE_SYNCED_KEY)
+}
+
+export const persistDoctypeLastSequence = (doctype, sequence) => {
+  const seqs = getAllLastSequences()
+  seqs[doctype] = sequence
+
+  window.localStorage.setItem(
+    LOCALSTORAGE_LASTSEQUENCES_KEY,
+    JSON.stringify(seqs)
+  )
+}
+
+export const getAllLastSequences = () => {
+  const item = window.localStorage.getItem(LOCALSTORAGE_LASTSEQUENCES_KEY)
+  return item ? JSON.parse(item) : {}
+}
+
+export const getDoctypeLastSequence = doctype => {
+  const seqs = getAllLastSequences()
+  return seqs[doctype]
+}
+
+export const destroyDoctypeLastSequence = doctype => {
+  const seqs = getAllLastSequences()
+  delete seqs[doctype]
+  window.localStorage.setItem(
+    LOCALSTORAGE_LASTSEQUENCES_KEY,
+    JSON.stringify(seqs)
+  )
+}
+
+export const persistWarmedUpQueries = warmedUpQueries => {
+  window.localStorage.setItem(
+    LOCALSTORAGE_WARMUPEDQUERIES_KEY,
+    JSON.stringify(warmedUpQueries)
+  )
+}
+
+export const getPersistedWarmedUpQueries = () => {
+  const item = window.localStorage.getItem(LOCALSTORAGE_WARMUPEDQUERIES_KEY)
+  if (!item) {
+    return {}
+  }
+  return JSON.parse(item)
+}
+
+export const destroyWarmedUpQueries = () => {
+  window.localStorage.removeItem(LOCALSTORAGE_WARMUPEDQUERIES_KEY)
+}

--- a/packages/cozy-pouch-link/src/remote.js
+++ b/packages/cozy-pouch-link/src/remote.js
@@ -1,3 +1,5 @@
+import AccessToken from './AccessToken'
+
 /**
  * Fetch remote instance
  *
@@ -6,8 +8,7 @@
  * @returns {object} The instance response
  */
 export const fetchRemoteInstance = async (url, params = {}) => {
-  const username = url.username
-  const password = url.password
+  const access = new AccessToken({ accessToken: url.password })
 
   Object.keys(params).forEach(key => {
     url.searchParams.set(key, params[key])
@@ -18,7 +19,7 @@ export const fetchRemoteInstance = async (url, params = {}) => {
   const headers = new Headers()
   headers.append('Accept', 'application/json')
   headers.append('Content-Type', 'application/json')
-  headers.append('Authorization', 'Basic ' + btoa(username + ':' + password))
+  headers.append('Authorization', access.toAuthHeader())
   const resp = await fetch(fetchUrl, { headers })
   const data = await resp.json()
   if (resp.ok) {

--- a/packages/cozy-pouch-link/src/remote.js
+++ b/packages/cozy-pouch-link/src/remote.js
@@ -1,0 +1,43 @@
+/**
+ * Fetch remote instance
+ *
+ * @param {URL} url - The remote instance URL, including the credentials
+ * @param {object} params - The params to query the remote instance
+ * @returns {object} The instance response
+ */
+export const fetchRemoteInstance = async (url, params = {}) => {
+  const username = url.username
+  const password = url.password
+
+  Object.keys(params).forEach(key => {
+    url.searchParams.set(key, params[key])
+  })
+  const fetchUrl = `${url.protocol}//${url.href.substring(
+    url.href.indexOf('@') + 1
+  )}`
+  const headers = new Headers()
+  headers.append('Accept', 'application/json')
+  headers.append('Content-Type', 'application/json')
+  headers.append('Authorization', 'Basic ' + btoa(username + ':' + password))
+  const resp = await fetch(fetchUrl, { headers })
+  const data = await resp.json()
+  if (resp.ok) {
+    return data
+  }
+  return null
+}
+
+/**
+ * Fetch last sequence from remote instance
+ *
+ * @param {string} baseUrl - The base URL of the remote instance
+ * @returns {string} The last sequence
+ */
+export const fetchRemoteLastSequence = async baseUrl => {
+  const remoteUrl = new URL(`${baseUrl}/_changes`)
+  const res = await fetchRemoteInstance(remoteUrl, {
+    limit: 1,
+    descending: true
+  })
+  return res.last_seq
+}

--- a/packages/cozy-pouch-link/src/startReplication.js
+++ b/packages/cozy-pouch-link/src/startReplication.js
@@ -45,7 +45,6 @@ export const startReplication = (
   replicationOptions,
   getReplicationURL
 ) => {
-  console.debug('start replication begin')
   let replication
   let docs = {}
   const start = new Date()

--- a/packages/cozy-pouch-link/src/startReplication.js
+++ b/packages/cozy-pouch-link/src/startReplication.js
@@ -31,6 +31,7 @@ const TIME_UNITS = [['ms', 1000], ['s', 60], ['m', 60], ['h', 24]]
  * @param {object} pouch                 Pouch database instance
  * @param {object} replicationOptions Any option supported by the Pouch replication API (https://pouchdb.com/api.html#replication)
  * @param {string} replicationOptions.strategy The direction of the replication. Can be "fromRemote",  "toRemote" or "sync"
+ * @param {boolean} replicationOptions.initialReplication Whether or not this is an initial replication
  * @param {Function} getReplicationURL A function that should return the remote replication URL
  *
  * @returns {Promise} A cancelable promise that resolves at the end of the replication
@@ -63,6 +64,14 @@ export const startReplication = (
         // as it avoids to replicate all revs history, which can lead to
         // performances issues
         docs = await replicateAllDocs(pouch, url)
+        const end = new Date()
+        if (process.env.NODE_ENV !== 'production') {
+          logger.info(
+            `PouchManager: initial replication with all_docs for ${url} took ${humanTimeDelta(
+              end - start
+            )}`
+          )
+        }
         return resolve(docs)
       })()
     }

--- a/packages/cozy-pouch-link/src/startReplication.spec.js
+++ b/packages/cozy-pouch-link/src/startReplication.spec.js
@@ -1,0 +1,75 @@
+import { fetchRemoteLastSequence, fetchRemoteInstance } from './remote'
+import { getLastReplicatedDocID } from './localStorage'
+
+import { replicateAllDocs } from './startReplication'
+
+jest.mock('./localStorage', () => ({
+  getLastReplicatedDocID: jest.fn(),
+  persistLastReplicatedDocID: jest.fn()
+}))
+
+jest.mock('./remote', () => ({
+  fetchRemoteLastSequence: jest.fn(),
+  fetchRemoteInstance: jest.fn()
+}))
+
+jest.mock('./helpers', () => ({
+  insertBulkDocs: jest.fn()
+}))
+
+const url = 'http://test.local'
+
+const generateDocs = nDocs => {
+  let docs = []
+  for (let i = 0; i < nDocs; i++) {
+    docs.push({ doc: { _id: i.toString() } })
+  }
+  return docs
+}
+
+describe('replication through _all_docs', () => {
+  beforeEach(() => {
+    fetchRemoteLastSequence.mockResolvedValue('10-xyz')
+  })
+  it('should replicate all docs', async () => {
+    getLastReplicatedDocID.mockReturnValue(null)
+    const dummyDocs = generateDocs(2)
+    fetchRemoteInstance.mockResolvedValue({ rows: dummyDocs })
+
+    const rep = await replicateAllDocs(null, url)
+    const expectedDocs = dummyDocs.map(doc => doc.doc)
+    expect(rep).toEqual(expectedDocs)
+  })
+
+  it('should replicate all docs when it gets more docs than the batch limit', async () => {
+    getLastReplicatedDocID.mockReturnValue(null)
+    const dummyDocs = generateDocs(1002)
+    fetchRemoteInstance.mockResolvedValueOnce({
+      rows: dummyDocs.slice(0, 1001)
+    })
+    fetchRemoteInstance.mockResolvedValueOnce({
+      rows: dummyDocs.slice(1000, 1002)
+    })
+
+    const rep = await replicateAllDocs(null, url)
+    const expectedDocs = dummyDocs.map(doc => doc.doc)
+    expect(rep).toEqual(expectedDocs)
+  })
+
+  it('should replicate from the last saved doc id', async () => {
+    getLastReplicatedDocID.mockReturnValue('5')
+    const dummyDocs = generateDocs(10)
+    fetchRemoteInstance.mockResolvedValue({ rows: dummyDocs.slice(5, 11) })
+
+    const rep = await replicateAllDocs(null, url)
+
+    const calledUrl = new URL(`${url}/_all_docs`)
+    expect(fetchRemoteInstance).toHaveBeenCalledWith(calledUrl, {
+      include_docs: true,
+      limit: 1000,
+      startkey_docid: '5'
+    })
+    const expectedDocs = dummyDocs.map(doc => doc.doc).slice(6, 11)
+    expect(rep).toEqual(expectedDocs)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -10616,7 +10616,7 @@ pouchdb-fetch@7.2.2:
     fetch-cookie "0.10.1"
     node-fetch "2.6.0"
 
-pouchdb-find@^7.0.0:
+pouchdb-find@7.2.2:
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/pouchdb-find/-/pouchdb-find-7.2.2.tgz#1227afdd761812d508fe0794b3e904518a721089"
   integrity sha512-BmFeFVQ0kHmDehvJxNZl9OmIztCjPlZlVSdpijuFbk/Fi1EFPU1BAv3kLC+6DhZuOqU/BCoaUBY9sn66pPY2ag==


### PR DESCRIPTION
At initialization time, we used to replicate docs from CouchDB to
PouchDB by using the replication protocol. This is problematic
because it replicates the revision history, making the indexing
potentially slower and increasing the database size.
Moreover, the replication protocol is also slower than just queyring
the _all_docs and inserting the documents in bulk.
Here are some numbers we measured on a database with 10K docs and
about 100K updates:

* Replication with CouchDB replication protocol: 34s
  * Includes revision history
* Replication with _all_docs + bulk insert: 13s
  * Does not include revision history
* Indexing with revisions: 38s
* Indexing without revisions: 26s

Note this only concern the initial replication, we continue to use the
CouchDB replication protocol for the next runs.