### PR TITLE
fix: improve types for cozy pass web

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -876,7 +876,7 @@ Derived `Association`s need to implement this method.
 | Param | Type | Description |
 | --- | --- | --- |
 | document | [<code>CozyClientDocument</code>](#CozyClientDocument) | Document to query |
-| client | [<code>CozyClient</code>](#CozyClient) | The CozyClient instance |
+| client | <code>object</code> | The CozyClient instance |
 | assoc | [<code>Association</code>](#Association) | Association containing info on how to build the query to fetch related documents |
 
 <a name="HasMany"></a>
@@ -966,7 +966,7 @@ We certainly should use something like `updateRelationship`
 | Param | Type | Description |
 | --- | --- | --- |
 | document | [<code>CozyClientDocument</code>](#CozyClientDocument) | Document to query |
-| client | [<code>CozyClient</code>](#CozyClient) | The CozyClient instance |
+| client | <code>object</code> | The CozyClient instance |
 | assoc | [<code>Association</code>](#Association) | The query params |
 
 <a name="HasManyInPlace"></a>
@@ -1040,7 +1040,7 @@ Raw property
 | Param | Type | Description |
 | --- | --- | --- |
 | document | [<code>CozyClientDocument</code>](#CozyClientDocument) | Document to query |
-| client | [<code>CozyClient</code>](#CozyClient) | The CozyClient instance |
+| client | <code>object</code> | The CozyClient instance |
 | assoc | [<code>Association</code>](#Association) | The query params |
 
 <a name="HasManyTriggers"></a>
@@ -3082,7 +3082,7 @@ want to them to trigger an exception during tests.
 | Param | Type | Description |
 | --- | --- | --- |
 | document | [<code>CozyClientDocument</code>](#CozyClientDocument) | Document to query |
-| client | [<code>CozyClient</code>](#CozyClient) | The CozyClient instance |
+| client | <code>object</code> | The CozyClient instance |
 | assoc | [<code>Association</code>](#Association) | The query params |
 
 <a name="query..common"></a>
@@ -3097,7 +3097,7 @@ want to them to trigger an exception during tests.
 | Param | Type | Description |
 | --- | --- | --- |
 | document | [<code>CozyClientDocument</code>](#CozyClientDocument) | Document to query |
-| client | [<code>CozyClient</code>](#CozyClient) | The CozyClient instance |
+| client | <code>object</code> | The CozyClient instance |
 | assoc | [<code>Association</code>](#Association) | The query params |
 
 <a name="query..common"></a>
@@ -3112,7 +3112,7 @@ want to them to trigger an exception during tests.
 | Param | Type | Description |
 | --- | --- | --- |
 | document | [<code>CozyClientDocument</code>](#CozyClientDocument) | Document to query |
-| client | [<code>CozyClient</code>](#CozyClient) | The CozyClient instance |
+| client | <code>object</code> | The CozyClient instance |
 | assoc | [<code>Association</code>](#Association) | The query params |
 
 <a name="query..common"></a>

--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -3672,7 +3672,12 @@ Helper to retrieve time series by their date interval and source.
 | Param | Type | Description |
 | --- | --- | --- |
 | client | <code>object</code> | The CozyClient instance |
-| The | <code>Object</code> | query params. |
+| params | <code>object</code> | The query params |
+| params.startDate | <code>Date</code> | The starting date of the series |
+| params.endDate | <code>Date</code> | The end date of the series |
+| params.dataType | <code>String</code> | The type of time series, e.g. 'electricity' |
+| params.source | <code>String</code> | The data source, e.g. 'enedis.fr' |
+| params.limit | <code>number</code> | Number of serie items to retrieve |
 
 **Properties**
 

--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -335,7 +335,11 @@ is loading.</p>
 <p>Useful for tests that we know will use console[type] but we do not
 want to them to trigger an exception during tests.</p>
 </dd>
-<dt><a href="#query">query()</a> ⇒ <code><a href="#QueryState">QueryState</a></code> | <code><a href="#QueryDefinition">QueryDefinition</a></code></dt>
+<dt><a href="#query">query(document, client, assoc)</a> ⇒ <code><a href="#CozyClientDocument">CozyClientDocument</a></code> | <code><a href="#QueryDefinition">QueryDefinition</a></code></dt>
+<dd></dd>
+<dt><a href="#query">query(document, client, assoc)</a> ⇒ <code><a href="#CozyClientDocument">CozyClientDocument</a></code> | <code><a href="#QueryDefinition">QueryDefinition</a></code></dt>
+<dd></dd>
+<dt><a href="#query">query(document, client, assoc)</a> ⇒ <code><a href="#CozyClientDocument">CozyClientDocument</a></code> | <code><a href="#QueryDefinition">QueryDefinition</a></code></dt>
 <dd></dd>
 <dt><a href="#authenticateWithSafari">authenticateWithSafari(url)</a> ⇒ <code>Promise</code></dt>
 <dd><p>Open a SafariView Controller and resolve with the URL containing the token</p>
@@ -731,7 +735,7 @@ the hydrated document (.data method). View components will access
         * [.query(queryDefinition)](#Association+query)
         * [.mutate()](#Association+mutate)
     * _static_
-        * [.query()](#Association.query) ⇒ [<code>QueryDefinition</code>](#QueryDefinition) \| [<code>QueryState</code>](#QueryState)
+        * [.query(document, client, assoc)](#Association.query) ⇒ [<code>CozyClientDocument</code>](#CozyClientDocument) \| [<code>QueryDefinition</code>](#QueryDefinition)
 
 <a name="Association+target"></a>
 
@@ -864,10 +868,17 @@ Performs a mutation on the relationship.
 **Kind**: instance method of [<code>Association</code>](#Association)  
 <a name="Association.query"></a>
 
-### Association.query() ⇒ [<code>QueryDefinition</code>](#QueryDefinition) \| [<code>QueryState</code>](#QueryState)
+### Association.query(document, client, assoc) ⇒ [<code>CozyClientDocument</code>](#CozyClientDocument) \| [<code>QueryDefinition</code>](#QueryDefinition)
 Derived `Association`s need to implement this method.
 
 **Kind**: static method of [<code>Association</code>](#Association)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | [<code>CozyClientDocument</code>](#CozyClientDocument) | Document to query |
+| client | [<code>CozyClient</code>](#CozyClient) | The CozyClient instance |
+| assoc | [<code>Association</code>](#Association) | Association containing info on how to build the query to fetch related documents |
+
 <a name="HasMany"></a>
 
 ## HasMany
@@ -883,9 +894,12 @@ Responsible for
 
 * [HasMany](#HasMany)
     * [new HasMany()](#new_HasMany_new)
-    * [.data](#HasMany+data)
-    * [.count](#HasMany+count) ⇒ <code>number</code>
-    * [.addById()](#HasMany+addById)
+    * _instance_
+        * [.data](#HasMany+data)
+        * [.count](#HasMany+count) ⇒ <code>number</code>
+        * [.addById()](#HasMany+addById)
+    * _static_
+        * [.query(document, client, assoc)](#HasMany.query) ⇒ [<code>CozyClientDocument</code>](#CozyClientDocument) \| [<code>QueryDefinition</code>](#QueryDefinition)
 
 <a name="new_HasMany_new"></a>
 
@@ -944,6 +958,17 @@ in order to synchronize your document with the store.
 it'll not be present in the store as well.
 We certainly should use something like `updateRelationship`
 
+<a name="HasMany.query"></a>
+
+### HasMany.query(document, client, assoc) ⇒ [<code>CozyClientDocument</code>](#CozyClientDocument) \| [<code>QueryDefinition</code>](#QueryDefinition)
+**Kind**: static method of [<code>HasMany</code>](#HasMany)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | [<code>CozyClientDocument</code>](#CozyClientDocument) | Document to query |
+| client | [<code>CozyClient</code>](#CozyClient) | The CozyClient instance |
+| assoc | [<code>Association</code>](#Association) | The query params |
+
 <a name="HasManyInPlace"></a>
 
 ## HasManyInPlace
@@ -960,7 +985,10 @@ only the ids.
 
 * [HasManyInPlace](#HasManyInPlace)
     * [new HasManyInPlace()](#new_HasManyInPlace_new)
-    * [.raw](#HasManyInPlace+raw) : <code>Array.&lt;string&gt;</code>
+    * _instance_
+        * [.raw](#HasManyInPlace+raw) : <code>Array.&lt;string&gt;</code>
+    * _static_
+        * [.query(document, client, assoc)](#HasManyInPlace.query) ⇒ [<code>CozyClientDocument</code>](#CozyClientDocument) \| [<code>QueryDefinition</code>](#QueryDefinition)
 
 <a name="new_HasManyInPlace_new"></a>
 
@@ -1004,6 +1032,17 @@ const todo = {
 Raw property
 
 **Kind**: instance property of [<code>HasManyInPlace</code>](#HasManyInPlace)  
+<a name="HasManyInPlace.query"></a>
+
+### HasManyInPlace.query(document, client, assoc) ⇒ [<code>CozyClientDocument</code>](#CozyClientDocument) \| [<code>QueryDefinition</code>](#QueryDefinition)
+**Kind**: static method of [<code>HasManyInPlace</code>](#HasManyInPlace)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | [<code>CozyClientDocument</code>](#CozyClientDocument) | Document to query |
+| client | [<code>CozyClient</code>](#CozyClient) | The CozyClient instance |
+| assoc | [<code>Association</code>](#Association) | The query params |
+
 <a name="HasManyTriggers"></a>
 
 ## HasManyTriggers ⇐ [<code>HasMany</code>](#HasMany)
@@ -3037,8 +3076,45 @@ want to them to trigger an exception during tests.
 **Kind**: global function  
 <a name="query"></a>
 
-## query() ⇒ [<code>QueryState</code>](#QueryState) \| [<code>QueryDefinition</code>](#QueryDefinition)
+## query(document, client, assoc) ⇒ [<code>CozyClientDocument</code>](#CozyClientDocument) \| [<code>QueryDefinition</code>](#QueryDefinition)
 **Kind**: global function  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | [<code>CozyClientDocument</code>](#CozyClientDocument) | Document to query |
+| client | [<code>CozyClient</code>](#CozyClient) | The CozyClient instance |
+| assoc | [<code>Association</code>](#Association) | The query params |
+
+<a name="query..common"></a>
+
+### query~common : [<code>Partial.&lt;QueryState&gt;</code>](#QueryState)
+**Kind**: inner constant of [<code>query</code>](#query)  
+<a name="query"></a>
+
+## query(document, client, assoc) ⇒ [<code>CozyClientDocument</code>](#CozyClientDocument) \| [<code>QueryDefinition</code>](#QueryDefinition)
+**Kind**: global function  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | [<code>CozyClientDocument</code>](#CozyClientDocument) | Document to query |
+| client | [<code>CozyClient</code>](#CozyClient) | The CozyClient instance |
+| assoc | [<code>Association</code>](#Association) | The query params |
+
+<a name="query..common"></a>
+
+### query~common : [<code>Partial.&lt;QueryState&gt;</code>](#QueryState)
+**Kind**: inner constant of [<code>query</code>](#query)  
+<a name="query"></a>
+
+## query(document, client, assoc) ⇒ [<code>CozyClientDocument</code>](#CozyClientDocument) \| [<code>QueryDefinition</code>](#QueryDefinition)
+**Kind**: global function  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | [<code>CozyClientDocument</code>](#CozyClientDocument) | Document to query |
+| client | [<code>CozyClient</code>](#CozyClient) | The CozyClient instance |
+| assoc | [<code>Association</code>](#Association) | The query params |
+
 <a name="query..common"></a>
 
 ### query~common : [<code>Partial.&lt;QueryState&gt;</code>](#QueryState)

--- a/packages/cozy-client/src/associations/Association.js
+++ b/packages/cozy-client/src/associations/Association.js
@@ -1,4 +1,5 @@
-import { QueryState } from '../types'
+import CozyClient from '../CozyClient'
+import { CozyClientDocument } from '../types'
 import { QueryDefinition } from '../queries/dsl'
 
 /**
@@ -223,7 +224,11 @@ class Association {
   /**
    * Derived `Association`s need to implement this method.
    *
-   * @returns {QueryDefinition | QueryState}
+   * @param {CozyClientDocument} document - Document to query
+   * @param {CozyClient} client - The CozyClient instance
+   * @param {Association} assoc - Association containing info on how to build the query to fetch related documents
+   *
+   * @returns {CozyClientDocument | QueryDefinition }
    */
   static query(document, client, assoc) {
     throw new Error('A custom relationship must define its query() function')

--- a/packages/cozy-client/src/associations/Association.js
+++ b/packages/cozy-client/src/associations/Association.js
@@ -225,7 +225,7 @@ class Association {
    *
    * @returns {QueryDefinition | QueryState}
    */
-  static query() {
+  static query(document, client, assoc) {
     throw new Error('A custom relationship must define its query() function')
   }
 }

--- a/packages/cozy-client/src/associations/Association.js
+++ b/packages/cozy-client/src/associations/Association.js
@@ -1,4 +1,3 @@
-import CozyClient from '../CozyClient'
 import { CozyClientDocument } from '../types'
 import { QueryDefinition } from '../queries/dsl'
 
@@ -225,7 +224,7 @@ class Association {
    * Derived `Association`s need to implement this method.
    *
    * @param {CozyClientDocument} document - Document to query
-   * @param {CozyClient} client - The CozyClient instance
+   * @param {object} client - The CozyClient instance
    * @param {Association} assoc - Association containing info on how to build the query to fetch related documents
    *
    * @returns {CozyClientDocument | QueryDefinition }

--- a/packages/cozy-client/src/associations/HasMany.js
+++ b/packages/cozy-client/src/associations/HasMany.js
@@ -1,6 +1,5 @@
 import get from 'lodash/get'
 import merge from 'lodash/merge'
-import CozyClient from '../CozyClient'
 import { QueryDefinition } from '../queries/dsl'
 import { getDocumentFromState, receiveQueryResult } from '../store'
 import { CozyClientDocument } from '../types'
@@ -229,7 +228,7 @@ class HasMany extends Association {
 
   /**
    * @param {CozyClientDocument} document - Document to query
-   * @param {CozyClient} client - The CozyClient instance
+   * @param {object} client - The CozyClient instance
    * @param {Association} assoc - The query params
    *
    * @returns {CozyClientDocument | QueryDefinition}

--- a/packages/cozy-client/src/associations/HasMany.js
+++ b/packages/cozy-client/src/associations/HasMany.js
@@ -1,8 +1,10 @@
 import get from 'lodash/get'
 import merge from 'lodash/merge'
-import Association from './Association'
+import CozyClient from '../CozyClient'
 import { QueryDefinition } from '../queries/dsl'
-import { receiveQueryResult, getDocumentFromState } from '../store'
+import { getDocumentFromState, receiveQueryResult } from '../store'
+import { CozyClientDocument } from '../types'
+import Association from './Association'
 
 /**
  * @typedef {object} Relationship
@@ -225,6 +227,13 @@ class HasMany extends Association {
     }
   }
 
+  /**
+   * @param {CozyClientDocument} document - Document to query
+   * @param {CozyClient} client - The CozyClient instance
+   * @param {Association} assoc - The query params
+   *
+   * @returns {CozyClientDocument | QueryDefinition}
+   */
   static query(document, client, assoc) {
     const relationships = get(document, `relationships.${assoc.name}.data`, [])
     const ids = relationships.map(assoc => assoc._id)

--- a/packages/cozy-client/src/associations/HasManyFiles.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.js
@@ -1,7 +1,10 @@
 import omit from 'lodash/omit'
-import HasMany from './HasMany'
-import { QueryDefinition, Mutations, Q } from '../queries/dsl'
+import CozyClient from '../CozyClient'
+import { Mutations, Q, QueryDefinition } from '../queries/dsl'
 import { getDocumentFromState } from '../store'
+import { CozyClientDocument } from '../types'
+import Association from './Association'
+import HasMany from './HasMany'
 
 /**
  *  This class is only used for photos albums relationships.
@@ -92,6 +95,13 @@ export default class HasManyFiles extends HasMany {
     return omit(doc, [this.name, `relationships.${this.name}`])
   }
 
+  /**
+   * @param {CozyClientDocument} document - Document to query
+   * @param {CozyClient} client - The CozyClient instance
+   * @param {Association} assoc - The query params
+   *
+   * @returns {CozyClientDocument | QueryDefinition}
+   */
   static query(document, client, assoc) {
     const key = [document._type, document._id]
     const cursor = [key, '']

--- a/packages/cozy-client/src/associations/HasManyFiles.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.js
@@ -1,5 +1,4 @@
 import omit from 'lodash/omit'
-import CozyClient from '../CozyClient'
 import { Mutations, Q, QueryDefinition } from '../queries/dsl'
 import { getDocumentFromState } from '../store'
 import { CozyClientDocument } from '../types'
@@ -97,7 +96,7 @@ export default class HasManyFiles extends HasMany {
 
   /**
    * @param {CozyClientDocument} document - Document to query
-   * @param {CozyClient} client - The CozyClient instance
+   * @param {object} client - The CozyClient instance
    * @param {Association} assoc - The query params
    *
    * @returns {CozyClientDocument | QueryDefinition}

--- a/packages/cozy-client/src/associations/HasManyInPlace.js
+++ b/packages/cozy-client/src/associations/HasManyInPlace.js
@@ -1,5 +1,7 @@
+import CozyClient from '../CozyClient'
+import { Q, QueryDefinition } from '../queries/dsl'
+import { CozyClientDocument } from '../types'
 import Association from './Association'
-import { Q } from '../queries/dsl'
 
 /**
  *
@@ -89,10 +91,17 @@ class HasManyInPlace extends Association {
     return (this.raw || []).map(_id => this.get(doctype, _id))
   }
 
-  static query(doc, client, relationship) {
-    const ids = doc[relationship.name]
+  /**
+   * @param {CozyClientDocument} document - Document to query
+   * @param {CozyClient} client - The CozyClient instance
+   * @param {Association} assoc - The query params
+   *
+   * @returns {CozyClientDocument | QueryDefinition}
+   */
+  static query(document, client, assoc) {
+    const ids = document[assoc.name]
     if (ids && ids > 0) {
-      return Q(relationship.doctype).getByIds(ids)
+      return Q(assoc.doctype).getByIds(ids)
     } else {
       return null
     }

--- a/packages/cozy-client/src/associations/HasManyInPlace.js
+++ b/packages/cozy-client/src/associations/HasManyInPlace.js
@@ -1,4 +1,3 @@
-import CozyClient from '../CozyClient'
 import { Q, QueryDefinition } from '../queries/dsl'
 import { CozyClientDocument } from '../types'
 import Association from './Association'
@@ -93,7 +92,7 @@ class HasManyInPlace extends Association {
 
   /**
    * @param {CozyClientDocument} document - Document to query
-   * @param {CozyClient} client - The CozyClient instance
+   * @param {object} client - The CozyClient instance
    * @param {Association} assoc - The query params
    *
    * @returns {CozyClientDocument | QueryDefinition}

--- a/packages/cozy-client/src/associations/HasOne.js
+++ b/packages/cozy-client/src/associations/HasOne.js
@@ -1,6 +1,5 @@
 import get from 'lodash/get'
 import set from 'lodash/set'
-import CozyClient from '../CozyClient'
 import { Q, QueryDefinition } from '../queries/dsl'
 import { CozyClientDocument } from '../types'
 import Association from './Association'
@@ -20,7 +19,7 @@ export default class HasOne extends Association {
 
   /**
    * @param {CozyClientDocument} document - Document to query
-   * @param {CozyClient} client - The CozyClient instance
+   * @param {object} client - The CozyClient instance
    * @param {Association} assoc - The query params
    *
    * @returns {CozyClientDocument | QueryDefinition}

--- a/packages/cozy-client/src/associations/HasOne.js
+++ b/packages/cozy-client/src/associations/HasOne.js
@@ -1,7 +1,9 @@
 import get from 'lodash/get'
 import set from 'lodash/set'
+import CozyClient from '../CozyClient'
+import { Q, QueryDefinition } from '../queries/dsl'
+import { CozyClientDocument } from '../types'
 import Association from './Association'
-import { Q } from '../queries/dsl'
 
 export default class HasOne extends Association {
   get raw() {
@@ -16,8 +18,15 @@ export default class HasOne extends Association {
     return this.get(this.doctype, this.raw._id)
   }
 
-  static query(doc, client, assoc) {
-    const relationship = get(doc, `relationships.${assoc.name}.data`, {})
+  /**
+   * @param {CozyClientDocument} document - Document to query
+   * @param {CozyClient} client - The CozyClient instance
+   * @param {Association} assoc - The query params
+   *
+   * @returns {CozyClientDocument | QueryDefinition}
+   */
+  static query(document, client, assoc) {
+    const relationship = get(document, `relationships.${assoc.name}.data`, {})
     if (!relationship || !relationship._id) {
       return null
     }

--- a/packages/cozy-client/src/associations/HasOneInPlace.js
+++ b/packages/cozy-client/src/associations/HasOneInPlace.js
@@ -1,5 +1,4 @@
 import Association from './Association'
-import CozyClient from '../CozyClient'
 import { Q, QueryDefinition } from '../queries/dsl'
 import { CozyClientDocument } from '../types'
 
@@ -18,7 +17,7 @@ export default class HasOneInPlace extends Association {
 
   /**
    * @param {CozyClientDocument} document - Document to query
-   * @param {CozyClient} client - The CozyClient instance
+   * @param {object} client - The CozyClient instance
    * @param {Association} assoc - The query params
    *
    * @returns {CozyClientDocument | QueryDefinition}

--- a/packages/cozy-client/src/associations/HasOneInPlace.js
+++ b/packages/cozy-client/src/associations/HasOneInPlace.js
@@ -1,6 +1,7 @@
 import Association from './Association'
+import CozyClient from '../CozyClient'
 import { Q, QueryDefinition } from '../queries/dsl'
-import { QueryState } from '../types'
+import { CozyClientDocument } from '../types'
 
 /**
  * Here the id of the document is directly set in the attribute
@@ -16,10 +17,14 @@ export default class HasOneInPlace extends Association {
   }
 
   /**
-   * @returns {QueryState | QueryDefinition}
+   * @param {CozyClientDocument} document - Document to query
+   * @param {CozyClient} client - The CozyClient instance
+   * @param {Association} assoc - The query params
+   *
+   * @returns {CozyClientDocument | QueryDefinition}
    */
-  static query(doc, client, assoc) {
-    const id = doc[assoc.name]
+  static query(document, client, assoc) {
+    const id = document[assoc.name]
     return (
       client.getDocumentFromState(assoc.doctype, id) ||
       Q(assoc.doctype).getById(id)

--- a/packages/cozy-client/src/models/timeseries.js
+++ b/packages/cozy-client/src/models/timeseries.js
@@ -64,7 +64,12 @@ export const saveTimeSeries = async (client, timeseriesOption) => {
  * Helper to retrieve time series by their date interval and source.
  *
  * @param {object} client - The CozyClient instance
- * @param {{ startDate, endDate, dataType, source, limit }} The query params.
+ * @param {object} params - The query params
+ * @param {Date} params.startDate - The starting date of the series
+ * @param {Date} params.endDate - The end date of the series
+ * @param {String} params.dataType - The type of time series, e.g. 'electricity'
+ * @param {String} params.source - The data source, e.g. 'enedis.fr'
+ * @param {number} params.limit - Number of serie items to retrieve
  *
  * @typedef TimeSeriesJSONAPI
  * @property data {Array<TimeSeries>} - The JSON-API data response

--- a/packages/cozy-client/types/associations/Association.d.ts
+++ b/packages/cozy-client/types/associations/Association.d.ts
@@ -77,7 +77,7 @@ declare class Association {
      *
      * @returns {QueryDefinition | QueryState}
      */
-    static query(): QueryDefinition | QueryState;
+    static query(document: any, client: any, assoc: any): QueryDefinition | QueryState;
     /**
      * @param  {object} target - Original object containing raw data
      * @param  {string} name - Attribute under which the association is stored

--- a/packages/cozy-client/types/associations/Association.d.ts
+++ b/packages/cozy-client/types/associations/Association.d.ts
@@ -76,12 +76,12 @@ declare class Association {
      * Derived `Association`s need to implement this method.
      *
      * @param {CozyClientDocument} document - Document to query
-     * @param {CozyClient} client - The CozyClient instance
+     * @param {object} client - The CozyClient instance
      * @param {Association} assoc - Association containing info on how to build the query to fetch related documents
      *
      * @returns {CozyClientDocument | QueryDefinition }
      */
-    static query(document: CozyClientDocument, client: CozyClient, assoc: Association): CozyClientDocument | QueryDefinition;
+    static query(document: CozyClientDocument, client: object, assoc: Association): CozyClientDocument | QueryDefinition;
     /**
      * @param  {object} target - Original object containing raw data
      * @param  {string} name - Attribute under which the association is stored
@@ -222,5 +222,4 @@ declare class Association {
     get data(): any;
 }
 import { CozyClientDocument } from "../types";
-import CozyClient from "../CozyClient";
 import { QueryDefinition } from "../queries/dsl";

--- a/packages/cozy-client/types/associations/Association.d.ts
+++ b/packages/cozy-client/types/associations/Association.d.ts
@@ -75,9 +75,13 @@ declare class Association {
     /**
      * Derived `Association`s need to implement this method.
      *
-     * @returns {QueryDefinition | QueryState}
+     * @param {CozyClientDocument} document - Document to query
+     * @param {CozyClient} client - The CozyClient instance
+     * @param {Association} assoc - Association containing info on how to build the query to fetch related documents
+     *
+     * @returns {CozyClientDocument | QueryDefinition }
      */
-    static query(document: any, client: any, assoc: any): QueryDefinition | QueryState;
+    static query(document: CozyClientDocument, client: CozyClient, assoc: Association): CozyClientDocument | QueryDefinition;
     /**
      * @param  {object} target - Original object containing raw data
      * @param  {string} name - Attribute under which the association is stored
@@ -217,5 +221,6 @@ declare class Association {
      */
     get data(): any;
 }
+import { CozyClientDocument } from "../types";
+import CozyClient from "../CozyClient";
 import { QueryDefinition } from "../queries/dsl";
-import { QueryState } from "../types";

--- a/packages/cozy-client/types/associations/HasMany.d.ts
+++ b/packages/cozy-client/types/associations/HasMany.d.ts
@@ -67,7 +67,6 @@ export type Relation = {
  * ```
  */
 declare class HasMany extends Association {
-    static query(document: any, client: any, assoc: any): QueryDefinition;
     constructor(target: any, name: string, doctype: string, options: {
         get: Function;
         query: Function;
@@ -107,4 +106,3 @@ declare class HasMany extends Association {
     dehydrate(doc: any): any;
 }
 import Association from "./Association";
-import { QueryDefinition } from "../queries/dsl";

--- a/packages/cozy-client/types/associations/HasManyInPlace.d.ts
+++ b/packages/cozy-client/types/associations/HasManyInPlace.d.ts
@@ -43,7 +43,6 @@ export default HasManyInPlace;
  *
  */
 declare class HasManyInPlace extends Association {
-    static query(doc: any, client: any, relationship: any): import("../queries/dsl").QueryDefinition;
     constructor(target: any, name: string, doctype: string, options: {
         get: Function;
         query: Function;

--- a/packages/cozy-client/types/associations/HasOne.d.ts
+++ b/packages/cozy-client/types/associations/HasOne.d.ts
@@ -1,5 +1,4 @@
 export default class HasOne extends Association {
-    static query(doc: any, client: any, assoc: any): import("../queries/dsl").QueryDefinition;
     constructor(target: any, name: string, doctype: string, options: {
         get: Function;
         query: Function;

--- a/packages/cozy-client/types/associations/HasOneInPlace.d.ts
+++ b/packages/cozy-client/types/associations/HasOneInPlace.d.ts
@@ -3,10 +3,6 @@
  * of the document, not in the relationships attribute
  */
 export default class HasOneInPlace extends Association {
-    /**
-     * @returns {QueryState | QueryDefinition}
-     */
-    static query(doc: any, client: any, assoc: any): QueryState | QueryDefinition;
     constructor(target: any, name: string, doctype: string, options: {
         get: Function;
         query: Function;
@@ -18,5 +14,3 @@ export default class HasOneInPlace extends Association {
 }
 export const BelongsToInPlace: typeof HasOneInPlace;
 import Association from "./Association";
-import { QueryState } from "../types";
-import { QueryDefinition } from "../queries/dsl";

--- a/packages/cozy-client/types/models/timeseries.d.ts
+++ b/packages/cozy-client/types/models/timeseries.d.ts
@@ -1,10 +1,10 @@
 export function saveTimeSeries(client: object, timeseriesOption: TimeSeries): Promise<any>;
 export function fetchTimeSeriesByIntervalAndSource(client: object, { startDate, endDate, dataType, source, limit }: {
-    startDate;
-    endDate;
-    dataType;
-    source;
-    limit;
+    startDate: Date;
+    endDate: Date;
+    dataType: string;
+    source: string;
+    limit: number;
 }): Promise<TimeSeriesJSONAPI>;
 export type TimeSeries = {
     /**


### PR DESCRIPTION
Those modifications are needed to make `cozy-pass-web` compilation work as this project is in Typescript.

Two modifications has to be discussed : 

- `timeseries.js` : TS was unable to type `fetchTimeSeriesByIntervalAndSource` arguments.
  - I removed deconstruction from parameters so it is easier to add type to it. But maybe there is another way do document types for destructured params?
  - I typed it with `TimeSeries` and I added the optional `limit` member to existing `@typedef`. I don't have enough knowledge on this project to tell if it should has its own type instead of reusing `TimeSeries`.
- `Association.js` : this class is inherited by `HasOneInPLace`, `HasOne`, `HasManyInPlace`, and `HasMany`.
  - Each of those children override `query()` but with 3 parameters.
  - Typescript complains about this signature difference
  - I added those 3 parameters to the base class method. But maybe I should have create a new base method with those parameters leaving the original one unchanged?