### PR TITLE
feat: Makes queryAll faster with many requests

### DIFF
--- a/packages/cozy-client/src/store/documents.js
+++ b/packages/cozy-client/src/store/documents.js
@@ -171,25 +171,7 @@ export const extractAndMergeDocument = (data, updatedStateWithIncluded) => {
   }
   const sortedData = keyBy(data, properId)
 
-  let mergedData = {}
-  if (updatedStateWithIncluded && updatedStateWithIncluded[doctype]) {
-    Object.values(updatedStateWithIncluded[doctype]).map(dataState => {
-      if (!mergedData[doctype]) mergedData[doctype] = {}
-      const id = properId(dataState)
-      if (sortedData[id]) {
-        mergedData[doctype][id] = {
-          ...dataState,
-          ...sortedData[id],
-          ...mergedData[doctype][id]
-        }
-      } else {
-        mergedData[doctype][id] = {
-          ...dataState,
-          ...mergedData[doctype][id]
-        }
-      }
-    })
-  }
+  let mergedData = Object.assign({}, updatedStateWithIncluded)
   Object.values(sortedData).map(data => {
     if (!mergedData[doctype]) mergedData[doctype] = {}
     const id = properId(data)
@@ -203,8 +185,5 @@ export const extractAndMergeDocument = (data, updatedStateWithIncluded) => {
     }
   })
 
-  return {
-    ...updatedStateWithIncluded,
-    ...mergedData
-  }
+  return mergedData
 }


### PR DESCRIPTION
When there many documents in the same doctype, and queryAll is used to
fetch them all, it can be very slow. It looks like Cozy-Client is taking
more and more time between requests to update its state.

The extractAndMergeDocument function is used to merge the documents in
state and the documents in the response. It was iterating on both sets
of documents, which seems useless. By iterating on just the new
documents, it can be faster and avoid the growing time between requests.