### PR TITLE
fix: Restore the log URL for mobile authentication

### DIFF
--- a/packages/cozy-client/src/authentication/mobile.js
+++ b/packages/cozy-client/src/authentication/mobile.js
@@ -107,6 +107,7 @@ export const authenticateWithCordova = async url => {
      * then get the "access_code" url and paste it in the prompt to let the
      * application initialize and redirect to other pages.
      */
+    console.log(url) // Useful for dev (see above).
     return new Promise(resolve => {
       setTimeout(() => {
         const token = prompt('Paste the url here:')


### PR DESCRIPTION
This log was mistakenly removed in a previous [commit](https://github.com/cozy/cozy-client/commit/390f46d47c8c80917c93d518ac201a1b40868329?branch=390f46d47c8c80917c93d518ac201a1b40868329&diff=unified#diff-e879aaa33e459b749f1f68b01b84a2faf1fccd65cc819c96e7afc6c8bcbb2c36L168) but it is necessary to authenticate in standalone mobile mode for apps such as Drive.