### PR TITLE
feat: Allow to pass null to instantiate a query

### DIFF
--- a/packages/cozy-client/src/mock.js
+++ b/packages/cozy-client/src/mock.js
@@ -9,7 +9,7 @@ const fillQueryInsideClient = (client, queryName, queryOptions) => {
   client.store.dispatch(initQuery(queryName, definition || Q(doctype)))
   client.store.dispatch(
     receiveQueryResult(queryName, {
-      data: data.map(doc => normalizeDoc(doc, doctype)),
+      data: data ? data.map(doc => normalizeDoc(doc, doctype)) : data,
       ...queryResult
     })
   )


### PR DESCRIPTION
During tests, it can be useful to instantiate a query with null to test edge cases, for example testing a component to see that it does not crash while the query has not been loaded yet.

EDIT: better description