### PR TITLE
feat: Handle multiple workers in TriggerCollection.find

### DIFF
--- a/packages/cozy-stack-client/src/TriggerCollection.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.js
@@ -31,7 +31,11 @@ const buildParamsUrl = (worker, type) => {
   const urlParams = new URLSearchParams()
 
   if (worker) {
-    urlParams.set('Worker', worker)
+    if (Array.isArray(worker.$in)) {
+      urlParams.set('Worker', worker.$in.join(','))
+    } else {
+      urlParams.set('Worker', worker)
+    }
   }
   if (type) {
     if (Array.isArray(type.$in)) {

--- a/packages/cozy-stack-client/src/TriggerCollection.spec.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.spec.js
@@ -182,6 +182,14 @@ describe('TriggerCollection', () => {
       )
     })
 
+    it('should call /jobs/triggers route if only worker selector is passed with multiple values', async () => {
+      await collection.find({ worker: { $in: ['client', 'konnector'] } })
+      expect(stackClient.fetchJSON).toHaveBeenLastCalledWith(
+        'GET',
+        '/jobs/triggers?Worker=client%2Ckonnector'
+      )
+    })
+
     it('should call /jobs/triggers route if only Worker and type selector is passed', async () => {
       await collection.find({ worker: 'thumbnail', type: '@cron' })
       expect(stackClient.fetchJSON).toHaveBeenLastCalledWith(
@@ -198,6 +206,17 @@ describe('TriggerCollection', () => {
       expect(stackClient.fetchJSON).toHaveBeenLastCalledWith(
         'GET',
         '/jobs/triggers?Worker=thumbnail&Type=%40cron%2C%40webhook'
+      )
+    })
+
+    it('should call /jobs/triggers route if only Worker and type selector is passed with multiple Worker values', async () => {
+      await collection.find({
+        worker: { $in: ['client', 'konnector'] },
+        type: '@cron'
+      })
+      expect(stackClient.fetchJSON).toHaveBeenLastCalledWith(
+        'GET',
+        '/jobs/triggers?Worker=client%2Ckonnector&Type=%40cron'
       )
     })
 


### PR DESCRIPTION
The trigger api allows the specification of multiple Workers like we already to for the `type` parameter

Now, if you want to get multiple types of workers in on request, you can do :+1: 

```javascript
await collection.find({worker: { $in: ['client', 'konnector']})
```