### PR TITLE
refactor: Use forceFileDownload in file collection

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -507,6 +507,7 @@ files associated to a specific document
 **Kind**: global class  
 
 * [FileCollection](#FileCollection)
+    * [.forceFileDownload](#FileCollection+forceFileDownload)
     * [.get(id)](#FileCollection+get) ⇒ <code>Object</code>
     * [.find(selector, options)](#FileCollection+find) ⇒ <code>Object</code>
     * [.findReferencedBy(document, options)](#FileCollection+findReferencedBy) ⇒ <code>object</code>
@@ -533,6 +534,18 @@ files associated to a specific document
     * [.findNotSynchronizedDirectories(oauthClient, options)](#FileCollection+findNotSynchronizedDirectories) ⇒ <code>Array.&lt;(object\|IOCozyFolder)&gt;</code>
     * [.addNotSynchronizedDirectories(oauthClient, directories)](#FileCollection+addNotSynchronizedDirectories) ⇒
     * [.removeNotSynchronizedDirectories(oauthClient, directories)](#FileCollection+removeNotSynchronizedDirectories) ⇒
+
+<a name="FileCollection+forceFileDownload"></a>
+
+### fileCollection.forceFileDownload
+Force a file download from the given href
+
+**Kind**: instance property of [<code>FileCollection</code>](#FileCollection)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| href | <code>string</code> | The link to download |
+| filename | <code>string</code> | The file name to download |
 
 <a name="FileCollection+get"></a>
 

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -3,7 +3,7 @@ import has from 'lodash/has'
 import get from 'lodash/get'
 import pick from 'lodash/pick'
 import DocumentCollection, { normalizeDoc } from './DocumentCollection'
-import { uri, slugify, forceFileDownload, formatBytes } from './utils'
+import { uri, slugify, formatBytes } from './utils'
 import * as querystring from './querystring'
 import { FetchError } from './errors'
 import { dontThrowNotFoundError } from './Collection'
@@ -505,6 +505,22 @@ class FileCollection extends DocumentCollection {
   }
 
   /**
+   * Force a file download from the given href
+   *
+   * @param {string} href - The link to download
+   * @param {string} filename - The file name to download
+   */
+  forceFileDownload = (href, filename) => {
+    const element = document.createElement('a')
+    element.setAttribute('href', href)
+    element.setAttribute('download', filename)
+    element.style.display = 'none'
+    document.body.appendChild(element)
+    element.click()
+    document.body.removeChild(element)
+  }
+
+  /**
    * Download a file or a specific version of the file
    *
    * @param {object} file io.cozy.files object
@@ -528,7 +544,7 @@ class FileCollection extends DocumentCollection {
     } else {
       href = await this.getDownloadLinkByRevision(versionId, filenameToUse)
     }
-    forceFileDownload(`${href}?Dl=1`, filenameToUse)
+    this.forceFileDownload(`${href}?Dl=1`, filenameToUse)
   }
 
   async fetchFileContent(id) {
@@ -567,7 +583,7 @@ class FileCollection extends DocumentCollection {
     const filename = slugify(notSecureFilename)
     const href = await this.getArchiveLinkByIds(fileIds, filename)
     const fullpath = this.stackClient.fullpath(href)
-    forceFileDownload(fullpath, filename + '.zip')
+    this.forceFileDownload(fullpath, filename + '.zip')
   }
 
   async getArchiveLinkByIds(ids, name = 'files') {

--- a/packages/cozy-stack-client/src/utils.js
+++ b/packages/cozy-stack-client/src/utils.js
@@ -58,16 +58,6 @@ export const slugify = text =>
     .replace(/^-+/, '') // Trim - from start of text
     .replace(/-+$/, '') // Trim - from end of text
 
-export const forceFileDownload = (href, filename) => {
-  const element = document.createElement('a')
-  element.setAttribute('href', href)
-  element.setAttribute('download', filename)
-  element.style.display = 'none'
-  document.body.appendChild(element)
-  element.click()
-  document.body.removeChild(element)
-}
-
 export const formatBytes = (bytes, decimals = 2) => {
   if (bytes === 0) return '0 Bytes'
 


### PR DESCRIPTION
Moving this method in the file collection allows to access it from an
app. This is typically useful for an encrypted file with Drive, because
we do not want the download link to be handled by the stack, as we have
to decrypt the binary first and then generate an URL from it.