### PR TITLE
fix: Konnectors collection now ignores id in manifest

### DIFF
--- a/packages/cozy-stack-client/src/AppCollection.js
+++ b/packages/cozy-stack-client/src/AppCollection.js
@@ -11,7 +11,12 @@ import { FetchError } from './errors'
 export const APPS_DOCTYPE = 'io.cozy.apps'
 
 export const normalizeApp = (app, doctype) => {
-  return { ...app, ...normalizeDoc(app, doctype), ...app.attributes }
+  return {
+    ...app.attributes,
+    ...app,
+    ...normalizeDoc(app, doctype),
+    id: app.id // ignores any 'id' attribute in the manifest
+  }
 }
 
 /**

--- a/packages/cozy-stack-client/src/AppCollection.spec.js
+++ b/packages/cozy-stack-client/src/AppCollection.spec.js
@@ -33,6 +33,14 @@ describe(`AppCollection`, () => {
     it('should return normalized documents', async () => {
       const resp = await collection.all()
       expect(resp.data[0]).toHaveDocumentIdentity()
+      expect(resp.data[0].id).toEqual('io.cozy.apps/drive')
+    })
+
+    it('should ignore id attribute in manifests', async () => {
+      const resp = await collection.all()
+      expect(
+        resp.data.every(app => app.id === `${app._type}/${app.slug}`)
+      ).toBe(true)
     })
   })
 

--- a/packages/cozy-stack-client/src/KonnectorCollection.spec.js
+++ b/packages/cozy-stack-client/src/KonnectorCollection.spec.js
@@ -42,6 +42,16 @@ describe(`KonnectorCollection`, () => {
     it('should return normalized documents', async () => {
       const resp = await collection.all()
       expect(resp.data[0]).toHaveDocumentIdentity()
+      expect(resp.data[0].id).toEqual('io.cozy.konnectors/bouibox')
+    })
+
+    it('should ignore id attribute in manifests', async () => {
+      const resp = await collection.all()
+      expect(
+        resp.data.every(
+          konnector => konnector.id === `${konnector._type}/${konnector.slug}`
+        )
+      ).toBe(true)
     })
   })
 

--- a/packages/cozy-stack-client/src/__tests__/fixtures/apps.js
+++ b/packages/cozy-stack-client/src/__tests__/fixtures/apps.js
@@ -4,6 +4,7 @@ export const ALL_APPS_RESPONSE = {
       type: 'io.cozy.apps',
       id: 'io.cozy.apps/drive',
       attributes: {
+        id: 'Drive',
         name: 'Drive',
         editor: 'Cozy',
         icon: 'public/app-icon.svg',

--- a/packages/cozy-stack-client/src/__tests__/fixtures/konnectors.js
+++ b/packages/cozy-stack-client/src/__tests__/fixtures/konnectors.js
@@ -4,6 +4,7 @@ export const ALL_KONNECTORS_RESPONSE = {
       type: 'io.cozy.konnectors',
       id: 'io.cozy.konnectors/bouibox',
       attributes: {
+        id: 'Boui Box',
         name: 'Boui Box',
         editor: 'Cozy',
         icon: 'bouibox.svg',


### PR DESCRIPTION
Or else the id in the manifest would replace the stack's id
attribute in io.cozy.konnectors doctype

And this could cause a crash in the home application
