### PR TITLE
feat: Use add and remove API for both has-one and has-many

### DIFF
--- a/docs/api/cozy-client/classes/hasmany.md
+++ b/docs/api/cozy-client/classes/hasmany.md
@@ -305,6 +305,30 @@ Derived `Association`s need to implement this method.
 
 ## Methods
 
+### add
+
+▸ **add**(`docsArg`): `CozyClientDocument`
+
+Add the relationships to the target document
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `docsArg` | `CozyClientDocument`\[] | Documents to add as relationships |
+
+*Returns*
+
+`CozyClientDocument`
+
+The saved target document
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:124](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L124)
+
+***
+
 ### addById
 
 ▸ **addById**(`idsArg`): `any`
@@ -328,7 +352,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:127](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L127)
+[packages/cozy-client/src/associations/HasMany.js:151](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L151)
 
 ***
 
@@ -368,7 +392,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:217](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L217)
+[packages/cozy-client/src/associations/HasMany.js:241](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L241)
 
 ***
 
@@ -436,7 +460,31 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:168](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L168)
+[packages/cozy-client/src/associations/HasMany.js:192](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L192)
+
+***
+
+### remove
+
+▸ **remove**(`docsArg`): `CozyClientDocument`
+
+Remove the relationships from the target document
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `docsArg` | `CozyClientDocument`\[] | Documents to remove as relationships |
+
+*Returns*
+
+`CozyClientDocument`
+
+The saved target document
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:136](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L136)
 
 ***
 
@@ -456,7 +504,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:148](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L148)
+[packages/cozy-client/src/associations/HasMany.js:172](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L172)
 
 ***
 
@@ -470,7 +518,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:159](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L159)
+[packages/cozy-client/src/associations/HasMany.js:183](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L183)
 
 ***
 
@@ -491,7 +539,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:189](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L189)
+[packages/cozy-client/src/associations/HasMany.js:213](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L213)
 
 ***
 
@@ -524,7 +572,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:193](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L193)
+[packages/cozy-client/src/associations/HasMany.js:217](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L217)
 
 ***
 
@@ -545,7 +593,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:182](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L182)
+[packages/cozy-client/src/associations/HasMany.js:206](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L206)
 
 ***
 
@@ -567,7 +615,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:250](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L250)
+[packages/cozy-client/src/associations/HasMany.js:274](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L274)
 
 ***
 
@@ -588,7 +636,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:259](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L259)
+[packages/cozy-client/src/associations/HasMany.js:283](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L283)
 
 ***
 
@@ -614,7 +662,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:236](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L236)
+[packages/cozy-client/src/associations/HasMany.js:260](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L260)
 
 ***
 
@@ -636,7 +684,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:297](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L297)
+[packages/cozy-client/src/associations/HasMany.js:321](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L321)
 
 ***
 
@@ -659,7 +707,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:271](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L271)
+[packages/cozy-client/src/associations/HasMany.js:295](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L295)
 
 ***
 
@@ -682,7 +730,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:321](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L321)
+[packages/cozy-client/src/associations/HasMany.js:345](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L345)
 
 ***
 
@@ -704,4 +752,4 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:332](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L332)
+[packages/cozy-client/src/associations/HasMany.js:356](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L356)

--- a/docs/api/cozy-client/classes/hasmanytriggers.md
+++ b/docs/api/cozy-client/classes/hasmanytriggers.md
@@ -242,6 +242,34 @@ Returns store documents
 
 ## Methods
 
+### add
+
+▸ **add**(`docsArg`): `CozyClientDocument`
+
+Add the relationships to the target document
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `docsArg` | `CozyClientDocument`\[] | Documents to add as relationships |
+
+*Returns*
+
+`CozyClientDocument`
+
+The saved target document
+
+*Inherited from*
+
+[HasMany](hasmany.md).[add](hasmany.md#add)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:124](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L124)
+
+***
+
 ### addById
 
 ▸ **addById**(`idsArg`): `any`
@@ -269,7 +297,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:127](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L127)
+[packages/cozy-client/src/associations/HasMany.js:151](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L151)
 
 ***
 
@@ -317,7 +345,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:217](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L217)
+[packages/cozy-client/src/associations/HasMany.js:241](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L241)
 
 ***
 
@@ -401,7 +429,35 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:168](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L168)
+[packages/cozy-client/src/associations/HasMany.js:192](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L192)
+
+***
+
+### remove
+
+▸ **remove**(`docsArg`): `CozyClientDocument`
+
+Remove the relationships from the target document
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `docsArg` | `CozyClientDocument`\[] | Documents to remove as relationships |
+
+*Returns*
+
+`CozyClientDocument`
+
+The saved target document
+
+*Inherited from*
+
+[HasMany](hasmany.md).[remove](hasmany.md#remove)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:136](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L136)
 
 ***
 
@@ -425,7 +481,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:148](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L148)
+[packages/cozy-client/src/associations/HasMany.js:172](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L172)
 
 ***
 
@@ -443,7 +499,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:159](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L159)
+[packages/cozy-client/src/associations/HasMany.js:183](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L183)
 
 ***
 
@@ -468,7 +524,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:189](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L189)
+[packages/cozy-client/src/associations/HasMany.js:213](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L213)
 
 ***
 
@@ -505,7 +561,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:193](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L193)
+[packages/cozy-client/src/associations/HasMany.js:217](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L217)
 
 ***
 
@@ -530,7 +586,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:182](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L182)
+[packages/cozy-client/src/associations/HasMany.js:206](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L206)
 
 ***
 
@@ -556,7 +612,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:250](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L250)
+[packages/cozy-client/src/associations/HasMany.js:274](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L274)
 
 ***
 
@@ -581,7 +637,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:259](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L259)
+[packages/cozy-client/src/associations/HasMany.js:283](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L283)
 
 ***
 
@@ -636,7 +692,7 @@ having for the 'konnector' worker, and then filter them based on their
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:297](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L297)
+[packages/cozy-client/src/associations/HasMany.js:321](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L321)
 
 ***
 
@@ -663,7 +719,7 @@ having for the 'konnector' worker, and then filter them based on their
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:271](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L271)
+[packages/cozy-client/src/associations/HasMany.js:295](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L295)
 
 ***
 
@@ -690,7 +746,7 @@ having for the 'konnector' worker, and then filter them based on their
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:321](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L321)
+[packages/cozy-client/src/associations/HasMany.js:345](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L345)
 
 ***
 
@@ -716,4 +772,4 @@ having for the 'konnector' worker, and then filter them based on their
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:332](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L332)
+[packages/cozy-client/src/associations/HasMany.js:356](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L356)

--- a/docs/api/cozy-client/classes/hasone.md
+++ b/docs/api/cozy-client/classes/hasone.md
@@ -264,6 +264,30 @@ Derived `Association`s need to implement this method.
 
 ## Methods
 
+### add
+
+▸ **add**(`doc`): `CozyClientDocument`
+
+Add the relationship to the target document
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `doc` | `CozyClientDocument` | Document to add as a relationship |
+
+*Returns*
+
+`CozyClientDocument`
+
+The saved target document
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasOne.js:41](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L41)
+
+***
+
 ### dehydrate
 
 ▸ **dehydrate**(`doc`): `any`
@@ -280,7 +304,25 @@ Derived `Association`s need to implement this method.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:58](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L58)
+[packages/cozy-client/src/associations/HasOne.js:89](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L89)
+
+***
+
+### remove
+
+▸ **remove**(): `CozyClientDocument`
+
+Remove the relationship from the target document
+
+*Returns*
+
+`CozyClientDocument`
+
+The saved target document
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasOne.js:51](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L51)
 
 ***
 
@@ -300,7 +342,27 @@ Derived `Association`s need to implement this method.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:35](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L35)
+[packages/cozy-client/src/associations/HasOne.js:75](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L75)
+
+***
+
+### setRelationship
+
+▸ **setRelationship**(`doc`): `void`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `doc` | `any` |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasOne.js:56](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L56)
 
 ***
 
@@ -314,7 +376,7 @@ Derived `Association`s need to implement this method.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:54](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L54)
+[packages/cozy-client/src/associations/HasOne.js:82](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L82)
 
 ***
 

--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -134,23 +134,23 @@ const firstAuthors = firstDoc.authors.data
 
 ### Add a relation to an existing document
 
-When the relationship is a `has-many` type, you can call the `addById(documentId)` to create the relationship:
+When the relationship is a `has-many` type, you can call the `add(docs)` to create the relationship:
 
 ```javascript
-const otherAuthorId = 'abc123'
+const otherAuthors = [{_id: 'Rivest'}, {_id: 'Shamir'}]
 const response = await client.query(query)
 const docs = response.data
 const firstDoc = docs[0]
-firstDoc.authors.addById(otherAuthorId)
+firstDoc.authors.add(otherAuthors)
 ```
 
-`addById` also accepts an array of document ids:
+`add` also accepts single document:
 
 ```javascript
-firstDoc.authors.addById([mainAuthorId, coAuthorId])
+firstDoc.authors.add({_id: 'Adleman'})
 ```
 
-When the relationship is a `has-one` type, use `set(document)` instead:
+Likewise, when the relationship is a `has-one`, use `add(doc)`:
 
 ```javascript
 const printer = {
@@ -161,31 +161,31 @@ const printer = {
 const response = await client.query(query)
 const docs = response.data
 const firstDoc = docs[0]
-firstDoc.printingCompany.set(printer)
+firstDoc.printingCompany.add(printer)
 ```
 
 ### Remove a relation to an existing document
 
-For `has-many` relationships, use the `removeById` method:
+For `has-many` relationships, use the `remove(docs)` method:
 
 ```javascript
-const otherAuthorId = 'abc123'
+const wrongAuthors = [{_id: 'James Wrong' }, {_id: 'Henry Mistake'}]
 const response = await client.query(query)
 const docs = response.data
 const firstDoc = docs[0]
-firstDoc.authors.removeById(otherAuthorId)
+firstDoc.authors.remove(wrongAuthors)
 ```
 
-Just like `addById`, `removeById` accepts an array of ids as parameter.
+Just like `add`, `remove` accepts a single document.
 
-For `has-one` relationships, use the `unset()` method:
+For `has-one` relationships, just use `remove()`, with no argument:
 
 
 ```javascript
 const response = await client.query(query)
 const docs = response.data
 const firstDoc = docs[0]
-firstDoc.printingCompany.unset()
+firstDoc.printingCompany.remove()
 ```
 
 ### Create a new file with existing relations

--- a/packages/cozy-client/src/associations/HasMany.js
+++ b/packages/cozy-client/src/associations/HasMany.js
@@ -116,6 +116,30 @@ class HasMany extends Association {
   }
 
   /**
+   * Add the relationships to the target document
+   *
+   * @param {CozyClientDocument[]} docsArg - Documents to add as relationships
+   * @returns {CozyClientDocument} The saved target document
+   */
+  add(docsArg) {
+    const docs = Array.isArray(docsArg) ? docsArg : [docsArg]
+    const ids = docs.map(doc => doc._id)
+    return this.addById(ids)
+  }
+
+  /**
+   * Remove the relationships from the target document
+   *
+   * @param {CozyClientDocument[]} docsArg - Documents to remove as relationships
+   * @returns {CozyClientDocument} The saved target document
+   */
+  remove(docsArg) {
+    const docs = Array.isArray(docsArg) ? docsArg : [docsArg]
+    const ids = docs.map(doc => doc._id)
+    return this.removeById(ids)
+  }
+
+  /**
    * Add a referenced document by id. You need to call save()
    * in order to synchronize your document with the store.
    *

--- a/packages/cozy-client/src/associations/HasMany.spec.js
+++ b/packages/cozy-client/src/associations/HasMany.spec.js
@@ -54,51 +54,87 @@ describe('HasMany', () => {
     }
   })
 
-  it('adds', () => {
-    hydrated.tasks.addById(4)
-    expect(hydrated.tasks.data).toEqual([
-      { doctype: 'io.cozy.tasks', id: 1 },
-      { doctype: 'io.cozy.tasks', id: 2 },
-      { doctype: 'io.cozy.tasks', id: 4 }
-    ])
-    expect(save).toHaveBeenCalled()
+  describe('add', () => {
+    it('adds by id', () => {
+      hydrated.tasks.addById(4)
+      expect(hydrated.tasks.data).toEqual([
+        { doctype: 'io.cozy.tasks', id: 1 },
+        { doctype: 'io.cozy.tasks', id: 2 },
+        { doctype: 'io.cozy.tasks', id: 4 }
+      ])
+      expect(save).toHaveBeenCalled()
+    })
+
+    it('doesnt add if already there', () => {
+      hydrated.tasks.addById(1)
+      expect(hydrated.tasks.data).toEqual([
+        { doctype: 'io.cozy.tasks', id: 1 },
+        { doctype: 'io.cozy.tasks', id: 2 }
+      ])
+    })
+
+    it('adds multiple ids', () => {
+      hydrated.tasks.addById([4, 5])
+
+      expect(hydrated.tasks.data).toEqual([
+        { doctype: 'io.cozy.tasks', id: 1 },
+        { doctype: 'io.cozy.tasks', id: 2 },
+        { doctype: 'io.cozy.tasks', id: 4 },
+        { doctype: 'io.cozy.tasks', id: 5 }
+      ])
+    })
+
+    it('adds by doc', () => {
+      hydrated.tasks.add({ _id: 4 })
+      expect(hydrated.tasks.data).toEqual([
+        { doctype: 'io.cozy.tasks', id: 1 },
+        { doctype: 'io.cozy.tasks', id: 2 },
+        { doctype: 'io.cozy.tasks', id: 4 }
+      ])
+    })
+
+    it('adds by multiple docs', () => {
+      hydrated.tasks.add([{ _id: 4 }, { _id: 5 }])
+      expect(hydrated.tasks.data).toEqual([
+        { doctype: 'io.cozy.tasks', id: 1 },
+        { doctype: 'io.cozy.tasks', id: 2 },
+        { doctype: 'io.cozy.tasks', id: 4 },
+        { doctype: 'io.cozy.tasks', id: 5 }
+      ])
+    })
   })
 
-  it('doesnt add if already there', () => {
-    hydrated.tasks.addById(1)
-    expect(hydrated.tasks.data).toEqual([
-      { doctype: 'io.cozy.tasks', id: 1 },
-      { doctype: 'io.cozy.tasks', id: 2 }
-    ])
-  })
+  describe('remove', () => {
+    it('removes by id', () => {
+      hydrated.tasks.removeById(2)
+      expect(hydrated.tasks.data).toEqual([{ doctype: 'io.cozy.tasks', id: 1 }])
+      expect(save).toHaveBeenCalled()
+    })
 
-  it('adds multiple ids', () => {
-    hydrated.tasks.addById([4, 5])
-    expect(hydrated.tasks.data).toEqual([
-      { doctype: 'io.cozy.tasks', id: 1 },
-      { doctype: 'io.cozy.tasks', id: 2 },
-      { doctype: 'io.cozy.tasks', id: 4 },
-      { doctype: 'io.cozy.tasks', id: 5 }
-    ])
-  })
+    it('doesnt remove if not there', () => {
+      hydrated.tasks.removeById(3)
+      expect(hydrated.tasks.data).toEqual([
+        { doctype: 'io.cozy.tasks', id: 1 },
+        { doctype: 'io.cozy.tasks', id: 2 }
+      ])
+    })
 
-  it('removes', () => {
-    hydrated.tasks.removeById(2)
-    expect(hydrated.tasks.data).toEqual([{ doctype: 'io.cozy.tasks', id: 1 }])
-    expect(save).toHaveBeenCalled()
-  })
+    it('can remove multiple docs from the relationship', () => {
+      hydrated.tasks.removeById([1, 2])
+      expect(hydrated.tasks.data).toEqual([])
+    })
 
-  it('doesnt remove if not there', () => {
-    hydrated.tasks.removeById(3)
-    expect(hydrated.tasks.data).toEqual([
-      { doctype: 'io.cozy.tasks', id: 1 },
-      { doctype: 'io.cozy.tasks', id: 2 }
-    ])
-  })
+    it('remove by doc', () => {
+      hydrated.tasks.remove({ _id: 2 })
+      expect(hydrated.tasks.data).toEqual([{ doctype: 'io.cozy.tasks', id: 1 }])
+      expect(save).toHaveBeenCalled()
+    })
 
-  it('can remove multiple docs from the relationship', () => {
-    hydrated.tasks.removeById([1, 2])
-    expect(hydrated.tasks.data).toEqual([])
+    it('remove by docs', () => {
+      hydrated.tasks.remove([{ _id: 1 }, { _id: 2 }])
+      expect(hydrated.tasks.data).toEqual([])
+      expect(save).toHaveBeenCalled()
+    })
   })
 
   it('updates the count metadata', () => {

--- a/packages/cozy-client/src/associations/HasOne.js
+++ b/packages/cozy-client/src/associations/HasOne.js
@@ -39,7 +39,7 @@ export default class HasOne extends Association {
    * @returns {CozyClientDocument} The saved target document
    */
   add(doc) {
-    this.set(doc)
+    this.setRelationship(doc)
     return this.save(this.target)
   }
 
@@ -49,11 +49,11 @@ export default class HasOne extends Association {
    * @returns {CozyClientDocument} The saved target document
    */
   remove() {
-    this.set(undefined)
+    this.setRelationship(undefined)
     return this.save(this.target)
   }
 
-  set(doc) {
+  setRelationship(doc) {
     if (doc && doc._type !== this.doctype) {
       throw new Error(
         `Tried to associate a ${doc._type} document to a HasOne relationship on ${this.doctype} document`
@@ -72,8 +72,18 @@ export default class HasOne extends Association {
     }
   }
 
+  set(doc) {
+    console.warn(
+      'set is deprecated for has-one relationships. Use `add` instead.'
+    )
+    this.setRelationship(doc)
+  }
+
   unset() {
-    this.set(undefined)
+    console.warn(
+      'unset is deprecated for has-one relationships. Use `remove` instead.'
+    )
+    this.setRelationship(undefined)
   }
 
   dehydrate(doc) {

--- a/packages/cozy-client/src/associations/HasOne.js
+++ b/packages/cozy-client/src/associations/HasOne.js
@@ -32,6 +32,27 @@ export default class HasOne extends Association {
     return Q(assoc.doctype).getById(relationship._id)
   }
 
+  /**
+   * Add the relationship to the target document
+   *
+   * @param {CozyClientDocument} doc - Document to add as a relationship
+   * @returns {CozyClientDocument} The saved target document
+   */
+  add(doc) {
+    this.set(doc)
+    return this.save(this.target)
+  }
+
+  /**
+   * Remove the relationship from the target document
+   *
+   * @returns {CozyClientDocument} The saved target document
+   */
+  remove() {
+    this.set(undefined)
+    return this.save(this.target)
+  }
+
   set(doc) {
     if (doc && doc._type !== this.doctype) {
       throw new Error(

--- a/packages/cozy-client/src/associations/HasOne.spec.js
+++ b/packages/cozy-client/src/associations/HasOne.spec.js
@@ -28,14 +28,16 @@ const fixtures = {
 const hydratedMaster = {
   ...fixtures.jediMaster,
   padawan: new HasOne(fixtures.jediMaster, 'padawan', 'io.cozy.jedis', {
-    get: jest.fn().mockReturnValue(fixtures.apprentice)
+    get: jest.fn().mockReturnValue(fixtures.apprentice),
+    save: jest.fn()
   })
 }
 
 const hydratedApprentice = {
   ...fixtures.apprentice,
   padawan: new HasOne(fixtures.apprentice, 'padawan', 'io.cozy.jedis', {
-    get: jest.fn().mockReturnValue(undefined)
+    get: jest.fn().mockReturnValue(undefined),
+    save: jest.fn()
   })
 }
 
@@ -120,6 +122,25 @@ describe('HasOne', () => {
       expect(hydratedMaster.padawan.raw).toEqual({
         _id: newPadawan._id,
         _type: newPadawan._type
+      })
+    })
+  })
+
+  describe('remove', () => {
+    it('should remove', () => {
+      hydratedMaster.padawan.remove()
+      expect(hydratedMaster.padawan.raw).toEqual(null)
+    })
+  })
+
+  describe('add', () => {
+    it('should add', () => {
+      hydratedMaster.padawan.remove()
+      hydratedMaster.padawan.add({ _id: 'luke', _type: 'io.cozy.jedis' })
+
+      expect(hydratedMaster.padawan.raw).toEqual({
+        _type: 'io.cozy.jedis',
+        _id: 'luke'
       })
     })
   })

--- a/packages/cozy-client/src/associations/HasOne.spec.js
+++ b/packages/cozy-client/src/associations/HasOne.spec.js
@@ -103,10 +103,13 @@ describe('HasOne', () => {
     })
   })
 
-  describe('set', () => {
+  describe('setRelationship', () => {
     it("should throw if the document to be set's type is not the same as the association type", () => {
       expect(() =>
-        hydratedMaster.padawan.set({ _id: '1', _type: 'io.cozy.stuff' })
+        hydratedMaster.padawan.setRelationship({
+          _id: '1',
+          _type: 'io.cozy.stuff'
+        })
       ).toThrow()
     })
 
@@ -117,7 +120,7 @@ describe('HasOne', () => {
         name: 'Bernard Nobody'
       }
 
-      hydratedMaster.padawan.set(newPadawan)
+      hydratedMaster.padawan.setRelationship(newPadawan)
 
       expect(hydratedMaster.padawan.raw).toEqual({
         _id: newPadawan._id,

--- a/packages/cozy-client/types/associations/HasMany.d.ts
+++ b/packages/cozy-client/types/associations/HasMany.d.ts
@@ -88,6 +88,20 @@ declare class HasMany extends Association {
     containsById(id: any): boolean;
     existsById(id: any): boolean;
     /**
+     * Add the relationships to the target document
+     *
+     * @param {CozyClientDocument[]} docsArg - Documents to add as relationships
+     * @returns {CozyClientDocument} The saved target document
+     */
+    add(docsArg: CozyClientDocument[]): CozyClientDocument;
+    /**
+     * Remove the relationships from the target document
+     *
+     * @param {CozyClientDocument[]} docsArg - Documents to remove as relationships
+     * @returns {CozyClientDocument} The saved target document
+     */
+    remove(docsArg: CozyClientDocument[]): CozyClientDocument;
+    /**
      * Add a referenced document by id. You need to call save()
      * in order to synchronize your document with the store.
      *
@@ -106,3 +120,4 @@ declare class HasMany extends Association {
     dehydrate(doc: any): any;
 }
 import Association from "./Association";
+import { CozyClientDocument } from "../types";

--- a/packages/cozy-client/types/associations/HasOne.d.ts
+++ b/packages/cozy-client/types/associations/HasOne.d.ts
@@ -6,8 +6,23 @@ export default class HasOne extends Association {
         save: Function;
         dispatch: Function;
     });
+    /**
+     * Add the relationship to the target document
+     *
+     * @param {CozyClientDocument} doc - Document to add as a relationship
+     * @returns {CozyClientDocument} The saved target document
+     */
+    add(doc: CozyClientDocument): CozyClientDocument;
+    /**
+     * Remove the relationship from the target document
+     *
+     * @returns {CozyClientDocument} The saved target document
+     */
+    remove(): CozyClientDocument;
+    setRelationship(doc: any): void;
     set(doc: any): void;
     unset(): void;
     dehydrate(doc: any): any;
 }
 import Association from "./Association";
+import { CozyClientDocument } from "../types";


### PR DESCRIPTION
We used to have `addById/removeById` for has-many relationships and
`set/unset` for has-one relationships, with different behaviour:
has-many saves the relationship in database, but not has-one.
To be consistent, we add `save/remove` API for both relationships.