### PR TITLE
fix: Move @types back to dependencies

### DIFF
--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -15,6 +15,8 @@
   },
   "dependencies": {
     "@cozy/minilog": "1.0.0",
+    "@types/jest": "^26.0.20",
+    "@types/lodash": "^4.14.170",
     "btoa": "^1.2.1",
     "cozy-device-helper": "^1.12.0",
     "cozy-flags": "2.7.1",
@@ -45,8 +47,6 @@
     "@material-ui/core": "4",
     "@testing-library/react": "^10.0.1",
     "@testing-library/react-hooks": "^3.2.1",
-    "@types/jest": "^26.0.20",
-    "@types/lodash": "^4.14.170",
     "babel-plugin-search-and-replace": "1.1.0",
     "btoa": "^1.2.1",
     "cozy-logger": "^1.6.0",


### PR DESCRIPTION
In a previous commit abd847ce4bb29f405fc80109fd78f65fd780d5f2 (https://github.com/cozy/cozy-client/pull/987), I moved `@types/xxx` from `dependencies` to `devDependencies` but I was wrong.

Some of those types are exposed to the package's API and may be manipulated by consuming apps.

For example : 
- `index.js` contains `export { default as compose } from 'lodash/flow'`
- `CozyClient.js` declares `getIncludesRelationships` which contains `return fromPairs(....`. This function is from `lodash` and return a lodash `Dictionary`

Due to this the generated `.d.ts` file will contain references to lodash :
```ts
getIncludesRelationships(queryDefinition: any): import("lodash").Dictionary<any>;
```

Then consuming TS apps (here `cozy-pass-web`) will require to install `@types/lodash` in order to compile.

To prevent this we should put those packages back into the `dependencies` section.