### PR TITLE
feat: Allow to query a HasManyFiles relation in both ways 

### DIFF
--- a/docs/api/cozy-client/classes/stacklink.md
+++ b/docs/api/cozy-client/classes/stacklink.md
@@ -30,7 +30,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:38](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L38)
+[packages/cozy-client/src/StackLink.js:39](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L39)
 
 ## Properties
 
@@ -40,7 +40,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:50](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L50)
+[packages/cozy-client/src/StackLink.js:51](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L51)
 
 ## Methods
 
@@ -62,7 +62,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:90](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L90)
+[packages/cozy-client/src/StackLink.js:91](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L91)
 
 ***
 
@@ -82,7 +82,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:69](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L69)
+[packages/cozy-client/src/StackLink.js:70](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L70)
 
 ***
 
@@ -102,7 +102,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:54](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L54)
+[packages/cozy-client/src/StackLink.js:55](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L55)
 
 ***
 
@@ -128,7 +128,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:62](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L62)
+[packages/cozy-client/src/StackLink.js:63](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L63)
 
 ***
 
@@ -142,4 +142,4 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:58](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L58)
+[packages/cozy-client/src/StackLink.js:59](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L59)

--- a/docs/api/cozy-client/interfaces/models.permission.document.md
+++ b/docs/api/cozy-client/interfaces/models.permission.document.md
@@ -14,7 +14,7 @@ Couchdb document like an io.cozy.files
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:9](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L9)
+[packages/cozy-client/src/models/permission.js:10](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L10)
 
 ***
 
@@ -24,7 +24,7 @@ Couchdb document like an io.cozy.files
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:11](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L11)
+[packages/cozy-client/src/models/permission.js:12](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L12)
 
 ***
 
@@ -34,7 +34,7 @@ Couchdb document like an io.cozy.files
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:10](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L10)
+[packages/cozy-client/src/models/permission.js:11](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L11)
 
 ***
 
@@ -44,4 +44,4 @@ Couchdb document like an io.cozy.files
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:12](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L12)
+[packages/cozy-client/src/models/permission.js:13](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L13)

--- a/docs/api/cozy-client/interfaces/models.permission.permission.md
+++ b/docs/api/cozy-client/interfaces/models.permission.permission.md
@@ -14,7 +14,7 @@ Permission document
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:160](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L160)
+[packages/cozy-client/src/models/permission.js:161](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L161)
 
 ***
 
@@ -26,4 +26,4 @@ Member information from the sharing
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:161](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L161)
+[packages/cozy-client/src/models/permission.js:162](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L162)

--- a/docs/api/cozy-client/interfaces/models.permission.permissionitem.md
+++ b/docs/api/cozy-client/interfaces/models.permission.permissionitem.md
@@ -14,7 +14,7 @@ defaults to `id`
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:22](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L22)
+[packages/cozy-client/src/models/permission.js:23](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L23)
 
 ***
 
@@ -26,7 +26,7 @@ a couch db database like 'io.cozy.files'
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:24](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L24)
+[packages/cozy-client/src/models/permission.js:25](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L25)
 
 ***
 
@@ -36,7 +36,7 @@ a couch db database like 'io.cozy.files'
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:23](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L23)
+[packages/cozy-client/src/models/permission.js:24](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L24)
 
 ***
 
@@ -48,4 +48,4 @@ ALL, GET, PUT, PATCH, DELETE, POST…
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:21](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L21)
+[packages/cozy-client/src/models/permission.js:22](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L22)

--- a/docs/api/cozy-client/modules/models.file.md
+++ b/docs/api/cozy-client/modules/models.file.md
@@ -12,7 +12,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:12](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L12)
+[packages/cozy-client/src/models/file.js:13](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L13)
 
 ## Functions
 
@@ -37,7 +37,7 @@ file object with path attribute
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:124](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L124)
+[packages/cozy-client/src/models/file.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L125)
 
 ***
 
@@ -62,7 +62,7 @@ Helper to query files based on qualification rules
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:244](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L244)
+[packages/cozy-client/src/models/file.js:245](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L245)
 
 ***
 
@@ -86,7 +86,7 @@ id of the parent folder, if any
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:138](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L138)
+[packages/cozy-client/src/models/file.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L139)
 
 ***
 
@@ -110,7 +110,7 @@ A description of the status
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:150](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L150)
+[packages/cozy-client/src/models/file.js:151](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L151)
 
 ***
 
@@ -134,7 +134,7 @@ A doctype
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:170](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L170)
+[packages/cozy-client/src/models/file.js:171](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L171)
 
 ***
 
@@ -158,7 +158,7 @@ The mime-type of the target file, or an empty string is the target is not a file
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:160](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L160)
+[packages/cozy-client/src/models/file.js:161](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L161)
 
 ***
 
@@ -182,7 +182,7 @@ Whether the file's metadata attribute exists
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:291](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L291)
+[packages/cozy-client/src/models/file.js:292](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L292)
 
 ***
 
@@ -202,7 +202,7 @@ Whether the file's metadata attribute exists
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:44](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L44)
+[packages/cozy-client/src/models/file.js:45](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L45)
 
 ***
 
@@ -222,7 +222,7 @@ Whether the file's metadata attribute exists
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:38](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L38)
+[packages/cozy-client/src/models/file.js:39](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L39)
 
 ***
 
@@ -242,7 +242,7 @@ Whether the file's metadata attribute exists
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:50](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L50)
+[packages/cozy-client/src/models/file.js:51](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L51)
 
 ***
 
@@ -264,7 +264,7 @@ Whether the file is supported by Only Office
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:72](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L72)
+[packages/cozy-client/src/models/file.js:73](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L73)
 
 ***
 
@@ -286,7 +286,7 @@ Whether the file is referenced by an album
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:266](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L266)
+[packages/cozy-client/src/models/file.js:267](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L267)
 
 ***
 
@@ -310,7 +310,7 @@ Returns whether the file is a shortcut to a sharing
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:190](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L190)
+[packages/cozy-client/src/models/file.js:191](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L191)
 
 ***
 
@@ -334,7 +334,7 @@ Returns whether the sharing shortcut is new
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:215](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L215)
+[packages/cozy-client/src/models/file.js:216](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L216)
 
 ***
 
@@ -356,7 +356,7 @@ Returns whether the file is a shortcut to a sharing
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:180](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L180)
+[packages/cozy-client/src/models/file.js:181](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L181)
 
 ***
 
@@ -378,7 +378,7 @@ Returns whether the sharing shortcut is new
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:204](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L204)
+[packages/cozy-client/src/models/file.js:205](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L205)
 
 ***
 
@@ -400,7 +400,7 @@ true if the file is a shortcut
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:97](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L97)
+[packages/cozy-client/src/models/file.js:98](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L98)
 
 ***
 
@@ -426,7 +426,7 @@ full normalized object
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:110](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L110)
+[packages/cozy-client/src/models/file.js:111](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L111)
 
 ***
 
@@ -452,7 +452,7 @@ Save the file with the given qualification
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:230](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L230)
+[packages/cozy-client/src/models/file.js:231](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L231)
 
 ***
 
@@ -476,7 +476,7 @@ But we want to exclude .txt and .md because the CozyUI Viewer can already show t
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:87](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L87)
+[packages/cozy-client/src/models/file.js:88](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L88)
 
 ***
 
@@ -500,4 +500,4 @@ Returns base filename and extension
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:22](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L22)
+[packages/cozy-client/src/models/file.js:23](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L23)

--- a/docs/api/cozy-client/modules/models.folder.md
+++ b/docs/api/cozy-client/modules/models.folder.md
@@ -23,7 +23,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/folder.js:7](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L7)
+[packages/cozy-client/src/models/folder.js:8](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L8)
 
 ## Functions
 
@@ -49,7 +49,7 @@ Folder document
 
 *Defined in*
 
-[packages/cozy-client/src/models/folder.js:65](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L65)
+[packages/cozy-client/src/models/folder.js:66](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L66)
 
 ***
 
@@ -75,7 +75,7 @@ Folder document
 
 *Defined in*
 
-[packages/cozy-client/src/models/folder.js:25](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L25)
+[packages/cozy-client/src/models/folder.js:26](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L26)
 
 ***
 
@@ -100,4 +100,4 @@ Folder referenced by the given document
 
 *Defined in*
 
-[packages/cozy-client/src/models/folder.js:86](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L86)
+[packages/cozy-client/src/models/folder.js:87](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L87)

--- a/docs/api/cozy-client/modules/models.permission.md
+++ b/docs/api/cozy-client/modules/models.permission.md
@@ -18,7 +18,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:16](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L16)
+[packages/cozy-client/src/models/permission.js:17](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L17)
 
 ## Functions
 
@@ -42,7 +42,7 @@ list of permissions
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:51](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L51)
+[packages/cozy-client/src/models/permission.js:52](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L52)
 
 ***
 
@@ -62,7 +62,7 @@ list of permissions
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:127](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L127)
+[packages/cozy-client/src/models/permission.js:128](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L128)
 
 ***
 
@@ -85,7 +85,7 @@ Checks if the permission item is about a specific doctype
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:65](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L65)
+[packages/cozy-client/src/models/permission.js:66](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L66)
 
 ***
 
@@ -120,4 +120,4 @@ both situation.
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:165](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L165)
+[packages/cozy-client/src/models/permission.js:166](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L166)

--- a/packages/cozy-client/src/StackLink.js
+++ b/packages/cozy-client/src/StackLink.js
@@ -1,6 +1,7 @@
 import { MutationTypes } from './queries/dsl'
 import CozyLink from './CozyLink'
 import { CozyClientDocument, CouchDBBulkResult } from './types'
+import { DOCTYPE_FILES } from './const'
 import { BulkEditError } from './errors'
 import zipWith from 'lodash/zipWith'
 
@@ -111,24 +112,24 @@ export default class StackLink extends CozyLink {
           .collection(props.referencedDocuments[0]._type)
           .removeReferencesTo(doc, props.referencedDocuments)
       case MutationTypes.ADD_REFERENCED_BY:
-        if (doc._type === 'io.cozy.files') {
+        if (doc._type === DOCTYPE_FILES) {
           return this.stackClient
-            .collection('io.cozy.files')
+            .collection(DOCTYPE_FILES)
             .addReferencedBy(doc, props.referencedDocuments)
         } else {
           throw new Error('The document type should be io.cozy.files')
         }
       case MutationTypes.REMOVE_REFERENCED_BY:
-        if (doc._type === 'io.cozy.files') {
+        if (doc._type === DOCTYPE_FILES) {
           return this.stackClient
-            .collection('io.cozy.files')
+            .collection(DOCTYPE_FILES)
             .removeReferencedBy(doc, props.referencedDocuments)
         } else {
           throw new Error('The document type should be io.cozy.files')
         }
       case MutationTypes.UPLOAD_FILE:
         return this.stackClient
-          .collection('io.cozy.files')
+          .collection(DOCTYPE_FILES)
           .upload(props.file, props.dirPath)
       default:
         return forward(mutation, result)

--- a/packages/cozy-client/src/associations/HasManyFiles.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.js
@@ -3,6 +3,7 @@ import omit from 'lodash/omit'
 import { Mutations, Q, QueryDefinition } from '../queries/dsl'
 import { getDocumentFromState } from '../store'
 import { CozyClientDocument } from '../types'
+import { DOCTYPE_FILES } from '../const'
 import Association from './Association'
 import HasMany from './HasMany'
 
@@ -13,7 +14,7 @@ import HasMany from './HasMany'
  */
 export default class HasManyFiles extends HasMany {
   async fetchMore() {
-    const queryDef = new QueryDefinition({ doctype: 'io.cozy.files' })
+    const queryDef = new QueryDefinition({ doctype: DOCTYPE_FILES })
     const relationships = this.getRelationship().data
     // Get last datetime for cursor
     const lastRelationship = relationships[relationships.length - 1]
@@ -67,9 +68,9 @@ export default class HasManyFiles extends HasMany {
   }
 
   addReferences(referencedDocs) {
-    if (this.target._type === 'io.cozy.files') {
+    if (this.target._type === DOCTYPE_FILES) {
       return Mutations.addReferencedBy(this.target, referencedDocs)
-    } else if (referencedDocs[0]._type === 'io.cozy.files') {
+    } else if (referencedDocs[0]._type === DOCTYPE_FILES) {
       return Mutations.addReferencesTo(this.target, referencedDocs)
     } else {
       throw new Error(
@@ -79,9 +80,9 @@ export default class HasManyFiles extends HasMany {
   }
 
   removeReferences(referencedDocs) {
-    if (this.target._type === 'io.cozy.files') {
+    if (this.target._type === DOCTYPE_FILES) {
       return Mutations.removeReferencedBy(this.target, referencedDocs)
-    } else if (referencedDocs[0]._type === 'io.cozy.files') {
+    } else if (referencedDocs[0]._type === DOCTYPE_FILES) {
       return Mutations.removeReferencesTo(this.target, referencedDocs)
     } else {
       throw new Error(
@@ -103,7 +104,7 @@ export default class HasManyFiles extends HasMany {
    * @returns {CozyClientDocument | QueryDefinition}
    */
   static query(document, client, assoc) {
-    if (document._type === 'io.cozy.files') {
+    if (document._type === DOCTYPE_FILES) {
       const refs = get(document, `relationships.referenced_by.data`, [])
       const ids = refs
         .filter(ref => ref.type === assoc.doctype)

--- a/packages/cozy-client/src/associations/HasManyFiles.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.js
@@ -1,5 +1,6 @@
 import get from 'lodash/get'
 import omit from 'lodash/omit'
+import uniq from 'lodash/uniq'
 import { Mutations, Q, QueryDefinition } from '../queries/dsl'
 import { getDocumentFromState } from '../store'
 import { CozyClientDocument } from '../types'
@@ -106,10 +107,9 @@ export default class HasManyFiles extends HasMany {
   static query(document, client, assoc) {
     if (document._type === DOCTYPE_FILES) {
       const refs = get(document, `relationships.referenced_by.data`, [])
-      const ids = refs
-        .filter(ref => ref.type === assoc.doctype)
-        .map(ref => ref.id)
-
+      const ids = uniq(
+        refs.filter(ref => ref.type === assoc.doctype).map(ref => ref.id)
+      )
       return ids.length > 0 ? Q(assoc.doctype).getByIds(ids) : null
     } else {
       const key = [document._type, document._id]

--- a/packages/cozy-client/src/associations/HasManyFiles.spec.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.spec.js
@@ -118,7 +118,12 @@ describe('HasManyFiles', () => {
       _id: 1,
       _type: DOCTYPE_FILES,
       relationships: {
-        referenced_by: { data: [{ id: '1234', type: 'io.cozy.todos' }] }
+        referenced_by: {
+          data: [
+            { id: '1234', type: 'io.cozy.todos' },
+            { id: '1234', type: 'io.cozy.todos' }
+          ]
+        }
       }
     }
     const queryDef = HasManyFiles.query(file, null, {

--- a/packages/cozy-client/src/associations/HasManyFiles.spec.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.spec.js
@@ -1,3 +1,4 @@
+import { DOCTYPE_FILES } from '../const'
 import HasManyFiles from './HasManyFiles'
 
 describe('HasManyFiles', () => {
@@ -10,8 +11,8 @@ describe('HasManyFiles', () => {
       relationships: {
         files: {
           data: [
-            { _id: 1, _type: 'io.cozy.files' },
-            { _id: 2, _type: 'io.cozy.files' }
+            { _id: 1, _type: DOCTYPE_FILES },
+            { _id: 2, _type: DOCTYPE_FILES }
           ]
         }
       }
@@ -27,7 +28,7 @@ describe('HasManyFiles', () => {
 
     hydrated = {
       ...original,
-      files: new HasManyFiles(original, 'files', 'io.cozy.files', {
+      files: new HasManyFiles(original, 'files', DOCTYPE_FILES, {
         get,
         save,
         mutate
@@ -38,14 +39,14 @@ describe('HasManyFiles', () => {
   it('adds relations', async () => {
     await hydrated.files.addById(4)
     expect(hydrated.files.data).toEqual([
-      { doctype: 'io.cozy.files', id: 1 },
-      { doctype: 'io.cozy.files', id: 2 },
-      { doctype: 'io.cozy.files', id: 4 }
+      { doctype: DOCTYPE_FILES, id: 1 },
+      { doctype: DOCTYPE_FILES, id: 2 },
+      { doctype: DOCTYPE_FILES, id: 4 }
     ])
     expect(mutate).toHaveBeenCalledWith({
       document: hydrated.files.target,
       mutationType: 'ADD_REFERENCES_TO',
-      referencedDocuments: [{ _type: 'io.cozy.files', _id: 4 }]
+      referencedDocuments: [{ _type: DOCTYPE_FILES, _id: 4 }]
     })
     expect(save).toHaveBeenCalled()
   })
@@ -53,17 +54,17 @@ describe('HasManyFiles', () => {
   it('adds multiple relations', async () => {
     await hydrated.files.addById([4, 5])
     expect(hydrated.files.data).toEqual([
-      { doctype: 'io.cozy.files', id: 1 },
-      { doctype: 'io.cozy.files', id: 2 },
-      { doctype: 'io.cozy.files', id: 4 },
-      { doctype: 'io.cozy.files', id: 5 }
+      { doctype: DOCTYPE_FILES, id: 1 },
+      { doctype: DOCTYPE_FILES, id: 2 },
+      { doctype: DOCTYPE_FILES, id: 4 },
+      { doctype: DOCTYPE_FILES, id: 5 }
     ])
     expect(mutate).toHaveBeenCalledWith({
       document: hydrated.files.target,
       mutationType: 'ADD_REFERENCES_TO',
       referencedDocuments: [
-        { _type: 'io.cozy.files', _id: 4 },
-        { _type: 'io.cozy.files', _id: 5 }
+        { _type: DOCTYPE_FILES, _id: 4 },
+        { _type: DOCTYPE_FILES, _id: 5 }
       ]
     })
     expect(save).toHaveBeenCalled()
@@ -71,11 +72,11 @@ describe('HasManyFiles', () => {
 
   it('removes relations', async () => {
     await hydrated.files.removeById(2)
-    expect(hydrated.files.data).toEqual([{ doctype: 'io.cozy.files', id: 1 }])
+    expect(hydrated.files.data).toEqual([{ doctype: DOCTYPE_FILES, id: 1 }])
     expect(mutate).toHaveBeenCalledWith({
       document: hydrated.files.target,
       mutationType: 'REMOVE_REFERENCES_TO',
-      referencedDocuments: [{ _type: 'io.cozy.files', _id: 2 }]
+      referencedDocuments: [{ _type: DOCTYPE_FILES, _id: 2 }]
     })
     expect(save).toHaveBeenCalled()
   })
@@ -87,8 +88,8 @@ describe('HasManyFiles', () => {
       document: hydrated.files.target,
       mutationType: 'REMOVE_REFERENCES_TO',
       referencedDocuments: [
-        { _type: 'io.cozy.files', _id: 1 },
-        { _type: 'io.cozy.files', _id: 2 }
+        { _type: DOCTYPE_FILES, _id: 1 },
+        { _type: DOCTYPE_FILES, _id: 2 }
       ]
     })
     expect(save).toHaveBeenCalled()
@@ -105,17 +106,17 @@ describe('HasManyFiles', () => {
   it('transform the doc-to-file relationship into query', () => {
     const queryDef = HasManyFiles.query(original, null, {
       name: 'files',
-      doctype: 'io.cozy.files'
+      doctype: DOCTYPE_FILES
     })
 
-    expect(queryDef.doctype).toEqual('io.cozy.files')
+    expect(queryDef.doctype).toEqual(DOCTYPE_FILES)
     expect(queryDef.referenced).toEqual(original)
   })
 
   it('transform the file-to-doc relationship into query', () => {
     const file = {
       _id: 1,
-      _type: 'io.cozy.files',
+      _type: DOCTYPE_FILES,
       relationships: {
         referenced_by: { data: [{ id: '1234', type: 'io.cozy.todos' }] }
       }

--- a/packages/cozy-client/src/associations/HasManyFiles.spec.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.spec.js
@@ -5,6 +5,7 @@ describe('HasManyFiles', () => {
   beforeEach(() => {
     original = {
       _type: 'io.cozy.todos',
+      _id: '1234',
       label: 'Get rich',
       relationships: {
         files: {
@@ -99,5 +100,31 @@ describe('HasManyFiles', () => {
       _type: 'io.cozy.todos'
     }
     expect(() => hydrated.files.insertDocuments([refTodo])).toThrow(Error)
+  })
+
+  it('transform the doc-to-file relationship into query', () => {
+    const queryDef = HasManyFiles.query(original, null, {
+      name: 'files',
+      doctype: 'io.cozy.files'
+    })
+
+    expect(queryDef.doctype).toEqual('io.cozy.files')
+    expect(queryDef.referenced).toEqual(original)
+  })
+
+  it('transform the file-to-doc relationship into query', () => {
+    const file = {
+      _id: 1,
+      _type: 'io.cozy.files',
+      relationships: {
+        referenced_by: { data: [{ id: '1234', type: 'io.cozy.todos' }] }
+      }
+    }
+    const queryDef = HasManyFiles.query(file, null, {
+      doctype: 'io.cozy.todos'
+    })
+
+    expect(queryDef.doctype).toEqual('io.cozy.todos')
+    expect(queryDef.ids).toEqual(['1234'])
   })
 })

--- a/packages/cozy-client/src/cli/index.js
+++ b/packages/cozy-client/src/cli/index.js
@@ -183,7 +183,6 @@ const readJSON = (fs, filename) => {
 const createClientInteractive = (clientOptions, serverOpts) => {
   global.fetch = nodeFetch
   global.btoa = btoa
-
   const serverOptions = merge(DEFAULT_SERVER_OPTIONS, serverOpts)
   const createClientFS = serverOptions.fs || fs
 

--- a/packages/cozy-client/src/const.js
+++ b/packages/cozy-client/src/const.js
@@ -1,1 +1,3 @@
 export const REGISTRATION_ABORT = 'REGISTRATION_ABORT'
+
+export const DOCTYPE_FILES = 'io.cozy.files'

--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -5,6 +5,7 @@ import has from 'lodash/has'
 import { setQualification } from './document'
 import { Q } from '../queries/dsl'
 import { IOCozyFile, QueryResult } from '../types'
+import { DOCTYPE_FILES } from '../const'
 import CozyClient from '../CozyClient'
 
 const FILE_TYPE = 'file'
@@ -109,7 +110,7 @@ export const isShortcut = file => {
  */
 export function normalize(file) {
   const id = file._id || file.id
-  const doctype = file._type || 'io.cozy.files'
+  const doctype = file._type || DOCTYPE_FILES
   return { _id: id, id, _type: doctype, ...file }
 }
 
@@ -230,7 +231,7 @@ export const isSharingShorcutNew = file => {
 export const saveFileQualification = async (client, file, qualification) => {
   const qualifiedFile = setQualification(file, qualification)
   return client
-    .collection('io.cozy.files')
+    .collection(DOCTYPE_FILES)
     .updateMetadataAttribute(file._id, qualifiedFile.metadata)
 }
 
@@ -243,7 +244,7 @@ export const saveFileQualification = async (client, file, qualification) => {
  */
 export const fetchFilesByQualificationRules = async (client, docRules) => {
   const { rules, count } = docRules
-  const query = Q('io.cozy.files')
+  const query = Q(DOCTYPE_FILES)
     .where({
       ...rules
     })

--- a/packages/cozy-client/src/models/folder.js
+++ b/packages/cozy-client/src/models/folder.js
@@ -1,6 +1,7 @@
 import sortBy from 'lodash/sortBy'
 import CozyClient from '../CozyClient'
 import { IOCozyFolder, CozyClientDocument } from '../types'
+import { DOCTYPE_FILES } from '../const'
 
 const APP_DOCTYPE = 'io.cozy.apps'
 
@@ -63,7 +64,7 @@ export const ensureMagicFolder = async (client, id, path) => {
  * @returns {Promise<IOCozyFolder>}  Folder document
  */
 export const createFolderWithReference = async (client, path, document) => {
-  const collection = client.collection('io.cozy.files')
+  const collection = client.collection(DOCTYPE_FILES)
   const dirId = await collection.ensureDirectoryExists(path)
   await collection.addReferencesTo(document, [
     {
@@ -85,7 +86,7 @@ export const createFolderWithReference = async (client, path, document) => {
  */
 export const getReferencedFolder = async (client, document) => {
   const { included } = await client
-    .collection('io.cozy.files')
+    .collection(DOCTYPE_FILES)
     .findReferencedBy(document)
   const foldersOutsideTrash = included.filter(
     folder => !/^\/\.cozy_trash/.test(folder.attributes.path)

--- a/packages/cozy-client/src/models/fsnative.js
+++ b/packages/cozy-client/src/models/fsnative.js
@@ -3,6 +3,7 @@ import { isMobileApp, isAndroidApp, isIOS } from 'cozy-device-helper'
 import CozyClient from '../CozyClient'
 import { CordovaWindow } from '../types'
 import logger from '../logger'
+import { DOCTYPE_FILES } from '../const'
 
 const ERROR_GET_DIRECTORY = 'Error to get directory'
 const ERROR_WRITE_FILE = 'Error to write file'
@@ -216,7 +217,7 @@ export const openFileWith = async (client, file) => {
     let fileData
     try {
       fileData = await client
-        .collection('io.cozy.files')
+        .collection(DOCTYPE_FILES)
         .fetchFileContent(file.id)
     } catch (e) {
       throw e.status === 404 ? 'missing' : 'offline'

--- a/packages/cozy-client/src/models/permission.js
+++ b/packages/cozy-client/src/models/permission.js
@@ -3,6 +3,7 @@ import get from 'lodash/get'
 import CozyClient from '../CozyClient'
 import { Q } from '../queries/dsl'
 import { getParentFolderId } from './file'
+import { DOCTYPE_FILES } from '../const'
 
 /**
  * @typedef {object} Document - Couchdb document like an io.cozy.files
@@ -92,7 +93,7 @@ async function findPermissionFor(options) {
   return _findPermissionFor({ doc, client, perms })
 
   async function getFile(id) {
-    const query = Q('io.cozy.files').getById(id)
+    const query = Q(DOCTYPE_FILES).getById(id)
     const data = await client.query(query)
     return data && data.data
   }
@@ -111,7 +112,7 @@ async function findPermissionFor(options) {
     if (perm) {
       // ok, there is a match
       return perm
-    } else if (type === 'io.cozy.files') {
+    } else if (type === DOCTYPE_FILES) {
       // for files, we recursively try to check for parent folders
       const parentId = getParentFolderId(doc)
       const parentFolder = parentId && (await getFile(parentId))

--- a/packages/cozy-client/types/const.d.ts
+++ b/packages/cozy-client/types/const.d.ts
@@ -1,1 +1,2 @@
 export const REGISTRATION_ABORT: "REGISTRATION_ABORT";
+export const DOCTYPE_FILES: "io.cozy.files";


### PR DESCRIPTION
When using a HasManyFiles relationship, we can manipulate documents from
the referenced doc, or from the referencing doc.

Let's assume the following photo albums:

```
{
  _id: '1234'
  _type: 'io.cozy.photos.albums'
}
```

And the following file, with a reference to the album:

```
{
  _id: '5678'
  _type: 'io.cozy.files',
  referenced_by: [
    {
      id: '1234'
      type: 'io.cozy.photos.albums'
    }
  ]
}
```

Previously, it was only possible to query the files from the album.
But, we might want to query the album directly from the file. This is
what we add here, by querying documents specified in the `referenced_by`
relationship specified in the file, through their id.