### PR TITLE
fix: Moved polyfills in createClientInteractive

### DIFF
--- a/packages/cozy-client/src/cli/index.js
+++ b/packages/cozy-client/src/cli/index.js
@@ -181,6 +181,9 @@ const readJSON = (fs, filename) => {
  * @returns {Promise<CozyClient>} - A client that is ready with a token
  */
 const createClientInteractive = (clientOptions, serverOpts) => {
+  global.fetch = nodeFetch
+  global.btoa = btoa
+  
   const serverOptions = merge(DEFAULT_SERVER_OPTIONS, serverOpts)
   const createClientFS = serverOptions.fs || fs
 
@@ -226,9 +229,6 @@ const createClientInteractive = (clientOptions, serverOpts) => {
 }
 
 const main = async () => {
-  global.fetch = nodeFetch
-  global.btoa = btoa
-
   const client = await createClientInteractive({
     scope: ['io.cozy.files'],
     uri: 'http://cozy.tools:8080',


### PR DESCRIPTION
Running a service using cozy-konnector-dev fails as it tries to authenticate first, calling btoa, which was not available in this context.

Polyfills for fetch and btoa have been moved inside createClientInteractive, as putting them at the top of the file would have caused to many side effects.