### PR TITLE
feat: Expose method to get the adapter name

### DIFF
--- a/docs/api/cozy-pouch-link.md
+++ b/docs/api/cozy-pouch-link.md
@@ -126,6 +126,7 @@ to respond to queries and mutations.
 * [PouchLink](#PouchLink)
     * [new PouchLink([opts])](#new_PouchLink_new)
     * [.replicationStatus](#PouchLink+replicationStatus) : <code>Record.&lt;string, SyncStatus&gt;</code>
+    * [.getPouchAdapterName](#PouchLink+getPouchAdapterName) ⇒ <code>string</code>
     * [.handleOnSync()](#PouchLink+handleOnSync)
     * [.startReplication()](#PouchLink+startReplication) ⇒ <code>void</code>
     * [.stopReplication()](#PouchLink+stopReplication) ⇒ <code>void</code>
@@ -151,6 +152,14 @@ constructor - Initializes a new PouchLink
 - Stores replication states per doctype
 
 **Kind**: instance property of [<code>PouchLink</code>](#PouchLink)  
+<a name="PouchLink+getPouchAdapterName"></a>
+
+### pouchLink.getPouchAdapterName ⇒ <code>string</code>
+Return the PouchDB adapter name.
+Should be IndexedDB for newest adapters.
+
+**Kind**: instance property of [<code>PouchLink</code>](#PouchLink)  
+**Returns**: <code>string</code> - The adapter name  
 <a name="PouchLink+handleOnSync"></a>
 
 ### pouchLink.handleOnSync()

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -577,6 +577,16 @@ class PouchLink extends CozyLink {
     }
     this.pouches.syncImmediately()
   }
+
+  /**
+   * Return the PouchDB adapter name.
+   * Should be IndexedDB for newest adapters.
+   *
+   * @returns {string} The adapter name
+   */
+  getPouchAdapterName = () => {
+    return getAdapterName()
+  }
 }
 
 export default PouchLink


### PR DESCRIPTION
It can be useful for an app to know which adapter is currently used, typically to
perform adapter migration.
Fix https://github.com/cozy/cozy-client/issues/1005