### PR TITLE
fix: Updating a file also sanitize its name

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -86,6 +86,10 @@ contains the indexed attributes which are not in correct order.</p>
 <dt><a href="#getAccessToken">getAccessToken()</a> ⇒ <code>string</code></dt>
 <dd><p>Get the app token string</p>
 </dd>
+<dt><a href="#sanitizeAttributes">sanitizeAttributes(attributes)</a> ⇒ <code><a href="#FileAttributes">FileAttributes</a></code> | <code><a href="#DirectoryAttributes">DirectoryAttributes</a></code></dt>
+<dd><p>Sanitize Attribute for an io.cozy.files</p>
+<p>Currently juste the name</p>
+</dd>
 <dt><a href="#garbageCollect">garbageCollect()</a></dt>
 <dd><p>Delete outdated results from cache</p>
 </dd>
@@ -1596,6 +1600,19 @@ Get the app token string
 **Kind**: global function  
 **Returns**: <code>string</code> - token  
 **See**: CozyStackClient.getAccessToken  
+<a name="sanitizeAttributes"></a>
+
+## sanitizeAttributes(attributes) ⇒ [<code>FileAttributes</code>](#FileAttributes) \| [<code>DirectoryAttributes</code>](#DirectoryAttributes)
+Sanitize Attribute for an io.cozy.files
+
+Currently juste the name
+
+**Kind**: global function  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| attributes | [<code>FileAttributes</code>](#FileAttributes) \| [<code>DirectoryAttributes</code>](#DirectoryAttributes) | Attributes of the created file/directory |
+
 <a name="garbageCollect"></a>
 
 ## garbageCollect()

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -58,6 +58,18 @@ const normalizeFile = file => ({
 
 const sanitizeFileName = name => name && name.trim()
 
+/**
+ * Sanitize Attribute for an io.cozy.files
+ *
+ * Currently juste the name
+ *
+ * @param {FileAttributes|DirectoryAttributes} attributes - Attributes of the created file/directory
+ * @returns {FileAttributes|DirectoryAttributes}
+ */
+const sanitizeAttributes = attributes => {
+  if (attributes.name) attributes.name = sanitizeFileName(attributes.name)
+  return attributes
+}
 const getFileTypeFromName = name =>
   mime.getType(name) || CONTENT_TYPE_OCTET_STREAM
 
@@ -753,11 +765,13 @@ class FileCollection extends DocumentCollection {
    * @returns {object}            Updated document
    */
   async updateAttributes(id, attributes) {
+    let attributesToSanitize = { ...attributes }
+    const sanitizedAttributes = sanitizeAttributes(attributesToSanitize)
     const resp = await this.stackClient.fetchJSON('PATCH', uri`/files/${id}`, {
       data: {
         type: 'io.cozy.files',
         id,
-        attributes
+        attributes: sanitizedAttributes
       }
     })
     return {

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -399,6 +399,16 @@ describe('FileCollection', () => {
         client.fetchJSON.mock.calls[client.fetchJSON.mock.calls.length - 1]
       ).toMatchSnapshot()
     })
+
+    it('should sanitize the filename', async () => {
+      await collection.updateAttributes('42', {
+        dir_id: '123',
+        name: 'Name '
+      })
+      expect(
+        client.fetchJSON.mock.calls[client.fetchJSON.mock.calls.length - 1]
+      ).toMatchSnapshot()
+    })
   })
 
   describe('updateMetadataAttribute', () => {

--- a/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
+++ b/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
@@ -191,6 +191,23 @@ Array [
 ]
 `;
 
+exports[`FileCollection updateAttributes should sanitize the filename 1`] = `
+Array [
+  "PATCH",
+  "/files/42",
+  Object {
+    "data": Object {
+      "attributes": Object {
+        "dir_id": "123",
+        "name": "Name",
+      },
+      "id": "42",
+      "type": "io.cozy.files",
+    },
+  },
+]
+`;
+
 exports[`FileCollection updateMetadataAttribute should call the right route 1`] = `
 Array [
   "POST",


### PR DESCRIPTION
Before the sanitize function was only called
during the creation of a file not during the 
update. 