### PR TITLE
Add API for Pouch migration

### DIFF
--- a/docs/api/cozy-pouch-link.md
+++ b/docs/api/cozy-pouch-link.md
@@ -68,6 +68,15 @@ and on demand immediately.</p>
 <dt><a href="#destroyWarmedUpQueries">destroyWarmedUpQueries</a></dt>
 <dd><p>Destroy the warmed queries</p>
 </dd>
+<dt><a href="#getAdapterName">getAdapterName</a> ⇒ <code>string</code></dt>
+<dd><p>Get the adapter name</p>
+</dd>
+<dt><a href="#persistAdapterName">persistAdapterName</a></dt>
+<dd><p>Persist the adapter name</p>
+</dd>
+<dt><a href="#migratePouch">migratePouch</a> ⇒ <code>object</code></dt>
+<dd><p>Migrate a PouchDB database to a new adapter.</p>
+</dd>
 <dt><a href="#fetchRemoteInstance">fetchRemoteInstance</a> ⇒ <code>object</code></dt>
 <dd><p>Fetch remote instance</p>
 </dd>
@@ -79,6 +88,12 @@ and on demand immediately.</p>
 <p>It uses the _all_docs view, and bulk insert the docs.
 Note it saves the last replicated _id for each run and
 starts from there in case the process stops before the end.</p>
+</dd>
+<dt><a href="#getDatabaseName">getDatabaseName</a> ⇒ <code>string</code></dt>
+<dd><p>Get the database name based on prefix and doctype</p>
+</dd>
+<dt><a href="#getPrefix">getPrefix</a> ⇒ <code>string</code></dt>
+<dd><p>Get the URI prefix</p>
 </dd>
 </dl>
 
@@ -404,6 +419,37 @@ Get the warmed up queries
 Destroy the warmed queries
 
 **Kind**: global constant  
+<a name="getAdapterName"></a>
+
+## getAdapterName ⇒ <code>string</code>
+Get the adapter name
+
+**Kind**: global constant  
+**Returns**: <code>string</code> - The adapter name  
+<a name="persistAdapterName"></a>
+
+## persistAdapterName
+Persist the adapter name
+
+**Kind**: global constant  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| adapter | <code>string</code> | The adapter name |
+
+<a name="migratePouch"></a>
+
+## migratePouch ⇒ <code>object</code>
+Migrate a PouchDB database to a new adapter.
+
+**Kind**: global constant  
+**Returns**: <code>object</code> - - The migrated pouch  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| oldPouch | <code>object</code> | The pouch to migrate |
+| toAdapter | <code>string</code> | The target adapter name |
+
 <a name="fetchRemoteInstance"></a>
 
 ## fetchRemoteInstance ⇒ <code>object</code>
@@ -446,6 +492,31 @@ starts from there in case the process stops before the end.
 | db | <code>object</code> | Pouch instance |
 | baseUrl | <code>string</code> | The remote instance |
 | doctype | <code>string</code> | The doctype to replicate |
+
+<a name="getDatabaseName"></a>
+
+## getDatabaseName ⇒ <code>string</code>
+Get the database name based on prefix and doctype
+
+**Kind**: global constant  
+**Returns**: <code>string</code> - The database name  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| } | <code>string</code> | prefix - The URL prefix |
+| doctype | <code>string</code> | The database doctype |
+
+<a name="getPrefix"></a>
+
+## getPrefix ⇒ <code>string</code>
+Get the URI prefix
+
+**Kind**: global constant  
+**Returns**: <code>string</code> - The URI prefix  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| uri | <code>string</code> | The Cozy URI |
 
 <a name="getQueryAlias"></a>
 

--- a/docs/api/cozy-pouch-link.md
+++ b/docs/api/cozy-pouch-link.md
@@ -74,9 +74,6 @@ and on demand immediately.</p>
 <dt><a href="#persistAdapterName">persistAdapterName</a></dt>
 <dd><p>Persist the adapter name</p>
 </dd>
-<dt><a href="#migratePouch">migratePouch</a> ⇒ <code>object</code></dt>
-<dd><p>Migrate a PouchDB database to a new adapter.</p>
-</dd>
 <dt><a href="#fetchRemoteInstance">fetchRemoteInstance</a> ⇒ <code>object</code></dt>
 <dd><p>Fetch remote instance</p>
 </dd>
@@ -102,6 +99,17 @@ starts from there in case the process stops before the end.</p>
 <dl>
 <dt><a href="#getQueryAlias">getQueryAlias(query)</a> ⇒ <code>string</code></dt>
 <dd></dd>
+</dl>
+
+## Typedefs
+
+<dl>
+<dt><a href="#MigrationParams">MigrationParams</a> : <code>object</code></dt>
+<dd><p>Migrate the current adapter</p>
+</dd>
+<dt><a href="#MigrationParams">MigrationParams</a> ⇒ <code>object</code></dt>
+<dd><p>Migrate a PouchDB database to a new adapter.</p>
+</dd>
 </dl>
 
 <a name="PouchLink"></a>
@@ -437,19 +445,6 @@ Persist the adapter name
 | --- | --- | --- |
 | adapter | <code>string</code> | The adapter name |
 
-<a name="migratePouch"></a>
-
-## migratePouch ⇒ <code>object</code>
-Migrate a PouchDB database to a new adapter.
-
-**Kind**: global constant  
-**Returns**: <code>object</code> - - The migrated pouch  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| oldPouch | <code>object</code> | The pouch to migrate |
-| toAdapter | <code>string</code> | The target adapter name |
-
 <a name="fetchRemoteInstance"></a>
 
 ## fetchRemoteInstance ⇒ <code>object</code>
@@ -527,4 +522,44 @@ Get the URI prefix
 | Param | Type |
 | --- | --- |
 | query | <code>QueryDefinition</code> | 
+
+<a name="MigrationParams"></a>
+
+## MigrationParams : <code>object</code>
+Migrate the current adapter
+
+**Kind**: global typedef  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| params | [<code>MigrationParams</code>](#MigrationParams) | Migration params |
+
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| [fromAdapter] | <code>string</code> | The current adapter type, e.g. 'idb' |
+| [toAdapter] | <code>string</code> | The new adapter type, e.g. 'indexeddb' |
+| [url] | <code>string</code> | The Cozy URL |
+| [plugins] | <code>Array.&lt;object&gt;</code> | The PouchDB plugins |
+
+<a name="MigrationParams"></a>
+
+## MigrationParams ⇒ <code>object</code>
+Migrate a PouchDB database to a new adapter.
+
+**Kind**: global typedef  
+**Returns**: <code>object</code> - - The migrated pouch  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| params | [<code>MigrationParams</code>](#MigrationParams) | The migration params |
+
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| [dbName] | <code>string</code> | The database name |
+| [fromAdapter] | <code>string</code> | The current adapter type, e.g. 'idb' |
+| [toAdapter] | <code>string</code> | The new adapter type, e.g. 'indexeddb' |
 

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -128,13 +128,8 @@ class PouchLink extends CozyLink {
       for (const doctype of doctypes) {
         const prefix = getPrefix(url)
         const dbName = getDatabaseName(prefix, doctype)
-        const oldPouch = new PouchDB(dbName, {
-          adapter: fromAdapter,
-          location: 'default'
-        })
-        await migratePouch(oldPouch, toAdapter)
-        await oldPouch.close()
-        await oldPouch.destroy()
+
+        await migratePouch({ dbName, fromAdapter, toAdapter })
       }
       persistAdapterName('indexeddb')
       // Reload page to benefit from new adapter

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -114,6 +114,11 @@ class PouchLink extends CozyLink {
     this.client = client
   }
 
+  /**
+   * Migrate the current adapter
+   *
+   * @param {{fromAdapter, toAdapter, url, plugins}} - The migration params
+   */
   async migrateAdapter({ fromAdapter, toAdapter, url, plugins }) {
     try {
       for (const plugin of plugins) {

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -117,7 +117,13 @@ class PouchLink extends CozyLink {
   /**
    * Migrate the current adapter
    *
-   * @param {{fromAdapter, toAdapter, url, plugins}} - The migration params
+   * @typedef {object} MigrationParams
+   * @property {string} [fromAdapter] - The current adapter type, e.g. 'idb'
+   * @property {string} [toAdapter] - The new adapter type, e.g. 'indexeddb'
+   * @property {string} [url] - The Cozy URL
+   * @property {Array<object>} [plugins] - The PouchDB plugins
+   *
+   * @param {MigrationParams} params - Migration params
    */
   async migrateAdapter({ fromAdapter, toAdapter, url, plugins }) {
     try {

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -22,7 +22,8 @@ import { getDatabaseName, getPrefix } from './utils'
 import {
   getPersistedSyncedDoctypes,
   persistAdapterName,
-  getAdapterName
+  getAdapterName,
+  destroyWarmedUpQueries
 } from './localStorage'
 
 PouchDB.plugin(PouchDBFind)
@@ -136,6 +137,7 @@ class PouchLink extends CozyLink {
         const dbName = getDatabaseName(prefix, doctype)
 
         await migratePouch({ dbName, fromAdapter, toAdapter })
+        destroyWarmedUpQueries() // force recomputing indexes
       }
       persistAdapterName('indexeddb')
     } catch (err) {

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -132,8 +132,6 @@ class PouchLink extends CozyLink {
         await migratePouch({ dbName, fromAdapter, toAdapter })
       }
       persistAdapterName('indexeddb')
-      // Reload page to benefit from new adapter
-      window.location.reload()
     } catch (err) {
       console.error('PouchLink: PouchDB migration failed. ', err)
     }

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -11,6 +11,7 @@ import logger from './logger'
 import { fetchRemoteLastSequence } from './remote'
 import { startReplication } from './startReplication'
 import * as localStorage from './localStorage'
+import { getDatabaseName } from './utils'
 
 const DEFAULT_DELAY = 30 * 1000
 
@@ -38,7 +39,7 @@ class PouchManager {
     this.pouches = fromPairs(
       doctypes.map(doctype => [
         doctype,
-        new PouchDB(this.getDatabaseName(doctype), pouchOptions)
+        new PouchDB(getDatabaseName(options.prefix, doctype), pouchOptions)
       ])
     )
     this.syncedDoctypes = localStorage.getPersistedSyncedDoctypes()
@@ -272,10 +273,6 @@ class PouchManager {
 
   isSynced(doctype) {
     return this.syncedDoctypes.includes(doctype)
-  }
-
-  getDatabaseName(doctype) {
-    return `${this.options.prefix}_${doctype}`
   }
 
   clearSyncedDoctypes() {

--- a/packages/cozy-pouch-link/src/localStorage.js
+++ b/packages/cozy-pouch-link/src/localStorage.js
@@ -5,6 +5,7 @@ export const LOCALSTORAGE_LASTSEQUENCES_KEY =
   'cozy-client-pouch-link-lastreplicationsequence'
 export const LOCALSTORAGE_LASTREPLICATEDDOCID_KEY =
   'cozy-client-pouch-link-lastreplicateddocid'
+export const LOCALSTORAGE_ADAPTERNAME = 'cozy-client-pouch-link-adaptername'
 
 /**
  * Persist the last replicated doc id for a doctype
@@ -165,4 +166,22 @@ export const getPersistedWarmedUpQueries = () => {
  */
 export const destroyWarmedUpQueries = () => {
   window.localStorage.removeItem(LOCALSTORAGE_WARMUPEDQUERIES_KEY)
+}
+
+/**
+ * Get the adapter name
+ *
+ * @returns {string} The adapter name
+ */
+export const getAdapterName = () => {
+  return window.localStorage.getItem(LOCALSTORAGE_ADAPTERNAME)
+}
+
+/**
+ * Persist the adapter name
+ *
+ * @param {string} adapter - The adapter name
+ */
+export const persistAdapterName = adapter => {
+  window.localStorage.setItem(LOCALSTORAGE_ADAPTERNAME, adapter)
 }

--- a/packages/cozy-pouch-link/src/migrations/adapter.js
+++ b/packages/cozy-pouch-link/src/migrations/adapter.js
@@ -1,0 +1,22 @@
+import PouchDB from 'pouchdb-browser'
+
+const getNewIndexedDBDatabaseName = dbName => {
+  return `${dbName}_indexeddb`
+}
+
+/**
+ * Migrate a PouchDB database to a new adapter.
+ *
+ * @param {object} oldPouch - The pouch to migrate
+ * @param {string} toAdapter - The target adapter name
+ * @returns {object} - The migrated pouch
+ */
+export const migratePouch = async (oldPouch, toAdapter) => {
+  const newdbName = getNewIndexedDBDatabaseName(oldPouch.name)
+  const newPouch = new PouchDB(newdbName, {
+    adapter: toAdapter,
+    location: 'default'
+  })
+  await oldPouch.replicate.to(newPouch, { batch_size: 1000 })
+  return newPouch
+}

--- a/packages/cozy-pouch-link/src/migrations/adapter.js
+++ b/packages/cozy-pouch-link/src/migrations/adapter.js
@@ -11,7 +11,11 @@ const getNewIndexedDBDatabaseName = dbName => {
  * @param {string} toAdapter - The target adapter name
  * @returns {object} - The migrated pouch
  */
-export const migratePouch = async (oldPouch, toAdapter) => {
+export const migratePouch = async ({ dbName, fromAdapter, toAdapter }) => {
+  let oldPouch = new PouchDB(dbName, {
+    adapter: fromAdapter,
+    location: 'default'
+  })
   const newdbName = getNewIndexedDBDatabaseName(oldPouch.name)
   const newPouch = new PouchDB(newdbName, {
     adapter: toAdapter,

--- a/packages/cozy-pouch-link/src/migrations/adapter.js
+++ b/packages/cozy-pouch-link/src/migrations/adapter.js
@@ -7,8 +7,12 @@ const getNewIndexedDBDatabaseName = dbName => {
 /**
  * Migrate a PouchDB database to a new adapter.
  *
- * @param {object} oldPouch - The pouch to migrate
- * @param {string} toAdapter - The target adapter name
+ * @typedef {object} MigrationParams
+ * @property {string} [dbName] - The database name
+ * @property {string} [fromAdapter] - The current adapter type, e.g. 'idb'
+ * @property {string} [toAdapter] - The new adapter type, e.g. 'indexeddb'
+ *
+ * @param {MigrationParams} params - The migration params
  * @returns {object} - The migrated pouch
  */
 export const migratePouch = async ({ dbName, fromAdapter, toAdapter }) => {

--- a/packages/cozy-pouch-link/src/migrations/adapter.js
+++ b/packages/cozy-pouch-link/src/migrations/adapter.js
@@ -18,5 +18,9 @@ export const migratePouch = async (oldPouch, toAdapter) => {
     location: 'default'
   })
   await oldPouch.replicate.to(newPouch, { batch_size: 1000 })
+
+  await oldPouch.destroy()
+  oldPouch = null // See https://web.dev/detached-window-memory-leaks/
+
   return newPouch
 }

--- a/packages/cozy-pouch-link/src/migrations/adapter.js
+++ b/packages/cozy-pouch-link/src/migrations/adapter.js
@@ -20,7 +20,7 @@ export const migratePouch = async ({ dbName, fromAdapter, toAdapter }) => {
     adapter: fromAdapter,
     location: 'default'
   })
-  const newdbName = getNewIndexedDBDatabaseName(oldPouch.name)
+  const newdbName = getNewIndexedDBDatabaseName(dbName)
   const newPouch = new PouchDB(newdbName, {
     adapter: toAdapter,
     location: 'default'

--- a/packages/cozy-pouch-link/src/migrations/adapter.spec.js
+++ b/packages/cozy-pouch-link/src/migrations/adapter.spec.js
@@ -1,0 +1,19 @@
+import { migratePouch } from './adapter'
+import PouchDB from 'pouchdb-browser'
+
+describe('adapter', () => {
+  PouchDB.plugin(require('pouchdb-adapter-memory'))
+
+  it('should migrate', async () => {
+    const oldPouch = new PouchDB('test', { adapter: 'memory' })
+    await oldPouch.put({
+      _id: 'hellodoc',
+      name: 'bugs'
+    })
+    const migrated = await migratePouch(oldPouch, 'memory')
+    expect(migrated.adapter).toEqual('memory')
+    const doc = await migrated.get('hellodoc')
+    expect(doc._id).toEqual('hellodoc')
+    expect(doc.name).toEqual('bugs')
+  })
+})

--- a/packages/cozy-pouch-link/src/migrations/adapter.spec.js
+++ b/packages/cozy-pouch-link/src/migrations/adapter.spec.js
@@ -10,7 +10,11 @@ describe('adapter', () => {
       _id: 'hellodoc',
       name: 'bugs'
     })
-    const migrated = await migratePouch(oldPouch, 'memory')
+    const migrated = await migratePouch({
+      dbName: 'test',
+      fromAdapter: 'memory',
+      toAdapter: 'memory'
+    })
     expect(migrated.adapter).toEqual('memory')
     const doc = await migrated.get('hellodoc')
     expect(doc._id).toEqual('hellodoc')

--- a/packages/cozy-pouch-link/src/utils.js
+++ b/packages/cozy-pouch-link/src/utils.js
@@ -1,0 +1,20 @@
+/**
+ * Get the database name based on prefix and doctype
+ *
+ * @param {string}} prefix - The URL prefix
+ * @param {string} doctype - The database doctype
+ * @returns {string} The database name
+ */
+export const getDatabaseName = (prefix, doctype) => {
+  return `${prefix}_${doctype}`
+}
+
+/**
+ * Get the URI prefix
+ *
+ * @param {string} uri - The Cozy URI
+ * @returns {string} The URI prefix
+ */
+export const getPrefix = uri => {
+  return uri.replace(/^https?:\/\//, '')
+}


### PR DESCRIPTION
PouchDB can use different kind of adapter, e.g. idb, sqlite, etc.
We want to be able to migrate the adapter, typically to use the new and
more performant IndexedDB adapter.

To perform such migration, we run a local replication between the old
and new database instance. By doing so, the user can migrate its data
without requiring an internet connection.

Note the migration can take some time, i.e. several minutes depending on
the device, the database size, etc.
It is the responsability of the app to to call the `migrateAdapter` API
and handle this migration on the UI level.

Once the adapter is migrated, the old database is removed, and the page
reloaded so the client will use the new Pouch. The adapter name is saved
in the localstorage to inform the app which adapter should be used.