### PR TITLE
feat: Add job setState

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -112,6 +112,9 @@ contains the indexed attributes which are not in correct order.</p>
 <dt><a href="#Stream">Stream</a> : <code>object</code></dt>
 <dd><p>Stream is not defined in a browser, but is on NodeJS environment</p>
 </dd>
+<dt><a href="#JobDocument">JobDocument</a> : <code>object</code></dt>
+<dd><p>Document representing a io.cozy.jobs</p>
+</dd>
 <dt><a href="#DesignDoc">DesignDoc</a> : <code>object</code></dt>
 <dd><p>Attributes representing a design doc</p>
 </dd>
@@ -1599,6 +1602,20 @@ Document representing a io.cozy.files
 Stream is not defined in a browser, but is on NodeJS environment
 
 **Kind**: global typedef  
+<a name="JobDocument"></a>
+
+## JobDocument : <code>object</code>
+Document representing a io.cozy.jobs
+
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| _id | <code>string</code> | Id of the job |
+| attributes.state | <code>string</code> | state of the job. Can be 'errored', 'running', 'queued', 'done' |
+| attributes.error | <code>string</code> | Error message of the job if any |
+
 <a name="DesignDoc"></a>
 
 ## DesignDoc : <code>object</code>

--- a/packages/cozy-stack-client/src/JobCollection.js
+++ b/packages/cozy-stack-client/src/JobCollection.js
@@ -75,6 +75,10 @@ class JobCollection {
    * @param {JobDocument} job - io.cozy.jobs document
    */
   async update(job) {
+    if (job.worker !== 'client') {
+      throw new Error('JobCollection.update only works for client workers')
+    }
+
     return this.stackClient.fetchJSON('PATCH', `/jobs/${job._id}`, {
       data: {
         type: JOBS_DOCTYPE,

--- a/packages/cozy-stack-client/src/JobCollection.js
+++ b/packages/cozy-stack-client/src/JobCollection.js
@@ -76,7 +76,9 @@ class JobCollection {
    */
   async update(job) {
     if (job.worker !== 'client') {
-      throw new Error('JobCollection.update only works for client workers')
+      throw new Error(
+        `JobCollection.update only works for client workers. ${job.worker} given`
+      )
     }
 
     return this.stackClient.fetchJSON('PATCH', `/jobs/${job._id}`, {

--- a/packages/cozy-stack-client/src/JobCollection.js
+++ b/packages/cozy-stack-client/src/JobCollection.js
@@ -56,6 +56,28 @@ class JobCollection {
   }
 
   /**
+   * Set the job's state
+   *
+   * @param {string} id: job's id
+   * @param {boolean} result: job's result
+   * @param {string} error: error message if any
+   *
+   * This does work only for jobs comming from @client triggers
+   */
+  async setState(id, result, error) {
+    return this.stackClient.fetchJSON('PATCH', `/jobs/${id}`, {
+      data: {
+        type: JOBS_DOCTYPE,
+        id,
+        attributes: {
+          state: result ? 'done' : 'errored',
+          error
+        }
+      }
+    })
+  }
+
+  /**
    * Polls a job state until it is finished
    *
    * `options.until` can be used to tweak when to stop waiting. It will be

--- a/packages/cozy-stack-client/src/JobCollection.spec.js
+++ b/packages/cozy-stack-client/src/JobCollection.spec.js
@@ -83,7 +83,7 @@ describe('job collection', () => {
     })
   })
 
-  describe('setState', () => {
+  describe('update', () => {
     beforeEach(() => {
       jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue({
         data: {
@@ -110,7 +110,12 @@ describe('job collection', () => {
 
     it('should call the expected stack endpoint when ok job', async () => {
       const jobId = '5396fc6299dd437d8d30fecd44745745'
-      await col.setState(jobId, true)
+      await col.update({
+        _id: jobId,
+        attributes: {
+          state: 'done'
+        }
+      })
       expect(stackClient.fetchJSON).toHaveBeenCalledWith(
         'PATCH',
         '/jobs/' + jobId,
@@ -128,7 +133,13 @@ describe('job collection', () => {
 
     it('should call the expected stack endpoint when error job', async () => {
       const jobId = '5396fc6299dd437d8d30fecd44745745'
-      await col.setState(jobId, false, 'LOGIN_FAILED')
+      await col.update({
+        _id: jobId,
+        attributes: {
+          state: 'errored',
+          error: 'LOGIN_FAILED'
+        }
+      })
       expect(stackClient.fetchJSON).toHaveBeenCalledWith(
         'PATCH',
         '/jobs/' + jobId,

--- a/packages/cozy-stack-client/src/JobCollection.spec.js
+++ b/packages/cozy-stack-client/src/JobCollection.spec.js
@@ -112,6 +112,7 @@ describe('job collection', () => {
       const jobId = '5396fc6299dd437d8d30fecd44745745'
       await col.update({
         _id: jobId,
+        worker: 'client',
         attributes: {
           state: 'done'
         }
@@ -135,6 +136,7 @@ describe('job collection', () => {
       const jobId = '5396fc6299dd437d8d30fecd44745745'
       await col.update({
         _id: jobId,
+        worker: 'client',
         attributes: {
           state: 'errored',
           error: 'LOGIN_FAILED'
@@ -154,6 +156,20 @@ describe('job collection', () => {
           }
         }
       )
+    })
+
+    it('should throw when the job is not a client worker', async () => {
+      const jobId = '5396fc6299dd437d8d30fecd44745745'
+      expect(async () => {
+        await col.update({
+          _id: jobId,
+          worker: 'notclient',
+          attributes: {
+            state: 'errored',
+            error: 'LOGIN_FAILED'
+          }
+        })
+      }).toThrow()
     })
   })
 

--- a/packages/cozy-stack-client/src/JobCollection.spec.js
+++ b/packages/cozy-stack-client/src/JobCollection.spec.js
@@ -83,6 +83,69 @@ describe('job collection', () => {
     })
   })
 
+  describe('setState', () => {
+    beforeEach(() => {
+      jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue({
+        data: {
+          type: 'io.cozy.jobs',
+          id: '5396fc6299dd437d8d30fecd44745745',
+          attributes: {
+            domain: 'me.cozy.tools',
+            worker: 'konnector',
+            state: 'done',
+            queued_at: '2016-09-19T12:35:08Z',
+            started_at: '2016-09-19T12:35:08Z',
+            error: ''
+          },
+          links: {
+            self: '/jobs/5396fc6299dd437d8d30fecd44745745'
+          }
+        }
+      })
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should call the expected stack endpoint when ok job', async () => {
+      const jobId = '5396fc6299dd437d8d30fecd44745745'
+      await col.setState(jobId, true)
+      expect(stackClient.fetchJSON).toHaveBeenCalledWith(
+        'PATCH',
+        '/jobs/' + jobId,
+        {
+          data: {
+            type: 'io.cozy.jobs',
+            id: jobId,
+            attributes: {
+              state: 'done'
+            }
+          }
+        }
+      )
+    })
+
+    it('should call the expected stack endpoint when error job', async () => {
+      const jobId = '5396fc6299dd437d8d30fecd44745745'
+      await col.setState(jobId, false, 'LOGIN_FAILED')
+      expect(stackClient.fetchJSON).toHaveBeenCalledWith(
+        'PATCH',
+        '/jobs/' + jobId,
+        {
+          data: {
+            type: 'io.cozy.jobs',
+            id: jobId,
+            attributes: {
+              state: 'errored',
+              error: 'LOGIN_FAILED'
+            }
+          }
+        }
+      )
+    })
+  })
+
   describe('waitFor', () => {
     it('should work', async () => {
       let i = 0

--- a/packages/cozy-stack-client/src/JobCollection.spec.js
+++ b/packages/cozy-stack-client/src/JobCollection.spec.js
@@ -159,8 +159,9 @@ describe('job collection', () => {
     })
 
     it('should throw when the job is not a client worker', async () => {
+      expect.assertions(1)
       const jobId = '5396fc6299dd437d8d30fecd44745745'
-      expect(async () => {
+      try {
         await col.update({
           _id: jobId,
           worker: 'notclient',
@@ -169,7 +170,11 @@ describe('job collection', () => {
             error: 'LOGIN_FAILED'
           }
         })
-      }).toThrow()
+      } catch (err) {
+        expect(err.message).toEqual(
+          `JobCollection.update only works for client workers. notclient given`
+        )
+      }
     })
   })
 


### PR DESCRIPTION
This allows to set a job's state.

This will only work for jobs of @client type. For this type of jobs, the client side launcher needs to set the result of the job itself since it is not launched in the stack's
environment.