### PR TITLE
feat: Add registry.fetchAppLatestVersion

### DIFF
--- a/docs/api/cozy-client/classes/registry.md
+++ b/docs/api/cozy-client/classes/registry.md
@@ -2,12 +2,6 @@
 
 # Class: Registry
 
-**`property`** {string} slug
-
-**`property`** {object} terms
-
-**`property`** {boolean} installed
-
 ## Constructors
 
 ### constructor
@@ -22,7 +16,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:35](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L35)
+[packages/cozy-client/src/registry.js:39](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L39)
 
 ## Properties
 
@@ -32,7 +26,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:39](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L39)
+[packages/cozy-client/src/registry.js:43](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L43)
 
 ## Methods
 
@@ -54,7 +48,7 @@ Fetch the status of a single app on the registry
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L125)
+[packages/cozy-client/src/registry.js:129](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L129)
 
 ***
 
@@ -69,7 +63,7 @@ Fetch the latest version of an app for the given channel and slug
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `params` | `Object` | Fetching parameters |
-| `params.channel` | `string` | The channel of the app to fetch |
+| `params.channel` | `RegistryAppChannel` | The channel of the app to fetch |
 | `params.slug` | `string` | The slug of the app to fetch |
 
 *Returns*
@@ -78,7 +72,7 @@ Fetch the latest version of an app for the given channel and slug
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:138](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L138)
+[packages/cozy-client/src/registry.js:142](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L142)
 
 ***
 
@@ -103,7 +97,7 @@ Fetch at most 200 apps from the channel
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:89](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L89)
+[packages/cozy-client/src/registry.js:93](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L93)
 
 ***
 
@@ -119,7 +113,7 @@ Fetch the list of apps that are in maintenance mode
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:114](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L114)
+[packages/cozy-client/src/registry.js:118](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L118)
 
 ***
 
@@ -144,7 +138,7 @@ Accepts the terms if the app has them.
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:52](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L52)
+[packages/cozy-client/src/registry.js:56](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L56)
 
 ***
 
@@ -166,4 +160,4 @@ Uninstalls an app.
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:73](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L73)
+[packages/cozy-client/src/registry.js:77](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L77)

--- a/docs/api/cozy-client/classes/registry.md
+++ b/docs/api/cozy-client/classes/registry.md
@@ -87,7 +87,7 @@ Fetch at most 200 apps from the channel
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `params` | `Object` | Fetching parameters |
-| `params.channel` | `string` | "dev"/"beta"/"stable" |
+| `params.channel` | `RegistryAppChannel` | The channel of the apps to fetch |
 | `params.limit` | `string` | maximum number of fetched apps - defaults to 200 |
 | `params.type` | `string` | "webapp" or "konnector" |
 

--- a/docs/api/cozy-client/classes/registry.md
+++ b/docs/api/cozy-client/classes/registry.md
@@ -58,6 +58,30 @@ Fetch the status of a single app on the registry
 
 ***
 
+### fetchAppLatestVersion
+
+▸ **fetchAppLatestVersion**(`params`): `RegistryApp`
+
+Fetch the latest version of an app for the given channel and slug
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `params` | `Object` | Fetching parameters |
+| `params.channel` | `string` | The channel of the app to fetch |
+| `params.slug` | `string` | The slug of the app to fetch |
+
+*Returns*
+
+`RegistryApp`
+
+*Defined in*
+
+[packages/cozy-client/src/registry.js:138](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L138)
+
+***
+
 ### fetchApps
 
 ▸ **fetchApps**(`params`): `Promise`<`RegistryApp`\[]>

--- a/packages/cozy-client/src/registry.js
+++ b/packages/cozy-client/src/registry.js
@@ -85,7 +85,7 @@ class Registry {
    *
    * @param  {object} params - Fetching parameters
    * @param  {string} params.type - "webapp" or "konnector"
-   * @param  {string} params.channel - "dev"/"beta"/"stable"
+   * @param  {RegistryAppChannel} params.channel - The channel of the apps to fetch
    * @param  {string} params.limit - maximum number of fetched apps - defaults to 200
    *
    * @returns {Promise<Array<RegistryApp>>}
@@ -141,7 +141,9 @@ class Registry {
    */
   fetchAppLatestVersion(params) {
     if (!params.slug || !params.channel) {
-      throw new Error('Need to pass a slug and channel param to use fetchAppLatestVersion')
+      throw new Error(
+        'Need to pass a slug and channel param to use fetchAppLatestVersion'
+      )
     }
     const { slug, channel } = params
     return this.client.stackClient.fetchJSON(

--- a/packages/cozy-client/src/registry.js
+++ b/packages/cozy-client/src/registry.js
@@ -140,6 +140,9 @@ class Registry {
    * @returns {RegistryApp}
    */
   fetchAppLatestVersion(params) {
+    if (!params.slug || !params.channel) {
+      throw new Error('Need to pass a slug and channel param to use fetchAppLatestVersion')
+    }
     const { slug, channel } = params
     return this.client.stackClient.fetchJSON(
       'GET',

--- a/packages/cozy-client/src/registry.js
+++ b/packages/cozy-client/src/registry.js
@@ -32,6 +32,10 @@ const getBaseRoute = app => {
  * @property {boolean} installed
  */
 
+/**
+ * @typedef {"dev"|"beta"|"stable"} RegistryAppChannel
+ */
+
 class Registry {
   constructor(options) {
     if (!options.client) {
@@ -131,7 +135,7 @@ class Registry {
    *
    * @param  {object} params - Fetching parameters
    * @param  {string} params.slug - The slug of the app to fetch
-   * @param  {string} params.channel - The channel of the app to fetch
+   * @param  {RegistryAppChannel} params.channel - The channel of the app to fetch
    *
    * @returns {RegistryApp}
    */

--- a/packages/cozy-client/src/registry.js
+++ b/packages/cozy-client/src/registry.js
@@ -125,6 +125,23 @@ class Registry {
   fetchApp(slug) {
     return this.client.stackClient.fetchJSON('GET', `/registry/${slug}`)
   }
+
+  /**
+   * Fetch the latest version of an app for the given channel and slug
+   *
+   * @param  {object} params - Fetching parameters
+   * @param  {string} params.slug - The slug of the app to fetch
+   * @param  {string} params.channel - The channel of the app to fetch
+   *
+   * @returns {RegistryApp}
+   */
+  fetchAppLatestVersion(params) {
+    const { slug, channel } = params
+    return this.client.stackClient.fetchJSON(
+      'GET',
+      `/registry/${slug}/${channel}/latest`
+    )
+  }
 }
 
 export default Registry

--- a/packages/cozy-client/src/registry.spec.js
+++ b/packages/cozy-client/src/registry.spec.js
@@ -121,6 +121,16 @@ describe('registry api', () => {
       )
     })
   })
+
+  describe('fetchAppLatestVersion', () => {
+    it('should call the correct route', async () => {
+      await api.fetchAppLatestVersion({ channel: 'stable', slug: 'ameli' })
+      expect(fetchJSON).toHaveBeenCalledWith(
+        'GET',
+        '/registry/ameli/stable/latest'
+      )
+    })
+  })
 })
 
 describe('transformRegistryFormatToStackFormat', () => {

--- a/packages/cozy-client/types/registry.d.ts
+++ b/packages/cozy-client/types/registry.d.ts
@@ -6,11 +6,15 @@ export type RegistryApp = {
     terms: object;
     installed: boolean;
 };
+export type RegistryAppChannel = "stable" | "dev" | "beta";
 /**
  * @typedef {object} RegistryApp
  * @property {string} slug
  * @property {object} terms
  * @property {boolean} installed
+ */
+/**
+ * @typedef {"dev"|"beta"|"stable"} RegistryAppChannel
  */
 declare class Registry {
     constructor(options: any);
@@ -63,12 +67,12 @@ declare class Registry {
      *
      * @param  {object} params - Fetching parameters
      * @param  {string} params.slug - The slug of the app to fetch
-     * @param  {string} params.channel - The channel of the app to fetch
+     * @param  {RegistryAppChannel} params.channel - The channel of the app to fetch
      *
      * @returns {RegistryApp}
      */
     fetchAppLatestVersion(params: {
         slug: string;
-        channel: string;
+        channel: RegistryAppChannel;
     }): RegistryApp;
 }

--- a/packages/cozy-client/types/registry.d.ts
+++ b/packages/cozy-client/types/registry.d.ts
@@ -58,4 +58,17 @@ declare class Registry {
      * @returns {RegistryApp}
      */
     fetchApp(slug: string): RegistryApp;
+    /**
+     * Fetch the latest version of an app for the given channel and slug
+     *
+     * @param  {object} params - Fetching parameters
+     * @param  {string} params.slug - The slug of the app to fetch
+     * @param  {string} params.channel - The channel of the app to fetch
+     *
+     * @returns {RegistryApp}
+     */
+    fetchAppLatestVersion(params: {
+        slug: string;
+        channel: string;
+    }): RegistryApp;
 }

--- a/packages/cozy-client/types/registry.d.ts
+++ b/packages/cozy-client/types/registry.d.ts
@@ -38,14 +38,14 @@ declare class Registry {
      *
      * @param  {object} params - Fetching parameters
      * @param  {string} params.type - "webapp" or "konnector"
-     * @param  {string} params.channel - "dev"/"beta"/"stable"
+     * @param  {RegistryAppChannel} params.channel - The channel of the apps to fetch
      * @param  {string} params.limit - maximum number of fetched apps - defaults to 200
      *
      * @returns {Promise<Array<RegistryApp>>}
      */
     fetchApps(params: {
         type: string;
-        channel: string;
+        channel: RegistryAppChannel;
         limit: string;
     }): Promise<Array<RegistryApp>>;
     /**


### PR DESCRIPTION
Getting the latest version of a channel is need by amiral app to be able to get the source code of the conector latest version of the channel installed on cozy-stack 