### PR TITLE
feat: Add OAuthClientsCollection

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -28,6 +28,9 @@ files associated to a specific document</p>
 <dd><p>Specialized <code>CozyStackClient</code> for mobile, implementing stack registration
 through OAuth.</p>
 </dd>
+<dt><a href="#OAuthClientsCollection">OAuthClientsCollection</a></dt>
+<dd><p>Implements <code>DocumentCollection</code> API to interact with the /settings/clients endpoint of the stack</p>
+</dd>
 <dt><a href="#PermissionCollection">PermissionCollection</a></dt>
 <dd><p>Implements <code>DocumentCollection</code> API along with specific methods for <code>io.cozy.permissions</code>.</p>
 </dd>
@@ -1161,6 +1164,58 @@ Updates the OAuth informations
 Reset the current OAuth client
 
 **Kind**: instance method of [<code>OAuthClient</code>](#OAuthClient)  
+<a name="OAuthClientsCollection"></a>
+
+## OAuthClientsCollection
+Implements `DocumentCollection` API to interact with the /settings/clients endpoint of the stack
+
+**Kind**: global class  
+
+* [OAuthClientsCollection](#OAuthClientsCollection)
+    * [.all(options)](#OAuthClientsCollection+all) ⇒ <code>object</code>
+    * [.get(id)](#OAuthClientsCollection+get) ⇒ <code>object</code>
+    * [.destroy(client)](#OAuthClientsCollection+destroy) ⇒ <code>Object</code>
+
+<a name="OAuthClientsCollection+all"></a>
+
+### oAuthClientsCollection.all(options) ⇒ <code>object</code>
+Fetches all OAuth clients
+
+**Kind**: instance method of [<code>OAuthClientsCollection</code>](#OAuthClientsCollection)  
+**Returns**: <code>object</code> - The JSON API conformant response.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | <code>object</code> | Query options |
+| options.limit | <code>number</code> | For pagination, the number of results to return. |
+| options.bookmark | <code>object</code> | For cursor-based pagination, the index cursor. |
+| options.keys | <code>array</code> | Ids of specific clients to return (within the current page), |
+
+<a name="OAuthClientsCollection+get"></a>
+
+### oAuthClientsCollection.get(id) ⇒ <code>object</code>
+Get an OAuth client by id
+
+**Kind**: instance method of [<code>OAuthClientsCollection</code>](#OAuthClientsCollection)  
+**Returns**: <code>object</code> - JsonAPI response containing normalized client as data attribute  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| id | <code>string</code> | The client id. |
+
+<a name="OAuthClientsCollection+destroy"></a>
+
+### oAuthClientsCollection.destroy(client) ⇒ <code>Object</code>
+Destroys the OAuth client on the server
+
+**Kind**: instance method of [<code>OAuthClientsCollection</code>](#OAuthClientsCollection)  
+**Returns**: <code>Object</code> - The deleted client  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| client | <code>io.cozy.oauth.clients</code> | The client document to destroy |
+| client._id | <code>string</code> | The client's id |
+
 <a name="PermissionCollection"></a>
 
 ## PermissionCollection

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -11,6 +11,9 @@ import PermissionCollection from './PermissionCollection'
 import TriggerCollection, { TRIGGERS_DOCTYPE } from './TriggerCollection'
 import SettingsCollection, { SETTINGS_DOCTYPE } from './SettingsCollection'
 import NotesCollection, { NOTES_DOCTYPE } from './NotesCollection'
+import OAuthClientsCollection, {
+  OAUTH_CLIENTS_DOCTYPE
+} from './OAuthClientsCollection'
 import ShortcutsCollection, { SHORTCUTS_DOCTYPE } from './ShortcutsCollection'
 import ContactsCollection, { CONTACTS_DOCTYPE } from './ContactsCollection'
 import getIconURL from './getIconURL'
@@ -80,6 +83,8 @@ class CozyStackClient {
         return new SettingsCollection(this)
       case NOTES_DOCTYPE:
         return new NotesCollection(this)
+      case OAUTH_CLIENTS_DOCTYPE:
+        return new OAuthClientsCollection(this)
       case SHORTCUTS_DOCTYPE:
         return new ShortcutsCollection(this)
       default:

--- a/packages/cozy-stack-client/src/OAuthClientsCollection.js
+++ b/packages/cozy-stack-client/src/OAuthClientsCollection.js
@@ -1,0 +1,125 @@
+import get from 'lodash/get'
+
+import DocumentCollection from './DocumentCollection'
+import { uri } from './utils'
+import * as querystring from './querystring'
+import { dontThrowNotFoundError } from './Collection'
+import { FetchError } from './errors'
+
+export const OAUTH_CLIENTS_DOCTYPE = 'io.cozy.oauth.clients'
+
+const normalizeDoc = DocumentCollection.normalizeDoctypeJsonApi(
+  OAUTH_CLIENTS_DOCTYPE
+)
+const normalizeOAuthClient = client => ({
+  ...normalizeDoc(client, OAUTH_CLIENTS_DOCTYPE),
+  ...client.attributes
+})
+
+/**
+ * Implements `DocumentCollection` API to interact with the /settings/clients endpoint of the stack
+ */
+class OAuthClientsCollection extends DocumentCollection {
+  constructor(stackClient) {
+    super(OAUTH_CLIENTS_DOCTYPE, stackClient)
+  }
+
+  /**
+   * Fetches all OAuth clients
+   *
+   * @param  {object} options           Query options
+   * @param  {number} options.limit     For pagination, the number of results to return.
+   * @param  {object} options.bookmark  For cursor-based pagination, the index cursor.
+   * @param  {array} options.keys       Ids of specific clients to return (within the current page),
+   * @returns {object}                  The JSON API conformant response.
+   */
+  async all(options = {}) {
+    const { limit = 100, bookmark, keys } = options
+
+    const params = {
+      'page[limit]': limit,
+      'page[cursor]': bookmark
+    }
+    const url = uri`/settings/clients`
+    const path = querystring.buildURL(url, params)
+    let resp
+    try {
+      resp = await this.stackClient.fetchJSON('GET', path)
+    } catch (error) {
+      return dontThrowNotFoundError(error)
+    }
+    const nextLink = get(resp, 'links.next', '')
+    const nextLinkURL = new URL(`${this.stackClient.uri}${nextLink}`)
+    const nextBookmark =
+      nextLinkURL.searchParams.get('page[cursor]') || undefined
+    const hasBookmark = nextBookmark !== undefined
+
+    if (keys) {
+      const data = resp.data
+        .filter(c => keys.includes(c.id))
+        .map(c => normalizeOAuthClient(c))
+      const meta = { ...resp.meta, count: data.length }
+
+      return {
+        data,
+        meta,
+        next: keys.length > data.length && hasBookmark,
+        bookmark: nextBookmark
+      }
+    } else {
+      return {
+        data: resp.data.map(c => normalizeOAuthClient(c)),
+        meta: resp.meta,
+        next: hasBookmark,
+        bookmark: nextBookmark
+      }
+    }
+  }
+
+  /**
+   * Get an OAuth client by id
+   *
+   * @param  {string} id The client id.
+   * @returns {object}  JsonAPI response containing normalized client as data attribute
+   */
+  async get(id) {
+    let resp = await this.all({ keys: [id] })
+
+    while (resp.next) {
+      resp = await this.all({ keys: [id], bookmark: resp.bookmark })
+    }
+
+    if (resp.data.length) {
+      return {
+        data: normalizeOAuthClient(resp.data[0])
+      }
+    } else {
+      resp.url = uri`/settings/clients/${id}`
+      resp.status = '404'
+      throw new FetchError(resp, 'Not Found')
+    }
+  }
+
+  /**
+   * Destroys the OAuth client on the server
+   *
+   * @param {io.cozy.oauth.clients} client     The client document to destroy
+   * @param {string}                client._id The client's id
+   *
+   * @returns {{ data }} The deleted client
+   */
+  async destroy({ _id }) {
+    const resp = await this.stackClient.fetchJSON(
+      'DELETE',
+      uri`/settings/clients/${_id}`
+    )
+    return {
+      data: { ...normalizeOAuthClient(resp.data), _deleted: true }
+    }
+  }
+}
+
+OAuthClientsCollection.normalizeDoctype =
+  DocumentCollection.normalizeDoctypeJsonApi
+
+export default OAuthClientsCollection

--- a/packages/cozy-stack-client/src/OAuthClientsCollection.spec.js
+++ b/packages/cozy-stack-client/src/OAuthClientsCollection.spec.js
@@ -1,0 +1,251 @@
+import OAuthClientsCollection from './OAuthClientsCollection'
+import CozyStackClient from './CozyStackClient'
+import { FetchError } from './errors'
+
+const DEFAULT_LIMIT = 100
+
+describe('OAuthClientsCollection', () => {
+  const setup = () => {
+    const stackClient = new CozyStackClient()
+    stackClient.uri = 'http://cozy.localhost'
+    const collection = new OAuthClientsCollection(stackClient)
+
+    return { stackClient, collection }
+  }
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('all', () => {
+    const { stackClient, collection } = setup()
+
+    it('should call the appropriate route', async () => {
+      jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue({
+        data: [],
+        links: {},
+        meta: { count: 0 }
+      })
+
+      await collection.all()
+      expect(stackClient.fetchJSON).toHaveBeenCalledWith(
+        'GET',
+        `/settings/clients?page[limit]=${DEFAULT_LIMIT}`
+      )
+    })
+
+    it('should normalize documents', async () => {
+      jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue({
+        data: [{ _id: '1', attributes: { client_kind: 'desktop' } }],
+        links: {},
+        meta: { count: 1 }
+      })
+      const result = await collection.all()
+      expect(result.data).toEqual([
+        {
+          _id: '1',
+          _type: 'io.cozy.oauth.clients',
+          id: '1',
+          client_kind: 'desktop',
+          attributes: { client_kind: 'desktop' }
+        }
+      ])
+      expect(result.next).toBe(false)
+    })
+
+    describe('when data is paginated', () => {
+      const RESPONSE = {
+        data: [
+          { id: '1', attributes: { client_kind: 'desktop' } },
+          { id: '2', attributes: { client_kind: 'mobile' } }
+        ],
+        links: {
+          next: '/settings/clients?page[cursor]=bookmark-id-123'
+        },
+        meta: {
+          count: 4
+        }
+      }
+
+      beforeEach(() => {
+        jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue(RESPONSE)
+      })
+
+      afterEach(() => {
+        stackClient.fetchJSON.mockReset()
+      })
+
+      it('should return a pagination bookmark', async () => {
+        const result = await collection.all()
+        expect(result.data).toEqual([
+          {
+            _id: '1',
+            _type: 'io.cozy.oauth.clients',
+            id: '1',
+            client_kind: 'desktop',
+            attributes: {
+              client_kind: 'desktop'
+            }
+          },
+          {
+            _id: '2',
+            _type: 'io.cozy.oauth.clients',
+            id: '2',
+            client_kind: 'mobile',
+            attributes: {
+              client_kind: 'mobile'
+            }
+          }
+        ])
+        expect(result.next).toBe(true)
+        expect(result.bookmark).toBe('bookmark-id-123')
+      })
+    })
+  })
+
+  describe('get', () => {
+    const { stackClient, collection } = setup()
+
+    describe('when requested document is in first results page', () => {
+      beforeEach(() => {
+        jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue({
+          data: [
+            { id: '1', attributes: { client_kind: 'desktop' } },
+            { id: '2', attributes: { client_kind: 'mobile' } }
+          ],
+          links: {},
+          meta: {
+            count: 2
+          }
+        })
+      })
+
+      afterEach(() => {
+        stackClient.fetchJSON.mockReset()
+      })
+
+      it('should call the appropriate route', async () => {
+        await collection.get('1')
+        expect(stackClient.fetchJSON).toHaveBeenCalledWith(
+          'GET',
+          `/settings/clients?page[limit]=${DEFAULT_LIMIT}`
+        )
+      })
+
+      it('should return the normalized client document whose _id was given', async () => {
+        const result1 = await collection.get('1')
+        expect(result1.data).toEqual({
+          _id: '1',
+          _type: 'io.cozy.oauth.clients',
+          id: '1',
+          client_kind: 'desktop',
+          attributes: {
+            client_kind: 'desktop'
+          }
+        })
+
+        const result2 = await collection.get('2')
+        expect(result2.data).toEqual({
+          _id: '2',
+          _type: 'io.cozy.oauth.clients',
+          id: '2',
+          client_kind: 'mobile',
+          attributes: {
+            client_kind: 'mobile'
+          }
+        })
+      })
+    })
+
+    describe('when requested document is not in first results page', () => {
+      beforeEach(() => {
+        jest
+          .spyOn(stackClient, 'fetchJSON')
+          .mockResolvedValueOnce({
+            data: [{ id: '1', attributes: { client_kind: 'desktop' } }],
+            links: {
+              next: '/settings/clients?page[cursor]=bookmark-id-123'
+            },
+            meta: {}
+          })
+          .mockResolvedValueOnce({
+            data: [{ id: '2', attributes: { client_kind: 'mobile' } }],
+            links: {},
+            meta: {}
+          })
+      })
+
+      afterEach(() => {
+        stackClient.fetchJSON.mockReset()
+      })
+
+      it('should fetch the next page', async () => {
+        await collection.get('2')
+        expect(stackClient.fetchJSON).toHaveBeenCalledWith(
+          'GET',
+          `/settings/clients?page[limit]=${DEFAULT_LIMIT}`
+        )
+        expect(stackClient.fetchJSON).toHaveBeenCalledWith(
+          'GET',
+          `/settings/clients?page[limit]=${DEFAULT_LIMIT}&page[cursor]=bookmark-id-123`
+        )
+      })
+
+      it('should return the normalized document in the end', async () => {
+        const result = await collection.get('2')
+        expect(result.data).toEqual({
+          _id: '2',
+          _type: 'io.cozy.oauth.clients',
+          id: '2',
+          client_kind: 'mobile',
+          attributes: {
+            client_kind: 'mobile'
+          }
+        })
+      })
+    })
+
+    describe('when no documents have the given id', () => {
+      beforeEach(() => {
+        jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue({
+          data: [],
+          links: {},
+          meta: {}
+        })
+      })
+
+      afterEach(() => {
+        stackClient.fetchJSON.mockReset()
+      })
+
+      it('should throw a Not Found error', async () => {
+        await expect(collection.get('2')).rejects.toThrow(
+          new FetchError({}, 'Not Found')
+        )
+      })
+    })
+  })
+
+  describe('destroy', () => {
+    const { stackClient, collection } = setup()
+
+    beforeEach(() => {
+      jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue({
+        data: { id: '1', attributes: { client_kind: 'desktop' } }
+      })
+    })
+
+    it('should call the appropriate route', async () => {
+      await collection.destroy({ _id: '1' })
+      expect(stackClient.fetchJSON).toHaveBeenCalledWith(
+        'DELETE',
+        '/settings/clients/1'
+      )
+    })
+
+    it('should add _deleted to the response', async () => {
+      const result = await collection.destroy({ _id: '1' })
+      expect(result.data._deleted).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
The `io.cozy.oauth.clients` doctype is protected so we need to
manually build a collection to query it.
We only add the `all`, `get` and `destroy` methods as they can be used
right away in the Settings app.