### PR TITLE
fix: Import react native in auth only when using it

### DIFF
--- a/packages/cozy-client/src/authentication/mobile.js
+++ b/packages/cozy-client/src/authentication/mobile.js
@@ -6,10 +6,6 @@ import {
   isIOSApp
 } from 'cozy-device-helper'
 import { CordovaWindow } from '../types'
-//@ts-ignore
-import { InAppBrowser } from 'react-native-inappbrowser-reborn'
-//@ts-ignore
-import { Linking } from 'react-native'
 
 /**
  * @type {CordovaWindow}
@@ -104,7 +100,12 @@ const authenticateWithInAppBrowser = url => {
  * @returns {Promise}
  */
 
-export const authenticateWithReactNativeInAppBrowser = url => {
+export const authenticateWithReactNativeInAppBrowser = async url => {
+  //@ts-ignore
+  const { InAppBrowser } = await import('react-native-inappbrowser-reborn')
+  //@ts-ignore
+  const { Linking } = await import('react-native')
+
   return new Promise((resolve, reject) => {
     InAppBrowser.open(url, {
       // iOS Properties


### PR DESCRIPTION
Some clients like Cozy Desktop don't use React Native and thus don't
include it as part of their dependencies.

This means that Cozy Client can't be imported anymore on those clients
now that React Native is a mandatory peer dependency and trying to do
so results in a import error.