### PR TITLE
feat: Handle Onboarding V2

### DIFF
--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -287,14 +287,19 @@ class OAuthClient extends CozyStackClient {
   getAuthCodeURL(stateCode, scopes = this.scope) {
     if (!this.isRegistered()) throw new NotRegisteredException()
 
-    const query = {
+    let query = {
       client_id: this.oauthOptions.clientID,
       redirect_uri: this.oauthOptions.redirectURI,
       state: stateCode,
       response_type: 'code',
       scope: scopes.join(' ')
     }
-
+    if (this.oauthOptions.registerToken) {
+      query = {
+        ...query,
+        registerToken: this.oauthOptions.registerToken
+      }
+    }
     return `${this.uri}/auth/authorize?${this.dataToQueryString(query)}`
   }
 

--- a/packages/cozy-stack-client/src/OAuthClient.spec.js
+++ b/packages/cozy-stack-client/src/OAuthClient.spec.js
@@ -107,6 +107,32 @@ describe('OAuthClient', () => {
       )
     })
 
+    it('should generate the auth code URL even with registerToken', () => {
+      const oauthOptions = {
+        ...REGISTERED_CLIENT_INIT_OPTIONS,
+        oauth: {
+          ...REGISTERED_CLIENT_INIT_OPTIONS.oauth,
+          registerToken: 'AZERTY'
+        }
+      }
+      const newClient = new OAuthClient(oauthOptions)
+      newClient.setToken({
+        tokenType: 'type',
+        accessToken: 'accessToken-abcd',
+        refreshToken: 'refresh-789',
+        scope: 'io.cozy.todos'
+      })
+      expect(
+        newClient.getAuthCodeURL('randomstatetoken', ['io.cozy.todos'])
+      ).toEqual(
+        `${REGISTERED_CLIENT_INIT_OPTIONS.uri}/auth/authorize?client_id=${
+          REGISTERED_CLIENT_INIT_OPTIONS.oauth.clientID
+        }&redirect_uri=${encodeURIComponent(
+          REGISTERED_CLIENT_INIT_OPTIONS.oauth.redirectURI
+        )}&state=randomstatetoken&response_type=code&scope=io.cozy.todos&registerToken=AZERTY`
+      )
+    })
+
     it('should get the access code from an URL', () => {
       const stateCode = 'myrandomcode'
       const accessCode = 'myaccesscode'


### PR DESCRIPTION
Now, in a specific workflow we can receive an registerToken and
we need to pass it to the authorize endpoint

So let's use the oauthOptions to write it


documentation is currently tested with a partner. I'll write it down to cozy-client after the first iteration