### PR TITLE
feat: Improve type documentation for CozyClient.fromDOM

### DIFF
--- a/docs/api/cozy-client.md
+++ b/docs/api/cozy-client.md
@@ -1153,7 +1153,7 @@ Responsible for
         * [.fromOldClient(oldClient)](#CozyClient.fromOldClient) ⇒ [<code>CozyClient</code>](#CozyClient)
         * [.fromOldOAuthClient(oldClient)](#CozyClient.fromOldOAuthClient) ⇒ [<code>Promise.&lt;CozyClient&gt;</code>](#CozyClient)
         * [.fromEnv([envArg], options)](#CozyClient.fromEnv) ⇒ [<code>CozyClient</code>](#CozyClient)
-        * [.fromDOM(options, selector)](#CozyClient.fromDOM) ⇒ <code>object</code>
+        * [.fromDOM(options, selector)](#CozyClient.fromDOM) ⇒ [<code>CozyClient</code>](#CozyClient)
         * [.registerHook(doctype, name, fn)](#CozyClient.registerHook)
 
 <a name="new_CozyClient_new"></a>
@@ -1686,12 +1686,12 @@ environment variables
 
 <a name="CozyClient.fromDOM"></a>
 
-### CozyClient.fromDOM(options, selector) ⇒ <code>object</code>
+### CozyClient.fromDOM(options, selector) ⇒ [<code>CozyClient</code>](#CozyClient)
 When used from an app, CozyClient can be instantiated from the data injected by the stack in
 the DOM.
 
 **Kind**: static method of [<code>CozyClient</code>](#CozyClient)  
-**Returns**: <code>object</code> - - CozyClient instance  
+**Returns**: [<code>CozyClient</code>](#CozyClient) - - CozyClient instance  
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -361,7 +361,7 @@ class CozyClient {
    *
    * @param  {object}   options  - CozyClient constructor options
    * @param  {string}   selector - Options
-   * @returns {object} - CozyClient instance
+   * @returns {CozyClient} - CozyClient instance
    */
   static fromDOM(options = {}, selector = '[role=application]') {
     const root = document.querySelector(selector)

--- a/packages/cozy-client/types/CozyClient.d.ts
+++ b/packages/cozy-client/types/CozyClient.d.ts
@@ -89,9 +89,9 @@ declare class CozyClient {
      *
      * @param  {object}   options  - CozyClient constructor options
      * @param  {string}   selector - Options
-     * @returns {object} - CozyClient instance
+     * @returns {CozyClient} - CozyClient instance
      */
-    static fromDOM(options?: object, selector?: string): object;
+    static fromDOM(options?: object, selector?: string): CozyClient;
     /**
      * Hooks are an observable system for events on documents.
      * There are at the moment only 2 hooks available.


### PR DESCRIPTION
Improved documentation by using correct type on `CozyClient.fromDOM` instead of generic `object`