### PR TITLE
fix: Allow 401 errors for expired tokens

### DIFF
--- a/packages/cozy-pouch-link/examples/periodic-sync/index.js
+++ b/packages/cozy-pouch-link/examples/periodic-sync/index.js
@@ -88,7 +88,7 @@ class App extends React.Component {
       replicationDelay: 2 * 1000,
       getReplicationURL: this.getReplicationURL,
       onError: err => {
-        if (err.error == 'code=400, message=Expired token') {
+        if (/Expired token/.test(err.error)) {
           console.log('You need to refresh the token')
         }
         this.setState({ error: err.error })

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -53,8 +53,9 @@ export const getReplicationURL = (uri, token, doctype) => {
 }
 
 const doNothing = () => {}
+const expiredTokenError = /Expired token/
 export const isExpiredTokenError = pouchError => {
-  return pouchError.error === 'code=400, message=Expired token'
+  return expiredTokenError.test(pouchError.error)
 }
 
 const normalizeAll = (docs, doctype) => {


### PR DESCRIPTION
The stack will change the http code used for expired tokens from 400 to
401. This change will allow cozy-client to try refreshing the token in
such cases.

See https://github.com/cozy/cozy-stack/pull/3173