### PR TITLE
fix: Move @types to devDependencies

### DIFF
--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -15,8 +15,6 @@
   },
   "dependencies": {
     "@cozy/minilog": "1.0.0",
-    "@types/jest": "^26.0.20",
-    "@types/lodash": "^4.14.170",
     "btoa": "^1.2.1",
     "cozy-device-helper": "^1.12.0",
     "cozy-flags": "2.7.1",
@@ -47,6 +45,8 @@
     "@material-ui/core": "4",
     "@testing-library/react": "^10.0.1",
     "@testing-library/react-hooks": "^3.2.1",
+    "@types/jest": "^26.0.20",
+    "@types/lodash": "^4.14.170",
     "babel-plugin-search-and-replace": "1.1.0",
     "btoa": "^1.2.1",
     "cozy-logger": "^1.6.0",


### PR DESCRIPTION
@types should not be in `dependencies` but `devDependencies`

This may create interferences with other @types in projects where cozy-client is imported