### PR TITLE
docs: Generate docs for cozy-client via typedoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '10'
+  - '12'
 cache:
   yarn: true
   directories:

--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -1,0 +1,19 @@
+cozy-client / [Exports](modules.md)
+
+# cozy-client
+
+A simple and declarative way of managing [cozy-stack](https://github.com/cozy/cozy-stack) API calls and resulting data.
+
+`cozy-client` is a convenient yet powerful way to bind `cozy-stack` queries to your (p)React components — but you can still benefit of it if you're not using React!
+
+*   [Getting started](../../docs/getting-started.md)
+*   [API docs](../../docs/api.md)
+
+## Contributing
+
+After making changes to code, it is necessary to
+
+*   build all the repository's packages `yarn build`
+*   update the generated API docs via `yarn docs`
+*   update the generated types via `yarn types`
+*   commit the result

--- a/docs/api/cozy-client/classes/association.md
+++ b/docs/api/cozy-client/classes/association.md
@@ -1,0 +1,327 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / Association
+
+# Class: Association
+
+Associations are used by components to access related store documents that are
+linked in a document. They are also responsible for building the `QueryDefinition` that is
+used by the client to automatically fetch relationship data.
+
+Hydrated documents used by components come with Association instances.
+
+**`interface`**
+
+**`description`**
+Example: The schema defines an `author` relationship :
+
+```js
+const BOOK_SCHEMA = {
+  relationships: {
+     author: 'has-one'
+  }
+}
+```
+
+Hydrated `books` will have the `author` association instance under the `author` key.
+Accessing `hydratedBook.author.data` gives you the author from the store, for example :
+
+```json
+{
+  "name": "St-Exupery",
+  "firstName": "Antoine",
+  "_id": "antoine"
+}
+```
+
+It is the responsibility of the relationship to decide how the relationship data is stored.
+For example, here since we use the default `has-one` relationship, the relationship data
+is stored in the `relationships` attribute of the original document (in our case here, our book
+would be
+
+```json
+{
+  "title": "Le petit prince",
+  "relationships": {
+    "author": {
+      "data": {
+        "doctype": "io.cozy.authors",
+        "_id": "antoine"
+      }
+    }
+  }
+}
+```
+
+In the case of an "in-place" relationship, the relationship data is stored directly under the attribute named
+by the relationship (in our case `author`). Our book would be
+
+```json
+{
+    "title": "Le petit prince",
+    "author": "antoine"
+}
+```
+
+***
+
+Each different type of Association may change:
+
+*   `get raw`: how the relationship data is stored (either as per the JSON API spec or
+    in a custom way)
+*   `get data`: how the store documents are then fetched from the store to be added to
+    the hydrated document (.data method). View components will access
+    `hydratedDoc[relationshipName].data`.
+*   `get query`: how to build the query to fetch related documents
+
+## Hierarchy
+
+*   **`Association`**
+
+    ↳ [`HasMany`](hasmany.md)
+
+    ↳ [`HasOne`](hasone.md)
+
+    ↳ [`HasOneInPlace`](hasoneinplace.md)
+
+    ↳ [`HasManyInPlace`](hasmanyinplace.md)
+
+## Constructors
+
+### constructor
+
+• **new Association**(`target`, `name`, `doctype`, `options`)
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `target` | `any` | Original object containing raw data |
+| `name` | `string` | Attribute under which the association is stored |
+| `doctype` | `string` | Doctype of the documents managed by the association |
+| `options` | `Object` | Options passed from the client |
+| `options.dispatch` | `Function` | Store's dispatch, comes from the client |
+| `options.get` | `Function` | Get a document from the store |
+| `options.mutate` | `Function` | Execute client mutate |
+| `options.query` | `Function` | Execute client query |
+| `options.save` | `Function` | Execute client save |
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:76](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L76)
+
+## Properties
+
+### dispatch
+
+• **dispatch**: `Function`
+
+Dispatch an action on the store.
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L139)
+
+***
+
+### doctype
+
+• **doctype**: `string`
+
+Doctype of the relationship
+
+**`example`** 'io.cozy.authors'
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L102)
+
+***
+
+### get
+
+• **get**: `Function`
+
+Returns the document from the store
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:110](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L110)
+
+***
+
+### mutate
+
+• **mutate**: `Function`
+
+Performs a mutation on the relationship.
+
+**`function`**
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L125)
+
+***
+
+### name
+
+• **name**: `string`
+
+The name of the relationship.
+
+**`example`** 'author'
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:95](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L95)
+
+***
+
+### query
+
+• **query**: `Function`
+
+Performs a query to retrieve relationship documents.
+
+**`param`**
+
+**`function`**
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L117)
+
+***
+
+### save
+
+• **save**: `Function`
+
+Saves the relationship in store.
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:132](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L132)
+
+***
+
+### target
+
+• **target**: `any`
+
+The original document declaring the relationship
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:89](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L89)
+
+## Accessors
+
+### data
+
+• `get` **data**(): `any`
+
+Returns the document(s) from the store
+
+For document with relationships stored as JSON API spec :
+
+```js
+const book = {
+  title: 'Moby Dick',
+  relationships: {
+    author: {
+      data: {
+        doctype: 'io.cozy.authors',
+        id: 'herman'
+      }
+    }
+  }
+ }
+```
+
+`data` will be
+
+```json
+{
+  "_id": "herman"
+  "_type": "io.cozy.authors",
+  "firstName": "herman",
+  "name": "Melville"
+}
+```
+
+Derived `Association`s need to implement this method.
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:219](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L219)
+
+***
+
+### raw
+
+• `get` **raw**(): `any`
+
+Returns the raw relationship data as stored in the original document
+
+For a document with relationships stored as JSON API spec:
+
+```js
+const book = {
+  title: 'Moby Dick',
+  relationships: {
+    author: {
+      data: {
+        doctype: 'io.cozy.authors',
+        id: 'herman'
+      }
+    }
+  }
+ }
+```
+
+Raw value will be
+
+```json
+{
+  "doctype": "io.cozy.authors",
+  "id": "herman"
+}
+```
+
+Derived `Association`s need to implement this method.
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:181](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L181)
+
+## Methods
+
+### query
+
+▸ `Static` **query**(`document`, `client`, `assoc`): [`QueryDefinition`](querydefinition.md) | `CozyClientDocument`
+
+Derived `Association`s need to implement this method.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `document` | `CozyClientDocument` | Document to query |
+| `client` | `any` | The CozyClient instance |
+| `assoc` | [`Association`](association.md) | Association containing info on how to build the query to fetch related documents |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md) | `CozyClientDocument`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:232](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L232)

--- a/docs/api/cozy-client/classes/cozyclient.md
+++ b/docs/api/cozy-client/classes/cozyclient.md
@@ -1,0 +1,1804 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / CozyClient
+
+# Class: CozyClient
+
+Responsible for
+
+*   Creating observable queries
+*   Hydration
+*   Creating plan for saving documents
+*   Associations
+
+## Constructors
+
+### constructor
+
+• **new CozyClient**(`rawOptions?`)
+
+**`example`**
+
+```js
+const client = new CozyClient({
+  schema: {
+    todos: {
+      doctype: 'io.cozy.todos',
+      relationships: {
+        authors: {
+          type: 'has-many',
+          doctype: 'io.cozy.persons'
+        }
+      }
+    }
+  }
+})
+```
+
+Cozy-Client will automatically call `this.login()` if provided with a token and an uri
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `rawOptions` | `ClientOptions` | Options |
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:121](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L121)
+
+## Properties
+
+### appMetadata
+
+• **appMetadata**: `any`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:155](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L155)
+
+***
+
+### capabilities
+
+• **capabilities**: `any`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:178](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L178)
+
+***
+
+### chain
+
+• **chain**: `any`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:174](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L174)
+
+***
+
+### client
+
+• **client**: `any`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1438](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1438)
+
+***
+
+### instanceOptions
+
+• **instanceOptions**: `Object`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:162](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L162)
+
+***
+
+### isLogged
+
+• **isLogged**: `boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:161](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L161)
+
+***
+
+### isRevoked
+
+• **isRevoked**: `boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:463](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L463)
+
+***
+
+### links
+
+• **links**: `any`\[]
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:171](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L171)
+
+***
+
+### loginPromise
+
+• **loginPromise**: `Promise`<`void`>
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:440](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L440)
+
+***
+
+### options
+
+• **options**: `Object`
+
+*Type declaration*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `autoHydrate` | `boolean` | - |
+| `client` | `any` | - |
+| `oauth` | `any` | - |
+| `onTokenRefresh` | `Function` | - |
+| `stackClient` | `any` | - |
+| `store` | `boolean` | If set to false, the client will not instantiate a Redux store automatically. Use this if you want to merge cozy-client's store with your own redux store. See [here](https://docs.cozy.io/en/cozy-client/react-integration/#1b-use-your-own-redux-store) for more information. |
+| `token` | `any` | - |
+| `uri` | `string` | - |
+| `warningForCustomHandlers` | `boolean` | - |
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:157](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L157)
+
+***
+
+### plugins
+
+• **plugins**: `Object`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:183](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L183)
+
+***
+
+### queryIdGenerator
+
+• **queryIdGenerator**: `QueryIDGenerator`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:159](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L159)
+
+***
+
+### schema
+
+• **schema**: `Schema`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:176](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L176)
+
+***
+
+### stackClient
+
+• **stackClient**: `any`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1414](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1414)
+
+***
+
+### store
+
+• **store**: `any`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1347](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1347)
+
+***
+
+### storeAccesors
+
+• **storeAccesors**: `any`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:196](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L196)
+
+***
+
+### storeAccessors
+
+• **storeAccessors**: `Object`
+
+*Type declaration*
+
+| Name | Type |
+| :------ | :------ |
+| `dispatch` | `any` |
+| `get` | `any` |
+| `mutate` | (`def`: `any`, `opts`: `any`) => `any` |
+| `query` | (`def`: `any`, `opts`: `any`) => `any` |
+| `save` | (`document`: `any`, `opts`: `any`) => `any` |
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1145](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1145)
+
+***
+
+### fetchPolicies
+
+▪ `Static` **fetchPolicies**: `Object`
+
+*Type declaration*
+
+| Name | Type |
+| :------ | :------ |
+| `noFetch` | () => `boolean` |
+| `olderThan` | (`delay`: `number`) => `Function` |
+
+***
+
+### hooks
+
+▪ `Static` **hooks**: `Object`
+
+***
+
+### version
+
+▪ `Static` **version**: `string`
+
+## Methods
+
+### \_login
+
+▸ **\_login**(`options`): `Promise`<`void`>
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `options` | `any` |
+
+*Returns*
+
+`Promise`<`void`>
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:443](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L443)
+
+***
+
+### addSchema
+
+▸ **addSchema**(`schemaDefinition`): `void`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `schemaDefinition` | `any` |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:399](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L399)
+
+***
+
+### all
+
+▸ **all**(`doctype`): [`QueryDefinition`](querydefinition.md)
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doctype` | `any` |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md)
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:540](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L540)
+
+***
+
+### authorize
+
+▸ **authorize**(`openURLCallback`): `Promise`<`Object`>
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `openURLCallback` | `any` |
+
+*Returns*
+
+`Promise`<`Object`>
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1280](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1280)
+
+***
+
+### checkForRevocation
+
+▸ **checkForRevocation**(): `Promise`<`any`>
+
+Returns whether the client has been revoked on the server
+
+*Returns*
+
+`Promise`<`any`>
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1361](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1361)
+
+***
+
+### collection
+
+▸ **collection**(`doctype`): `any`
+
+Forwards to a stack client instance and returns
+a [DocumentCollection](https://docs.cozy.io/en/cozy-client/api/cozy-stack-client/#DocumentCollection) instance.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `doctype` | `string` | The collection doctype. |
+
+*Returns*
+
+`any`
+
+Collection corresponding to the doctype
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:532](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L532)
+
+***
+
+### create
+
+▸ **create**(`type`, `doc`, `references`, `options?`): `Promise`<`any`>
+
+Creates a document and saves it on the server
+
+**`example`**
+
+```js
+await client.create('io.cozy.todos', {
+  label: 'My todo',
+  relationships: {
+    authors: {
+      data: [{_id: 1, _type: 'io.cozy.persons'}]
+    }
+  }
+})
+```
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `type` | `string` | Doctype of the document |
+| `doc` | `any` | Document to save |
+| `references` | `Object` | - |
+| `options` | `any` | Mutation options |
+
+*Returns*
+
+`Promise`<`any`>
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:587](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L587)
+
+***
+
+### createClient
+
+▸ **createClient**(): `void`
+
+If no stack client has been passed in options, creates a default stack
+client and attaches handlers for revocation and token refresh.
+If a stackClient has been passed in options, ensure it has handlers for
+revocation and token refresh.
+
+If `oauth` options are passed, stackClient is an OAuthStackClient.
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1395](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1395)
+
+***
+
+### destroy
+
+▸ **destroy**(`document`, `mutationOptions?`): `Promise`<`CozyClientDocument`>
+
+Destroys a document. {before,after}:destroy hooks will be fired.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `document` | `CozyClientDocument` | Document to be deleted |
+| `mutationOptions` | `Object` | - |
+
+*Returns*
+
+`Promise`<`CozyClientDocument`>
+
+The document that has been deleted
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:776](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L776)
+
+***
+
+### dispatch
+
+▸ **dispatch**(`action`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `action` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1466](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1466)
+
+***
+
+### emit
+
+▸ **emit**(...`args`): `void`
+
+Gets overrided by MicroEE.mixin
+This is here just so typescript does not scream
+
+TODO Find a better way to make TS understand that emit is
+a method from cozy-client
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | `any`\[] |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:223](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L223)
+
+***
+
+### ensureCozyMetadata
+
+▸ **ensureCozyMetadata**(`document`, `options?`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `document` | `any` |
+| `options` | `Object` |
+| `options.event` | `string` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:608](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L608)
+
+***
+
+### ensureQueryExists
+
+▸ **ensureQueryExists**(`queryId`, `queryDefinition`, `options`): `void`
+
+Makes sure that the query exists in the store
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `queryId` | `string` | Id of the query |
+| `queryDefinition` | [`QueryDefinition`](querydefinition.md) | Definition of the query |
+| `options` | `QueryOptions` | - |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:797](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L797)
+
+***
+
+### ensureStore
+
+▸ **ensureStore**(): `void`
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1352](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1352)
+
+***
+
+### fetch
+
+▸ **fetch**(`method`, `path`, `body`, `options?`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `method` | `any` |
+| `path` | `any` |
+| `body` | `any` |
+| `options` | `Object` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:536](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L536)
+
+***
+
+### fetchQueryAndGetFromState
+
+▸ **fetchQueryAndGetFromState**(`query`): `Promise`<`QueryState`>
+
+Executes a query and returns the results from internal store.
+
+Can be useful in pure JS context (without React)
+Has a behavior close to <Query /> or useQuery
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `query` | `any` | Query with definition and options |
+
+*Returns*
+
+`Promise`<`QueryState`>
+
+Query state
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1241](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1241)
+
+***
+
+### find
+
+▸ **find**(`doctype`, `selector?`): [`QueryDefinition`](querydefinition.md)
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doctype` | `any` |
+| `selector` | `any` |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md)
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:549](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L549)
+
+***
+
+### generateRandomId
+
+▸ **generateRandomId**(): `string`
+
+*Returns*
+
+`string`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1121](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1121)
+
+***
+
+### get
+
+▸ **get**(`doctype`, `id`): [`QueryDefinition`](querydefinition.md)
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doctype` | `any` |
+| `id` | `any` |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md)
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:556](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L556)
+
+***
+
+### getAssociation
+
+▸ **getAssociation**(`document`, `associationName`): `any`
+
+Creates an association that is linked to the store.
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `document` | `any` |
+| `associationName` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1128](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1128)
+
+***
+
+### getClient
+
+▸ **getClient**(): `any`
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1448](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1448)
+
+***
+
+### getCollectionFromState
+
+▸ **getCollectionFromState**(`type`): `CozyClientDocument`\[]
+
+Get a collection of documents from the internal store.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `type` | `string` | Doctype of the collection |
+
+*Returns*
+
+`CozyClientDocument`\[]
+
+Array of documents or null if the collection does not exist.
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1164](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1164)
+
+***
+
+### getDocumentFromState
+
+▸ **getDocumentFromState**(`type`, `id`): `CozyClientDocument`
+
+Get a document from the internal store.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `type` | `string` | Doctype of the document |
+| `id` | `string` | Id of the document |
+
+*Returns*
+
+`CozyClientDocument`
+
+Document or null if the object does not exist.
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1181](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1181)
+
+***
+
+### getDocumentSavePlan
+
+▸ **getDocumentSavePlan**(`document`, `referencesByName`): `any`
+
+Creates a list of mutations to execute to create a document and its relationships.
+
+```js
+const baseDoc = { _type: 'io.cozy.todo', label: 'Go hiking' }
+// relations can be arrays or single objects
+const relationships = {
+  attachments: [{ _id: 12345, _type: 'io.cozy.files' }, { _id: 6789, _type: 'io.cozy.files' }],
+  bills: { _id: 9999, _type: 'io.cozy.bills' }
+}
+client.getDocumentSavePlan(baseDoc, relationships)
+```
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `document` | `any` | Document to create |
+| `referencesByName` | `Object` | - |
+
+*Returns*
+
+`any`
+
+One or more mutation to execute
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:687](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L687)
+
+***
+
+### getIncludesRelationships
+
+▸ **getIncludesRelationships**(`queryDefinition`): `Dictionary`<`any`>
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `queryDefinition` | `any` |
+
+*Returns*
+
+`Dictionary`<`any`>
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1048](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1048)
+
+***
+
+### getInstanceOptions
+
+▸ **getInstanceOptions**(): `any`
+
+getInstanceOptions - Returns current instance options, such as domain or app slug
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1475](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1475)
+
+***
+
+### getQueryFromState
+
+▸ **getQueryFromState**(`id`, `options?`): `QueryState`
+
+Get a query from the internal store.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` | Id of the query (set via Query.props.as) |
+| `options` | `Object` | Options |
+| `options.hydrated` | `boolean` | - |
+| `options.singleDocData` | `any` | - |
+
+*Returns*
+
+`QueryState`
+
+*   Query state or null if it does not exist.
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1202](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1202)
+
+***
+
+### getRelationshipStoreAccessors
+
+▸ **getRelationshipStoreAccessors**(): `Object`
+
+Returns the accessors that are given to the relationships for them
+to deal with the stores.
+
+Relationships need to have access to the store to ping it when
+a modification (addById/removeById etc...) has been done. This wakes
+the store up, which in turn will update the `<Query>`s and re-render the data.
+
+*Returns*
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `dispatch` | `any` |
+| `get` | `any` |
+| `mutate` | (`def`: `any`, `opts`: `any`) => `any` |
+| `query` | (`def`: `any`, `opts`: `any`) => `any` |
+| `save` | (`document`: `any`, `opts`: `any`) => `any` |
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1144](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1144)
+
+***
+
+### getStackClient
+
+▸ **getStackClient**(): `any`
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1455](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1455)
+
+***
+
+### handleRevocationChange
+
+▸ **handleRevocationChange**(`state`): `void`
+
+Sets public attribute and emits event related to revocation
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `state` | `any` |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1366](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1366)
+
+***
+
+### handleTokenRefresh
+
+▸ **handleTokenRefresh**(`token`): `void`
+
+Emits event when token is refreshed
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `token` | `any` |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1377](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1377)
+
+***
+
+### hydrateDocument
+
+▸ **hydrateDocument**(`document`, `schemaArg`): `any`
+
+Resolves relationships on a document.
+
+The original document is kept in the target attribute of
+the relationship
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `document` | `CozyClientDocument` | for which relationships must be resolved |
+| `schemaArg` | `Schema` | - |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1091](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1091)
+
+***
+
+### hydrateDocuments
+
+▸ **hydrateDocuments**(`doctype`, `documents`): `any`\[]
+
+Returns documents with their relationships resolved according to their schema.
+If related documents are not in the store, they will not be fetched automatically.
+Instead, the relationships will have null documents.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `doctype` | `string` | Doctype of the documents being hydrated |
+| `documents` | `CozyClientDocument`\[] | Documents to be hydrated |
+
+*Returns*
+
+`any`\[]
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1068](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1068)
+
+***
+
+### hydrateRelationships
+
+▸ **hydrateRelationships**(`document`, `schemaRelationships`): `Object`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `document` | `any` |
+| `schemaRelationships` | `any` |
+
+*Returns*
+
+`Object`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1102)
+
+***
+
+### isReactNative
+
+▸ **isReactNative**(): `boolean`
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1264](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1264)
+
+***
+
+### loadInstanceOptionsFromDOM
+
+▸ **loadInstanceOptionsFromDOM**(`selector?`): `void`
+
+loadInstanceOptionsFromDOM - Loads the dataset injected by the Stack in web pages and exposes it through getInstanceOptions
+
+*Parameters*
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `selector` | `string` | `'[role=application]'` |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1486](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1486)
+
+***
+
+### login
+
+▸ **login**(`options`): `Promise`<`any`>
+
+Notify the links that they can start and set isLogged to true.
+
+On mobile, where url/token are set after instantiation, use this method
+to set the token and uri via options.
+
+Emits
+
+*   "beforeLogin" at the beginning, before links have been set up
+*   "login" when the client is fully logged in and links have been set up
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options` | `Object` | - |
+| `options.token` | `string` | If passed, the token is set on the client |
+| `options.uri` | `string` | If passed, the uri is set on the client |
+
+*Returns*
+
+`Promise`<`any`>
+
+*   Resolves when all links have been setup and client is fully logged in
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:432](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L432)
+
+***
+
+### logout
+
+▸ **logout**(): `Promise`<`any`>
+
+Logs out the client and reset all the links
+
+Emits
+
+*   "beforeLogout" at the beginning, before links have been reset
+*   "login" when the client is fully logged out and links have been reset
+
+*Returns*
+
+`Promise`<`any`>
+
+*   Resolves when all links have been reset and client is fully logged out
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:479](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L479)
+
+***
+
+### makeNewDocument
+
+▸ **makeNewDocument**(`doctype`): `any`
+
+Creates (locally) a new document for the given doctype.
+This document is hydrated : its relationships are there
+and working.
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doctype` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1114](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1114)
+
+***
+
+### makeObservableQuery
+
+▸ **makeObservableQuery**(`queryDefinition`, `options?`): `default`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `queryDefinition` | `any` |
+| `options` | `Object` |
+
+*Returns*
+
+`default`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:890](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L890)
+
+***
+
+### mutate
+
+▸ **mutate**(`mutationDefinition`, `__namedParameters?`): `Promise`<`any`>
+
+Mutate a document
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `mutationDefinition` | `any` | Describe the mutation |
+| `__namedParameters` | `Object` | - |
+| `__namedParameters.as` | `string` | - |
+| `__namedParameters.update` | `Function` | - |
+| `__namedParameters.updateQueries` | `Function` | - |
+
+*Returns*
+
+`Promise`<`any`>
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:908](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L908)
+
+***
+
+### on
+
+▸ **on**(...`args`): `void`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | `any`\[] |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:224](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L224)
+
+***
+
+### query
+
+▸ **query**(`queryDefinition`, `__namedParameters?`): `Promise`<`any`>
+
+Executes a query and returns its results.
+
+Results from the query will be saved internally and can be retrieved via
+`getQueryFromState` or directly using `<Query />`. `<Query />` automatically
+executes its query when mounted if no fetch policy has been indicated.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `queryDefinition` | [`QueryDefinition`](querydefinition.md) | Definition that will be executed |
+| `__namedParameters` | `QueryOptions` | - |
+
+*Returns*
+
+`Promise`<`any`>
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:820](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L820)
+
+***
+
+### queryAll
+
+▸ **queryAll**(`queryDefinition`, `options`): `Promise`<`any`\[]>
+
+Will fetch all documents for a `queryDefinition`, automatically fetching more
+documents if the total of documents is superior to the pagination limit. Can
+result in a lot of network requests.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `queryDefinition` | [`QueryDefinition`](querydefinition.md) | Definition to be executed |
+| `options` | `any` | Options to the query |
+
+*Returns*
+
+`Promise`<`any`\[]>
+
+All documents matching the query
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:868](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L868)
+
+***
+
+### reducer
+
+▸ **reducer**(): (`state`: { `documents`: {} = {}; `queries`: {} = {} }, `action`: `any`) => { `documents`: `any` ; `queries`: `Record`<`string`, `QueryState`>  }
+
+*Returns*
+
+`fn`
+
+▸ (`state?`, `action`): `Object`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `state` | `Object` |
+| `state.documents` | `Object` |
+| `state.queries` | `Object` |
+| `action` | `any` |
+
+*Returns*
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `documents` | `any` |
+| `queries` | `Record`<`string`, `QueryState`> |
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1462](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1462)
+
+***
+
+### register
+
+▸ **register**(`cozyURL`): `any`
+
+Performs a complete OAuth flow using a Cordova webview
+or React Native WebView for auth.
+The `register` method's name has been chosen for compat reasons with the Authentication compo.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `cozyURL` | `string` | Receives the URL of the cozy instance. |
+
+*Returns*
+
+`any`
+
+Contains the fetched token and the client information.
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1258](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1258)
+
+***
+
+### registerClientOnLinks
+
+▸ **registerClientOnLinks**(): `void`
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:403](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L403)
+
+***
+
+### registerPlugin
+
+▸ **registerPlugin**(`Plugin`, `options`): `any`
+
+A plugin is a class whose constructor receives the client as first argument.
+The main mean of interaction with the client should be with events
+like "login"/"logout".
+
+The plugin system is meant to encourage separation of concerns, modularity
+and testability : instead of registering events at module level, please
+create a plugin that subscribes to events.
+
+Plugin instances are stored internally in the `plugins` attribute of the client
+and can be accessed via this mean. A plugin class must have the attribute
+`pluginName` that will be use as the key in the `plugins` object.
+
+Two plugins with the same `pluginName` cannot co-exist.
+
+**`example`**
+
+```js
+class AlertPlugin {
+  constructor(client, options) {
+    this.client = client
+    this.options = options
+    this.handleLogin = this.handleLogin.bind(this)
+    this.handleLogout = this.handleLogout.bind(this)
+    this.client.on("login", this.handleLogin)
+    this.client.on("logout", this.handleLogout)
+  }
+
+  handleLogin() {
+    alert(this.options.onLoginAlert)
+  }
+
+  handleLogout() {
+    alert(this.options.onLogoutAlert)
+  }
+}
+
+AlertPlugin.pluginName = 'alerts'
+
+client.registerPlugin(AlertPlugin, {
+  onLoginAlert: 'client has logged in !',
+  onLogoutAlert: 'client has logged out !'
+})
+
+// the instance of the plugin is accessible via
+client.plugins.alerts
+```
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `Plugin` | `any` |
+| `options` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:274](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L274)
+
+***
+
+### removeListener
+
+▸ **removeListener**(...`args`): `void`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | `any`\[] |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:225](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L225)
+
+***
+
+### renewAuthorization
+
+▸ **renewAuthorization**(): `any`
+
+Renews the token if, for instance, new permissions are required or token
+has expired.
+
+*Returns*
+
+`any`
+
+Contains the fetched token and the client information.
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1311](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1311)
+
+***
+
+### requestMutation
+
+▸ **requestMutation**(`definition`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `definition` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1032](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1032)
+
+***
+
+### save
+
+▸ **save**(`document`, `mutationOptions?`): `Promise`<`any`>
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `document` | `any` |
+| `mutationOptions` | `Object` |
+
+*Returns*
+
+`Promise`<`any`>
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:602](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L602)
+
+***
+
+### setData
+
+▸ **setData**(`data`): `void`
+
+Directly set the data in the store, without using a query
+This is useful for cases like Pouch replication, which wants to
+set some data in the store.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `data` | `any` | Data that is inserted in the store. Shape: { doctype: \[data] } |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1507](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1507)
+
+***
+
+### setStore
+
+▸ **setStore**(`store`, `__namedParameters?`): `void`
+
+Sets the internal store of the client. Use this when you want to have cozy-client's
+internal store colocated with your existing Redux store.
+
+Typically, you would need to do this only once in your application, this is why
+setStore throws if you do it twice. If you really need to set the store again,
+use options.force = true.
+
+**`example`**
+
+    const client = new CozyClient()
+    const store = createStore(combineReducers({
+      todos: todoReducer,
+      cozy: client.reducer()
+    })
+    client.setStore(store)
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `store` | `any` | A redux store |
+| `__namedParameters` | `Object` | - |
+| `__namedParameters.force` | `boolean` | - |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1337](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1337)
+
+***
+
+### startOAuthFlow
+
+▸ **startOAuthFlow**(`openURLCallback`): `Promise`<`any`>
+
+Performs a complete OAuth flow, including updating the internal token at the end.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `openURLCallback` | `Function` | Receives the URL to present to the user as a parameter, and should return a promise that resolves with the URL the user was redirected to after accepting the permissions. |
+
+*Returns*
+
+`Promise`<`any`>
+
+Contains the fetched token and the client information. These should be stored and used to restore the client.
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1274](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1274)
+
+***
+
+### toJSON
+
+▸ **toJSON**(): `CozyClient`
+
+*Returns*
+
+`CozyClient`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1514](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1514)
+
+***
+
+### triggerHook
+
+▸ **triggerHook**(`name`, `document`): `void`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `name` | `any` |
+| `document` | `any` |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:761](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L761)
+
+***
+
+### upload
+
+▸ **upload**(`file`, `dirPath`, `mutationOptions?`): `Promise`<`any`>
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `file` | `any` |
+| `dirPath` | `any` |
+| `mutationOptions` | `Object` |
+
+*Returns*
+
+`Promise`<`any`>
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:786](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L786)
+
+***
+
+### validate
+
+▸ **validate**(`document`): `Promise`<`Object`>
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `document` | `any` |
+
+*Returns*
+
+`Promise`<`Object`>
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:598](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L598)
+
+***
+
+### watchQuery
+
+▸ **watchQuery**(...`args`): `default`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | `any`\[] |
+
+*Returns*
+
+`default`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:883](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L883)
+
+***
+
+### fromDOM
+
+▸ `Static` **fromDOM**(`options?`, `selector?`): [`CozyClient`](cozyclient.md)
+
+When used from an app, CozyClient can be instantiated from the data injected by the stack in
+the DOM.
+
+*Parameters*
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `options` | `any` | `{}` | CozyClient constructor options |
+| `selector` | `string` | `'[role=application]'` | Options |
+
+*Returns*
+
+[`CozyClient`](cozyclient.md)
+
+*   CozyClient instance
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:366](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L366)
+
+***
+
+### fromEnv
+
+▸ `Static` **fromEnv**(`envArg`, `options?`): [`CozyClient`](cozyclient.md)
+
+In konnector/service context, CozyClient can be instantiated from
+environment variables
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `envArg` | `any` | - |
+| `options` | `any` | Options |
+
+*Returns*
+
+[`CozyClient`](cozyclient.md)
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:338](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L338)
+
+***
+
+### fromOldClient
+
+▸ `Static` **fromOldClient**(`oldClient`, `options`): [`CozyClient`](cozyclient.md)
+
+To help with the transition from cozy-client-js to cozy-client, it is possible to instantiate
+a client with a cookie-based instance of cozy-client-js.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `oldClient` | `any` | An instance of the deprecated cozy-client |
+| `options` | `any` | - |
+
+*Returns*
+
+[`CozyClient`](cozyclient.md)
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:297](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L297)
+
+***
+
+### fromOldOAuthClient
+
+▸ `Static` **fromOldOAuthClient**(`oldClient`, `options`): `Promise`<[`CozyClient`](cozyclient.md)>
+
+To help with the transition from cozy-client-js to cozy-client, it is possible to instantiate
+a client with an OAuth-based instance of cozy-client-js.
+
+Warning: unlike other instantiators, this one needs to be awaited.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `oldClient` | `any` | An instance of the deprecated cozy-client |
+| `options` | `any` | - |
+
+*Returns*
+
+`Promise`<[`CozyClient`](cozyclient.md)>
+
+An instance of a client, configured from the old client
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:314](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L314)
+
+***
+
+### registerHook
+
+▸ `Static` **registerHook**(`doctype`, `name`, `fn`): `void`
+
+Hooks are an observable system for events on documents.
+There are at the moment only 2 hooks available.
+
+*   before:destroy, called just before a document is destroyed via CozyClient::destroy
+*   after:destroy, called after a document is destroyed via CozyClient::destroy
+
+**`example`**
+
+    CozyClient.registerHook('io.cozy.bank.accounts', 'before:destroy', () => {
+      console.log('A io.cozy.bank.accounts is being destroyed')
+    })
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `doctype` | `string` | Doctype on which the hook will be registered |
+| `name` | `string` | Name of the hook |
+| `fn` | `Function` | Callback to be executed |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:755](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L755)

--- a/docs/api/cozy-client/classes/cozylink.md
+++ b/docs/api/cozy-client/classes/cozylink.md
@@ -1,0 +1,47 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / CozyLink
+
+# Class: CozyLink
+
+## Hierarchy
+
+*   **`CozyLink`**
+
+    ↳ [`StackLink`](stacklink.md)
+
+## Constructors
+
+### constructor
+
+• **new CozyLink**(`requestHandler`)
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `requestHandler` | `any` |
+
+*Defined in*
+
+[packages/cozy-client/src/CozyLink.js:1](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyLink.js#L1)
+
+## Methods
+
+### request
+
+▸ **request**(`operation`, `result`, `forward`): `void`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `operation` | `any` |
+| `result` | `any` |
+| `forward` | `any` |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyLink.js:8](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyLink.js#L8)

--- a/docs/api/cozy-client/classes/cozyprovider.md
+++ b/docs/api/cozy-client/classes/cozyprovider.md
@@ -1,0 +1,118 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / CozyProvider
+
+# Class: CozyProvider
+
+## Hierarchy
+
+*   `Component`
+
+    ↳ **`CozyProvider`**
+
+## Constructors
+
+### constructor
+
+• **new CozyProvider**(`props`, `context`)
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `any` |
+| `context` | `any` |
+
+*Overrides*
+
+Component.constructor
+
+*Defined in*
+
+[packages/cozy-client/src/Provider.jsx:16](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/Provider.jsx#L16)
+
+## Properties
+
+### childContextTypes
+
+▪ `Static` **childContextTypes**: `Object`
+
+*Type declaration*
+
+| Name | Type |
+| :------ | :------ |
+| `client` | `Validator`<`object`> |
+| `store` | `Requireable`<`object`> |
+
+*Defined in*
+
+[packages/cozy-client/src/Provider.jsx:28](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/Provider.jsx#L28)
+
+***
+
+### contextTypes
+
+▪ `Static` **contextTypes**: `Object`
+
+*Type declaration*
+
+| Name | Type |
+| :------ | :------ |
+| `store` | `Requireable`<`object`> |
+
+*Defined in*
+
+[packages/cozy-client/src/Provider.jsx:33](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/Provider.jsx#L33)
+
+***
+
+### propTypes
+
+▪ `Static` **propTypes**: `Object`
+
+*Type declaration*
+
+| Name | Type |
+| :------ | :------ |
+| `children` | `Validator`<`ReactElementLike`> |
+| `client` | `Validator`<`object`> |
+| `store` | `Requireable`<`InferProps`<`Object`>> |
+
+*Defined in*
+
+[packages/cozy-client/src/Provider.jsx:12](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/Provider.jsx#L12)
+
+## Methods
+
+### getChildContext
+
+▸ **getChildContext**(): `Object`
+
+*Returns*
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `client` | `any` |
+| `store` | `any` |
+
+*Defined in*
+
+[packages/cozy-client/src/Provider.jsx:37](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/Provider.jsx#L37)
+
+***
+
+### render
+
+▸ **render**(): `Element`
+
+*Returns*
+
+`Element`
+
+*Overrides*
+
+Component.render
+
+*Defined in*
+
+[packages/cozy-client/src/Provider.jsx:44](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/Provider.jsx#L44)

--- a/docs/api/cozy-client/classes/hasmany.md
+++ b/docs/api/cozy-client/classes/hasmany.md
@@ -1,0 +1,707 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / HasMany
+
+# Class: HasMany
+
+Related documents are stored in the relationships attribute of the object,
+following the JSON API spec.
+
+Responsible for
+
+*   Creating relationships
+*   Removing relationships
+
+**`description`**
+
+    const schema = {
+      todos: {
+         doctype: 'io.cozy.todos',
+         relationships: {
+           tasks: {
+             doctype: 'io.cozy.tasks',
+             type: 'has-many'
+           }
+         }
+       }
+    }
+
+    const todo = {
+      label: "Protect people's privacy",
+      relationships: {
+        tasks: {
+          data: [
+            {_id: 1, _type: 'io.cozy.tasks'},
+            {_id: 2, _type: 'io.cozy.tasks'}
+          ]
+        }
+      }
+    }
+
+## Hierarchy
+
+*   [`Association`](association.md)
+
+    ↳ **`HasMany`**
+
+    ↳↳ [`HasManyTriggers`](hasmanytriggers.md)
+
+## Constructors
+
+### constructor
+
+• **new HasMany**(`target`, `name`, `doctype`, `options`)
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `target` | `any` | Original object containing raw data |
+| `name` | `string` | Attribute under which the association is stored |
+| `doctype` | `string` | Doctype of the documents managed by the association |
+| `options` | `Object` | Options passed from the client |
+| `options.dispatch` | `Function` | Store's dispatch, comes from the client |
+| `options.get` | `Function` | Get a document from the store |
+| `options.mutate` | `Function` | Execute client mutate |
+| `options.query` | `Function` | Execute client query |
+| `options.save` | `Function` | Execute client save |
+
+*Inherited from*
+
+[Association](association.md).[constructor](association.md#constructor)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:76](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L76)
+
+## Properties
+
+### dispatch
+
+• **dispatch**: `Function`
+
+Dispatch an action on the store.
+
+*Inherited from*
+
+[Association](association.md).[dispatch](association.md#dispatch)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L139)
+
+***
+
+### doctype
+
+• **doctype**: `string`
+
+Doctype of the relationship
+
+**`example`** 'io.cozy.authors'
+
+*Inherited from*
+
+[Association](association.md).[doctype](association.md#doctype)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L102)
+
+***
+
+### get
+
+• **get**: `Function`
+
+Returns the document from the store
+
+*Inherited from*
+
+[Association](association.md).[get](association.md#get)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:110](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L110)
+
+***
+
+### mutate
+
+• **mutate**: `Function`
+
+Performs a mutation on the relationship.
+
+**`function`**
+
+*Inherited from*
+
+[Association](association.md).[mutate](association.md#mutate)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L125)
+
+***
+
+### name
+
+• **name**: `string`
+
+The name of the relationship.
+
+**`example`** 'author'
+
+*Inherited from*
+
+[Association](association.md).[name](association.md#name)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:95](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L95)
+
+***
+
+### query
+
+• **query**: `Function`
+
+Performs a query to retrieve relationship documents.
+
+**`param`**
+
+**`function`**
+
+*Inherited from*
+
+[Association](association.md).[query](association.md#query)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L117)
+
+***
+
+### save
+
+• **save**: `Function`
+
+Saves the relationship in store.
+
+*Inherited from*
+
+[Association](association.md).[save](association.md#save)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:132](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L132)
+
+***
+
+### target
+
+• **target**: `any`
+
+The original document declaring the relationship
+
+*Inherited from*
+
+[Association](association.md).[target](association.md#target)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:89](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L89)
+
+## Accessors
+
+### count
+
+• `get` **count**(): `number`
+
+Returns the total number of documents in the relationship.
+Does not handle documents absent from the store. If you want
+to do that, you can use .data.length.
+
+*Returns*
+
+`number`
+
+*   Total number of documents in the relationships
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:93](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L93)
+
+***
+
+### data
+
+• `get` **data**(): `any`
+
+Returns store documents
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:76](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L76)
+
+***
+
+### hasMore
+
+• `get` **hasMore**(): `any`
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:82](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L82)
+
+***
+
+### raw
+
+• `get` **raw**(): `any`
+
+Returns the raw relationship data as stored in the original document
+
+For a document with relationships stored as JSON API spec:
+
+```js
+const book = {
+  title: 'Moby Dick',
+  relationships: {
+    author: {
+      data: {
+        doctype: 'io.cozy.authors',
+        id: 'herman'
+      }
+    }
+  }
+ }
+```
+
+Raw value will be
+
+```json
+{
+  "doctype": "io.cozy.authors",
+  "id": "herman"
+}
+```
+
+Derived `Association`s need to implement this method.
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:69](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L69)
+
+## Methods
+
+### addById
+
+▸ **addById**(`idsArg`): `any`
+
+Add a referenced document by id. You need to call save()
+in order to synchronize your document with the store.
+
+**`todo`** We shouldn't create the array of relationship manually since
+it'll not be present in the store as well.
+We certainly should use something like `updateRelationship`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `idsArg` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:127](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L127)
+
+***
+
+### containsById
+
+▸ **containsById**(`id`): `boolean`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `id` | `any` |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:108](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L108)
+
+***
+
+### dehydrate
+
+▸ **dehydrate**(`doc`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:217](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L217)
+
+***
+
+### exists
+
+▸ **exists**(`document`): `boolean`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `document` | `any` |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:104](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L104)
+
+***
+
+### existsById
+
+▸ **existsById**(`id`): `boolean`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `id` | `any` |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:114](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L114)
+
+***
+
+### fetchMore
+
+▸ **fetchMore**(): `void`
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:100](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L100)
+
+***
+
+### getRelationship
+
+▸ **getRelationship**(): `any`
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:168](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L168)
+
+***
+
+### removeById
+
+▸ **removeById**(`idsArg`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `idsArg` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:148](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L148)
+
+***
+
+### updateMetaCount
+
+▸ **updateMetaCount**(): `void`
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:159](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L159)
+
+***
+
+### updateRelationship
+
+▸ **updateRelationship**(`target`, `updateFn`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `target` | `any` |
+| `updateFn` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:189](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L189)
+
+***
+
+### updateRelationshipData
+
+▸ **updateRelationshipData**(`getUpdatedRelationshipData`): (`dispatch`: `any`, `getState`: `any`) => `void`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `getUpdatedRelationshipData` | `any` |
+
+*Returns*
+
+`fn`
+
+▸ (`dispatch`, `getState`): `void`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `dispatch` | `any` |
+| `getState` | `any` |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:193](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L193)
+
+***
+
+### updateTargetRelationship
+
+▸ **updateTargetRelationship**(`store`, `updateFn`): `void`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `store` | `any` |
+| `updateFn` | `any` |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:182](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L182)
+
+***
+
+### getHasManyItem
+
+▸ `Static` **getHasManyItem**(`doc`, `relName`, `relItemId`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+| `relName` | `string` |
+| `relItemId` | `string` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:250](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L250)
+
+***
+
+### getHasManyItems
+
+▸ `Static` **getHasManyItems**(`doc`, `relName`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+| `relName` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:259](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L259)
+
+***
+
+### query
+
+▸ `Static` **query**(`document`, `client`, `assoc`): [`QueryDefinition`](querydefinition.md) | `CozyClientDocument`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `document` | `CozyClientDocument` | Document to query |
+| `client` | `any` | The CozyClient instance |
+| `assoc` | [`Association`](association.md) | The query params |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md) | `CozyClientDocument`
+
+*Overrides*
+
+[Association](association.md).[query](association.md#query)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:236](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L236)
+
+***
+
+### removeHasManyItem
+
+▸ `Static` **removeHasManyItem**(`doc`, `relName`, `relItemId`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+| `relName` | `string` |
+| `relItemId` | `string` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:297](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L297)
+
+***
+
+### setHasManyItem
+
+▸ `Static` **setHasManyItem**(`doc`, `relName`, `relItemId`, `relItemAttrs`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+| `relName` | `string` |
+| `relItemId` | `string` |
+| `relItemAttrs` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:271](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L271)
+
+***
+
+### updateHasManyItem
+
+▸ `Static` **updateHasManyItem**(`doc`, `relName`, `relItemId`, `updater`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+| `relName` | `string` |
+| `relItemId` | `string` |
+| `updater` | `Function` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:321](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L321)
+
+***
+
+### updateRelationship
+
+▸ `Static` **updateRelationship**(`doc`, `relName`, `updateFn`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+| `relName` | `any` |
+| `updateFn` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:332](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L332)

--- a/docs/api/cozy-client/classes/hasmanyinplace.md
+++ b/docs/api/cozy-client/classes/hasmanyinplace.md
@@ -1,0 +1,396 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / HasManyInPlace
+
+# Class: HasManyInPlace
+
+Used when related documents are stored directly under the attribute with
+only the ids.
+
+**`property`** {Function} get
+
+**`description`**
+
+An example document representing a TODO. See as the related
+tasks are represented via ids.
+
+```js
+const todo = {
+  label: "Protect people's privacy",
+  tasks: [1, 2]
+}
+```
+
+Here is the `Schema` that would represent this kind of document.
+Components receiving todos via `Query`s would have an instance of `HasManyInPlace`
+as their `tasks` attribute.
+
+```js
+const schema = {
+  todos: {
+     doctype: 'io.cozy.todos',
+     relationships: {
+       tasks: {
+         doctype: 'io.cozy.tasks',
+         type: 'has-many-in-place'
+       }
+     }
+   }
+}
+
+const todo = {
+  label: "Get rich",
+  tasks: [1, 2]
+}
+```
+
+## Hierarchy
+
+*   [`Association`](association.md)
+
+    ↳ **`HasManyInPlace`**
+
+## Constructors
+
+### constructor
+
+• **new HasManyInPlace**(`target`, `name`, `doctype`, `options`)
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `target` | `any` | Original object containing raw data |
+| `name` | `string` | Attribute under which the association is stored |
+| `doctype` | `string` | Doctype of the documents managed by the association |
+| `options` | `Object` | Options passed from the client |
+| `options.dispatch` | `Function` | Store's dispatch, comes from the client |
+| `options.get` | `Function` | Get a document from the store |
+| `options.mutate` | `Function` | Execute client mutate |
+| `options.query` | `Function` | Execute client query |
+| `options.save` | `Function` | Execute client save |
+
+*Inherited from*
+
+[Association](association.md).[constructor](association.md#constructor)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:76](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L76)
+
+## Properties
+
+### dispatch
+
+• **dispatch**: `Function`
+
+Dispatch an action on the store.
+
+*Inherited from*
+
+[Association](association.md).[dispatch](association.md#dispatch)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L139)
+
+***
+
+### doctype
+
+• **doctype**: `string`
+
+Doctype of the relationship
+
+**`example`** 'io.cozy.authors'
+
+*Inherited from*
+
+[Association](association.md).[doctype](association.md#doctype)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L102)
+
+***
+
+### get
+
+• **get**: `Function`
+
+Returns the document from the store
+
+*Inherited from*
+
+[Association](association.md).[get](association.md#get)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:110](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L110)
+
+***
+
+### mutate
+
+• **mutate**: `Function`
+
+Performs a mutation on the relationship.
+
+**`function`**
+
+*Inherited from*
+
+[Association](association.md).[mutate](association.md#mutate)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L125)
+
+***
+
+### name
+
+• **name**: `string`
+
+The name of the relationship.
+
+**`example`** 'author'
+
+*Inherited from*
+
+[Association](association.md).[name](association.md#name)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:95](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L95)
+
+***
+
+### query
+
+• **query**: `Function`
+
+Performs a query to retrieve relationship documents.
+
+**`param`**
+
+**`function`**
+
+*Inherited from*
+
+[Association](association.md).[query](association.md#query)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L117)
+
+***
+
+### save
+
+• **save**: `Function`
+
+Saves the relationship in store.
+
+*Inherited from*
+
+[Association](association.md).[save](association.md#save)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:132](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L132)
+
+***
+
+### target
+
+• **target**: `any`
+
+The original document declaring the relationship
+
+*Inherited from*
+
+[Association](association.md).[target](association.md#target)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:89](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L89)
+
+## Accessors
+
+### data
+
+• `get` **data**(): `any`\[]
+
+Returns the document(s) from the store
+
+For document with relationships stored as JSON API spec :
+
+```js
+const book = {
+  title: 'Moby Dick',
+  relationships: {
+    author: {
+      data: {
+        doctype: 'io.cozy.authors',
+        id: 'herman'
+      }
+    }
+  }
+ }
+```
+
+`data` will be
+
+```json
+{
+  "_id": "herman"
+  "_type": "io.cozy.authors",
+  "firstName": "herman",
+  "name": "Melville"
+}
+```
+
+Derived `Association`s need to implement this method.
+
+*Returns*
+
+`any`\[]
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasManyInPlace.js:88](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L88)
+
+***
+
+### raw
+
+• `get` **raw**(): `string`\[]
+
+Raw property
+
+*Returns*
+
+`string`\[]
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasManyInPlace.js:54](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L54)
+
+## Methods
+
+### addById
+
+▸ **addById**(`id`): `void`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `id` | `any` |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasManyInPlace.js:58](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L58)
+
+***
+
+### dehydrate
+
+▸ **dehydrate**(`doc`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasManyInPlace.js:81](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L81)
+
+***
+
+### existsById
+
+▸ **existsById**(`id`): `boolean`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `id` | `any` |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasManyInPlace.js:71](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L71)
+
+***
+
+### getRelationship
+
+▸ **getRelationship**(): `any`
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasManyInPlace.js:76](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L76)
+
+***
+
+### removeById
+
+▸ **removeById**(`id`): `void`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `id` | `any` |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasManyInPlace.js:63](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L63)
+
+***
+
+### query
+
+▸ `Static` **query**(`document`, `client`, `assoc`): [`QueryDefinition`](querydefinition.md) | `CozyClientDocument`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `document` | `CozyClientDocument` | Document to query |
+| `client` | `any` | The CozyClient instance |
+| `assoc` | [`Association`](association.md) | The query params |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md) | `CozyClientDocument`
+
+*Overrides*
+
+[Association](association.md).[query](association.md#query)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasManyInPlace.js:100](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L100)

--- a/docs/api/cozy-client/classes/hasmanytriggers.md
+++ b/docs/api/cozy-client/classes/hasmanytriggers.md
@@ -1,0 +1,719 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / HasManyTriggers
+
+# Class: HasManyTriggers
+
+Association used for konnectors to retrieve all their related triggers.
+
+## Hierarchy
+
+*   [`HasMany`](hasmany.md)
+
+    ↳ **`HasManyTriggers`**
+
+## Constructors
+
+### constructor
+
+• **new HasManyTriggers**(`target`, `name`, `doctype`, `options`)
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `target` | `any` | Original object containing raw data |
+| `name` | `string` | Attribute under which the association is stored |
+| `doctype` | `string` | Doctype of the documents managed by the association |
+| `options` | `Object` | Options passed from the client |
+| `options.dispatch` | `Function` | Store's dispatch, comes from the client |
+| `options.get` | `Function` | Get a document from the store |
+| `options.mutate` | `Function` | Execute client mutate |
+| `options.query` | `Function` | Execute client query |
+| `options.save` | `Function` | Execute client save |
+
+*Inherited from*
+
+[HasMany](hasmany.md).[constructor](hasmany.md#constructor)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:76](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L76)
+
+## Properties
+
+### dispatch
+
+• **dispatch**: `Function`
+
+Dispatch an action on the store.
+
+*Inherited from*
+
+[HasMany](hasmany.md).[dispatch](hasmany.md#dispatch)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L139)
+
+***
+
+### doctype
+
+• **doctype**: `string`
+
+Doctype of the relationship
+
+**`example`** 'io.cozy.authors'
+
+*Inherited from*
+
+[HasMany](hasmany.md).[doctype](hasmany.md#doctype)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L102)
+
+***
+
+### get
+
+• **get**: `Function`
+
+Returns the document from the store
+
+*Inherited from*
+
+[HasMany](hasmany.md).[get](hasmany.md#get)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:110](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L110)
+
+***
+
+### mutate
+
+• **mutate**: `Function`
+
+Performs a mutation on the relationship.
+
+**`function`**
+
+*Inherited from*
+
+[HasMany](hasmany.md).[mutate](hasmany.md#mutate)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L125)
+
+***
+
+### name
+
+• **name**: `string`
+
+The name of the relationship.
+
+**`example`** 'author'
+
+*Inherited from*
+
+[HasMany](hasmany.md).[name](hasmany.md#name)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:95](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L95)
+
+***
+
+### query
+
+• **query**: `Function`
+
+Performs a query to retrieve relationship documents.
+
+**`param`**
+
+**`function`**
+
+*Inherited from*
+
+[HasMany](hasmany.md).[query](hasmany.md#query)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L117)
+
+***
+
+### save
+
+• **save**: `Function`
+
+Saves the relationship in store.
+
+*Inherited from*
+
+[HasMany](hasmany.md).[save](hasmany.md#save)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:132](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L132)
+
+***
+
+### target
+
+• **target**: `any`
+
+The original document declaring the relationship
+
+*Inherited from*
+
+[HasMany](hasmany.md).[target](hasmany.md#target)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:89](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L89)
+
+## Accessors
+
+### count
+
+• `get` **count**(): `number`
+
+Returns the total number of documents in the relationship.
+Does not handle documents absent from the store. If you want
+to do that, you can use .data.length.
+
+*Returns*
+
+`number`
+
+*   Total number of documents in the relationships
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:93](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L93)
+
+***
+
+### data
+
+• `get` **data**(): `any`
+
+Returns store documents
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasManyTriggers.js:12](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyTriggers.js#L12)
+
+***
+
+### hasMore
+
+• `get` **hasMore**(): `any`
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:82](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L82)
+
+***
+
+### raw
+
+• `get` **raw**(): `any`
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:69](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L69)
+
+## Methods
+
+### addById
+
+▸ **addById**(`idsArg`): `any`
+
+Add a referenced document by id. You need to call save()
+in order to synchronize your document with the store.
+
+**`todo`** We shouldn't create the array of relationship manually since
+it'll not be present in the store as well.
+We certainly should use something like `updateRelationship`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `idsArg` | `any` |
+
+*Returns*
+
+`any`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[addById](hasmany.md#addbyid)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:127](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L127)
+
+***
+
+### containsById
+
+▸ **containsById**(`id`): `boolean`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `id` | `any` |
+
+*Returns*
+
+`boolean`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[containsById](hasmany.md#containsbyid)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:108](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L108)
+
+***
+
+### dehydrate
+
+▸ **dehydrate**(`doc`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+
+*Returns*
+
+`any`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[dehydrate](hasmany.md#dehydrate)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:217](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L217)
+
+***
+
+### exists
+
+▸ **exists**(`document`): `boolean`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `document` | `any` |
+
+*Returns*
+
+`boolean`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[exists](hasmany.md#exists)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:104](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L104)
+
+***
+
+### existsById
+
+▸ **existsById**(`id`): `boolean`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `id` | `any` |
+
+*Returns*
+
+`boolean`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[existsById](hasmany.md#existsbyid)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:114](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L114)
+
+***
+
+### fetchMore
+
+▸ **fetchMore**(): `void`
+
+*Returns*
+
+`void`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[fetchMore](hasmany.md#fetchmore)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:100](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L100)
+
+***
+
+### getRelationship
+
+▸ **getRelationship**(): `any`
+
+*Returns*
+
+`any`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[getRelationship](hasmany.md#getrelationship)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:168](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L168)
+
+***
+
+### removeById
+
+▸ **removeById**(`idsArg`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `idsArg` | `any` |
+
+*Returns*
+
+`any`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[removeById](hasmany.md#removebyid)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:148](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L148)
+
+***
+
+### updateMetaCount
+
+▸ **updateMetaCount**(): `void`
+
+*Returns*
+
+`void`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[updateMetaCount](hasmany.md#updatemetacount)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:159](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L159)
+
+***
+
+### updateRelationship
+
+▸ **updateRelationship**(`target`, `updateFn`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `target` | `any` |
+| `updateFn` | `any` |
+
+*Returns*
+
+`any`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[updateRelationship](hasmany.md#updaterelationship)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:189](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L189)
+
+***
+
+### updateRelationshipData
+
+▸ **updateRelationshipData**(`getUpdatedRelationshipData`): (`dispatch`: `any`, `getState`: `any`) => `void`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `getUpdatedRelationshipData` | `any` |
+
+*Returns*
+
+`fn`
+
+▸ (`dispatch`, `getState`): `void`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `dispatch` | `any` |
+| `getState` | `any` |
+
+*Returns*
+
+`void`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[updateRelationshipData](hasmany.md#updaterelationshipdata)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:193](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L193)
+
+***
+
+### updateTargetRelationship
+
+▸ **updateTargetRelationship**(`store`, `updateFn`): `void`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `store` | `any` |
+| `updateFn` | `any` |
+
+*Returns*
+
+`void`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[updateTargetRelationship](hasmany.md#updatetargetrelationship)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:182](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L182)
+
+***
+
+### getHasManyItem
+
+▸ `Static` **getHasManyItem**(`doc`, `relName`, `relItemId`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+| `relName` | `string` |
+| `relItemId` | `string` |
+
+*Returns*
+
+`any`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[getHasManyItem](hasmany.md#gethasmanyitem)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:250](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L250)
+
+***
+
+### getHasManyItems
+
+▸ `Static` **getHasManyItems**(`doc`, `relName`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+| `relName` | `any` |
+
+*Returns*
+
+`any`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[getHasManyItems](hasmany.md#gethasmanyitems)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:259](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L259)
+
+***
+
+### query
+
+▸ `Static` **query**(`doc`, `client`): [`QueryDefinition`](querydefinition.md)
+
+In this association the query is special, we need to fetch all the triggers
+having for the 'konnector' worker, and then filter them based on their
+`message.konnector` attribute
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+| `client` | `any` |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md)
+
+*Overrides*
+
+[HasMany](hasmany.md).[query](hasmany.md#query)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasManyTriggers.js:21](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyTriggers.js#L21)
+
+***
+
+### removeHasManyItem
+
+▸ `Static` **removeHasManyItem**(`doc`, `relName`, `relItemId`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+| `relName` | `string` |
+| `relItemId` | `string` |
+
+*Returns*
+
+`any`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[removeHasManyItem](hasmany.md#removehasmanyitem)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:297](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L297)
+
+***
+
+### setHasManyItem
+
+▸ `Static` **setHasManyItem**(`doc`, `relName`, `relItemId`, `relItemAttrs`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+| `relName` | `string` |
+| `relItemId` | `string` |
+| `relItemAttrs` | `any` |
+
+*Returns*
+
+`any`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[setHasManyItem](hasmany.md#sethasmanyitem)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:271](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L271)
+
+***
+
+### updateHasManyItem
+
+▸ `Static` **updateHasManyItem**(`doc`, `relName`, `relItemId`, `updater`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+| `relName` | `string` |
+| `relItemId` | `string` |
+| `updater` | `Function` |
+
+*Returns*
+
+`any`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[updateHasManyItem](hasmany.md#updatehasmanyitem)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:321](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L321)
+
+***
+
+### updateRelationship
+
+▸ `Static` **updateRelationship**(`doc`, `relName`, `updateFn`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+| `relName` | `any` |
+| `updateFn` | `any` |
+
+*Returns*
+
+`any`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[updateRelationship](hasmany.md#updaterelationship)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:332](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L332)

--- a/docs/api/cozy-client/classes/hasone.md
+++ b/docs/api/cozy-client/classes/hasone.md
@@ -1,0 +1,343 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / HasOne
+
+# Class: HasOne
+
+## Hierarchy
+
+*   [`Association`](association.md)
+
+    ↳ **`HasOne`**
+
+## Constructors
+
+### constructor
+
+• **new HasOne**(`target`, `name`, `doctype`, `options`)
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `target` | `any` | Original object containing raw data |
+| `name` | `string` | Attribute under which the association is stored |
+| `doctype` | `string` | Doctype of the documents managed by the association |
+| `options` | `Object` | Options passed from the client |
+| `options.dispatch` | `Function` | Store's dispatch, comes from the client |
+| `options.get` | `Function` | Get a document from the store |
+| `options.mutate` | `Function` | Execute client mutate |
+| `options.query` | `Function` | Execute client query |
+| `options.save` | `Function` | Execute client save |
+
+*Inherited from*
+
+[Association](association.md).[constructor](association.md#constructor)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:76](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L76)
+
+## Properties
+
+### dispatch
+
+• **dispatch**: `Function`
+
+Dispatch an action on the store.
+
+*Inherited from*
+
+[Association](association.md).[dispatch](association.md#dispatch)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L139)
+
+***
+
+### doctype
+
+• **doctype**: `string`
+
+Doctype of the relationship
+
+**`example`** 'io.cozy.authors'
+
+*Inherited from*
+
+[Association](association.md).[doctype](association.md#doctype)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L102)
+
+***
+
+### get
+
+• **get**: `Function`
+
+Returns the document from the store
+
+*Inherited from*
+
+[Association](association.md).[get](association.md#get)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:110](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L110)
+
+***
+
+### mutate
+
+• **mutate**: `Function`
+
+Performs a mutation on the relationship.
+
+**`function`**
+
+*Inherited from*
+
+[Association](association.md).[mutate](association.md#mutate)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L125)
+
+***
+
+### name
+
+• **name**: `string`
+
+The name of the relationship.
+
+**`example`** 'author'
+
+*Inherited from*
+
+[Association](association.md).[name](association.md#name)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:95](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L95)
+
+***
+
+### query
+
+• **query**: `Function`
+
+Performs a query to retrieve relationship documents.
+
+**`param`**
+
+**`function`**
+
+*Inherited from*
+
+[Association](association.md).[query](association.md#query)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L117)
+
+***
+
+### save
+
+• **save**: `Function`
+
+Saves the relationship in store.
+
+*Inherited from*
+
+[Association](association.md).[save](association.md#save)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:132](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L132)
+
+***
+
+### target
+
+• **target**: `any`
+
+The original document declaring the relationship
+
+*Inherited from*
+
+[Association](association.md).[target](association.md#target)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:89](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L89)
+
+## Accessors
+
+### data
+
+• `get` **data**(): `any`
+
+Returns the document(s) from the store
+
+For document with relationships stored as JSON API spec :
+
+```js
+const book = {
+  title: 'Moby Dick',
+  relationships: {
+    author: {
+      data: {
+        doctype: 'io.cozy.authors',
+        id: 'herman'
+      }
+    }
+  }
+ }
+```
+
+`data` will be
+
+```json
+{
+  "_id": "herman"
+  "_type": "io.cozy.authors",
+  "firstName": "herman",
+  "name": "Melville"
+}
+```
+
+Derived `Association`s need to implement this method.
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasOne.js:12](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L12)
+
+***
+
+### raw
+
+• `get` **raw**(): `any`
+
+Returns the raw relationship data as stored in the original document
+
+For a document with relationships stored as JSON API spec:
+
+```js
+const book = {
+  title: 'Moby Dick',
+  relationships: {
+    author: {
+      data: {
+        doctype: 'io.cozy.authors',
+        id: 'herman'
+      }
+    }
+  }
+ }
+```
+
+Raw value will be
+
+```json
+{
+  "doctype": "io.cozy.authors",
+  "id": "herman"
+}
+```
+
+Derived `Association`s need to implement this method.
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasOne.js:8](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L8)
+
+## Methods
+
+### dehydrate
+
+▸ **dehydrate**(`doc`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasOne.js:58](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L58)
+
+***
+
+### set
+
+▸ **set**(`doc`): `void`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasOne.js:35](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L35)
+
+***
+
+### unset
+
+▸ **unset**(): `void`
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasOne.js:54](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L54)
+
+***
+
+### query
+
+▸ `Static` **query**(`document`, `client`, `assoc`): [`QueryDefinition`](querydefinition.md) | `CozyClientDocument`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `document` | `CozyClientDocument` | Document to query |
+| `client` | `any` | The CozyClient instance |
+| `assoc` | [`Association`](association.md) | The query params |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md) | `CozyClientDocument`
+
+*Overrides*
+
+[Association](association.md).[query](association.md#query)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasOne.js:27](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L27)

--- a/docs/api/cozy-client/classes/hasoneinplace.md
+++ b/docs/api/cozy-client/classes/hasoneinplace.md
@@ -1,0 +1,312 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / HasOneInPlace
+
+# Class: HasOneInPlace
+
+Here the id of the document is directly set in the attribute
+of the document, not in the relationships attribute
+
+## Hierarchy
+
+*   [`Association`](association.md)
+
+    ↳ **`HasOneInPlace`**
+
+## Constructors
+
+### constructor
+
+• **new HasOneInPlace**(`target`, `name`, `doctype`, `options`)
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `target` | `any` | Original object containing raw data |
+| `name` | `string` | Attribute under which the association is stored |
+| `doctype` | `string` | Doctype of the documents managed by the association |
+| `options` | `Object` | Options passed from the client |
+| `options.dispatch` | `Function` | Store's dispatch, comes from the client |
+| `options.get` | `Function` | Get a document from the store |
+| `options.mutate` | `Function` | Execute client mutate |
+| `options.query` | `Function` | Execute client query |
+| `options.save` | `Function` | Execute client save |
+
+*Inherited from*
+
+[Association](association.md).[constructor](association.md#constructor)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:76](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L76)
+
+## Properties
+
+### dispatch
+
+• **dispatch**: `Function`
+
+Dispatch an action on the store.
+
+*Inherited from*
+
+[Association](association.md).[dispatch](association.md#dispatch)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L139)
+
+***
+
+### doctype
+
+• **doctype**: `string`
+
+Doctype of the relationship
+
+**`example`** 'io.cozy.authors'
+
+*Inherited from*
+
+[Association](association.md).[doctype](association.md#doctype)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L102)
+
+***
+
+### get
+
+• **get**: `Function`
+
+Returns the document from the store
+
+*Inherited from*
+
+[Association](association.md).[get](association.md#get)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:110](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L110)
+
+***
+
+### mutate
+
+• **mutate**: `Function`
+
+Performs a mutation on the relationship.
+
+**`function`**
+
+*Inherited from*
+
+[Association](association.md).[mutate](association.md#mutate)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L125)
+
+***
+
+### name
+
+• **name**: `string`
+
+The name of the relationship.
+
+**`example`** 'author'
+
+*Inherited from*
+
+[Association](association.md).[name](association.md#name)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:95](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L95)
+
+***
+
+### query
+
+• **query**: `Function`
+
+Performs a query to retrieve relationship documents.
+
+**`param`**
+
+**`function`**
+
+*Inherited from*
+
+[Association](association.md).[query](association.md#query)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L117)
+
+***
+
+### save
+
+• **save**: `Function`
+
+Saves the relationship in store.
+
+*Inherited from*
+
+[Association](association.md).[save](association.md#save)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:132](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L132)
+
+***
+
+### target
+
+• **target**: `any`
+
+The original document declaring the relationship
+
+*Inherited from*
+
+[Association](association.md).[target](association.md#target)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/Association.js:89](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L89)
+
+## Accessors
+
+### data
+
+• `get` **data**(): `any`
+
+Returns the document(s) from the store
+
+For document with relationships stored as JSON API spec :
+
+```js
+const book = {
+  title: 'Moby Dick',
+  relationships: {
+    author: {
+      data: {
+        doctype: 'io.cozy.authors',
+        id: 'herman'
+      }
+    }
+  }
+ }
+```
+
+`data` will be
+
+```json
+{
+  "_id": "herman"
+  "_type": "io.cozy.authors",
+  "firstName": "herman",
+  "name": "Melville"
+}
+```
+
+Derived `Association`s need to implement this method.
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasOneInPlace.js:14](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOneInPlace.js#L14)
+
+***
+
+### raw
+
+• `get` **raw**(): `any`
+
+Returns the raw relationship data as stored in the original document
+
+For a document with relationships stored as JSON API spec:
+
+```js
+const book = {
+  title: 'Moby Dick',
+  relationships: {
+    author: {
+      data: {
+        doctype: 'io.cozy.authors',
+        id: 'herman'
+      }
+    }
+  }
+ }
+```
+
+Raw value will be
+
+```json
+{
+  "doctype": "io.cozy.authors",
+  "id": "herman"
+}
+```
+
+Derived `Association`s need to implement this method.
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasOneInPlace.js:10](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOneInPlace.js#L10)
+
+## Methods
+
+### dehydrate
+
+▸ **dehydrate**(`doc`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasOneInPlace.js:33](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOneInPlace.js#L33)
+
+***
+
+### query
+
+▸ `Static` **query**(`document`, `client`, `assoc`): [`QueryDefinition`](querydefinition.md) | `CozyClientDocument`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `document` | `CozyClientDocument` | Document to query |
+| `client` | `any` | The CozyClient instance |
+| `assoc` | [`Association`](association.md) | The query params |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md) | `CozyClientDocument`
+
+*Overrides*
+
+[Association](association.md).[query](association.md#query)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasOneInPlace.js:25](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOneInPlace.js#L25)

--- a/docs/api/cozy-client/classes/models.document.qualification.md
+++ b/docs/api/cozy-client/classes/models.document.qualification.md
@@ -1,0 +1,249 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](../modules/models.md) / [document](../modules/models.document.md) / Qualification
+
+# Class: Qualification
+
+[models](../modules/models.md).[document](../modules/models.document.md).Qualification
+
+This class is used to create document Qualification, i.e. metadata
+attributes used to describe the document.
+The qualifications model is stored in the assets, associating
+labels to attributes, namely: purpose, sourceCategory, sourceSubCategory
+and subjects.
+A qualification can be customized accordingly to rules detailed in
+the checkValueAttributes method.
+
+## Constructors
+
+### constructor
+
+• **new Qualification**(`label`, `attributes?`)
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `label` | `string` | The qualification label |
+| `attributes` | [`QualificationAttributes`](../interfaces/models.document.qualificationattributes.md) | Qualification's attributes |
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:22](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L22)
+
+## Properties
+
+### label
+
+• **label**: `string`
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:31](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L31)
+
+***
+
+### purpose
+
+• **purpose**: `string`
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:35](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L35)
+
+***
+
+### sourceCategory
+
+• **sourceCategory**: `string`
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:39](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L39)
+
+***
+
+### sourceSubCategory
+
+• **sourceSubCategory**: `string`
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:41](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L41)
+
+***
+
+### subjects
+
+• **subjects**: `string`\[]
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:43](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L43)
+
+## Methods
+
+### checkAttributes
+
+▸ **checkAttributes**(`attributes`): `void`
+
+Check the given qualification attributes respects the following rules:
+
+*   For the given label, if a purpose, sourceCategory or sourceSubCategory
+    attribute is defined in the model, it must match the given qualification.
+*   If not defined in the model for the label, a custom purpose, sourceCategory or
+    sourceSubCategory value can be defined, if it exist in their respective
+    known values list.
+*   For the given label, if subjects are defined in the model, they must be included
+    in the given qualification.
+*   If extra subjects are set, they should exist in the known values.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `attributes` | `any` | The qualification attributes to check |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:63](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L63)
+
+***
+
+### setPurpose
+
+▸ **setPurpose**(`purpose`): [`Qualification`](models.document.qualification.md)
+
+Set purpose to the qualification.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `purpose` | `any`\[] | The purpose to set. |
+
+*Returns*
+
+[`Qualification`](models.document.qualification.md)
+
+The Qualification object.
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:146](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L146)
+
+***
+
+### setSourceCategory
+
+▸ **setSourceCategory**(`sourceCategory`): [`Qualification`](models.document.qualification.md)
+
+Set sourceCategory to the qualification.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `sourceCategory` | `any`\[] | The sourceCategory to set. |
+
+*Returns*
+
+[`Qualification`](models.document.qualification.md)
+
+The Qualification object.
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:156](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L156)
+
+***
+
+### setSourceSubCategory
+
+▸ **setSourceSubCategory**(`sourceSubCategory`): [`Qualification`](models.document.qualification.md)
+
+Set sourceSubCategory to the qualification.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `sourceSubCategory` | `any`\[] | The sourceSubCategory to set. |
+
+*Returns*
+
+[`Qualification`](models.document.qualification.md)
+
+The Qualification object.
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:169](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L169)
+
+***
+
+### setSubjects
+
+▸ **setSubjects**(`subjects`): [`Qualification`](models.document.qualification.md)
+
+Set subjects to the qualification.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `subjects` | `any`\[] | The subjects to set. |
+
+*Returns*
+
+[`Qualification`](models.document.qualification.md)
+
+The Qualification object.
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:182](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L182)
+
+***
+
+### toQualification
+
+▸ **toQualification**(): `any`
+
+Returns the qualification attributes
+
+*Returns*
+
+`any`
+
+The qualification attributes
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:194](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L194)
+
+***
+
+### getByLabel
+
+▸ `Static` **getByLabel**(`label`): [`Qualification`](models.document.qualification.md)
+
+Returns the qualification associated to a label.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `label` | `string` | The label to qualify |
+
+*Returns*
+
+[`Qualification`](models.document.qualification.md)
+
+*   The qualification
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:203](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L203)

--- a/docs/api/cozy-client/classes/query.md
+++ b/docs/api/cozy-client/classes/query.md
@@ -1,0 +1,237 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / Query
+
+# Class: Query
+
+## Hierarchy
+
+*   `Component`
+
+    ↳ **`Query`**
+
+## Constructors
+
+### constructor
+
+• **new Query**(`props`, `context`)
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `any` |
+| `context` | `any` |
+
+*Overrides*
+
+Component.constructor
+
+*Defined in*
+
+[packages/cozy-client/src/Query.jsx:91](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/Query.jsx#L91)
+
+## Properties
+
+### childrenArgs
+
+• **childrenArgs**: `any`\[]
+
+*Defined in*
+
+[packages/cozy-client/src/Query.jsx:163](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/Query.jsx#L163)
+
+***
+
+### client
+
+• **client**: [`CozyClient`](cozyclient.md)
+
+Current client
+
+*Defined in*
+
+[packages/cozy-client/src/Query.jsx:99](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/Query.jsx#L99)
+
+***
+
+### observableQuery
+
+• **observableQuery**: `default`
+
+Observable query to connect store to query
+
+*Defined in*
+
+[packages/cozy-client/src/Query.jsx:106](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/Query.jsx#L106)
+
+***
+
+### queryUnsubscribe
+
+• **queryUnsubscribe**: `Function`
+
+Callback to unsubscribe from observable query
+
+*Defined in*
+
+[packages/cozy-client/src/Query.jsx:112](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/Query.jsx#L112)
+
+***
+
+### contextTypes
+
+▪ `Static` **contextTypes**: `Object`
+
+*Type declaration*
+
+| Name | Type |
+| :------ | :------ |
+| `client` | `Requireable`<`object`> |
+| `store` | `Requireable`<`object`> |
+
+***
+
+### defaultProps
+
+▪ `Static` **defaultProps**: `Object`
+
+*Type declaration*
+
+| Name | Type |
+| :------ | :------ |
+| `enabled` | `boolean` |
+
+***
+
+### propTypes
+
+▪ `Static` **propTypes**: `Object`
+
+*Type declaration*
+
+| Name | Type |
+| :------ | :------ |
+| `as` | `Requireable`<`string`> |
+| `children` | `Validator`<`fn`> |
+| `enabled` | `Requireable`<`boolean`> |
+| `fetchPolicy` | `Requireable`<`fn`> |
+| `query` | `Validator`<`object`> |
+
+## Methods
+
+### componentDidMount
+
+▸ **componentDidMount**(): `void`
+
+*Returns*
+
+`void`
+
+*Overrides*
+
+Component.componentDidMount
+
+*Defined in*
+
+[packages/cozy-client/src/Query.jsx:124](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/Query.jsx#L124)
+
+***
+
+### componentDidUpdate
+
+▸ **componentDidUpdate**(`prevProps`): `void`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `prevProps` | `any` |
+
+*Returns*
+
+`void`
+
+*Overrides*
+
+Component.componentDidUpdate
+
+*Defined in*
+
+[packages/cozy-client/src/Query.jsx:146](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/Query.jsx#L146)
+
+***
+
+### componentWillUnmount
+
+▸ **componentWillUnmount**(): `void`
+
+*Returns*
+
+`void`
+
+*Overrides*
+
+Component.componentWillUnmount
+
+*Defined in*
+
+[packages/cozy-client/src/Query.jsx:152](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/Query.jsx#L152)
+
+***
+
+### executeQueryRespectingFetchPolicy
+
+▸ **executeQueryRespectingFetchPolicy**(): `void`
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/Query.jsx:131](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/Query.jsx#L131)
+
+***
+
+### onQueryChange
+
+▸ **onQueryChange**(): `void`
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/Query.jsx:158](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/Query.jsx#L158)
+
+***
+
+### recomputeChildrenArgs
+
+▸ **recomputeChildrenArgs**(): `void`
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/Query.jsx:163](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/Query.jsx#L163)
+
+***
+
+### render
+
+▸ **render**(): `any`
+
+*Returns*
+
+`any`
+
+*Overrides*
+
+Component.render
+
+*Defined in*
+
+[packages/cozy-client/src/Query.jsx:167](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/Query.jsx#L167)

--- a/docs/api/cozy-client/classes/querydefinition.md
+++ b/docs/api/cozy-client/classes/querydefinition.md
@@ -1,0 +1,601 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / QueryDefinition
+
+# Class: QueryDefinition
+
+Chainable API to create query definitions to retrieve documents
+from a Cozy. `QueryDefinition`s are sent to links.
+
+## Constructors
+
+### constructor
+
+• **new QueryDefinition**(`options?`)
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options` | `Object` | Initial options for the query definition |
+| `options.bookmark` | `string` | - |
+| `options.cursor` | `Cursor` | - |
+| `options.doctype` | `string` | - |
+| `options.fields` | `any`\[] | - |
+| `options.id` | `string` | - |
+| `options.ids` | `any`\[] | - |
+| `options.includes` | `string`\[] | - |
+| `options.indexedFields` | `any`\[] | - |
+| `options.limit` | `number` | - |
+| `options.partialFilter` | `any` | - |
+| `options.referenced` | `string` | - |
+| `options.selector` | `any` | - |
+| `options.skip` | `number` | - |
+| `options.sort` | `any`\[] | - |
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:27](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L27)
+
+## Properties
+
+### bookmark
+
+• **bookmark**: `string`
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:60](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L60)
+
+***
+
+### cursor
+
+• **cursor**: `Cursor`
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:59](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L59)
+
+***
+
+### doctype
+
+• **doctype**: `string`
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:47](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L47)
+
+***
+
+### fields
+
+• **fields**: `any`\[]
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:51](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L51)
+
+***
+
+### id
+
+• **id**: `string`
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:48](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L48)
+
+***
+
+### ids
+
+• **ids**: `any`\[]
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:49](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L49)
+
+***
+
+### includes
+
+• **includes**: `string`\[]
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:55](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L55)
+
+***
+
+### indexedFields
+
+• **indexedFields**: `any`\[]
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:52](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L52)
+
+***
+
+### limit
+
+• **limit**: `number`
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:57](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L57)
+
+***
+
+### partialFilter
+
+• **partialFilter**: `any`
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:53](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L53)
+
+***
+
+### referenced
+
+• **referenced**: `string`
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:56](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L56)
+
+***
+
+### selector
+
+• **selector**: `any`
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:50](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L50)
+
+***
+
+### skip
+
+• **skip**: `number`
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:58](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L58)
+
+***
+
+### sort
+
+• **sort**: `any`\[]
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:54](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L54)
+
+## Methods
+
+### UNSAFE_noLimit
+
+▸ **UNSAFE_noLimit**(): [`QueryDefinition`](querydefinition.md)
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md)
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:235](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L235)
+
+***
+
+### checkSelector
+
+▸ **checkSelector**(`selector`): `void`
+
+Checks the selector predicates.
+
+It is useful to warn the developer when a partial index might be used.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `selector` | `any` | The selector definition |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:108](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L108)
+
+***
+
+### checkSortOrder
+
+▸ **checkSortOrder**(`__namedParameters`): `void`
+
+Checks if the sort order matches the index' fields order.
+
+When sorting with CouchDB, it is required to:
+
+*   use indexed fields
+*   keep the same order than the indexed fields.
+
+See https://docs.cozy.io/en/tutorials/data/queries/#sort-data-with-mango
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `__namedParameters` | `PartialQueryDefinition` |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:75](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L75)
+
+***
+
+### getById
+
+▸ **getById**(`id`): [`QueryDefinition`](querydefinition.md)
+
+Query a single document on its id.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` | The document id. |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md)
+
+The QueryDefinition object.
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:129](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L129)
+
+***
+
+### getByIds
+
+▸ **getByIds**(`ids`): [`QueryDefinition`](querydefinition.md)
+
+Query several documents on their ids.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `ids` | `any`\[] | The documents ids. |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md)
+
+The QueryDefinition object.
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:142](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L142)
+
+***
+
+### include
+
+▸ **include**(`includes`): [`QueryDefinition`](querydefinition.md)
+
+Includes documents having a relationships with the ones queried.
+For example, query albums including the photos.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `includes` | `any`\[] | The documents to include. |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md)
+
+The QueryDefinition object.
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:218](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L218)
+
+***
+
+### indexFields
+
+▸ **indexFields**(`indexedFields`): [`QueryDefinition`](querydefinition.md)
+
+Specify which fields should be indexed. This prevent the automatic indexing of the mango fields.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `indexedFields` | `any`\[] | The fields to index. |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md)
+
+The QueryDefinition object.
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:175](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L175)
+
+***
+
+### limitBy
+
+▸ **limitBy**(`limit`): [`QueryDefinition`](querydefinition.md)
+
+Maximum number of documents returned, useful for pagination. Default is 100.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `limit` | `number` | The document's limit. |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md)
+
+The QueryDefinition object.
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:231](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L231)
+
+***
+
+### offset
+
+▸ **offset**(`skip`): [`QueryDefinition`](querydefinition.md)
+
+Skip the first ‘n’ documents, where ‘n’ is the value specified.
+
+Beware, this [performs badly](http://docs.couchdb.org/en/stable/ddocs/views/pagination.html#paging-alternate-method) on view's index.
+Prefer cursor-based pagination in such situation.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `skip` | `number` | The number of documents to skip. |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md)
+
+The QueryDefinition object.
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:248](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L248)
+
+***
+
+### offsetBookmark
+
+▸ **offsetBookmark**(`bookmark`): [`QueryDefinition`](querydefinition.md)
+
+Use [bookmark](https://docs.couchdb.org/en/2.2.0/api/database/find.html#pagination) pagination.
+Note this only applies for mango-queries (not views) and is way more efficient than skip pagination.
+The bookmark is a string returned by the \_find response and can be seen as a pointer in
+the index for the next query.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `bookmark` | `string` | The bookmark to continue a previous paginated query. |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md)
+
+The QueryDefinition object.
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:286](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L286)
+
+***
+
+### offsetCursor
+
+▸ **offsetCursor**(`cursor`): [`QueryDefinition`](querydefinition.md)
+
+Use [cursor-based](https://docs.cozy.io/en/cozy-stack/jsonapi/#pagination) pagination.
+*Warning*: this is only useful for views.
+The cursor is a \[startkey, startkey_docid] array, where startkey is the view's key,
+e.g. \["io.cozy.photos.albums", "album-id"] and startkey_docid is the id of
+the starting document of the query, e.g. "file-id".
+Use the last docid of each query as startkey_docid to paginate or leave blank for the first query.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `cursor` | `Cursor` | The cursor for pagination. |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md)
+
+The QueryDefinition object.
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:268](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L268)
+
+***
+
+### partialIndex
+
+▸ **partialIndex**(`partialFilter`): [`QueryDefinition`](querydefinition.md)
+
+Specify a [partial index](https://docs.couchdb.org/en/stable/api/database/find.html#find-partial-indexes).
+The filter must follow the same syntax than the selector.
+
+A partial index includes a filter, used to select documents before the indexing.
+You can find more information about partial indexes [here](https://docs.cozy.io/en/tutorials/data/advanced/#partial-indexes)
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `partialFilter` | `any` | The filter definition. |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md)
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:189](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L189)
+
+***
+
+### referencedBy
+
+▸ **referencedBy**(`document`): [`QueryDefinition`](querydefinition.md)
+
+Use the [file reference system](https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/)
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `document` | `any` | The reference document |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md)
+
+The QueryDefinition object.
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:301](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L301)
+
+***
+
+### select
+
+▸ **select**(`fields`): [`QueryDefinition`](querydefinition.md)
+
+Specify which fields of each object should be returned. If it is omitted, the entire object is returned.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `fields` | `any`\[] | The fields to return. |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md)
+
+The QueryDefinition object.
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:165](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L165)
+
+***
+
+### sortBy
+
+▸ **sortBy**(`sort`): [`QueryDefinition`](querydefinition.md)
+
+Specify how to sort documents, following the [sort syntax](http://docs.couchdb.org/en/latest/api/database/find.html#find-sort)
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `sort` | `any`\[] | The list of field name and direction pairs. |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md)
+
+The QueryDefinition object.
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:199](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L199)
+
+***
+
+### toDefinition
+
+▸ **toDefinition**(): `Object`
+
+*Returns*
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `bookmark` | `string` |
+| `cursor` | `Cursor` |
+| `doctype` | `string` |
+| `fields` | `any`\[] |
+| `id` | `string` |
+| `ids` | `any`\[] |
+| `includes` | `string`\[] |
+| `indexedFields` | `any`\[] |
+| `limit` | `number` |
+| `partialFilter` | `any` |
+| `referenced` | `string` |
+| `selector` | `any` |
+| `skip` | `number` |
+| `sort` | `any`\[] |
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:305](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L305)
+
+***
+
+### where
+
+▸ **where**(`selector`): [`QueryDefinition`](querydefinition.md)
+
+Query documents with a [mango selector](http://docs.couchdb.org/en/latest/api/database/find.html#find-selectors).
+Each field passed in the selector will be indexed, except if the indexField option is used.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `selector` | `any` | The Mango selector. |
+
+*Returns*
+
+[`QueryDefinition`](querydefinition.md)
+
+The QueryDefinition object.
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:153](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L153)

--- a/docs/api/cozy-client/classes/registry.md
+++ b/docs/api/cozy-client/classes/registry.md
@@ -1,0 +1,145 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / Registry
+
+# Class: Registry
+
+**`property`** {string} slug
+
+**`property`** {object} terms
+
+**`property`** {boolean} installed
+
+## Constructors
+
+### constructor
+
+• **new Registry**(`options`)
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `options` | `any` |
+
+*Defined in*
+
+[packages/cozy-client/src/registry.js:35](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L35)
+
+## Properties
+
+### client
+
+• **client**: `any`
+
+*Defined in*
+
+[packages/cozy-client/src/registry.js:39](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L39)
+
+## Methods
+
+### fetchApp
+
+▸ **fetchApp**(`slug`): `RegistryApp`
+
+Fetch the status of a single app on the registry
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `slug` | `string` | The slug of the app to fetch |
+
+*Returns*
+
+`RegistryApp`
+
+*Defined in*
+
+[packages/cozy-client/src/registry.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L125)
+
+***
+
+### fetchApps
+
+▸ **fetchApps**(`params`): `Promise`<`RegistryApp`\[]>
+
+Fetch at most 200 apps from the channel
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `params` | `Object` | Fetching parameters |
+| `params.channel` | `string` | "dev"/"beta"/"stable" |
+| `params.limit` | `string` | maximum number of fetched apps - defaults to 200 |
+| `params.type` | `string` | "webapp" or "konnector" |
+
+*Returns*
+
+`Promise`<`RegistryApp`\[]>
+
+*Defined in*
+
+[packages/cozy-client/src/registry.js:89](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L89)
+
+***
+
+### fetchAppsInMaintenance
+
+▸ **fetchAppsInMaintenance**(): `RegistryApp`\[]
+
+Fetch the list of apps that are in maintenance mode
+
+*Returns*
+
+`RegistryApp`\[]
+
+*Defined in*
+
+[packages/cozy-client/src/registry.js:114](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L114)
+
+***
+
+### installApp
+
+▸ **installApp**(`app`, `source`): `Promise`<`any`>
+
+Installs or updates an app from a source.
+
+Accepts the terms if the app has them.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `app` | `RegistryApp` | App to be installed |
+| `source` | `string` | String (ex: registry://drive/stable) |
+
+*Returns*
+
+`Promise`<`any`>
+
+*Defined in*
+
+[packages/cozy-client/src/registry.js:52](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L52)
+
+***
+
+### uninstallApp
+
+▸ **uninstallApp**(`app`): `Promise`<`any`>
+
+Uninstalls an app.
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `app` | `any` |
+
+*Returns*
+
+`Promise`<`any`>
+
+*Defined in*
+
+[packages/cozy-client/src/registry.js:73](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L73)

--- a/docs/api/cozy-client/classes/stacklink.md
+++ b/docs/api/cozy-client/classes/stacklink.md
@@ -1,0 +1,143 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / StackLink
+
+# Class: StackLink
+
+## Hierarchy
+
+*   [`CozyLink`](cozylink.md)
+
+    ↳ **`StackLink`**
+
+## Constructors
+
+### constructor
+
+• **new StackLink**(`__namedParameters?`)
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `__namedParameters` | `Object` |
+| `__namedParameters.client` | `any` |
+| `__namedParameters.stackClient` | `any` |
+
+*Overrides*
+
+[CozyLink](cozylink.md).[constructor](cozylink.md#constructor)
+
+*Defined in*
+
+[packages/cozy-client/src/StackLink.js:7](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L7)
+
+## Properties
+
+### stackClient
+
+• **stackClient**: `any`
+
+*Defined in*
+
+[packages/cozy-client/src/StackLink.js:19](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L19)
+
+## Methods
+
+### executeMutation
+
+▸ **executeMutation**(`mutation`, `result`, `forward`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `mutation` | `any` |
+| `result` | `any` |
+| `forward` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/StackLink.js:59](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L59)
+
+***
+
+### executeQuery
+
+▸ **executeQuery**(`query`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `query` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/StackLink.js:38](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L38)
+
+***
+
+### registerClient
+
+▸ **registerClient**(`client`): `void`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `client` | `any` |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/StackLink.js:23](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L23)
+
+***
+
+### request
+
+▸ **request**(`operation`, `result`, `forward`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `operation` | `any` |
+| `result` | `any` |
+| `forward` | `any` |
+
+*Returns*
+
+`any`
+
+*Overrides*
+
+[CozyLink](cozylink.md).[request](cozylink.md#request)
+
+*Defined in*
+
+[packages/cozy-client/src/StackLink.js:31](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L31)
+
+***
+
+### reset
+
+▸ **reset**(): `void`
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/StackLink.js:27](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L27)

--- a/docs/api/cozy-client/interfaces/models.document.qualificationattributes.md
+++ b/docs/api/cozy-client/interfaces/models.document.qualificationattributes.md
@@ -1,0 +1,65 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](../modules/models.md) / [document](../modules/models.document.md) / QualificationAttributes
+
+# Interface: QualificationAttributes<>
+
+[models](../modules/models.md).[document](../modules/models.document.md).QualificationAttributes
+
+## Properties
+
+### label
+
+• **label**: `string`
+
+The qualification label.
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:6](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L6)
+
+***
+
+### purpose
+
+• **purpose**: `string`
+
+The document purpose.
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:7](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L7)
+
+***
+
+### sourceCategory
+
+• **sourceCategory**: `string`
+
+The activity field of the document source.
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:8](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L8)
+
+***
+
+### sourceSubCategory
+
+• **sourceSubCategory**: `string`
+
+The sub-activity field of the document source.
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:9](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L9)
+
+***
+
+### subjects
+
+• **subjects**: `string`\[]
+
+On what is about the document.
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:10](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L10)

--- a/docs/api/cozy-client/interfaces/models.instance.settingsinfo.md
+++ b/docs/api/cozy-client/interfaces/models.instance.settingsinfo.md
@@ -1,0 +1,41 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](../modules/models.md) / [instance](../modules/models.instance.md) / SettingsInfo
+
+# Interface: SettingsInfo<>
+
+[models](../modules/models.md).[instance](../modules/models.instance.md).SettingsInfo
+
+## Properties
+
+### context
+
+• **context**: `any`
+
+Object returned by /settings/context
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:13](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L13)
+
+***
+
+### diskUsage
+
+• **diskUsage**: `any`
+
+Object returned by /settings/disk-usage
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:15](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L15)
+
+***
+
+### instance
+
+• **instance**: `any`
+
+Object returned by /settings/instance
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:14](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L14)

--- a/docs/api/cozy-client/interfaces/models.permission.document.md
+++ b/docs/api/cozy-client/interfaces/models.permission.document.md
@@ -1,0 +1,47 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](../modules/models.md) / [permission](../modules/models.permission.md) / Document
+
+# Interface: Document<>
+
+[models](../modules/models.md).[permission](../modules/models.permission.md).Document
+
+Couchdb document like an io.cozy.files
+
+## Properties
+
+### \_id
+
+• **\_id**: `string`
+
+*Defined in*
+
+[packages/cozy-client/src/models/permission.js:9](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L9)
+
+***
+
+### \_type
+
+• **\_type**: `string`
+
+*Defined in*
+
+[packages/cozy-client/src/models/permission.js:11](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L11)
+
+***
+
+### id
+
+• **id**: `string`
+
+*Defined in*
+
+[packages/cozy-client/src/models/permission.js:10](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L10)
+
+***
+
+### type
+
+• **type**: `string`
+
+*Defined in*
+
+[packages/cozy-client/src/models/permission.js:12](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L12)

--- a/docs/api/cozy-client/interfaces/models.permission.permission.md
+++ b/docs/api/cozy-client/interfaces/models.permission.permission.md
@@ -1,0 +1,29 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](../modules/models.md) / [permission](../modules/models.permission.md) / Permission
+
+# Interface: Permission<>
+
+[models](../modules/models.md).[permission](../modules/models.permission.md).Permission
+
+## Properties
+
+### data
+
+• **data**: `any`
+
+Permission document
+
+*Defined in*
+
+[packages/cozy-client/src/models/permission.js:160](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L160)
+
+***
+
+### included
+
+• **included**: `any`\[]
+
+Member information from the sharing
+
+*Defined in*
+
+[packages/cozy-client/src/models/permission.js:161](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L161)

--- a/docs/api/cozy-client/interfaces/models.permission.permissionitem.md
+++ b/docs/api/cozy-client/interfaces/models.permission.permissionitem.md
@@ -1,0 +1,51 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](../modules/models.md) / [permission](../modules/models.permission.md) / PermissionItem
+
+# Interface: PermissionItem<>
+
+[models](../modules/models.md).[permission](../modules/models.permission.md).PermissionItem
+
+## Properties
+
+### selector
+
+• **selector**: `string`
+
+defaults to `id`
+
+*Defined in*
+
+[packages/cozy-client/src/models/permission.js:22](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L22)
+
+***
+
+### type
+
+• **type**: `string`
+
+a couch db database like 'io.cozy.files'
+
+*Defined in*
+
+[packages/cozy-client/src/models/permission.js:24](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L24)
+
+***
+
+### values
+
+• **values**: `string`\[]
+
+*Defined in*
+
+[packages/cozy-client/src/models/permission.js:23](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L23)
+
+***
+
+### verbs
+
+• **verbs**: [`PermissionVerb`](../modules/models.permission.md#permissionverb)\[]
+
+ALL, GET, PUT, PATCH, DELETE, POST…
+
+*Defined in*
+
+[packages/cozy-client/src/models/permission.js:21](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L21)

--- a/docs/api/cozy-client/interfaces/models.timeseries.timeseries.md
+++ b/docs/api/cozy-client/interfaces/models.timeseries.timeseries.md
@@ -1,0 +1,89 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](../modules/models.md) / [timeseries](../modules/models.timeseries.md) / TimeSeries
+
+# Interface: TimeSeries<>
+
+[models](../modules/models.md).[timeseries](../modules/models.timeseries.md).TimeSeries
+
+## Properties
+
+### dataType
+
+• **dataType**: `string`
+
+The type of time series, e.g. 'electricity'
+
+*Defined in*
+
+[packages/cozy-client/src/models/timeseries.js:23](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L23)
+
+***
+
+### endDate
+
+• **endDate**: `Date`
+
+The end date of the series
+
+*Defined in*
+
+[packages/cozy-client/src/models/timeseries.js:25](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L25)
+
+***
+
+### endType
+
+• **endType**: `Date`
+
+The starting date of the series
+
+*Defined in*
+
+[packages/cozy-client/src/models/timeseries.js:26](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L26)
+
+***
+
+### series
+
+• **series**: `any`\[]
+
+An array of objects representing the time series
+
+*Defined in*
+
+[packages/cozy-client/src/models/timeseries.js:29](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L29)
+
+***
+
+### source
+
+• **source**: `string`
+
+The data source, e.g. 'enedis.fr'
+
+*Defined in*
+
+[packages/cozy-client/src/models/timeseries.js:27](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L27)
+
+***
+
+### startDate
+
+• **startDate**: `Date`
+
+The starting date of the series
+
+*Defined in*
+
+[packages/cozy-client/src/models/timeseries.js:24](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L24)
+
+***
+
+### theme
+
+• **theme**: `string`
+
+The theme used to group time series, e.g. 'energy'
+
+*Defined in*
+
+[packages/cozy-client/src/models/timeseries.js:28](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L28)

--- a/docs/api/cozy-client/interfaces/models.timeseries.timeseriesjsonapi.md
+++ b/docs/api/cozy-client/interfaces/models.timeseries.timeseriesjsonapi.md
@@ -1,0 +1,17 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](../modules/models.md) / [timeseries](../modules/models.timeseries.md) / TimeSeriesJSONAPI
+
+# Interface: TimeSeriesJSONAPI<>
+
+[models](../modules/models.md).[timeseries](../modules/models.timeseries.md).TimeSeriesJSONAPI
+
+## Properties
+
+### data
+
+• **data**: [`TimeSeries`](models.timeseries.timeseries.md)\[]
+
+The JSON-API data response
+
+*Defined in*
+
+[packages/cozy-client/src/models/timeseries.js:75](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L75)

--- a/docs/api/cozy-client/modules.md
+++ b/docs/api/cozy-client/modules.md
@@ -1,0 +1,603 @@
+[cozy-client](README.md) / Exports
+
+# cozy-client
+
+## Namespaces
+
+*   [manifest](modules/manifest.md)
+*   [models](modules/models.md)
+
+## Classes
+
+*   [Association](classes/association.md)
+*   [CozyClient](classes/cozyclient.md)
+*   [CozyLink](classes/cozylink.md)
+*   [CozyProvider](classes/cozyprovider.md)
+*   [HasMany](classes/hasmany.md)
+*   [HasManyInPlace](classes/hasmanyinplace.md)
+*   [HasManyTriggers](classes/hasmanytriggers.md)
+*   [HasOne](classes/hasone.md)
+*   [HasOneInPlace](classes/hasoneinplace.md)
+*   [Query](classes/query.md)
+*   [QueryDefinition](classes/querydefinition.md)
+*   [Registry](classes/registry.md)
+*   [StackLink](classes/stacklink.md)
+
+## Properties
+
+### RealTimeQueries
+
+• **RealTimeQueries**: `MemoExoticComponent`<`fn`>
+
+## Variables
+
+### MutationTypes
+
+• `Const` **MutationTypes**: `Object`
+
+*Type declaration*
+
+| Name | Type |
+| :------ | :------ |
+| `ADD_REFERENCED_BY` | `string` |
+| `ADD_REFERENCES_TO` | `string` |
+| `CREATE_DOCUMENT` | `string` |
+| `DELETE_DOCUMENT` | `string` |
+| `REMOVE_REFERENCED_BY` | `string` |
+| `REMOVE_REFERENCES_TO` | `string` |
+| `UPDATE_DOCUMENT` | `string` |
+| `UPLOAD_FILE` | `string` |
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:445](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L445)
+
+***
+
+### Mutations
+
+• `Const` **Mutations**: `Object`
+
+*Type declaration*
+
+| Name | Type |
+| :------ | :------ |
+| `addReferencedBy` | (`document`: `any`, `referencedDocuments`: `any`) => { `document`: `any` ; `mutationType`: `string` ; `referencedDocuments`: `any`  } |
+| `addReferencesTo` | (`document`: `any`, `referencedDocuments`: `any`) => { `document`: `any` ; `mutationType`: `string` ; `referencedDocuments`: `any`  } |
+| `createDocument` | (`document`: `any`) => { `document`: `any` ; `mutationType`: `string`  } |
+| `deleteDocument` | (`document`: `any`) => { `document`: `any` ; `mutationType`: `string`  } |
+| `removeReferencedBy` | (`document`: `any`, `referencedDocuments`: `any`) => { `document`: `any` ; `mutationType`: `string` ; `referencedDocuments`: `any`  } |
+| `removeReferencesTo` | (`document`: `any`, `referencedDocuments`: `any`) => { `document`: `any` ; `mutationType`: `string` ; `referencedDocuments`: `any`  } |
+| `updateDocument` | (`document`: `any`) => { `document`: `any` ; `mutationType`: `string`  } |
+| `uploadFile` | (`file`: `any`, `dirPath`: `any`) => { `dirPath`: `any` ; `file`: `any` ; `mutationType`: `string`  } |
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:434](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L434)
+
+***
+
+### fetchPolicies
+
+• `Const` **fetchPolicies**: `Object`
+
+Use those fetch policies with `<Query />` to limit the number of re-fetch.
+
+**`example`**
+
+    import { fetchPolicies } from 'cozy-client'
+    const olderThan30s = fetchPolicies.olderThan(30 * 1000)
+    <Query fetchPolicy={olderThan30s} />
+
+*Type declaration*
+
+| Name | Type |
+| :------ | :------ |
+| `noFetch` | () => `boolean` |
+| `olderThan` | (`delay`: `number`) => `Function` |
+
+*Defined in*
+
+[packages/cozy-client/src/policies.js:11](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/policies.js#L11)
+
+## Functions
+
+### Q
+
+▸ `Const` **Q**(`doctype`): [`QueryDefinition`](classes/querydefinition.md)
+
+Helper to create a QueryDefinition. Recommended way to create
+query definitions.
+
+**`example`**
+
+    import { Q } from 'cozy-client'
+
+    const qDef = Q('io.cozy.todos').where({ _id: '1234' })
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `doctype` | `string` | Doctype of the query definition |
+
+*Returns*
+
+[`QueryDefinition`](classes/querydefinition.md)
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:338](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L338)
+
+***
+
+### cancelable
+
+▸ `Const` **cancelable**(`promise`): `CancelablePromise`
+
+Wraps a promise so that it can be canceled
+
+Rejects with canceled: true as soon as cancel is called
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `promise` | `Promise`<`any`> | Promise |
+
+*Returns*
+
+`CancelablePromise`
+
+*   Promise with .cancel method
+
+*Defined in*
+
+[packages/cozy-client/src/utils.js:14](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/utils.js#L14)
+
+***
+
+### createMockClient
+
+▸ `Const` **createMockClient**(`__namedParameters`): [`CozyClient`](classes/cozyclient.md)
+
+Creates a client suitable for use in tests
+
+*   client.{query,save} are mocked
+*   client.stackClient.fetchJSON is mocked
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `__namedParameters` | `Object` |
+| `__namedParameters.clientOptions` | `any` |
+| `__namedParameters.queries` | `any` |
+| `__namedParameters.remote` | `any` |
+
+*Returns*
+
+[`CozyClient`](classes/cozyclient.md)
+
+*Defined in*
+
+[packages/cozy-client/src/mock.js:41](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/mock.js#L41)
+
+***
+
+### dehydrate
+
+▸ `Const` **dehydrate**(`document`): `Object`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `document` | `any` |
+
+*Returns*
+
+`Object`
+
+*Defined in*
+
+[packages/cozy-client/src/helpers.js:3](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L3)
+
+***
+
+### generateWebLink
+
+▸ `Const` **generateWebLink**(`__namedParameters`): `string`
+
+generateWebLink - Construct a link to a web app
+
+This function does not get its cozy url from a CozyClient instance so it can
+be used to build urls that point to other Cozies than the user's own Cozy.
+This is useful when pointing to the Cozy of the owner of a shared note for
+example.
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `__namedParameters` | `Object` |
+| `__namedParameters.cozyUrl` | `string` |
+| `__namedParameters.hash` | `string` |
+| `__namedParameters.pathname` | `string` |
+| `__namedParameters.searchParams` | `any`\[] |
+| `__namedParameters.slug` | `string` |
+| `__namedParameters.subDomainType` | `string` |
+
+*Returns*
+
+`string`
+
+Generated URL
+
+*Defined in*
+
+[packages/cozy-client/src/helpers.js:51](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L51)
+
+***
+
+### getDoctypeFromOperation
+
+▸ `Const` **getDoctypeFromOperation**(`operation`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `operation` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/queries/dsl.js:412](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L412)
+
+***
+
+### getQueryFromState
+
+▸ `Const` **getQueryFromState**(`state`, `queryId`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `state` | `any` |
+| `queryId` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/store/index.js:99](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/store/index.js#L99)
+
+***
+
+### hasQueryBeenLoaded
+
+▸ `Const` **hasQueryBeenLoaded**(`col`): `any`
+
+Returns whether a query has been loaded at least once
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `col` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/utils.js:48](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/utils.js#L48)
+
+***
+
+### isQueryLoading
+
+▸ `Const` **isQueryLoading**(`col`): `boolean`
+
+Returns whether the result of a query (given via queryConnect or Query)
+is loading.
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `col` | `any` |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/utils.js:37](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/utils.js#L37)
+
+***
+
+### queryConnect
+
+▸ `Const` **queryConnect**(`querySpecs`): `Function`
+
+**`function`**
+
+**`description`** HOC creator to connect component to several queries in a declarative manner
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `querySpecs` | `any` | Definition of the queries |
+
+*Returns*
+
+`Function`
+
+*   HOC to apply to a component
+
+*Defined in*
+
+[packages/cozy-client/src/hoc.jsx:73](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hoc.jsx#L73)
+
+***
+
+### queryConnectFlat
+
+▸ `Const` **queryConnectFlat**(`querySpecs`): `Function`
+
+**`function`**
+
+**`description`** HOC creator to connect component to several queries in a declarative manner
+The only difference with queryConnect is that it does not wrap the component in N component
+if there are N queries, only 1 extra level of nesting is introduced.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `querySpecs` | `any` | Definition of the queries |
+
+*Returns*
+
+`Function`
+
+*   HOC to apply to a component
+
+*Defined in*
+
+[packages/cozy-client/src/hoc.jsx:89](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hoc.jsx#L89)
+
+***
+
+### useAppLinkWithStoreFallback
+
+▸ `Const` **useAppLinkWithStoreFallback**(`slug`, `client`, `path?`): `Object`
+
+*Parameters*
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `slug` | `any` | `undefined` |
+| `client` | `any` | `undefined` |
+| `path` | `string` | `''` |
+
+*Returns*
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `fetchStatus` | `string` |
+| `isInstalled` | `boolean` |
+| `url` | `any` |
+
+*Defined in*
+
+[packages/cozy-client/src/hooks/useAppLinkWithStoreFallback.jsx:9](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hooks/useAppLinkWithStoreFallback.jsx#L9)
+
+***
+
+### useAppsInMaintenance
+
+▸ `Const` **useAppsInMaintenance**(`client`): `"io.cozy.apps"`\[]
+
+Returns all apps in maintenance
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`CozyClient`](classes/cozyclient.md) | CozyClient instance |
+
+*Returns*
+
+`"io.cozy.apps"`\[]
+
+An array with all apps in maintenance
+
+*Defined in*
+
+[packages/cozy-client/src/hooks/useAppsInMaintenance.jsx:13](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hooks/useAppsInMaintenance.jsx#L13)
+
+***
+
+### useCapabilities
+
+▸ `Const` **useCapabilities**(`client`): `Object`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `client` | `any` |
+
+*Returns*
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `capabilities` | `undefined` |
+| `fetchStatus` | `string` |
+
+*Defined in*
+
+[packages/cozy-client/src/hooks/useCapabilities.jsx:4](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hooks/useCapabilities.jsx#L4)
+
+***
+
+### useClient
+
+▸ `Const` **useClient**(): [`CozyClient`](classes/cozyclient.md)
+
+Returns the cozy client from the context
+
+*Returns*
+
+[`CozyClient`](classes/cozyclient.md)
+
+*   Current cozy client
+
+*Defined in*
+
+[packages/cozy-client/src/hooks/useClient.js:9](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hooks/useClient.js#L9)
+
+***
+
+### useFetchShortcut
+
+▸ `Const` **useFetchShortcut**(`client`, `id`): `Object`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `client` | `any` |
+| `id` | `any` |
+
+*Returns*
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `fetchStatus` | `string` |
+| `shortcutImg` | `any` |
+| `shortcutInfos` | `any` |
+
+*Defined in*
+
+[packages/cozy-client/src/hooks/useFetchShortcut.jsx:3](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hooks/useFetchShortcut.jsx#L3)
+
+***
+
+### useQuery
+
+▸ `Const` **useQuery**(`queryDefinition`, `options`): `UseQueryReturnValue`
+
+Fetches a queryDefinition and returns the queryState
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `queryDefinition` | `any` | Definition created with Q() |
+| `options` | `Object` | Options |
+| `options.as` | `any` | Name for the query \[required] |
+| `options.enabled` | `boolean` | If set to false, the query won't be executed |
+| `options.fetchPolicy` | `any` | Fetch policy |
+| `options.singleDocData` | `any` | If true, the "data" returned will be a single doc instead of an array for single doc queries. Defaults to false for backward compatibility but will be set to true in the future. |
+
+*Returns*
+
+`UseQueryReturnValue`
+
+*Defined in*
+
+[packages/cozy-client/src/hooks/useQuery.js:36](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hooks/useQuery.js#L36)
+
+***
+
+### withClient
+
+▸ `Const` **withClient**(`WrappedComponent`): `Function`
+
+**`function`**
+
+**`description`** HOC to provide client from context as prop
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `WrappedComponent` | `Component`<`any`, `any`, `any`> | wrapped component |
+
+*Returns*
+
+`Function`
+
+*   Component that will receive client as prop
+
+*Defined in*
+
+[packages/cozy-client/src/hoc.jsx:15](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hoc.jsx#L15)
+
+***
+
+### withMutation
+
+▸ `Const` **withMutation**(`mutation`, `options?`): `Function`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `mutation` | `any` |
+| `options` | `Object` |
+
+*Returns*
+
+`Function`
+
+*Defined in*
+
+[packages/cozy-client/src/withMutation.jsx:8](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/withMutation.jsx#L8)
+
+***
+
+### withMutations
+
+▸ `Const` **withMutations**(...`mutations`): `Function`
+
+**`function`**
+
+**`description`** HOC to provide mutations to components. Needs client in context or as prop.
+
+**`deprecated`** Prefer to use withClient and access directly the client.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `...mutations` | `Function`\[] | One ore more mutations, which are function taking CozyClient as parameter and returning an object containing one or more mutations as attributes. |
+
+*Returns*
+
+`Function`
+
+*   Component that will receive mutations as props
+
+*Defined in*
+
+[packages/cozy-client/src/withMutations.jsx:23](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/withMutations.jsx#L23)

--- a/docs/api/cozy-client/modules/manifest.md
+++ b/docs/api/cozy-client/modules/manifest.md
@@ -1,0 +1,87 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / manifest
+
+# Namespace: manifest
+
+## Functions
+
+### areTermsValid
+
+▸ **areTermsValid**(`terms`): `boolean`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `terms` | `any` |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/manifest.js:33](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/manifest.js#L33)
+
+***
+
+### isPartnershipValid
+
+▸ **isPartnershipValid**(`partnership`): `boolean`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `partnership` | `any` |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/manifest.js:37](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/manifest.js#L37)
+
+***
+
+### sanitize
+
+▸ **sanitize**(`manifest`): `any`
+
+Normalize app manifest, retrocompatibility for old manifests
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `manifest` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/manifest.js:47](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/manifest.js#L47)
+
+***
+
+### sanitizeCategories
+
+▸ **sanitizeCategories**(`categories`): `any`
+
+Filters unauthorized categories. Defaults to \['others'] if no suitable category.
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `categories` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/manifest.js:26](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/manifest.js#L26)

--- a/docs/api/cozy-client/modules/models.account.md
+++ b/docs/api/cozy-client/modules/models.account.md
@@ -1,0 +1,111 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](models.md) / account
+
+# Namespace: account
+
+[models](models.md).account
+
+## Type aliases
+
+### CozyAccount
+
+Ƭ **CozyAccount**<>: `object`
+
+*Defined in*
+
+[packages/cozy-client/src/models/account.js:7](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/account.js#L7)
+
+## Functions
+
+### getContractSyncStatusFromAccount
+
+▸ `Const` **getContractSyncStatusFromAccount**(`account`, `contractId`): `any`
+
+Returns whether a contract is synced from account relationship
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `account` | `any` | Cozy account |
+| `contractId` | `any` | - |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/models/account.js:44](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/account.js#L44)
+
+***
+
+### getMutedErrors
+
+▸ `Const` **getMutedErrors**(`account`): `any`\[]
+
+getMutedErrors - Returns the list of errors that have been muted for the given account
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `account` | `any` | io.cozy.accounts |
+
+*Returns*
+
+`any`\[]
+
+An array of errors with a `type` and `mutedAt` field
+
+*Defined in*
+
+[packages/cozy-client/src/models/account.js:17](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/account.js#L17)
+
+***
+
+### muteError
+
+▸ `Const` **muteError**(`account`, `errorType`): `any`
+
+muteError - Adds an error to the list of muted errors for the given account
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `account` | `any` | io.cozy.accounts |
+| `errorType` | `string` | The type of the error to mute |
+
+*Returns*
+
+`any`
+
+An updated io.cozy.accounts
+
+*Defined in*
+
+[packages/cozy-client/src/models/account.js:27](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/account.js#L27)
+
+***
+
+### setContractSyncStatusInAccount
+
+▸ `Const` **setContractSyncStatusInAccount**(`account`, `contractId`, `syncStatus`): `any`
+
+Sets contract sync status into account relationship
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `account` | `any` | Cozy account |
+| `contractId` | `any` | - |
+| `syncStatus` | `any` | - |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/models/account.js:57](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/account.js#L57)

--- a/docs/api/cozy-client/modules/models.applications.md
+++ b/docs/api/cozy-client/modules/models.applications.md
@@ -1,0 +1,125 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](models.md) / applications
+
+# Namespace: applications
+
+[models](models.md).applications
+
+## Functions
+
+### getAppDisplayName
+
+▸ `Const` **getAppDisplayName**(`app`, `lang`): `string`
+
+getAppDisplayName - Combines the translated prefix and name of the app into a single string.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `app` | `any` | io.cozy.apps or io.cozy.konnectors document |
+| `lang` | `string` | Locale to use |
+
+*Returns*
+
+`string`
+
+Name of the app suitable for display
+
+*Defined in*
+
+[packages/cozy-client/src/models/applications.js:73](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/applications.js#L73)
+
+***
+
+### getStoreInstallationURL
+
+▸ `Const` **getStoreInstallationURL**(`appData?`, `app?`): `string`
+
+Returns the store URL to install/update an app/konnector
+
+*Parameters*
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `appData` | `any`\[] | `[]` |
+| `app` | `any` | `{}` |
+
+*Returns*
+
+`string`
+
+URL as string
+
+*Defined in*
+
+[packages/cozy-client/src/models/applications.js:34](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/applications.js#L34)
+
+***
+
+### getStoreURL
+
+▸ `Const` **getStoreURL**(`appData?`, `app?`): `string`
+
+Returns the store URL of an app/konnector
+
+*Parameters*
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `appData` | `any`\[] | `[]` |
+| `app` | `any` | `{}` |
+
+*Returns*
+
+`string`
+
+URL as string
+
+*Defined in*
+
+[packages/cozy-client/src/models/applications.js:11](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/applications.js#L11)
+
+***
+
+### getUrl
+
+▸ `Const` **getUrl**(`app`): `string`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `app` | `any` | io.cozy.apps document |
+
+*Returns*
+
+`string`
+
+url to the app
+
+*Defined in*
+
+[packages/cozy-client/src/models/applications.js:61](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/applications.js#L61)
+
+***
+
+### isInstalled
+
+▸ `Const` **isInstalled**(`apps?`, `wantedApp?`): `any`
+
+*Parameters*
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `apps` | `any`\[] | `[]` | Array of apps returned by /apps /konnectors |
+| `wantedApp` | `any` | `{}` | io.cozy.app with at least a slug |
+
+*Returns*
+
+`any`
+
+The io.cozy.app is installed or undefined if not
+
+*Defined in*
+
+[packages/cozy-client/src/models/applications.js:50](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/applications.js#L50)

--- a/docs/api/cozy-client/modules/models.contact.md
+++ b/docs/api/cozy-client/modules/models.contact.md
@@ -1,0 +1,351 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](models.md) / contact
+
+# Namespace: contact
+
+[models](models.md).contact
+
+## Functions
+
+### getDefaultSortIndexValue
+
+▸ `Const` **getDefaultSortIndexValue**(`contact`): `string`
+
+Returns 'byFamilyNameGivenNameEmailCozyUrl' index of a contact
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `contact` | `any` | A contact |
+
+*Returns*
+
+`string`
+
+*   the contact's 'byFamilyNameGivenNameEmailCozyUrl' index
+
+*Defined in*
+
+[packages/cozy-client/src/models/contact.js:197](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L197)
+
+***
+
+### getDisplayName
+
+▸ `Const` **getDisplayName**(`contact`): `string`
+
+Returns a display name for the contact
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `contact` | `any` | A contact |
+
+*Returns*
+
+`string`
+
+*   the contact's display name
+
+*Defined in*
+
+[packages/cozy-client/src/models/contact.js:159](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L159)
+
+***
+
+### getFullname
+
+▸ `Const` **getFullname**(`contact`): `string`
+
+Returns the contact's fullname
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `contact` | `any` | A contact |
+
+*Returns*
+
+`string`
+
+*   The contact's fullname
+
+*Defined in*
+
+[packages/cozy-client/src/models/contact.js:121](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L121)
+
+***
+
+### getIndexByFamilyNameGivenNameEmailCozyUrl
+
+▸ `Const` **getIndexByFamilyNameGivenNameEmailCozyUrl**(`contact`): `string`
+
+Returns 'byFamilyNameGivenNameEmailCozyUrl' index of a contact
+
+**`deprecated`** Prefer to use getDefaultSortIndexValue.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `contact` | `any` | A contact |
+
+*Returns*
+
+`string`
+
+*   the contact's 'byFamilyNameGivenNameEmailCozyUrl' index
+
+*Defined in*
+
+[packages/cozy-client/src/models/contact.js:218](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L218)
+
+***
+
+### getInitials
+
+▸ `Const` **getInitials**(`contact`): `string`
+
+Returns the initials of the contact.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `contact` | `any` | A contact |
+
+*Returns*
+
+`string`
+
+*   the contact's initials
+
+*Defined in*
+
+[packages/cozy-client/src/models/contact.js:15](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L15)
+
+***
+
+### getPrimaryAddress
+
+▸ `Const` **getPrimaryAddress**(`contact`): `string`
+
+Returns the contact's main address
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `contact` | `any` | A contact |
+
+*Returns*
+
+`string`
+
+*   The contact's main address
+
+*Defined in*
+
+[packages/cozy-client/src/models/contact.js:88](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L88)
+
+***
+
+### getPrimaryCozy
+
+▸ `Const` **getPrimaryCozy**(`contact`): `string`
+
+Returns the contact's main cozy
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `contact` | `any` | A contact |
+
+*Returns*
+
+`string`
+
+*   The contact's main cozy
+
+*Defined in*
+
+[packages/cozy-client/src/models/contact.js:53](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L53)
+
+***
+
+### getPrimaryCozyDomain
+
+▸ `Const` **getPrimaryCozyDomain**(`contact`): `string`
+
+Returns the contact's main cozy url without protocol
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `contact` | `any` | A contact |
+
+*Returns*
+
+`string`
+
+*   The contact's main cozy url
+
+*Defined in*
+
+[packages/cozy-client/src/models/contact.js:64](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L64)
+
+***
+
+### getPrimaryEmail
+
+▸ `Const` **getPrimaryEmail**(`contact`): `string`
+
+Returns the contact's main email
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `contact` | `any` | A contact |
+
+*Returns*
+
+`string`
+
+*   The contact's main email
+
+*Defined in*
+
+[packages/cozy-client/src/models/contact.js:42](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L42)
+
+***
+
+### getPrimaryOrFirst
+
+▸ `Const` **getPrimaryOrFirst**(`property`): (`obj`: `any`) => `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `property` | `any` |
+
+*Returns*
+
+`fn`
+
+▸ (`obj`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `obj` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/models/contact.js:4](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L4)
+
+***
+
+### getPrimaryPhone
+
+▸ `Const` **getPrimaryPhone**(`contact`): `string`
+
+Returns the contact's main phone number
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `contact` | `any` | A contact |
+
+*Returns*
+
+`string`
+
+*   The contact's main phone number
+
+*Defined in*
+
+[packages/cozy-client/src/models/contact.js:79](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L79)
+
+***
+
+### makeDefaultSortIndexValue
+
+▸ `Const` **makeDefaultSortIndexValue**(`contact`): `string`
+
+Makes 'byFamilyNameGivenNameEmailCozyUrl' index of a contact
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `contact` | `any` | A contact |
+
+*Returns*
+
+`string`
+
+*   the contact's 'byFamilyNameGivenNameEmailCozyUrl' index
+
+*Defined in*
+
+[packages/cozy-client/src/models/contact.js:173](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L173)
+
+***
+
+### makeDisplayName
+
+▸ `Const` **makeDisplayName**(`contact`): `string`
+
+Makes displayName from contact data
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `contact` | `any` | A contact |
+
+*Returns*
+
+`string`
+
+*   The contact's displayName
+
+*Defined in*
+
+[packages/cozy-client/src/models/contact.js:135](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L135)
+
+***
+
+### makeFullname
+
+▸ `Const` **makeFullname**(`contact`): `string`
+
+Makes fullname from contact name
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `contact` | `any` | A contact |
+
+*Returns*
+
+`string`
+
+*   The contact's fullname
+
+*Defined in*
+
+[packages/cozy-client/src/models/contact.js:97](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L97)

--- a/docs/api/cozy-client/modules/models.document.md
+++ b/docs/api/cozy-client/modules/models.document.md
@@ -1,0 +1,62 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](models.md) / document
+
+# Namespace: document
+
+[models](models.md).document
+
+## Classes
+
+*   [Qualification](../classes/models.document.qualification.md)
+
+## Interfaces
+
+*   [QualificationAttributes](../interfaces/models.document.qualificationattributes.md)
+
+## Functions
+
+### getQualification
+
+▸ `Const` **getQualification**(`document`): [`Qualification`](../classes/models.document.qualification.md)
+
+Helper to get the qualification from a document
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `document` | `any` | The document |
+
+*Returns*
+
+[`Qualification`](../classes/models.document.qualification.md)
+
+*   The document qualification
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:239](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L239)
+
+***
+
+### setQualification
+
+▸ `Const` **setQualification**(`document`, `qualification`): `any`
+
+Set the qualification to the document metadata
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `document` | `any` | The document to set the qualification |
+| `qualification` | [`Qualification`](../classes/models.document.qualification.md) | The qualification to set |
+
+*Returns*
+
+`any`
+
+*   The qualified document
+
+*Defined in*
+
+[packages/cozy-client/src/models/document.js:222](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document.js#L222)

--- a/docs/api/cozy-client/modules/models.file.md
+++ b/docs/api/cozy-client/modules/models.file.md
@@ -1,0 +1,503 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](models.md) / file
+
+# Namespace: file
+
+[models](models.md).file
+
+## Variables
+
+### ALBUMS_DOCTYPE
+
+• `Const` **ALBUMS_DOCTYPE**: `"io.cozy.photos.albums"`
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:12](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L12)
+
+## Functions
+
+### ensureFilePath
+
+▸ **ensureFilePath**(`file`, `parent`): `any`
+
+Ensure the file has a `path` attribute, or build it
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `any` | object representing the file |
+| `parent` | `any` | parent directory for the file |
+
+*Returns*
+
+`any`
+
+file object with path attribute
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:124](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L124)
+
+***
+
+### fetchFilesByQualificationRules
+
+▸ `Const` **fetchFilesByQualificationRules**(`client`, `docRules`): `Promise`<`any`>
+
+Helper to query files based on qualification rules
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | `any` | The CozyClient instance |
+| `docRules` | `any` | the rules containing the searched qualification and the count |
+
+*Returns*
+
+`Promise`<`any`>
+
+*   The files found by the rules
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:244](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L244)
+
+***
+
+### getParentFolderId
+
+▸ **getParentFolderId**(`file`): `string`
+
+Get the id of the parent folder (`null` for the root folder)
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `any` | io.cozy.files document |
+
+*Returns*
+
+`string`
+
+id of the parent folder, if any
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:138](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L138)
+
+***
+
+### getSharingShortcutStatus
+
+▸ `Const` **getSharingShortcutStatus**(`file`): `string`
+
+Returns the status of a sharing shortcut.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `IOCozyFile` | io.cozy.files document |
+
+*Returns*
+
+`string`
+
+A description of the status
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:150](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L150)
+
+***
+
+### getSharingShortcutTargetDoctype
+
+▸ `Const` **getSharingShortcutTargetDoctype**(`file`): `string`
+
+Returns the doctype of the target of the sharing shortcut.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `IOCozyFile` | io.cozy.files document |
+
+*Returns*
+
+`string`
+
+A doctype
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:170](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L170)
+
+***
+
+### getSharingShortcutTargetMime
+
+▸ `Const` **getSharingShortcutTargetMime**(`file`): `string`
+
+Returns the mime type of the target of the sharing shortcut, if it is a file.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `IOCozyFile` | io.cozy.files document |
+
+*Returns*
+
+`string`
+
+The mime-type of the target file, or an empty string is the target is not a file.
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:160](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L160)
+
+***
+
+### hasMetadataAttribute
+
+▸ `Const` **hasMetadataAttribute**(`__namedParameters`): `boolean`
+
+Whether the file's metadata attribute exists
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `__namedParameters` | `Object` |
+| `__namedParameters.attribute` | `string` |
+| `__namedParameters.file` | `IOCozyFile` |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:291](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L291)
+
+***
+
+### isDirectory
+
+▸ `Const` **isDirectory**(`file`): `boolean`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `IOCozyFile` | io.cozy.files |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:44](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L44)
+
+***
+
+### isFile
+
+▸ `Const` **isFile**(`file`): `boolean`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `IOCozyFile` | io.cozy.files |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:38](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L38)
+
+***
+
+### isNote
+
+▸ `Const` **isNote**(`file`): `boolean`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `IOCozyFile` | io.cozy.files |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:50](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L50)
+
+***
+
+### isOnlyOfficeFile
+
+▸ `Const` **isOnlyOfficeFile**(`file`): `boolean`
+
+Whether the file is supported by Only Office
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `IOCozyFile` | io.cozy.file document |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:72](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L72)
+
+***
+
+### isReferencedByAlbum
+
+▸ `Const` **isReferencedByAlbum**(`file`): `boolean`
+
+Whether the file is referenced by an album
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `IOCozyFile` | An io.cozy.files document |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:266](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L266)
+
+***
+
+### isSharingShorcut
+
+▸ `Const` **isSharingShorcut**(`file`): `boolean`
+
+Returns whether the file is a shortcut to a sharing
+
+**`deprecated`** Prefer to use isSharingShortcut.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `IOCozyFile` | io.cozy.files document |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:190](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L190)
+
+***
+
+### isSharingShorcutNew
+
+▸ `Const` **isSharingShorcutNew**(`file`): `boolean`
+
+Returns whether the sharing shortcut is new
+
+**`deprecated`** Prefer to use isSharingShortcutNew.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `any` | io.cozy.files document |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:215](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L215)
+
+***
+
+### isSharingShortcut
+
+▸ `Const` **isSharingShortcut**(`file`): `boolean`
+
+Returns whether the file is a shortcut to a sharing
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `IOCozyFile` | io.cozy.files document |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:180](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L180)
+
+***
+
+### isSharingShortcutNew
+
+▸ `Const` **isSharingShortcutNew**(`file`): `boolean`
+
+Returns whether the sharing shortcut is new
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `IOCozyFile` | io.cozy.files document |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:204](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L204)
+
+***
+
+### isShortcut
+
+▸ `Const` **isShortcut**(`file`): `boolean`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `IOCozyFile` | io.cozy.files |
+
+*Returns*
+
+`boolean`
+
+true if the file is a shortcut
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:97](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L97)
+
+***
+
+### normalize
+
+▸ **normalize**(`file`): `any`
+
+Normalizes an object representing a io.cozy.files object
+
+Ensures existence of `_id` and `_type`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `any` | object representing the file |
+
+*Returns*
+
+`any`
+
+full normalized object
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:110](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L110)
+
+***
+
+### saveFileQualification
+
+▸ `Const` **saveFileQualification**(`client`, `file`, `qualification`): `Promise`<`IOCozyFile`>
+
+Save the file with the given qualification
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`CozyClient`](../classes/cozyclient.md) | The CozyClient instance |
+| `file` | `IOCozyFile` | The file to qualify |
+| `qualification` | `any` | The file qualification |
+
+*Returns*
+
+`Promise`<`IOCozyFile`>
+
+*   The saved file
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:230](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L230)
+
+***
+
+### shouldBeOpenedByOnlyOffice
+
+▸ `Const` **shouldBeOpenedByOnlyOffice**(`file`): `boolean`
+
+Whether the file should be opened by only office
+We want to be consistent with the stack so we check the class attributes
+But we want to exclude .txt and .md because the CozyUI Viewer can already show them
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `IOCozyFile` | io.cozy.file document |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:87](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L87)
+
+***
+
+### splitFilename
+
+▸ `Const` **splitFilename**(`file`): `any`
+
+Returns base filename and extension
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `IOCozyFile` | An io.cozy.files |
+
+*Returns*
+
+`any`
+
+{filename, extension}
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:22](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L22)

--- a/docs/api/cozy-client/modules/models.folder.md
+++ b/docs/api/cozy-client/modules/models.folder.md
@@ -1,0 +1,103 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](models.md) / folder
+
+# Namespace: folder
+
+[models](models.md).folder
+
+## Variables
+
+### MAGIC_FOLDERS
+
+• `Const` **MAGIC_FOLDERS**: `Object`
+
+*Type declaration*
+
+| Name | Type |
+| :------ | :------ |
+| `ADMINISTRATIVE` | `string` |
+| `HOME` | `string` |
+| `NOTES` | `string` |
+| `PHOTOS` | `string` |
+| `PHOTOS_BACKUP` | `string` |
+| `PHOTOS_UPLOAD` | `string` |
+
+*Defined in*
+
+[packages/cozy-client/src/models/folder.js:7](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L7)
+
+## Functions
+
+### createFolderWithReference
+
+▸ `Const` **createFolderWithReference**(`client`, `path`, `document`): `Promise`<`IOCozyFile`>
+
+Create a folder with a reference to the given document
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`CozyClient`](../classes/cozyclient.md) | cozy-client instance |
+| `path` | `string` | Folder path |
+| `document` | `CozyClientDocument` | Document to make reference to. Any doctype. |
+
+*Returns*
+
+`Promise`<`IOCozyFile`>
+
+Folder document
+
+*Defined in*
+
+[packages/cozy-client/src/models/folder.js:65](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L65)
+
+***
+
+### ensureMagicFolder
+
+▸ `Const` **ensureMagicFolder**(`client`, `id`, `path`): `Promise`<`IOCozyFile`>
+
+Returns a "Magic Folder", given its id. See https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.apps/#special-iocozyapps-doctypes
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`CozyClient`](../classes/cozyclient.md) | cozy-client instance |
+| `id` | `string` | Magic Folder id. `CozyFolder.magicFolders` contains the ids of folders that can be magic folders. |
+| `path` | `string` | Default path to use if magic folder does not exist |
+
+*Returns*
+
+`Promise`<`IOCozyFile`>
+
+Folder document
+
+*Defined in*
+
+[packages/cozy-client/src/models/folder.js:25](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L25)
+
+***
+
+### getReferencedFolder
+
+▸ `Const` **getReferencedFolder**(`client`, `document`): `Promise`<`IOCozyFile`>
+
+Returns the most recent folder referenced by the given document
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`CozyClient`](../classes/cozyclient.md) | cozy-client instance |
+| `document` | `CozyClientDocument` | Document to get references from |
+
+*Returns*
+
+`Promise`<`IOCozyFile`>
+
+Folder referenced by the given document
+
+*Defined in*
+
+[packages/cozy-client/src/models/folder.js:86](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L86)

--- a/docs/api/cozy-client/modules/models.instance.md
+++ b/docs/api/cozy-client/modules/models.instance.md
@@ -1,0 +1,195 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](models.md) / instance
+
+# Namespace: instance
+
+[models](models.md).instance
+
+## Interfaces
+
+*   [SettingsInfo](../interfaces/models.instance.settingsinfo.md)
+
+## Type aliases
+
+### ContextInfo
+
+Ƭ **ContextInfo**<>: `object`
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:7](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L7)
+
+***
+
+### DiskUsageInfo
+
+Ƭ **DiskUsageInfo**<>: `object`
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:8](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L8)
+
+***
+
+### InstanceInfo
+
+Ƭ **InstanceInfo**<>: `object`
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:6](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L6)
+
+## Functions
+
+### arePremiumLinksEnabled
+
+▸ `Const` **arePremiumLinksEnabled**(`instanceInfo`): `boolean`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `instanceInfo` | `any` |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:22](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L22)
+
+***
+
+### buildPremiumLink
+
+▸ `Const` **buildPremiumLink**(`instanceInfo`): `string`
+
+Returns the link to the Premium page on the Cozy's Manager
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `instanceInfo` | `any` | Instance information |
+
+*Returns*
+
+`string`
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:69](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L69)
+
+***
+
+### getUuid
+
+▸ `Const` **getUuid**(`instanceInfo`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `instanceInfo` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:31](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L31)
+
+***
+
+### hasAnOffer
+
+▸ `Const` **hasAnOffer**(`data`): `boolean`
+
+Returns if an instance has subscribed to one of our offers
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `data` | [`SettingsInfo`](../interfaces/models.instance.settingsinfo.md) | Object containing all the results from /settings/\* |
+
+*Returns*
+
+`boolean`
+
+Does the cozy have offers
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:55](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L55)
+
+***
+
+### isFreemiumUser
+
+▸ `Const` **isFreemiumUser**(`instanceInfo`): `boolean`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `instanceInfo` | `any` |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:27](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L27)
+
+***
+
+### isSelfHosted
+
+▸ `Const` **isSelfHosted**(`instanceInfo`): `boolean`
+
+**`property`** {ContextInfo} context - Object returned by /settings/context
+
+**`property`** {InstanceInfo} instance - Object returned by /settings/instance
+
+**`property`** {DiskUsageInfo} diskUsage - Object returned by /settings/disk-usage
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `instanceInfo` | `any` |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:19](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L19)
+
+***
+
+### shouldDisplayOffers
+
+▸ `Const` **shouldDisplayOffers**(`data`): `boolean`
+
+Returns whether an instance is concerned by our offers
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `data` | [`SettingsInfo`](../interfaces/models.instance.settingsinfo.md) | Object containing all the results from /settings/\* |
+
+*Returns*
+
+`boolean`
+
+Should we display offers
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:41](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L41)

--- a/docs/api/cozy-client/modules/models.md
+++ b/docs/api/cozy-client/modules/models.md
@@ -1,0 +1,38 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / models
+
+# Namespace: models
+
+## Namespaces
+
+*   [account](models.account.md)
+*   [applications](models.applications.md)
+*   [contact](models.contact.md)
+*   [document](models.document.md)
+*   [file](models.file.md)
+*   [folder](models.folder.md)
+*   [instance](models.instance.md)
+*   [note](models.note.md)
+*   [permission](models.permission.md)
+*   [timeseries](models.timeseries.md)
+*   [trigger](models.trigger.md)
+*   [utils](models.utils.md)
+
+## Variables
+
+### accounts
+
+• `Const` **accounts**: [`account`](models.account.md)
+
+*Defined in*
+
+[packages/cozy-client/src/models/index.js:16](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/index.js#L16)
+
+***
+
+### triggers
+
+• `Const` **triggers**: [`trigger`](models.trigger.md)
+
+*Defined in*
+
+[packages/cozy-client/src/models/index.js:15](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/index.js#L15)

--- a/docs/api/cozy-client/modules/models.note.md
+++ b/docs/api/cozy-client/modules/models.note.md
@@ -1,0 +1,73 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](models.md) / note
+
+# Namespace: note
+
+[models](models.md).note
+
+## Functions
+
+### fetchURL
+
+▸ `Const` **fetchURL**(`client`, `file`): `Promise`<`string`>
+
+Fetch and build an URL to open a note.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | `any` | CozyClient instance |
+| `file` | `any` | io.cozy.file object |
+
+*Returns*
+
+`Promise`<`string`>
+
+url
+
+*Defined in*
+
+[packages/cozy-client/src/models/note.js:29](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L29)
+
+***
+
+### generatePrivateUrl
+
+▸ `Const` **generatePrivateUrl**(`notesAppUrl`, `file`, `options?`): `string`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `notesAppUrl` | `string` | URL to the Notes App (https://notes.foo.mycozy.cloud) |
+| `file` | `any` | io.cozy.files object |
+| `options` | `Object` | - |
+
+*Returns*
+
+`string`
+
+*Defined in*
+
+[packages/cozy-client/src/models/note.js:7](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L7)
+
+***
+
+### generateUrlForNote
+
+▸ `Const` **generateUrlForNote**(`notesAppUrl`, `file`): `string`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `notesAppUrl` | `any` |
+| `file` | `any` |
+
+*Returns*
+
+`string`
+
+*Defined in*
+
+[packages/cozy-client/src/models/note.js:16](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L16)

--- a/docs/api/cozy-client/modules/models.permission.md
+++ b/docs/api/cozy-client/modules/models.permission.md
@@ -1,0 +1,123 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](models.md) / permission
+
+# Namespace: permission
+
+[models](models.md).permission
+
+## Interfaces
+
+*   [Document](../interfaces/models.permission.document.md)
+*   [Permission](../interfaces/models.permission.permission.md)
+*   [PermissionItem](../interfaces/models.permission.permissionitem.md)
+
+## Type aliases
+
+### PermissionVerb
+
+Ƭ **PermissionVerb**<>: `"ALL"` | `"GET"` | `"PATCH"` | `"POST"` | `"PUT"` | `"DELETE"`
+
+*Defined in*
+
+[packages/cozy-client/src/models/permission.js:16](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L16)
+
+## Functions
+
+### fetchOwn
+
+▸ **fetchOwn**(`client`): `Promise`<[`PermissionItem`](../interfaces/models.permission.permissionitem.md)\[]>
+
+Fetches the list of permissions blocks
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`CozyClient`](../classes/cozyclient.md) | - |
+
+*Returns*
+
+`Promise`<[`PermissionItem`](../interfaces/models.permission.permissionitem.md)\[]>
+
+list of permissions
+
+*Defined in*
+
+[packages/cozy-client/src/models/permission.js:51](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L51)
+
+***
+
+### isDocumentReadOnly
+
+▸ **isDocumentReadOnly**(`args`): `Promise`<`boolean`>
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `args` | `any` |
+
+*Returns*
+
+`Promise`<`boolean`>
+
+*Defined in*
+
+[packages/cozy-client/src/models/permission.js:127](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L127)
+
+***
+
+### isForType
+
+▸ **isForType**(`permission`, `type`): `boolean`
+
+Checks if the permission item is about a specific doctype
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `permission` | [`PermissionItem`](../interfaces/models.permission.permissionitem.md) | - |
+| `type` | `string` | doctype |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/models/permission.js:65](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L65)
+
+***
+
+### isShortcutCreatedOnTheRecipientCozy
+
+▸ `Const` **isShortcutCreatedOnTheRecipientCozy**(`permission`): `boolean`
+
+When a cozy to cozy sharing is created Cozy's stack creates a
+shortcut in `/Inbox of sharing` on the recipient's cozy to have a
+quick access even when the sharing is not accepted yet.
+
+However, this file is created only if the stack knows the URL of the cozy.
+This is not always the case.
+
+This method is here to tell us if the shortcut's file is created
+on the recipient's cozy. It can be used to make an UI distinction between the
+both situation.
+
+**`property`** {object} data Permission document
+
+**`property`** {Array} included Member information from the sharing
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `permission` | [`Permission`](../interfaces/models.permission.permission.md) | From getOwnPermissions mainly |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/models/permission.js:165](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L165)

--- a/docs/api/cozy-client/modules/models.timeseries.md
+++ b/docs/api/cozy-client/modules/models.timeseries.md
@@ -1,0 +1,65 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](models.md) / timeseries
+
+# Namespace: timeseries
+
+[models](models.md).timeseries
+
+## Interfaces
+
+*   [TimeSeries](../interfaces/models.timeseries.timeseries.md)
+*   [TimeSeriesJSONAPI](../interfaces/models.timeseries.timeseriesjsonapi.md)
+
+## Functions
+
+### fetchTimeSeriesByIntervalAndSource
+
+▸ `Const` **fetchTimeSeriesByIntervalAndSource**(`client`, `__namedParameters`): `Promise`<[`TimeSeriesJSONAPI`](../interfaces/models.timeseries.timeseriesjsonapi.md)>
+
+Helper to retrieve time series by their date interval and source.
+
+**`property`** data {Array<TimeSeries>} - The JSON-API data response
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | `any` | The CozyClient instance |
+| `__namedParameters` | `Object` | - |
+| `__namedParameters.dataType` | `string` | - |
+| `__namedParameters.endDate` | `Date` | - |
+| `__namedParameters.limit` | `number` | - |
+| `__namedParameters.source` | `string` | - |
+| `__namedParameters.startDate` | `Date` | - |
+
+*Returns*
+
+`Promise`<[`TimeSeriesJSONAPI`](../interfaces/models.timeseries.timeseriesjsonapi.md)>
+
+The TimeSeries found by the query in JSON-API format
+
+*Defined in*
+
+[packages/cozy-client/src/models/timeseries.js:78](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L78)
+
+***
+
+### saveTimeSeries
+
+▸ `Const` **saveTimeSeries**(`client`, `timeseriesOption`): `Promise`<`any`>
+
+Helper to save a time series document.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | `any` | The CozyClient instance |
+| `timeseriesOption` | [`TimeSeries`](../interfaces/models.timeseries.timeseries.md) | The time series to save |
+
+*Returns*
+
+`Promise`<`any`>
+
+*Defined in*
+
+[packages/cozy-client/src/models/timeseries.js:40](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L40)

--- a/docs/api/cozy-client/modules/models.trigger.md
+++ b/docs/api/cozy-client/modules/models.trigger.md
@@ -1,0 +1,47 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](models.md) / trigger
+
+# Namespace: trigger
+
+[models](models.md).trigger
+
+## Variables
+
+### triggerStates
+
+• `Const` **triggerStates**: `Object`
+
+Trigger states come from /jobs/triggers
+
+*Type declaration*
+
+| Name | Type |
+| :------ | :------ |
+| `getLastErrorType` | (`triggerState`: `any`) => `any` |
+| `getLastExecution` | (`triggerState`: `any`) => `any` |
+| `getLastSuccess` | (`triggerState`: `any`) => `any` |
+| `getLastsuccess` | (`triggerState`: `any`) => `any` |
+| `isErrored` | (`triggerState`: `any`) => `boolean` |
+
+*Defined in*
+
+[packages/cozy-client/src/models/trigger.js:17](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/trigger.js#L17)
+
+***
+
+### triggers
+
+• `Const` **triggers**: `Object`
+
+*Type declaration*
+
+| Name | Type |
+| :------ | :------ |
+| `getAccountId` | (`trigger`: `any`) => `string` |
+| `getKonnector` | (`trigger`: `any`) => `string` | `void` |
+| `hasActionableError` | (`trigger`: `any`) => `boolean` |
+| `isKonnectorWorker` | (`trigger`: `any`) => `boolean` |
+| `isLatestErrorMuted` | (`trigger`: `any`, `account`: `any`) => `boolean` |
+
+*Defined in*
+
+[packages/cozy-client/src/models/trigger.js:38](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/trigger.js#L38)

--- a/docs/api/cozy-client/modules/models.utils.md
+++ b/docs/api/cozy-client/modules/models.utils.md
@@ -1,0 +1,46 @@
+[cozy-client](../README.md) / [Exports](../modules.md) / [models](models.md) / utils
+
+# Namespace: utils
+
+[models](models.md).utils
+
+## Functions
+
+### getCreatedByApp
+
+▸ `Const` **getCreatedByApp**(`doc`): `any`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[packages/cozy-client/src/models/utils.js:8](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/utils.js#L8)
+
+***
+
+### hasBeenUpdatedByApp
+
+▸ `Const` **hasBeenUpdatedByApp**(`doc`, `appSlug`): `boolean`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+| `appSlug` | `any` |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/models/utils.js:3](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/utils.js#L3)

--- a/package.json
+++ b/package.json
@@ -22,6 +22,12 @@
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "redux-mock-store": "1.5.4",
+    "remark-cli": "^9.0.0",
+    "typedoc": "^0.21.0",
+    "typedoc-plugin-markdown": "^3.10.1",
+    "typedoc-plugin-rename-defaults": "^0.1.0",
+    "unist-util-find": "^1.0.2",
+    "unist-util-visit": "^3.1.0",
     "whatwg-fetch": "^3.0.0"
   },
   "private": true,
@@ -35,7 +41,8 @@
     "build": "lerna run build --parallel",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "clean": "rm -rf packages/*/dist",
-    "docs": "node scripts/docs.js",
+    "docs": "node scripts/docs.js && yarn docs:cozy-client",
+    "docs:cozy-client": "yarn typedoc --hideInPageTOC --excludeExternals --excludePrivate --tsconfig packages/cozy-client/tsconfig.json packages/cozy-client/src/index.js --out docs/api/cozy-client --gitRevision master && yarn remark -o -u ./scripts/strip-typedoc-headings.mjs docs/api/cozy-client/",
     "types": "cd packages/cozy-client && yarn typecheck"
   },
   "commitlint": {

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -20,6 +20,9 @@ const main = async () => {
   const packages = await globPromise('packages/*')
   await fs.mkdirp(path.resolve(docsFolder, 'api'))
   for (let pkg of packages) {
+    if (pkg === 'cozy-client') {
+       continue // documentation for cozy-client is made via typedoc
+    }
     const files = await globPromise(`${pkg}/src/**/*.js*`, {
       ignore: ['*.spec.js']
     })

--- a/scripts/strip-typedoc-headings.mjs
+++ b/scripts/strip-typedoc-headings.mjs
@@ -1,0 +1,53 @@
+/**
+ * Used to replace typedoc headings level 4/5 by emphasis text.
+ * Otherwise, the headings are present in the right navigation and
+ * this is too much.
+ */
+
+'use strict';
+
+import { visit } from 'unist-util-visit'
+import find from 'unist-util-find'
+
+const typedocHeadingsToStrip = {
+  'Defined in': true,
+  'Parameters': true,
+  'Returns': true,
+  'Type declaration': true,
+  'Inherited from': true,
+  'Overrides': true
+}
+
+const isTypedocHeadingToStrip = (node) => {
+  return node.type === 'heading' && node.children.length == 1 &&
+    (node.depth == 4 || node.depth == 5) && typedocHeadingsToStrip[node.children[0].value] 
+}
+
+export default function (options) {
+  const settings = options || {};
+
+  function transform(node) {
+    if (isTypedocHeadingToStrip(node)) {
+      node.type = 'emphasis'
+    }
+    return node;
+  }
+
+  function getNode(tree, value) {
+    if (typeof value === 'string') {
+      return find(tree, {type: 'heading', children: [{value}]});
+    }
+    if (typeof value === 'number') {
+      return tree.children[value];
+    }
+    return find(tree, value);
+  }
+
+  function transformer(tree) {
+    visit(tree, n => {
+      return transform(n);
+    });
+  }
+
+  return transformer;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2557,6 +2557,13 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.170.tgz#0d67711d4bf7f4ca5147e9091b847479b87925d6"
   integrity sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==
 
+"@types/mdast@^3.0.0":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.3.tgz#2d7d671b1cd1ea3deb306ea75036c2a0407d2deb"
+  integrity sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==
+  dependencies:
+    "@types/unist" "*"
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -2620,6 +2627,11 @@
   integrity sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==
   dependencies:
     "@types/react-test-renderer" "*"
+
+"@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
+  integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -2866,6 +2878,14 @@ anymatch@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
   integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
+anymatch@~3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
+  integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
@@ -3860,6 +3880,21 @@ chokidar@^2.1.5:
   optionalDependencies:
     fsevents "^1.2.7"
 
+chokidar@^3.0.0:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
+  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 chokidar@^3.4.0:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.3.tgz#c1df38231448e45ca4ac588e6c79573ba6a57d5b"
@@ -4806,7 +4841,7 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -5231,6 +5266,11 @@ emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 emoji-regex@^9.0.0:
   version "9.2.0"
@@ -5935,6 +5975,13 @@ fastparse@^1.1.2:
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
   integrity sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
 
+fault@^1.0.0, fault@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.4.tgz#eafcfc0a6d214fc94601e170df29954a4f842f13"
+  integrity sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==
+  dependencies:
+    format "^0.2.0"
+
 fb-watchman@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.1.tgz#fc84fb39d2709cf3ff6d743706157bb5708a8a85"
@@ -5958,6 +6005,13 @@ figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
   integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
+figures@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
+  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   dependencies:
     escape-string-regexp "^1.0.5"
 
@@ -6107,6 +6161,11 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+format@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
+  integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
@@ -6180,6 +6239,11 @@ fsevents@~2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+
+fsevents@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -6393,6 +6457,13 @@ glob-parent@^5.0.0, glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
+glob-parent@~5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+  dependencies:
+    is-glob "^4.0.1"
+
 glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
@@ -6402,6 +6473,18 @@ glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.0.3, glob@^7.1.7:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -6463,6 +6546,18 @@ handlebars@^4.7.6:
   version "4.7.6"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
   integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.0"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
+handlebars@^4.7.7:
+  version "4.7.7"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
+  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
   dependencies:
     minimist "^1.2.5"
     neo-async "^2.6.0"
@@ -6811,6 +6906,11 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
+ignore@^5.0.0:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
+  integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+
 immediate@3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
@@ -6911,6 +7011,11 @@ ini@^1.3.2, ini@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+
+ini@^1.3.5:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 init-package-json@^1.10.3:
   version "1.10.3"
@@ -7047,6 +7152,11 @@ is-buffer@^1.1.4, is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
+is-buffer@^2.0.0:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
+
 is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.1.5, is-callable@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.2.tgz#c7c6715cd22d4ddb48d3e19970223aceabb080d9"
@@ -7145,6 +7255,11 @@ is-dom@^1.0.0:
     is-object "^1.0.1"
     is-window "^1.0.2"
 
+is-empty@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-empty/-/is-empty-1.2.0.tgz#de9bb5b278738a05a0b09a57e1fb4d4a341a9f6b"
+  integrity sha1-3pu1snhzigWgsJpX4ftNSjQan2s=
+
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
@@ -7178,6 +7293,11 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-generator-fn@^2.0.0:
   version "2.1.0"
@@ -7256,6 +7376,11 @@ is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
+
+is-plain-obj@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
@@ -7895,6 +8020,14 @@ js-yaml@^3.10.0, js-yaml@^3.13.0, js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.6.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
+  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js2xmlparser@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/js2xmlparser/-/js2xmlparser-4.0.1.tgz#670ef71bc5661f089cc90481b99a05a1227ae3bd"
@@ -8152,6 +8285,13 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
+json5@^2.0.0, json5@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
+  dependencies:
+    minimist "^1.2.5"
+
 json5@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
@@ -8404,6 +8544,15 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+libnpmconfig@^1.0.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/libnpmconfig/-/libnpmconfig-1.2.1.tgz#c0c2f793a74e67d4825e5039e7a02a0044dfcbc0"
+  integrity sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==
+  dependencies:
+    figgy-pudding "^3.5.1"
+    find-up "^3.0.0"
+    ini "^1.3.5"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -8457,6 +8606,14 @@ load-json-file@^5.3.0:
     pify "^4.0.1"
     strip-bom "^3.0.0"
     type-fest "^0.3.0"
+
+load-plugin@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/load-plugin/-/load-plugin-3.0.0.tgz#8f3ce57cf4e5111639911012487bc1c2ba3d0e6c"
+  integrity sha512-od7eKCCZ62ITvFf8nHHrIiYmgOHb4xVNDRDqxBWSaao5FZyyZVX8OmRCbwjDGPrSrgIulwPNyBsWCGnhiDC0oQ==
+  dependencies:
+    libnpmconfig "^1.0.0"
+    resolve-from "^5.0.0"
 
 loader-utils@^1.0.0:
   version "1.4.0"
@@ -8540,6 +8697,11 @@ lodash.isplainobject@^4.0.6:
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
 
+lodash.iteratee@^4.5.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.iteratee/-/lodash.iteratee-4.7.0.tgz#be4177db289a8ccc3c0990f1db26b5b22fc1554c"
+  integrity sha1-vkF32yiajMw8CZDx2ya1si/BVUw=
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -8600,6 +8762,11 @@ lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 log-symbols@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
@@ -8613,6 +8780,11 @@ lolex@^5.0.0:
   integrity sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
+
+longest-streak@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
+  integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -8652,6 +8824,11 @@ ltgt@~2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.1.3.tgz#10851a06d9964b971178441c23c9e52698eece34"
   integrity sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ=
+
+lunr@^2.3.9:
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
+  integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
 
 lz-string@^1.4.4:
   version "1.4.4"
@@ -8758,6 +8935,11 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
+markdown-extensions@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/markdown-extensions/-/markdown-extensions-1.1.1.tgz#fea03b539faeaee9b4ef02a3769b455b189f7fc3"
+  integrity sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==
+
 markdown-it-anchor@^5.2.7:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz#d549acd64856a8ecd1bea58365ef385effbac744"
@@ -8784,6 +8966,11 @@ marked@^1.1.0:
   resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.9.tgz#53786f8b05d4c01a2a5a76b7d1ec9943d29d72dc"
   integrity sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==
 
+marked@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-2.1.2.tgz#59579e17b02443312caa1509994d5a0b18ae38e1"
+  integrity sha512-ueJhIvklJJw04qxQbGIAu63EXwwOCYc7yKMBjgagTM4rjC5QtWyqSNgW7jCosV1/Km/1TUfs5qEpAqcGG0Mo5g==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -8799,6 +8986,34 @@ mdast-add-list-metadata@1.0.1:
   integrity sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==
   dependencies:
     unist-util-visit-parents "1.1.2"
+
+mdast-util-from-markdown@^0.8.0:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz#d1ef2ca42bc377ecb0463a987910dae89bd9a28c"
+  integrity sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-string "^2.0.0"
+    micromark "~2.11.0"
+    parse-entities "^2.0.0"
+    unist-util-stringify-position "^2.0.0"
+
+mdast-util-to-markdown@^0.6.0:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz#b33f67ca820d69e6cc527a93d4039249b504bebe"
+  integrity sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    longest-streak "^2.0.0"
+    mdast-util-to-string "^2.0.0"
+    parse-entities "^2.0.0"
+    repeat-string "^1.0.0"
+    zwitch "^1.0.0"
+
+mdast-util-to-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz#b8cfe6a713e1091cb5b728fc48885a4767f8b97b"
+  integrity sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==
 
 mdn-data@2.0.14:
   version "2.0.14"
@@ -8921,6 +9136,14 @@ microee@0.0.6, microee@^0.0.6:
   resolved "https://registry.yarnpkg.com/microee/-/microee-0.0.6.tgz#a12bdb0103681e8b126a9b071eba4c467c78fffe"
   integrity sha1-oSvbAQNoHosSapsHHrpMRnx4//4=
 
+micromark@~2.11.0:
+  version "2.11.4"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-2.11.4.tgz#d13436138eea826383e822449c9a5c50ee44665a"
+  integrity sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==
+  dependencies:
+    debug "^4.0.0"
+    parse-entities "^2.0.0"
+
 micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -8998,7 +9221,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@^3.0.2, minimatch@^3.0.4:
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -9639,6 +9862,13 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+onigasm@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/onigasm/-/onigasm-2.2.5.tgz#cc4d2a79a0fa0b64caec1f4c7ea367585a676892"
+  integrity sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==
+  dependencies:
+    lru-cache "^5.1.1"
+
 open@^7.0.2:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/open/-/open-7.3.0.tgz#45461fdee46444f3645b6e14eb3ca94b82e1be69"
@@ -9908,6 +10138,18 @@ parse-entities@^1.1.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.2.tgz#c31bf0f653b6661354f8973559cb86dd1d5edf50"
   integrity sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
+parse-entities@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-2.0.0.tgz#53c6eb5b9314a1f4ec99fa0fdf7ce01ecda0cbe8"
+  integrity sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==
   dependencies:
     character-entities "^1.0.0"
     character-entities-legacy "^1.0.0"
@@ -10803,7 +11045,7 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
-progress@^2.0.0:
+progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -11407,6 +11649,13 @@ readdirp@~3.5.0:
   dependencies:
     picomatch "^2.2.1"
 
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
+  dependencies:
+    picomatch "^2.2.1"
+
 realpath-native@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.1.0.tgz#2003294fea23fb0672f2476ebe22fcf498a2d65c"
@@ -11596,6 +11845,15 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+remark-cli@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/remark-cli/-/remark-cli-9.0.0.tgz#6f7951e7a72217535f2e32b7a6d3f638fe182f86"
+  integrity sha512-y6kCXdwZoMoh0Wo4Och1tDW50PmMc86gW6GpF08v9d+xUCEJE2wwXdQ+TnTaUamRnfFdU+fE+eNf2PJ53cyq8g==
+  dependencies:
+    markdown-extensions "^1.1.0"
+    remark "^13.0.0"
+    unified-args "^8.0.0"
+
 remark-parse@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
@@ -11617,6 +11875,29 @@ remark-parse@^5.0.0:
     vfile-location "^2.0.0"
     xtend "^4.0.1"
 
+remark-parse@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-9.0.0.tgz#4d20a299665880e4f4af5d90b7c7b8a935853640"
+  integrity sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==
+  dependencies:
+    mdast-util-from-markdown "^0.8.0"
+
+remark-stringify@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-9.0.1.tgz#576d06e910548b0a7191a71f27b33f1218862894"
+  integrity sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==
+  dependencies:
+    mdast-util-to-markdown "^0.6.0"
+
+remark@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/remark/-/remark-13.0.0.tgz#d15d9bf71a402f40287ebe36067b66d54868e425"
+  integrity sha512-HDz1+IKGtOyWN+QgBiAT0kn+2s6ovOxHyPAFGKVE81VSzJ+mq7RwHFledEvB5F1p4iJvOah/LOKdFuzvRnNLCA==
+  dependencies:
+    remark-parse "^9.0.0"
+    remark-stringify "^9.0.0"
+    unified "^9.1.0"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -11627,7 +11908,7 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
   integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
-repeat-string@^1.5.4, repeat-string@^1.6.1:
+repeat-string@^1.0.0, repeat-string@^1.5.0, repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
@@ -12042,6 +12323,15 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+shiki@^0.9.3:
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.9.5.tgz#c8da81a05fbfd1810729c6873901a729a72ec541"
+  integrity sha512-XFn+rl3wIowDjzdr5DlHoHgQphXefgUTs2bNp/bZu4WF9gTrTLnKwio3f28VjiFG6Jpip7yQn/p4mMj6OrjrtQ==
+  dependencies:
+    json5 "^2.2.0"
+    onigasm "^2.2.5"
+    vscode-textmate "5.2.0"
+
 side-channel@^1.0.2, side-channel@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.3.tgz#cdc46b057550bbab63706210838df5d4c19519c3"
@@ -12425,6 +12715,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
+string-width@^4.0.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
+  integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
+
 string.prototype.matchall@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.3.tgz#24243399bc31b0a49d19e2b74171a15653ec996a"
@@ -12502,6 +12801,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
+  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+  dependencies:
+    ansi-regex "^5.0.0"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -12601,7 +12907,7 @@ supports-color@^5.2.0, supports-color@^5.3.0, supports-color@^5.4.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^6.1.0:
+supports-color@^6.0.0, supports-color@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
@@ -12909,6 +13215,14 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+to-vfile@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/to-vfile/-/to-vfile-6.1.0.tgz#5f7a3f65813c2c4e34ee1f7643a5646344627699"
+  integrity sha512-BxX8EkCxOAZe+D/ToHdDsJcVI4HqQfmw0tCkp31zf3dNP/XWIAjU4CmeuSwsSoOzOTqHPOL0KUzyZqJplkD0Qw==
+  dependencies:
+    is-buffer "^2.0.0"
+    vfile "^4.0.0"
+
 toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
@@ -13063,6 +13377,38 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typedoc-default-themes@^0.12.10:
+  version "0.12.10"
+  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz#614c4222fe642657f37693ea62cad4dafeddf843"
+  integrity sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==
+
+typedoc-plugin-markdown@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.10.1.tgz#9d15c16c1a29da4c137123565019d1de967987b4"
+  integrity sha512-C7s9p6DOGagPPp65g7af8OKm6Ou0rT/TP0Nphy6PQ4w6bC9BZnlOzWt1l05ER38HhON6/2prONnYwEMK5YOYCA==
+  dependencies:
+    handlebars "^4.7.7"
+
+typedoc-plugin-rename-defaults@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-rename-defaults/-/typedoc-plugin-rename-defaults-0.1.0.tgz#85af526b8a3827d47dfbf8863191529f2179c6b8"
+  integrity sha512-SVif2oxXEUNGITPVBi0LIXJvLgOAHgi8JWbWNaX2r7M7XrYCZholBL1MnaRWvOukQpSODdwOrZhc0YATuO68Sg==
+
+typedoc@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.21.0.tgz#d35dd69b1566032cd893f4f6f21f37156f5f78d2"
+  integrity sha512-InmPBVlpOXptIkg/WnsQhbGYhv9cuDh/cRACUSautQ0QwcJPLAK2kHcfP0Pld6z/NiDvHc159fMq2qS+b/ALUw==
+  dependencies:
+    glob "^7.1.7"
+    handlebars "^4.7.7"
+    lodash "^4.17.21"
+    lunr "^2.3.9"
+    marked "^2.1.1"
+    minimatch "^3.0.0"
+    progress "^2.0.3"
+    shiki "^0.9.3"
+    typedoc-default-themes "^0.12.10"
+
 typescript@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
@@ -13162,6 +13508,43 @@ unicode-trie@^0.3.1:
     pako "^0.2.5"
     tiny-inflate "^1.0.0"
 
+unified-args@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/unified-args/-/unified-args-8.1.0.tgz#a27dbe996a49fbbf3d9f5c6a98008ab9b0ee6ae5"
+  integrity sha512-t1HPS1cQPsVvt/6EtyWIbQGurza5684WGRigNghZRvzIdHm3LPgMdXPyGx0npORKzdiy5+urkF0rF5SXM8lBuQ==
+  dependencies:
+    camelcase "^5.0.0"
+    chalk "^3.0.0"
+    chokidar "^3.0.0"
+    fault "^1.0.2"
+    json5 "^2.0.0"
+    minimist "^1.2.0"
+    text-table "^0.2.0"
+    unified-engine "^8.0.0"
+
+unified-engine@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/unified-engine/-/unified-engine-8.1.0.tgz#a846e11705fb8589d1250cd27500b56021d8a3e2"
+  integrity sha512-ptXTWUf9HZ2L9xto7tre+hSdSN7M9S0rypUpMAcFhiDYjrXLrND4If+8AZOtPFySKI/Zhfxf7GVAR34BqixDUA==
+  dependencies:
+    concat-stream "^2.0.0"
+    debug "^4.0.0"
+    fault "^1.0.0"
+    figures "^3.0.0"
+    glob "^7.0.3"
+    ignore "^5.0.0"
+    is-buffer "^2.0.0"
+    is-empty "^1.0.0"
+    is-plain-obj "^2.0.0"
+    js-yaml "^3.6.1"
+    load-plugin "^3.0.0"
+    parse-json "^5.0.0"
+    to-vfile "^6.0.0"
+    trough "^1.0.0"
+    unist-util-inspect "^5.0.0"
+    vfile-reporter "^6.0.0"
+    vfile-statistics "^1.1.0"
+
 unified@^6.1.5:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
@@ -13173,6 +13556,18 @@ unified@^6.1.5:
     trough "^1.0.0"
     vfile "^2.0.0"
     x-is-string "^0.1.0"
+
+unified@^9.1.0:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.1.tgz#ae18d5674c114021bfdbdf73865ca60f410215a3"
+  integrity sha512-juWjuI8Z4xFg8pJbnEZ41b5xjGUWGHqXALmBZ3FC3WX0PIx1CZBIIJ6mXbYMcf6Yw4Fi0rFUTA1cdz/BglbOhA==
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-buffer "^2.0.0"
+    is-plain-obj "^2.0.0"
+    trough "^1.0.0"
+    vfile "^4.0.0"
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -13208,10 +13603,30 @@ unique-slug@^2.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
+unist-util-find@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/unist-util-find/-/unist-util-find-1.0.2.tgz#4d5b01a69fca2a382ad4f55f9865e402129ecf56"
+  integrity sha512-ft06UDYzqi9o9RmGP0sZWI/zvLLQiBW2/MD+rW6mDqbOWDcmknGX9orQPspfuGRYWr8eSJAmfsBcvOpfGRJseA==
+  dependencies:
+    lodash.iteratee "^4.5.0"
+    unist-util-visit "^1.1.0"
+
+unist-util-inspect@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-inspect/-/unist-util-inspect-5.0.1.tgz#168c8770a99902318ca268f8c391e294bcf44540"
+  integrity sha512-fPNWewS593JSmg49HbnE86BJKuBi1/nMWhDSccBvbARfxezEuJV85EaARR9/VplveiwCoLm2kWq+DhP8TBaDpw==
+  dependencies:
+    is-empty "^1.0.0"
+
 unist-util-is@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
   integrity sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
+
+unist-util-is@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-5.1.0.tgz#93cab236c0d98e7c02265f6cfa3efe8b117a628c"
+  integrity sha512-pWspZ+AvTqYbC+xWeRmzGqbcY8Na08Eowlfs2xchWTYot8vBBAq+syrE/LWS0bw1D/JOu4lwzDbEb6Mz13tK+g==
 
 unist-util-remove-position@^1.0.0:
   version "1.1.4"
@@ -13225,6 +13640,13 @@ unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
   integrity sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==
 
+unist-util-stringify-position@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz#cce3bfa1cdf85ba7375d1d5b17bdc4cada9bd9da"
+  integrity sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==
+  dependencies:
+    "@types/unist" "^2.0.2"
+
 unist-util-visit-parents@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz#f6e3afee8bdbf961c0e6f028ea3c0480028c3d06"
@@ -13237,12 +13659,29 @@ unist-util-visit-parents@^2.0.0:
   dependencies:
     unist-util-is "^3.0.0"
 
+unist-util-visit-parents@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-4.1.1.tgz#e83559a4ad7e6048a46b1bdb22614f2f3f4724f2"
+  integrity sha512-1xAFJXAKpnnJl8G7K5KgU7FY55y3GcLIXqkzUj5QF/QVP7biUm0K0O2oqVkYsdjzJKifYeWn9+o6piAK2hGSHw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+
 unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
   integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
   dependencies:
     unist-util-visit-parents "^2.0.0"
+
+unist-util-visit@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-3.1.0.tgz#9420d285e1aee938c7d9acbafc8e160186dbaf7b"
+  integrity sha512-Szoh+R/Ll68QWAyQyZZpQzZQm2UPbxibDvaY8Xc9SUtYgPsDzx5AWSk++UUt2hJuow8mvwR+rG+LQLw+KsuAKA==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+    unist-util-visit-parents "^4.0.0"
 
 universal-user-agent@^4.0.0:
   version "4.0.1"
@@ -13419,6 +13858,36 @@ vfile-message@^1.0.0:
   dependencies:
     unist-util-stringify-position "^1.1.1"
 
+vfile-message@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-2.0.4.tgz#5b43b88171d409eae58477d13f23dd41d52c371a"
+  integrity sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-stringify-position "^2.0.0"
+
+vfile-reporter@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/vfile-reporter/-/vfile-reporter-6.0.2.tgz#cbddaea2eec560f27574ce7b7b269822c191a676"
+  integrity sha512-GN2bH2gs4eLnw/4jPSgfBjo+XCuvnX9elHICJZjVD4+NM0nsUrMTvdjGY5Sc/XG69XVTgLwj7hknQVc6M9FukA==
+  dependencies:
+    repeat-string "^1.5.0"
+    string-width "^4.0.0"
+    supports-color "^6.0.0"
+    unist-util-stringify-position "^2.0.0"
+    vfile-sort "^2.1.2"
+    vfile-statistics "^1.1.0"
+
+vfile-sort@^2.1.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/vfile-sort/-/vfile-sort-2.2.2.tgz#720fe067ce156aba0b411a01bb0dc65596aa1190"
+  integrity sha512-tAyUqD2R1l/7Rn7ixdGkhXLD3zsg+XLAeUDUhXearjfIcpL1Hcsj5hHpCoy/gvfK/Ws61+e972fm0F7up7hfYA==
+
+vfile-statistics@^1.1.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/vfile-statistics/-/vfile-statistics-1.1.4.tgz#b99fd15ecf0f44ba088cc973425d666cb7a9f245"
+  integrity sha512-lXhElVO0Rq3frgPvFBwahmed3X03vjPF8OcjKMy8+F1xU/3Q3QU3tKEDp743SFtb74PdF0UWpxPvtOP0GCLheA==
+
 vfile@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
@@ -13429,6 +13898,16 @@ vfile@^2.0.0:
     unist-util-stringify-position "^1.0.0"
     vfile-message "^1.0.0"
 
+vfile@^4.0.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-4.2.1.tgz#03f1dce28fc625c625bc6514350fbdb00fa9e624"
+  integrity sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    is-buffer "^2.0.0"
+    unist-util-stringify-position "^2.0.0"
+    vfile-message "^2.0.0"
+
 vlq@^0.2.2:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
@@ -13438,6 +13917,11 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+vscode-textmate@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.2.0.tgz#01f01760a391e8222fe4f33fbccbd1ad71aed74e"
+  integrity sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==
 
 vue-eslint-parser@^5.0.0:
   version "5.0.0"
@@ -13811,3 +14295,8 @@ yargs@^14.2.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^15.0.1"
+
+zwitch@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-1.0.5.tgz#d11d7381ffed16b742f6af7b3f223d5cd9fe9920"
+  integrity sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==


### PR DESCRIPTION
Result visible here: https://ptbrowne.github.io/cozy-docs-v3/en/cozy-client/api/cozy-client/modules/

jsdoc does not correctly parse some typescript supported syntaxes
(imports for example, or type property extraction). It caused problem
when trying to some types. See https://github.com/cozy/cozy-client/issues/969
By using typedoc, we stay in the typescript ecosystem and use the same parser.

Here, jsdoc is replaced by typedoc to generate the API documentation of
cozy-client in markdown.

remark is used to postprocess the generated markdown documentation to strip
deep headings and replace them with emphasis nodes so that they do not
appear on the right table of contents on https://docs.cozy.io.

An interesting side effect is that each class / or namespace is on one
page, it makes it easier to navigate the doc and to see the API.

Fix https://github.com/cozy/cozy-client/issues/969

Next steps would be (to fully use typescript across the repo, and to remove jsdoc) :

- Move tsconfig.json to the root of the workspace so that it is usable by every package
- Run typecheck on every package
- Have typedoc generate the documentation for all package