### PR TITLE
feat: Include_docs is done by default by fetchChanges

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -104,6 +104,16 @@ contains the indexed attributes which are not in correct order.</p>
 ## Typedefs
 
 <dl>
+<dt><a href="#CouchOptionsRaw">CouchOptionsRaw</a> : <code>object</code></dt>
+<dd><p>Calls _changes route from CouchDB
+No further treatment is done contrary to fetchchanges</p>
+</dd>
+<dt><a href="#FetchChangesReturnValue">FetchChangesReturnValue</a> ⇒ <code><a href="#FetchChangesReturnValue">FetchChangesReturnValue</a></code></dt>
+<dd><p>Use Couch _changes API
+Deleted and design docs are filtered by default, thus documents are retrieved in the response
+(include_docs is set to true in the parameters of _changes).</p>
+<p>You should use fetchChangesRaw to have low level control on _changes parameters.</p>
+</dd>
 <dt><a href="#DirectoryAttributes">DirectoryAttributes</a> : <code>object</code></dt>
 <dd><p>Attributes used for directory creation</p>
 </dd>
@@ -301,7 +311,6 @@ Abstracts a collection of documents of the same doctype, providing CRUD methods 
     * [.fetchAllMangoIndexes()](#DocumentCollection+fetchAllMangoIndexes) ⇒ <code>Array</code>
     * [.destroyIndex(index)](#DocumentCollection+destroyIndex) ⇒ <code>object</code>
     * [.copyIndex(existingIndex, newIndexName)](#DocumentCollection+copyIndex) ⇒ <code>object</code>
-    * [.fetchChanges(couchOptions, options)](#DocumentCollection+fetchChanges)
 
 <a name="DocumentCollection+all"></a>
 
@@ -447,18 +456,6 @@ having to recompute the existing index.
 | --- | --- | --- |
 | existingIndex | <code>object</code> | The design doc to copy |
 | newIndexName | <code>string</code> | The name of the copy |
-
-<a name="DocumentCollection+fetchChanges"></a>
-
-### documentCollection.fetchChanges(couchOptions, options)
-Use Couch _changes API
-
-**Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| couchOptions | <code>object</code> | Couch options for changes https://kutt.it/5r7MNQ |
-| options | <code>object</code> | { includeDesign: false, includeDeleted: false } |
 
 <a name="FileCollection"></a>
 
@@ -1631,6 +1628,49 @@ Memoize with maxDuration and custom key
 Get a uniform formatted URL and SSL information according to a provided URL
 
 **Kind**: global function  
+<a name="CouchOptionsRaw"></a>
+
+## CouchOptionsRaw : <code>object</code>
+Calls _changes route from CouchDB
+No further treatment is done contrary to fetchchanges
+
+**Kind**: global typedef  
+**See**: https://docs.couchdb.org/en/stable/api/database/changes.html  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| since | <code>string</code> | Bookmark telling CouchDB from which point in time should changes be returned |
+| doc_ids | <code>Array.&lt;string&gt;</code> | Only return changes for a subset of documents |
+| includeDocs | <code>boolean</code> | Includes full documents as part of results |
+| couchOptions | [<code>CouchOptionsRaw</code>](#CouchOptionsRaw) | Couch options for changes https://kutt.it/5r7MNQ |
+
+<a name="FetchChangesReturnValue"></a>
+
+## FetchChangesReturnValue ⇒ [<code>FetchChangesReturnValue</code>](#FetchChangesReturnValue)
+Use Couch _changes API
+Deleted and design docs are filtered by default, thus documents are retrieved in the response
+(include_docs is set to true in the parameters of _changes).
+
+You should use fetchChangesRaw to have low level control on _changes parameters.
+
+**Kind**: global typedef  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| since | <code>string</code> | Bookmark telling CouchDB from which point in time should changes be returned |
+| doc_ids | <code>Array.&lt;string&gt;</code> | Only return changes for a subset of documents |
+| couchOptions | <code>CouchOptions</code> | Couch options for changes |
+| options | <code>FetchChangesOptions</code> | Further options on the returned documents. By default, it is set to                                         { includeDesign: false, includeDeleted: false } |
+
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| includeDesign | <code>boolean</code> | Whether to include changes from design docs (needs include_docs to be true) |
+| includeDeleted | <code>boolean</code> | Whether to include changes for deleted documents (needs include_docs to be true) |
+| newLastSeq | <code>string</code> |  |
+| documents | <code>Array.&lt;object&gt;</code> |  |
+
 <a name="DirectoryAttributes"></a>
 
 ## DirectoryAttributes : <code>object</code>

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -925,7 +925,7 @@ describe('DocumentCollection', () => {
 
   describe('changes', () => {
     const collection = new DocumentCollection('io.cozy.todos', client)
-    const defaultCouchOptions = { include_docs: true, since: 'my-seq' }
+    const defaultCouchOptions = { since: 'my-seq' }
     beforeEach(() => {
       client.fetchJSON.mockReturnValueOnce(
         Promise.resolve({
@@ -944,7 +944,7 @@ describe('DocumentCollection', () => {
       await collection.fetchChanges()
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'GET',
-        '/data/io.cozy.todos/_changes',
+        '/data/io.cozy.todos/_changes?include_docs=true',
         undefined
       )
     })
@@ -955,7 +955,7 @@ describe('DocumentCollection', () => {
       console.warn.mockRestore()
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'GET',
-        '/data/io.cozy.todos/_changes?include_docs=true&since=my-seq',
+        '/data/io.cozy.todos/_changes?since=my-seq&include_docs=true',
         undefined
       )
     })
@@ -964,7 +964,7 @@ describe('DocumentCollection', () => {
       await collection.fetchChanges({ limit: 100 })
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'GET',
-        '/data/io.cozy.todos/_changes?limit=100',
+        '/data/io.cozy.todos/_changes?limit=100&include_docs=true',
         undefined
       )
     })
@@ -973,16 +973,109 @@ describe('DocumentCollection', () => {
       await collection.fetchChanges({ doc_ids: [1, 2, 3] })
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'POST',
-        '/data/io.cozy.todos/_changes?filter=_doc_ids',
+        '/data/io.cozy.todos/_changes?include_docs=true&filter=_doc_ids',
         { doc_ids: [1, 2, 3] }
       )
+    })
+
+    it('should  be possible to call fetchChangesRaw with include_docs false', async () => {
+      client.fetchJSON = jest.fn().mockReturnValue({
+        last_seq:
+          '5-g1AAAAIreJyVkEsKwjAURZ-toI5cgq5A0sQ0OrI70XyppcaRY92J7kR3ojupaSPUUgotgRd4yTlwbw4A0zRUMLdnpaMkwmyF3Ily9xBwEIuiKLI05KOTW0wkV4rruP29UyGWbordzwKVxWBNOGMKZhertDlarbr5pOT3DV4gudUC9-MPJX9tpEAYx4TQASns2E24ucuJ7rXJSL1BbEgf3vTwpmedCZkYa7Pulck7Xt7x_usFU2aIHOD4eEfVTVA5KMGUkqhNZV-8_o5i',
+        pending: 0,
+        results: [
+          {
+            changes: [
+              {
+                rev: '2-7051cbe5c8faecd085a3fa619e6e6337'
+              }
+            ],
+            id: '6478c2ae800dfc387396d14e1fc39626',
+            seq:
+              '3-g1AAAAG3eJzLYWBg4MhgTmHgz8tPSTV0MDQy1zMAQsMcoARTIkOS_P___7MSGXAqSVIAkkn2IFUZzIkMuUAee5pRqnGiuXkKA2dpXkpqWmZeagpu_Q4g_fGEbEkAqaqH2sIItsXAyMjM2NgUUwdOU_JYgCRDA5ACGjQfn30QlQsgKvcjfGaQZmaUmmZClM8gZhyAmHGfsG0PICrBPmQC22ZqbGRqamyIqSsLAAArcXo'
+          },
+          {
+            changes: [
+              {
+                rev: '3-7379b9e515b161226c6559d90c4dc49f'
+              }
+            ],
+            deleted: true,
+            id: '5bbc9ca465f1b0fcd62362168a7c8831',
+            seq:
+              '4-g1AAAAHXeJzLYWBg4MhgTmHgz8tPSTV0MDQy1zMAQsMcoARTIkOS_P___7MymBMZc4EC7MmJKSmJqWaYynEakaQAJJPsoaYwgE1JM0o1TjQ3T2HgLM1LSU3LzEtNwa3fAaQ_HqQ_kQG3qgSQqnoUtxoYGZkZG5uS4NY8FiDJ0ACkgAbNx2cfROUCiMr9CJ8ZpJkZpaaZEOUziBkHIGbcJ2zbA4hKsA-ZwLaZGhuZmhobYurKAgCz33kh'
+          },
+          {
+            changes: [
+              {
+                rev: '6-460637e73a6288cb24d532bf91f32969'
+              },
+              {
+                rev: '5-eeaa298781f60b7bcae0c91bdedd1b87'
+              }
+            ],
+            id: '729eb57437745e506b333068fff665ae',
+            seq:
+              '5-g1AAAAIReJyVkE0OgjAQRkcwUVceQU9g-mOpruQm2tI2SLCuXOtN9CZ6E70JFmpCCCFCmkyTdt6bfJMDwDQNFcztWWkcY8JXyB2cu49AgFwURZGloRid3MMkEUoJHbXbOxVy6arc_SxQWQzRVHCuYHaxSpuj1aqbj0t-3-AlSrZakn78oeSvjRSIkIhSNiCFHbsKN3c50b02mURvEB-yD296eNOzzoRMRLRZ98rkHS_veGcC_nR-fGe1gaCaxihhjOI2lX0BhniHaA'
+          }
+        ]
+      })
+      const changes = await collection.fetchChangesRaw({ includeDocs: false })
+
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'GET',
+        '/data/io.cozy.todos/_changes?include_docs=false',
+        undefined
+      )
+
+      expect(changes).toEqual({
+        pending: 0,
+        last_seq:
+          '5-g1AAAAIreJyVkEsKwjAURZ-toI5cgq5A0sQ0OrI70XyppcaRY92J7kR3ojupaSPUUgotgRd4yTlwbw4A0zRUMLdnpaMkwmyF3Ily9xBwEIuiKLI05KOTW0wkV4rruP29UyGWbordzwKVxWBNOGMKZhertDlarbr5pOT3DV4gudUC9-MPJX9tpEAYx4TQASns2E24ucuJ7rXJSL1BbEgf3vTwpmedCZkYa7Pulck7Xt7x_usFU2aIHOD4eEfVTVA5KMGUkqhNZV-8_o5i',
+        results: [
+          {
+            changes: [
+              {
+                rev: '2-7051cbe5c8faecd085a3fa619e6e6337'
+              }
+            ],
+            id: '6478c2ae800dfc387396d14e1fc39626',
+            seq:
+              '3-g1AAAAG3eJzLYWBg4MhgTmHgz8tPSTV0MDQy1zMAQsMcoARTIkOS_P___7MSGXAqSVIAkkn2IFUZzIkMuUAee5pRqnGiuXkKA2dpXkpqWmZeagpu_Q4g_fGEbEkAqaqH2sIItsXAyMjM2NgUUwdOU_JYgCRDA5ACGjQfn30QlQsgKvcjfGaQZmaUmmZClM8gZhyAmHGfsG0PICrBPmQC22ZqbGRqamyIqSsLAAArcXo'
+          },
+          {
+            changes: [
+              {
+                rev: '3-7379b9e515b161226c6559d90c4dc49f'
+              }
+            ],
+            deleted: true,
+            id: '5bbc9ca465f1b0fcd62362168a7c8831',
+            seq:
+              '4-g1AAAAHXeJzLYWBg4MhgTmHgz8tPSTV0MDQy1zMAQsMcoARTIkOS_P___7MymBMZc4EC7MmJKSmJqWaYynEakaQAJJPsoaYwgE1JM0o1TjQ3T2HgLM1LSU3LzEtNwa3fAaQ_HqQ_kQG3qgSQqnoUtxoYGZkZG5uS4NY8FiDJ0ACkgAbNx2cfROUCiMr9CJ8ZpJkZpaaZEOUziBkHIGbcJ2zbA4hKsA-ZwLaZGhuZmhobYurKAgCz33kh'
+          },
+          {
+            changes: [
+              {
+                rev: '6-460637e73a6288cb24d532bf91f32969'
+              },
+              {
+                rev: '5-eeaa298781f60b7bcae0c91bdedd1b87'
+              }
+            ],
+            id: '729eb57437745e506b333068fff665ae',
+            seq:
+              '5-g1AAAAIReJyVkE0OgjAQRkcwUVceQU9g-mOpruQm2tI2SLCuXOtN9CZ6E70JFmpCCCFCmkyTdt6bfJMDwDQNFcztWWkcY8JXyB2cu49AgFwURZGloRid3MMkEUoJHbXbOxVy6arc_SxQWQzRVHCuYHaxSpuj1aqbj0t-3-AlSrZakn78oeSvjRSIkIhSNiCFHbsKN3c50b02mURvEB-yD296eNOzzoRMRLRZ98rkHS_veGcC_nR-fGe1gaCaxihhjOI2lX0BhniHaA'
+          }
+        ]
+      })
     })
 
     it('should call the right route', async () => {
       const changes = await collection.fetchChanges(defaultCouchOptions)
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'GET',
-        '/data/io.cozy.todos/_changes?include_docs=true&since=my-seq',
+        '/data/io.cozy.todos/_changes?since=my-seq&include_docs=true',
         undefined
       )
       expect(changes).toEqual({


### PR DESCRIPTION
Fetch changes needs to have the docs included in the changes response
since it filters null documents, deleted documents, and design docs.
With include_docs: false, fetchChanges was not functional, thus it makes
no sense to support it. Now, the caller of fetchChanges doesn't need to
pass include_docs: true, it is set automatically by
DocumentCollection::fetchChanges.

Fix https://github.com/cozy/cozy-client/issues/966

See https://github.com/cozy/cozy-banks/pull/2124/commits/b358741e8949e9e158194e84ca77e94e02695902 for an example of bug that can be avoided with this change (include_docs: true had been forgotten, thus no doc changes were returned).