### PR TITLE
feat: Infer content-type from file extension

### DIFF
--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -870,23 +870,22 @@ class FileCollection extends DocumentCollection {
 
     let { contentType, contentLength, checksum, lastModifiedDate, ifMatch } =
       options || {}
+
     if (!contentType) {
-      if (isBuffer) {
-        contentType = CONTENT_TYPE_OCTET_STREAM
-      } else if (isFile) {
-        contentType =
-          data.type ||
-          getFileTypeFromName(data.name.toLowerCase()) ||
-          CONTENT_TYPE_OCTET_STREAM
-        if (!lastModifiedDate) {
-          lastModifiedDate = data.lastModifiedDate
-        }
-      } else if (isBlob) {
-        contentType = data.type || CONTENT_TYPE_OCTET_STREAM
-      } else if (isStream) {
-        contentType = CONTENT_TYPE_OCTET_STREAM
-      } else if (typeof data === 'string') {
+      if (typeof data === 'string') {
         contentType = 'text/plain'
+      } else {
+        if (data.type) {
+          // The type is specified in the file object
+          contentType = data.type
+        } else {
+          // Extract the name from the path and infer the type
+          const sPath = path.split('?')
+          const params = sPath.length > 1 ? sPath[1] : ''
+          const name = new URLSearchParams(params).get('Name')
+          contentType =
+            getFileTypeFromName(name.toLowerCase()) || CONTENT_TYPE_OCTET_STREAM
+        }
       }
     }
 

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -889,10 +889,10 @@ class FileCollection extends DocumentCollection {
       }
     }
 
-    if (lastModifiedDate && typeof lastModifiedDate === 'string') {
+    lastModifiedDate = lastModifiedDate || data.lastModified
+    if (lastModifiedDate) {
       lastModifiedDate = new Date(lastModifiedDate)
     }
-
     const headers = {
       'Content-Type': contentType
     }

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -478,7 +478,8 @@ describe('FileCollection', () => {
       const expectedOptions = {
         headers: {
           'Content-MD5': 'a6dabd99832b270468e254814df2ed20',
-          'Content-Type': 'application/epub+zip'
+          'Content-Type': 'application/epub+zip',
+          Date: new Date(data.lastModified).toGMTString()
         }
       }
       expect(client.fetchJSON).toHaveBeenCalledWith(
@@ -515,7 +516,8 @@ describe('FileCollection', () => {
       const expectedOptions = {
         headers: {
           'Content-MD5': 'a6dabd99832b270468e254814df2ed20',
-          'Content-Type': 'application/epub+zip'
+          'Content-Type': 'application/epub+zip',
+          Date: new Date(data.lastModified).toGMTString()
         }
       }
       expect(client.fetchJSON).toHaveBeenCalledWith(
@@ -548,7 +550,8 @@ describe('FileCollection', () => {
         headers: {
           'Content-MD5': 'a6dabd99832b270468e254814df2ed20',
           'Content-Type': 'application/epub+zip',
-          'Content-Length': '1234'
+          'Content-Length': '1234',
+          Date: new Date(data.lastModified).toGMTString()
         }
       }
       expect(client.fetchJSON).toHaveBeenCalledWith(
@@ -582,7 +585,8 @@ describe('FileCollection', () => {
       const expectedOptions = {
         headers: {
           'Content-MD5': 'a6dabd99832b270468e254814df2ed20',
-          'Content-Type': 'application/epub+zip'
+          'Content-Type': 'application/epub+zip',
+          Date: new Date(data.lastModified).toGMTString()
         }
       }
       expect(client.fetchJSON).toHaveBeenCalledWith(
@@ -595,12 +599,18 @@ describe('FileCollection', () => {
       data = new ArrayBuffer(8)
       params.name = 'mydoc.epub'
       params.contentType = 'application/epub+zip'
+      const newExpectedOptions = {
+        headers: {
+          'Content-MD5': 'a6dabd99832b270468e254814df2ed20',
+          'Content-Type': 'application/epub+zip'
+        }
+      }
       await collection.updateFile(data, params)
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'PUT',
         expectedPath,
         data,
-        expectedOptions
+        newExpectedOptions
       )
     })
   })
@@ -738,7 +748,8 @@ describe('FileCollection', () => {
       const expectedPath = `/files/${dirId}?Name=mydoc.epub&Type=file&Executable=false&MetadataID=&Size=`
       const expectedOptions = {
         headers: {
-          'Content-Type': 'application/epub+zip'
+          'Content-Type': 'application/epub+zip',
+          Date: new Date(data.lastModified).toGMTString()
         }
       }
       expect(client.fetchJSON).toHaveBeenCalledWith(
@@ -772,7 +783,8 @@ describe('FileCollection', () => {
       const expectedPath = `/files/${dirId}?Name=mydoc.epub&Type=file&Executable=false&MetadataID=${metadataId}&Size=`
       const expectedOptions = {
         headers: {
-          'Content-Type': 'application/epub+zip'
+          'Content-Type': 'application/epub+zip',
+          Date: new Date(data.lastModified).toGMTString()
         }
       }
       expect(client.fetchJSON).toHaveBeenCalledWith(
@@ -800,7 +812,8 @@ describe('FileCollection', () => {
       const expectedOptions = {
         headers: {
           'Content-Type': 'application/epub+zip',
-          'Content-Length': String(contentLength)
+          'Content-Length': String(contentLength),
+          Date: new Date(data.lastModified).toGMTString()
         }
       }
       expect(client.fetchJSON).toHaveBeenCalledWith(
@@ -858,6 +871,7 @@ describe('FileCollection', () => {
         expectedOptions
       )
     })
+
     it('should set the File content-type', async () => {
       const data = new File([''], fileName)
       const path = `/files/${dirId}?Name=${fileName}&Type=file`
@@ -865,7 +879,8 @@ describe('FileCollection', () => {
 
       const expectedOptions = {
         headers: {
-          'Content-Type': 'application/epub+zip'
+          'Content-Type': 'application/epub+zip',
+          Date: new Date(data.lastModified).toGMTString()
         }
       }
       expect(client.fetchJSON).toHaveBeenCalledWith(
@@ -903,6 +918,45 @@ describe('FileCollection', () => {
       const expectedOptions = {
         headers: {
           'Content-Type': 'application/octet-stream'
+        }
+      }
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        path,
+        data,
+        expectedOptions
+      )
+    })
+
+    it('should set the lastModifiedDate from File', async () => {
+      const data = new File([''], fileName)
+      const path = `/files/${dirId}?Name=${name}&Type=file`
+      await collection.doUpload(data, path, {})
+
+      const expectedOptions = {
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          Date: new Date(data.lastModified).toGMTString()
+        }
+      }
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        path,
+        data,
+        expectedOptions
+      )
+    })
+
+    it('should set the given lastModifiedDate', async () => {
+      const data = new File([''], fileName)
+      const path = `/files/${dirId}?Name=${name}&Type=file`
+      const lastModifiedDate = new Date('2021-01-01')
+      await collection.doUpload(data, path, { lastModifiedDate })
+
+      const expectedOptions = {
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          Date: lastModifiedDate.toGMTString()
         }
       }
       expect(client.fetchJSON).toHaveBeenCalledWith(


### PR DESCRIPTION
We used to infer the file content-type only for File objects. However,
it can be useful to extend this for binary structs such as ArrayBuffer,
typically when dealing with encryption. Say we have decrypted a file,
represented as an ArrayBuffer: we have no way to know its content-type
without inferring it from the name, as it was previously encrypted with
a specific content-type.