### PR TITLE
feat: Pass name as param in updateFile

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -731,11 +731,8 @@ updateFile - Updates a file's data
 
 | Param | Type | Description |
 | --- | --- | --- |
-| data | <code>object</code> | Javascript File object |
-| params | <code>object</code> | Additional parameters |
-| params.fileId | <code>string</code> | The id of the file to update (required) |
-| params.executable | <code>boolean</code> | Whether the file is executable or not |
-| params.metadata | <code>object</code> | Metadata to be attached to the File io.cozy.file |
+| data | <code>File</code> \| <code>Blob</code> \| [<code>Stream</code>](#Stream) \| <code>string</code> \| <code>ArrayBuffer</code> | file to be uploaded |
+| params | [<code>FileAttributes</code>](#FileAttributes) | Additional parameters |
 | params.options | <code>object</code> | Options to pass to doUpload method (additional headers) |
 
 <a name="FileCollection+download"></a>
@@ -1833,6 +1830,7 @@ Attributes used for file creation
 | dirId | <code>string</code> | Id of the parent directory. |
 | name | <code>string</code> | Name of the created file. |
 | lastModifiedDate | <code>Date</code> | Can be used to set the last modified date of a file. |
+| executable | <code>boolean</code> | Whether or not the file is executable |
 | metadata | <code>object</code> | io.cozy.files.metadata to attach to the file |
 
 <a name="FileDocument"></a>

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -24,6 +24,7 @@ import { dontThrowNotFoundError } from './Collection'
  * @property {string} dirId - Id of the parent directory.
  * @property {string} name - Name of the created file.
  * @property {Date} lastModifiedDate - Can be used to set the last modified date of a file.
+ * @property {boolean} executable - Whether or not the file is executable
  * @property {object} metadata io.cozy.files.metadata to attach to the file
  */
 
@@ -431,29 +432,25 @@ class FileCollection extends DocumentCollection {
   /**
    * updateFile - Updates a file's data
    *
-   * @param  {object}  data               Javascript File object
-   * @param  {object}  params             Additional parameters
-   * @param  {string}  params.fileId      The id of the file to update (required)
-   * @param  {boolean} params.executable  Whether the file is executable or not
-   * @param  {object}  params.metadata    Metadata to be attached to the File io.cozy.file
+   * @param {File|Blob|Stream|string|ArrayBuffer} data file to be uploaded
+   * @param {FileAttributes} params       Additional parameters
    * @param  {object}  params.options     Options to pass to doUpload method (additional headers)
-   * @returns {object}                     Updated document
+   * @returns {object}                    Updated document
    */
   async updateFile(
     data,
-    { executable = false, fileId, metadata, ...options } = {}
+    { executable = false, fileId, name = '', metadata, ...options } = {}
   ) {
     if (!fileId || typeof fileId !== 'string') {
       throw new Error('missing fileId argument')
     }
-
-    // handle case where data is a file and contains the name
-    if (typeof data.name !== 'string') {
+    // name might be set in a File object
+    const fileName = name || data.name
+    if (!fileName || typeof fileName !== 'string') {
       throw new Error('missing name in data argument')
     }
-
-    const name = sanitizeFileName(data.name)
-    if (typeof name !== 'string' || name === '') {
+    const sanitizedName = sanitizeFileName(fileName)
+    if (typeof sanitizedName !== 'string' || sanitizedName === '') {
       throw new Error('missing name argument')
     }
     /**
@@ -466,7 +463,7 @@ class FileCollection extends DocumentCollection {
      * (no size limit since we can use the body for that) and after we use the ID.
      */
     let metadataId
-    let path = uri`/files/${fileId}?Name=${name}&Type=file&Executable=${executable}`
+    let path = uri`/files/${fileId}?Name=${sanitizedName}&Type=file&Executable=${executable}`
     if (metadata) {
       const meta = await this.createFileMetadata(metadata)
       metadataId = meta.data.id

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -566,6 +566,43 @@ describe('FileCollection', () => {
         }
       })
     })
+    it('should have a file name', async () => {
+      let data = new File([''], '')
+      const params = {
+        fileId: '59140416-b95f',
+        checksum: 'a6dabd99832b270468e254814df2ed20'
+      }
+      await expect(collection.updateFile(data, params)).rejects.toThrow()
+
+      data = new File([''], 'mydoc.epub')
+      await collection.updateFile(data, params)
+      const expectedPath =
+        '/files/59140416-b95f?Name=mydoc.epub&Type=file&Executable=false'
+
+      const expectedOptions = {
+        headers: {
+          'Content-MD5': 'a6dabd99832b270468e254814df2ed20',
+          'Content-Type': 'application/epub+zip'
+        }
+      }
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'PUT',
+        expectedPath,
+        data,
+        expectedOptions
+      )
+
+      data = new ArrayBuffer(8)
+      params.name = 'mydoc.epub'
+      expectedOptions.headers['Content-Type'] = 'application/octet-stream'
+      await collection.updateFile(data, params)
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'PUT',
+        expectedPath,
+        data,
+        expectedOptions
+      )
+    })
   })
 
   describe('emptyTrash', () => {


### PR DESCRIPTION
We used to expect the updated file to be a File object with its name set
directly inside the File.
However, we could also manipulate files as ArrayBuffer. Hence, it is
necessary to be able to pass the name as a param.