### PR TITLE
feat: Replace fetchAppLatestVersion by fetchAppVersion

### DIFF
--- a/docs/api/cozy-client/classes/registry.md
+++ b/docs/api/cozy-client/classes/registry.md
@@ -16,7 +16,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:39](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L39)
+[packages/cozy-client/src/registry.js:38](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L38)
 
 ## Properties
 
@@ -26,7 +26,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:43](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L43)
+[packages/cozy-client/src/registry.js:42](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L42)
 
 ## Methods
 
@@ -48,13 +48,13 @@ Fetch the status of a single app on the registry
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:129](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L129)
+[packages/cozy-client/src/registry.js:128](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L128)
 
 ***
 
-### fetchAppLatestVersion
+### fetchAppVersion
 
-▸ **fetchAppLatestVersion**(`params`): `RegistryApp`
+▸ **fetchAppVersion**(`params`): `RegistryApp`
 
 Fetch the latest version of an app for the given channel and slug
 
@@ -65,6 +65,7 @@ Fetch the latest version of an app for the given channel and slug
 | `params` | `Object` | Fetching parameters |
 | `params.channel` | `RegistryAppChannel` | The channel of the app to fetch |
 | `params.slug` | `string` | The slug of the app to fetch |
+| `params.version` | `string` | The version of the app to fetch. Can also be "latest" |
 
 *Returns*
 
@@ -97,7 +98,7 @@ Fetch at most 200 apps from the channel
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:93](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L93)
+[packages/cozy-client/src/registry.js:92](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L92)
 
 ***
 
@@ -113,7 +114,7 @@ Fetch the list of apps that are in maintenance mode
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:118](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L118)
+[packages/cozy-client/src/registry.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L117)
 
 ***
 
@@ -138,7 +139,7 @@ Accepts the terms if the app has them.
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:56](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L56)
+[packages/cozy-client/src/registry.js:55](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L55)
 
 ***
 
@@ -160,4 +161,4 @@ Uninstalls an app.
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:77](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L77)
+[packages/cozy-client/src/registry.js:76](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L76)

--- a/packages/cozy-client/src/registry.js
+++ b/packages/cozy-client/src/registry.js
@@ -1,6 +1,5 @@
 import get from 'lodash/get'
 import 'url-search-params-polyfill'
-
 import termUtils from './terms'
 import { APP_TYPE } from './constants'
 
@@ -136,20 +135,25 @@ class Registry {
    * @param  {object} params - Fetching parameters
    * @param  {string} params.slug - The slug of the app to fetch
    * @param  {RegistryAppChannel} params.channel - The channel of the app to fetch
+   * @param  {string} params.version - The version of the app to fetch. Can also be "latest"
    *
    * @returns {RegistryApp}
    */
-  fetchAppLatestVersion(params) {
-    if (!params.slug || !params.channel) {
-      throw new Error(
-        'Need to pass a slug and channel param to use fetchAppLatestVersion'
-      )
+  fetchAppVersion(params) {
+    if (!params.slug) {
+      throw new Error('Need to pass a slug to use fetchAppVersion')
     }
-    const { slug, channel } = params
-    return this.client.stackClient.fetchJSON(
-      'GET',
-      `/registry/${slug}/${channel}/latest`
-    )
+    const { slug, channel, version } = params
+    const finalChannel =
+      !channel && (!version || version === 'latest') ? 'stable' : channel
+    let url = `/registry/${slug}/`
+    if (finalChannel) {
+      url += `${finalChannel}/${version || 'latest'}`
+    } else {
+      url += `${version}`
+    }
+
+    return this.client.stackClient.fetchJSON('GET', url)
   }
 }
 

--- a/packages/cozy-client/src/registry.spec.js
+++ b/packages/cozy-client/src/registry.spec.js
@@ -122,12 +122,23 @@ describe('registry api', () => {
     })
   })
 
-  describe('fetchAppLatestVersion', () => {
-    it('should call the correct route', async () => {
-      await api.fetchAppLatestVersion({ channel: 'stable', slug: 'ameli' })
+  describe('fetchAppVersion', () => {
+    it('should call the correct route when a channel is given', async () => {
+      await api.fetchAppVersion({ channel: 'stable', slug: 'ameli' })
       expect(fetchJSON).toHaveBeenCalledWith(
         'GET',
         '/registry/ameli/stable/latest'
+      )
+    })
+    it('should call the correct route when a specific version is given', async () => {
+      await api.fetchAppVersion({ version: '1.1.1', slug: 'mgen' })
+      expect(fetchJSON).toHaveBeenCalledWith('GET', '/registry/mgen/1.1.1')
+    })
+    it('should call the correct route when neither a version or a channel is given', async () => {
+      await api.fetchAppVersion({ slug: 'impots' })
+      expect(fetchJSON).toHaveBeenCalledWith(
+        'GET',
+        '/registry/impots/stable/latest'
       )
     })
   })

--- a/packages/cozy-client/types/devtools/Pouch.d.ts
+++ b/packages/cozy-client/types/devtools/Pouch.d.ts
@@ -1,0 +1,6 @@
+export default PouchDevTool;
+/**
+ * Allows to view state and manage the PouchLink of the current cozy
+ * client.
+ */
+declare function PouchDevTool(): JSX.Element;

--- a/packages/cozy-client/types/registry.d.ts
+++ b/packages/cozy-client/types/registry.d.ts
@@ -68,11 +68,13 @@ declare class Registry {
      * @param  {object} params - Fetching parameters
      * @param  {string} params.slug - The slug of the app to fetch
      * @param  {RegistryAppChannel} params.channel - The channel of the app to fetch
+     * @param  {string} params.version - The version of the app to fetch. Can also be "latest"
      *
      * @returns {RegistryApp}
      */
-    fetchAppLatestVersion(params: {
+    fetchAppVersion(params: {
         slug: string;
         channel: RegistryAppChannel;
+        version: string;
     }): RegistryApp;
 }


### PR DESCRIPTION
The stack's registry API also allow to get a specific version of an app
and this is needed by the amiral app.

This is a breaking change since the fetchAppLatestVersion won't exist
anymore, but it is not used yet. I think it is safe to replace it now.- feat: Replace fetchAppLatestVersion by fetchAppVersion
