### PR TITLE
feat: Add sharing rules for bitwarden organizations

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -115,6 +115,9 @@ See <a href="https://docs.cozy.io/en/cozy-stack/sharing-design/#description-of-a
 <dt><a href="#getSharingPolicyForFile">getSharingPolicyForFile(document, sharingType)</a> ⇒ <code><a href="#SharingPolicy">SharingPolicy</a></code></dt>
 <dd><p>Compute the sharing policy for a File based on its sharing type</p>
 </dd>
+<dt><a href="#getSharingRulesForOrganizations">getSharingRulesForOrganizations(document)</a> ⇒ <code><a href="#Rule">Array.&lt;Rule&gt;</a></code></dt>
+<dd><p>Compute the rules that define how to share an Organization. See <a href="https://docs.cozy.io/en/cozy-stack/sharing-design/#description-of-a-sharing">https://docs.cozy.io/en/cozy-stack/sharing-design/#description-of-a-sharing</a></p>
+</dd>
 <dt><a href="#toRelationshipItem">toRelationshipItem(item)</a> ⇒ <code><a href="#RelationshipItem">RelationshipItem</a></code></dt>
 <dd><p>Compute the RelationshipItem that can be referenced as a sharing recipient</p>
 </dd>
@@ -1729,6 +1732,18 @@ Compute the sharing policy for a File based on its sharing type
 | --- | --- | --- |
 | document | [<code>Sharing</code>](#Sharing) | The document to share. Should have and _id and a name |
 | sharingType | [<code>SharingType</code>](#SharingType) | The type of the sharing |
+
+<a name="getSharingRulesForOrganizations"></a>
+
+## getSharingRulesForOrganizations(document) ⇒ [<code>Array.&lt;Rule&gt;</code>](#Rule)
+Compute the rules that define how to share an Organization. See https://docs.cozy.io/en/cozy-stack/sharing-design/#description-of-a-sharing
+
+**Kind**: global function  
+**Returns**: [<code>Array.&lt;Rule&gt;</code>](#Rule) - The rules that define how to share an Organization  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | [<code>Sharing</code>](#Sharing) | The document to share. Should have and _id and a name |
 
 <a name="toRelationshipItem"></a>
 

--- a/packages/cozy-stack-client/src/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/SharingCollection.spec.js
@@ -23,6 +23,11 @@ const RECIPIENT = {
     email: [{ address: 'jdoe@doe.com', primary: true }]
   }
 }
+const ORGANIZATION = {
+  _type: 'com.bitwarden.organizations',
+  _id: 'SOME_ORGANIZATION_ID',
+  name: 'SOME_ORGANIZATION_NAME'
+}
 
 const SHARING = {
   _id: 'sharing_1'
@@ -367,6 +372,54 @@ describe('SharingCollection', () => {
                 title: FILE.name,
                 update: 'sync',
                 values: [FILE._id]
+              }
+            ]
+          },
+          relationships: {
+            recipients: {
+              data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
+            }
+          },
+          type: 'io.cozy.sharings'
+        }
+      })
+    })
+
+    it('should creates a sharing for an organization with the most open rules, no preview and with recipients', async () => {
+      const sharingDesc = 'foos'
+      const openSharing = true
+      const previewPath = undefined
+      await collection.create({
+        document: ORGANIZATION,
+        recipients: [RECIPIENT],
+        openSharing,
+        previewPath,
+        description: sharingDesc
+      })
+
+      expect(client.fetchJSON).toHaveBeenCalledWith('POST', '/sharings/', {
+        data: {
+          attributes: {
+            description: sharingDesc,
+            open_sharing: openSharing,
+            preview_path: undefined,
+            rules: [
+              {
+                title: 'SOME_ORGANIZATION_NAME',
+                doctype: 'com.bitwarden.organizations',
+                values: ['SOME_ORGANIZATION_ID'],
+                add: 'sync',
+                update: 'sync',
+                remove: 'sync'
+              },
+              {
+                title: 'Ciphers',
+                doctype: 'com.bitwarden.ciphers',
+                values: ['SOME_ORGANIZATION_ID'],
+                add: 'sync',
+                update: 'sync',
+                remove: 'sync',
+                selector: 'organization_id'
               }
             ]
           },


### PR DESCRIPTION
In order to implement folders and ciphers sharing inside of Cozy Pass we need to implement rules that are specific to Bitwarden's organizations

Note: in the Cozy's context, a folder is equivalent to a Bitwarden's organization containing a single collection with the same name. That's why the name "folder" doesn't appears in this new code

This PR is needed for https://github.com/cozy/cozy-pass-web/pull/32