### PR TITLE
Update pouchdb-browser

### DIFF
--- a/packages/cozy-pouch-link/package.json
+++ b/packages/cozy-pouch-link/package.json
@@ -14,8 +14,8 @@
     "@cozy/minilog": "1.0.0",
     "cozy-client": "^23.17.3",
     "cozy-device-helper": "^1.12.0",
-    "pouchdb-browser": "^7.0.0",
-    "pouchdb-find": "7.2.2"
+    "pouchdb-browser": "^7.2.2",
+    "pouchdb-find": "^7.2.2"
   },
   "devDependencies": {
     "@babel/cli": "7.12.8",

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -298,6 +298,7 @@ class PouchManager {
       localStorage.persistWarmedUpQueries(this.warmedUpQueries)
       logger.log('PouchManager: warmupQueries for ' + doctype + ' are done')
     } catch (err) {
+      logger.error('PouchManager: Could not warm up queries', err)
       delete this.warmedUpQueries[doctype]
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10861,7 +10861,7 @@ pouchdb-binary-utils@7.2.2:
   dependencies:
     buffer-from "1.1.1"
 
-pouchdb-browser@^7.0.0:
+pouchdb-browser@^7.2.2:
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/pouchdb-browser/-/pouchdb-browser-7.2.2.tgz#cf933cb25661b31c6691f7038f8fc3f757c093d0"
   integrity sha512-90pkngk9/F95knUwOhGQ0xuNzG51uIecF5kD5AfNdhqqrV9wbngz+I3QA7u/9eVyZRVyOrTrT3oaKcNqAB7Brg==
@@ -10911,7 +10911,7 @@ pouchdb-fetch@7.2.2:
     fetch-cookie "0.10.1"
     node-fetch "2.6.0"
 
-pouchdb-find@7.2.2:
+pouchdb-find@^7.2.2:
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/pouchdb-find/-/pouchdb-find-7.2.2.tgz#1227afdd761812d508fe0794b3e904518a721089"
   integrity sha512-BmFeFVQ0kHmDehvJxNZl9OmIztCjPlZlVSdpijuFbk/Fi1EFPU1BAv3kLC+6DhZuOqU/BCoaUBY9sn66pPY2ag==


### PR DESCRIPTION
The latest version of pouchdb browser will lets use the indexeddb
adapter. An app could chose to use the indexeddb adapter.