### PR TITLE
fix: Change sharing rule for `com.bitwarden.organizations`

### DIFF
--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -384,7 +384,7 @@ const getSharingRulesForOrganizations = document => {
       values: [_id],
       add: 'sync',
       update: 'sync',
-      remove: 'sync'
+      remove: 'revoke'
     },
     {
       title: 'Ciphers',

--- a/packages/cozy-stack-client/src/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/SharingCollection.spec.js
@@ -410,7 +410,7 @@ describe('SharingCollection', () => {
                 values: ['SOME_ORGANIZATION_ID'],
                 add: 'sync',
                 update: 'sync',
-                remove: 'sync'
+                remove: 'revoke'
               },
               {
                 title: 'Ciphers',


### PR DESCRIPTION
When Alice delete an organization that is shared with Bob, then we
want to revoke Bob's access to this organization

This allow to cast a `deleted` realtime event to Bob so the
organization is removed from their vault without having to refresh the
client