### PR TITLE
useQuery with enabled at false

### DIFF
--- a/packages/cozy-client/src/hooks/useQuery.js
+++ b/packages/cozy-client/src/hooks/useQuery.js
@@ -40,21 +40,22 @@ const useQuery = (queryDefinition, options) => {
     )
   }
 
-  if (!queryDefinition) {
+  const { as, enabled = true } = options
+
+  if (enabled && !queryDefinition) {
     logger.warn('Bad query', queryDefinition)
     throw new Error('Bad query')
   }
 
   const definition = resolveToValue(queryDefinition)
-  const { as, enabled = true } = options
 
-  if (!as) {
+  if (enabled && !as) {
     throw new Error('You must specify options.as when using useQuery')
   }
 
   const client = useClient()
   const queryState = useSelector(() => {
-    if (options.singleDocData === undefined && queryDefinition.id) {
+    if (enabled && options.singleDocData === undefined && queryDefinition.id) {
       logger.warn(
         'useQuery options.singleDocData will pass to true in a next version of cozy-client, please add it now to prevent any problem in the future.'
       )
@@ -79,7 +80,7 @@ const useQuery = (queryDefinition, options) => {
     return client.query(generateFetchMoreQueryDefinition(queryState), { as })
   }, [as, client])
 
-  return { ...queryState, fetchMore: fetchMore }
+  return { ...queryState, fetchMore }
 }
 
 export const useQueries = querySpecs => {

--- a/packages/cozy-client/src/hooks/useQuery.js
+++ b/packages/cozy-client/src/hooks/useQuery.js
@@ -61,10 +61,12 @@ const useQuery = (queryDefinition, options) => {
       )
     }
 
-    return client.getQueryFromState(as, {
-      hydrated: get(options, 'hydrated', true),
-      singleDocData: get(options, 'singleDocData', false)
-    })
+    return enabled
+      ? client.getQueryFromState(as, {
+          hydrated: get(options, 'hydrated', true),
+          singleDocData: get(options, 'singleDocData', false)
+        })
+      : { data: null, fetchStatus: 'loaded' }
   })
 
   useEffect(

--- a/packages/cozy-client/src/hooks/useQuery.js
+++ b/packages/cozy-client/src/hooks/useQuery.js
@@ -68,10 +68,7 @@ const useQuery = (queryDefinition, options) => {
 
   useEffect(
     () => {
-      if (enabled === false) {
-        return
-      }
-      client.query(definition, options)
+      enabled && client.query(definition, options)
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [as, enabled]

--- a/packages/cozy-client/src/hooks/useQuery.spec.jsx
+++ b/packages/cozy-client/src/hooks/useQuery.spec.jsx
@@ -80,7 +80,7 @@ describe('use query', () => {
 
     expect(current).toMatchObject({
       data: null,
-      fetchStatus: 'pending'
+      fetchStatus: 'loaded'
     })
   })
 

--- a/packages/cozy-client/src/hooks/useQuery.spec.jsx
+++ b/packages/cozy-client/src/hooks/useQuery.spec.jsx
@@ -66,6 +66,24 @@ describe('use query', () => {
     expect(client.query).not.toHaveBeenCalled()
   })
 
+  it('should work without query definition nor as if enabled is set to false', () => {
+    const {
+      hookResult: {
+        result: { current }
+      }
+    } = setupQuery({
+      queryDefinition: null,
+      queryOptions: {
+        enabled: false
+      }
+    })
+
+    expect(current).toMatchObject({
+      data: null,
+      fetchStatus: 'pending'
+    })
+  })
+
   it('should return a single doc data for a single doc query if singleDocData is provided', () => {
     const {
       hookResult: {


### PR DESCRIPTION
Avec `enabled` à `false` ça me paraît plus logique d'une part de pouvoir l'utiliser sans queriDefinition, et d'autre part que ça retourne une requête résolue `loaded` et non en résolution `pending`, pour ne pas avoir une app "en attente".

Cela permet de conditionner un second useQuery en fonction d'un premier. Exemple :

```
const query = buildQuery('id')
const result = useQuery(query.definition, query.options)
const data = { result }

const id = data && data.id
const q = id && buildQ(id)
const qDef = q ? q.definition : null
const qOpts = q ? q.options : null
const r = useQuery(qDef, {...qOpts, enabled: !!id})
```

BREAKING CHANGE: `useQuery` with `enabled` at `false` now returns a result with `fetchStatus: "loaded"` (and not `pending`) and `data: null`

fix https://github.com/cozy/cozy-client/issues/961