### PR TITLE
Fix OAuth clients' realtime updates

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -1174,7 +1174,7 @@ Implements `DocumentCollection` API to interact with the /settings/clients endpo
 * [OAuthClientsCollection](#OAuthClientsCollection)
     * [.all(options)](#OAuthClientsCollection+all) ⇒ <code>object</code>
     * [.get(id)](#OAuthClientsCollection+get) ⇒ <code>object</code>
-    * [.destroy(client)](#OAuthClientsCollection+destroy) ⇒ <code>Object</code>
+    * [.destroy(oauthClient)](#OAuthClientsCollection+destroy) ⇒ <code>Object</code>
 
 <a name="OAuthClientsCollection+all"></a>
 
@@ -1189,7 +1189,7 @@ Fetches all OAuth clients
 | options | <code>object</code> | Query options |
 | options.limit | <code>number</code> | For pagination, the number of results to return. |
 | options.bookmark | <code>object</code> | For cursor-based pagination, the index cursor. |
-| options.keys | <code>array</code> | Ids of specific clients to return (within the current page), |
+| options.keys | <code>Array</code> | Ids of specific clients to return (within the current page), |
 
 <a name="OAuthClientsCollection+get"></a>
 
@@ -1205,7 +1205,7 @@ Get an OAuth client by id
 
 <a name="OAuthClientsCollection+destroy"></a>
 
-### oAuthClientsCollection.destroy(client) ⇒ <code>Object</code>
+### oAuthClientsCollection.destroy(oauthClient) ⇒ <code>Object</code>
 Destroys the OAuth client on the server
 
 **Kind**: instance method of [<code>OAuthClientsCollection</code>](#OAuthClientsCollection)  
@@ -1213,8 +1213,7 @@ Destroys the OAuth client on the server
 
 | Param | Type | Description |
 | --- | --- | --- |
-| client | <code>io.cozy.oauth.clients</code> | The client document to destroy |
-| client._id | <code>string</code> | The client's id |
+| oauthClient | <code>io.cozy.oauth.clients</code> | The client document to destroy |
 
 <a name="PermissionCollection"></a>
 

--- a/packages/cozy-client/src/RealTimeQueries.spec.jsx
+++ b/packages/cozy-client/src/RealTimeQueries.spec.jsx
@@ -4,80 +4,96 @@ import RealTimeQueries from './RealTimeQueries'
 import { createMockClient } from './mock'
 import CozyProvider from './Provider'
 
+const setup = async doctype => {
+  const realtimeCallbacks = {}
+  const client = new createMockClient({})
+  client.plugins.realtime = {
+    subscribe: jest.fn((event, doctype, callback) => {
+      realtimeCallbacks[event] = callback
+    }),
+    unsubscribe: jest.fn()
+  }
+  client.dispatch = jest.fn()
+
+  const { unmount } = render(
+    <CozyProvider client={client}>
+      <RealTimeQueries doctype={doctype} />
+    </CozyProvider>
+  )
+
+  await waitFor(() =>
+    expect(client.plugins.realtime.subscribe).toHaveBeenCalledTimes(3)
+  )
+
+  return { client, realtimeCallbacks, unmount }
+}
+
 describe('RealTimeQueries', () => {
   it('notifies the cozy-client store', async () => {
-    const realtimeCallbacks = {}
-    const client = new createMockClient({})
-    client.plugins.realtime = {
-      subscribe: jest.fn((event, doctype, callback) => {
-        realtimeCallbacks[event] = callback
-      }),
-      unsubscribe: jest.fn()
-    }
-    client.dispatch = jest.fn()
+    const { client, realtimeCallbacks, unmount } = await setup('io.cozy.files')
 
-    const { unmount } = render(
-      <CozyProvider client={client}>
-        <RealTimeQueries doctype="io.cozy.files" />
-      </CozyProvider>
-    )
-
-    await waitFor(() =>
-      expect(client.plugins.realtime.subscribe).toHaveBeenCalledTimes(3)
-    )
-
-    realtimeCallbacks['created']({ id: 'mock-created', type: 'file' })
+    realtimeCallbacks['created']({ _id: 'mock-created', type: 'file' })
     expect(client.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         definition: {
-          document: { id: 'mock-created', type: 'file' },
+          document: {
+            _id: 'mock-created',
+            _type: 'io.cozy.files',
+            type: 'file'
+          },
           mutationType: 'CREATE_DOCUMENT'
         },
         mutationId: '1',
         response: {
           data: {
+            _id: 'mock-created',
             _type: 'io.cozy.files',
-            type: 'file',
-            id: 'mock-created',
-            _id: 'mock-created'
+            type: 'file'
           }
         },
         type: 'RECEIVE_MUTATION_RESULT'
       })
     )
 
-    realtimeCallbacks['updated']({ id: 'mock-updated', type: 'file' })
+    realtimeCallbacks['updated']({ _id: 'mock-updated', type: 'file' })
     expect(client.dispatch).toHaveBeenCalledWith({
       definition: {
-        document: { id: 'mock-updated', type: 'file' },
+        document: {
+          _id: 'mock-updated',
+          _type: 'io.cozy.files',
+          type: 'file'
+        },
         mutationType: 'UPDATE_DOCUMENT'
       },
       mutationId: '2',
       response: {
         data: {
+          _id: 'mock-updated',
           _type: 'io.cozy.files',
-          type: 'file',
-          id: 'mock-updated',
-          _id: 'mock-updated'
+          type: 'file'
         }
       },
       type: 'RECEIVE_MUTATION_RESULT'
     })
 
-    realtimeCallbacks['deleted']({ id: 'mock-deleted', type: 'file' })
+    realtimeCallbacks['deleted']({ _id: 'mock-deleted', type: 'file' })
     expect(client.dispatch).toHaveBeenCalledWith({
       definition: {
-        document: { id: 'mock-deleted', type: 'file', _deleted: true },
+        document: {
+          _id: 'mock-deleted',
+          _type: 'io.cozy.files',
+          type: 'file',
+          _deleted: true
+        },
         mutationType: 'DELETE_DOCUMENT'
       },
       mutationId: '3',
       response: {
         data: {
-          _deleted: true,
+          _id: 'mock-deleted',
           _type: 'io.cozy.files',
           type: 'file',
-          id: 'mock-deleted',
-          _id: 'mock-deleted'
+          _deleted: true
         }
       },
       type: 'RECEIVE_MUTATION_RESULT'
@@ -85,5 +101,42 @@ describe('RealTimeQueries', () => {
 
     unmount()
     expect(client.plugins.realtime.unsubscribe).toHaveBeenCalledTimes(3)
+  })
+
+  it('deals with other doctypes than io.cozy.files', async () => {
+    const { client, realtimeCallbacks, unmount } = await setup(
+      'io.cozy.oauth.clients'
+    )
+
+    realtimeCallbacks['created']({
+      _id: 'mock-created',
+      client_kind: 'desktop',
+      client_name: 'Cozy Drive (hostname)'
+    })
+    expect(client.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        definition: {
+          document: {
+            _id: 'mock-created',
+            _type: 'io.cozy.oauth.clients',
+            client_kind: 'desktop',
+            client_name: 'Cozy Drive (hostname)'
+          },
+          mutationType: 'CREATE_DOCUMENT'
+        },
+        mutationId: '1',
+        response: {
+          data: {
+            _id: 'mock-created',
+            _type: 'io.cozy.oauth.clients',
+            client_kind: 'desktop',
+            client_name: 'Cozy Drive (hostname)'
+          }
+        },
+        type: 'RECEIVE_MUTATION_RESULT'
+      })
+    )
+
+    unmount()
   })
 })

--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -7,7 +7,9 @@ import { QueryDefinition } from './queries/dsl'
  * @typedef {"io.cozy.notes"} NotesDoctype
  * @typedef {"io.cozy.apps"} AppsDoctype
  * @typedef {"io.cozy.settings"} SettingsDoctype
- * @typedef {AccountsDoctype|TriggersDoctype|KonnectorsDoctype|NotesDoctype|AppsDoctype|SettingsDoctype} KnownDoctype
+ * @typedef {"io.cozy-oauth.clients"} OAuthClientsDoctype
+ * @typedef {"io.cozy.files"} FilesDoctype
+ * @typedef {AccountsDoctype|TriggersDoctype|KonnectorsDoctype|NotesDoctype|AppsDoctype|SettingsDoctype|OAuthClientsDoctype|FilesDoctype} KnownDoctype
  * @typedef {KnownDoctype|string} Doctype
  */
 
@@ -113,13 +115,14 @@ import { QueryDefinition } from './queries/dsl'
  * @property {string} [_id] - Id of the document
  * @property {string} [_type] - Type of the document
  * @property {string} [_rev] - Current revision of the document
- * @property {string} [_deleted] - When the document has been deleted
+ * @property {boolean} [_deleted] - When the document has been deleted
  * @property {object} [relationships] - Relationships of the document
  */
 
 /**
  * @typedef {object} FileDocument - An io.cozy.files document
  * @property {string} _id - Id of the file
+ * @property {FilesDoctype} _type - Doctype of the file
  * @property {string} name - Name of the file
  * @property {object} metadata - Metadata of the file
  * @property {object} type - Type of the file
@@ -130,10 +133,29 @@ import { QueryDefinition } from './queries/dsl'
 /**
  * @typedef {object} FolderDocument - An io.cozy.files document
  * @property {string} _id - Id of the folder
+ * @property {FilesDoctype} _type - Doctype of the folder
  * @property {string} name - Name of the folder
  * @property {object} metadata - Metadata of the folder
  * @property {object} type - Type of the folder
  * @typedef {CozyClientDocument & FileDocument} IOCozyFolder - An io.cozy.files document
+ */
+
+/**
+ * @typedef {object} OAuthClientDocument - An io.cozy.oauth.clients document
+ * @property {string} _id - Id of the client
+ * @property {OAuthClientsDoctype} _type - Doctype of the client
+ * @property {string} software_id
+ * @property {string} software_version
+ * @property {string} client_id
+ * @property {string} client_name
+ * @property {string} client_kind
+ * @property {string} client_uri
+ * @property {string} logo_uri
+ * @property {string} policy_uri
+ * @property {string} notification_platform
+ * @property {string} notification_device_token
+ * @property {Array<String>} redirect_uris
+ * @typedef {CozyClientDocument & OAuthClientDocument} IOCozyOAuthClient - An io.cozy.oauth.clients document
  */
 
 /**
@@ -182,6 +204,14 @@ import { QueryDefinition } from './queries/dsl'
  * @property {object} SafariViewController
  * @property {Function} resolveLocalFileSystemURL
  * @property {Function} handleOpenURL
+ */
+
+/**
+ * @typedef {object} CouchDBDocument - A document
+ * @property {string} _id - Id of the document
+ * @property {string} _rev - Current revision of the document
+ * @property {boolean} [_deleted] - When the document has been deleted
+ * @property {object} [relationships] - Relationships of the document
  */
 
 /**

--- a/packages/cozy-client/types/RealTimeQueries.d.ts
+++ b/packages/cozy-client/types/RealTimeQueries.d.ts
@@ -1,4 +1,5 @@
 declare var _default: import("react").MemoExoticComponent<({ doctype }: {
-    doctype: string;
+    doctype: Doctype;
 }) => null>;
 export default _default;
+import { Doctype } from "./types";

--- a/packages/cozy-client/types/models/permission.d.ts
+++ b/packages/cozy-client/types/models/permission.d.ts
@@ -52,7 +52,7 @@ export type Document = {
     _type: string;
     type: string;
 };
-export type PermissionVerb = "DELETE" | "ALL" | "GET" | "PATCH" | "POST" | "PUT";
+export type PermissionVerb = "DELETE" | "PUT" | "POST" | "GET" | "ALL" | "PATCH";
 export type PermissionItem = {
     /**
      * - ALL, GET, PUT, PATCH, DELETE, POST…

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -6,7 +6,9 @@ export type KonnectorsDoctype = "io.cozy.konnectors";
 export type NotesDoctype = "io.cozy.notes";
 export type AppsDoctype = "io.cozy.apps";
 export type SettingsDoctype = "io.cozy.settings";
-export type KnownDoctype = "io.cozy.accounts" | "io.cozy.triggers" | "io.cozy.konnectors" | "io.cozy.notes" | "io.cozy.apps" | "io.cozy.settings";
+export type OAuthClientsDoctype = "io.cozy-oauth.clients";
+export type FilesDoctype = "io.cozy.files";
+export type KnownDoctype = "io.cozy.files" | "io.cozy.accounts" | "io.cozy.triggers" | "io.cozy.konnectors" | "io.cozy.notes" | "io.cozy.apps" | "io.cozy.settings" | "io.cozy-oauth.clients";
 export type Doctype = string;
 export type Link = any;
 export type Mutation = any;
@@ -108,7 +110,7 @@ export type CozyClientDocument = {
     /**
      * - When the document has been deleted
      */
-    _deleted?: string;
+    _deleted?: boolean;
     /**
      * - Relationships of the document
      */
@@ -122,6 +124,10 @@ export type FileDocument = {
      * - Id of the file
      */
     _id: string;
+    /**
+     * - Doctype of the file
+     */
+    _type: FilesDoctype;
     /**
      * - Name of the file
      */
@@ -152,6 +158,10 @@ export type FolderDocument = {
      */
     _id: string;
     /**
+     * - Doctype of the folder
+     */
+    _type: FilesDoctype;
+    /**
      * - Name of the folder
      */
     name: string;
@@ -168,6 +178,34 @@ export type FolderDocument = {
  * - An io.cozy.files document
  */
 export type IOCozyFolder = CozyClientDocument & FileDocument;
+/**
+ * - An io.cozy.oauth.clients document
+ */
+export type OAuthClientDocument = {
+    /**
+     * - Id of the client
+     */
+    _id: string;
+    /**
+     * - Doctype of the client
+     */
+    _type: OAuthClientsDoctype;
+    software_id: string;
+    software_version: string;
+    client_id: string;
+    client_name: string;
+    client_kind: string;
+    client_uri: string;
+    logo_uri: string;
+    policy_uri: string;
+    notification_platform: string;
+    notification_device_token: string;
+    redirect_uris: Array<string>;
+};
+/**
+ * - An io.cozy.oauth.clients document
+ */
+export type IOCozyOAuthClient = CozyClientDocument & OAuthClientDocument;
 export type ClientError = {
     status?: string;
 };
@@ -192,6 +230,27 @@ export type CordovaWindow = {
     SafariViewController: object;
     resolveLocalFileSystemURL: Function;
     handleOpenURL: Function;
+};
+/**
+ * - A document
+ */
+export type CouchDBDocument = {
+    /**
+     * - Id of the document
+     */
+    _id: string;
+    /**
+     * - Current revision of the document
+     */
+    _rev: string;
+    /**
+     * - When the document has been deleted
+     */
+    _deleted?: boolean;
+    /**
+     * - Relationships of the document
+     */
+    relationships?: object;
 };
 /**
  * - An item of the CouchDB bulk docs response

--- a/packages/cozy-stack-client/src/OAuthClientsCollection.js
+++ b/packages/cozy-stack-client/src/OAuthClientsCollection.js
@@ -30,7 +30,7 @@ class OAuthClientsCollection extends DocumentCollection {
    * @param  {object} options           Query options
    * @param  {number} options.limit     For pagination, the number of results to return.
    * @param  {object} options.bookmark  For cursor-based pagination, the index cursor.
-   * @param  {array} options.keys       Ids of specific clients to return (within the current page),
+   * @param  {Array} options.keys       Ids of specific clients to return (within the current page),
    * @returns {object}                  The JSON API conformant response.
    */
   async all(options = {}) {
@@ -103,18 +103,14 @@ class OAuthClientsCollection extends DocumentCollection {
   /**
    * Destroys the OAuth client on the server
    *
-   * @param {io.cozy.oauth.clients} client     The client document to destroy
-   * @param {string}                client._id The client's id
-   *
+   * @param {io.cozy.oauth.clients} oauthClient     The client document to destroy
    * @returns {{ data }} The deleted client
    */
-  async destroy({ _id }) {
-    const resp = await this.stackClient.fetchJSON(
-      'DELETE',
-      uri`/settings/clients/${_id}`
-    )
+  async destroy(oauthClient) {
+    const { _id } = oauthClient
+    await this.stackClient.fetchJSON('DELETE', uri`/settings/clients/${_id}`)
     return {
-      data: { ...normalizeOAuthClient(resp.data), _deleted: true }
+      data: { ...normalizeOAuthClient(oauthClient), _deleted: true }
     }
   }
 }

--- a/packages/cozy-stack-client/src/OAuthClientsCollection.spec.js
+++ b/packages/cozy-stack-client/src/OAuthClientsCollection.spec.js
@@ -228,24 +228,32 @@ describe('OAuthClientsCollection', () => {
 
   describe('destroy', () => {
     const { stackClient, collection } = setup()
+    const client = {
+      _id: '1',
+      attributes: { client_kind: 'desktop' }
+    }
 
     beforeEach(() => {
-      jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue({
-        data: { id: '1', attributes: { client_kind: 'desktop' } }
-      })
+      jest.spyOn(stackClient, 'fetchJSON').mockResolvedValue()
     })
 
     it('should call the appropriate route', async () => {
-      await collection.destroy({ _id: '1' })
+      await collection.destroy(client)
       expect(stackClient.fetchJSON).toHaveBeenCalledWith(
         'DELETE',
         '/settings/clients/1'
       )
     })
 
-    it('should add _deleted to the response', async () => {
-      const result = await collection.destroy({ _id: '1' })
-      expect(result.data._deleted).toBe(true)
+    it('should add _deleted to the normalized document', async () => {
+      const result = await collection.destroy(client)
+      expect(result.data).toEqual({
+        ...client,
+        id: '1',
+        _type: 'io.cozy.oauth.clients',
+        client_kind: 'desktop',
+        _deleted: true
+      })
     })
   })
 })


### PR DESCRIPTION
Using the `realtime` plugin and `RealTimeQueries` component with `io.cozy-oauth.clients` documents would not work for 2 reasons:
1. the realtime subscriptions would always set documents' doctype to `io.cozy.files`, no matter what data they would receive
2. the `OAuthClientsCollection.destroy()` method would expect cozy-stack to return data while the `DELETE /settings/clients/:id` route only returns a response header when successful