### PR TITLE
docs: Add build instructions required to run `yarn typecheck`

### DIFF
--- a/packages/cozy-client/README.md
+++ b/packages/cozy-client/README.md
@@ -11,6 +11,7 @@ A simple and declarative way of managing [cozy-stack](https://github.com/cozy/co
 
 After making changes to code, it is necessary to 
 
+* build all the repository's packages `yarn build`
 * update the generated API docs via `yarn docs`
 * update the generated types via `cd packages/cozy-client; yarn typecheck`
 * commit the result


### PR DESCRIPTION
`yarn typecheck` should be run after `yarn build` on repository's root
If not TS may not be able to resolve dependencies between `cozy-client`
and `cozy-stack-client`