### PR TITLE
fix: Method to get adapter name should be static

### DIFF
--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -99,6 +99,16 @@ class PouchLink extends CozyLink {
     this.replicationStatus = this.replicationStatus || {}
   }
 
+  /**
+   * Return the PouchDB adapter name.
+   * Should be IndexedDB for newest adapters.
+   *
+   * @returns {string} The adapter name
+   */
+  static getPouchAdapterName = () => {
+    return getAdapterName()
+  }
+
   getReplicationURL(doctype) {
     const url = this.client && this.client.stackClient.uri
     const token = this.client && this.client.stackClient.token
@@ -576,16 +586,6 @@ class PouchLink extends CozyLink {
       return
     }
     this.pouches.syncImmediately()
-  }
-
-  /**
-   * Return the PouchDB adapter name.
-   * Should be IndexedDB for newest adapters.
-   *
-   * @returns {string} The adapter name
-   */
-  getPouchAdapterName = () => {
-    return getAdapterName()
   }
 }
 


### PR DESCRIPTION
in order to use it without instantiating PouchLink

Car nous avons besoin d'utiliser cette méthode avant l'instanciation de PouchLink, afin de déterminer comment instancier un new PouchLink.