### PR TITLE
Fix references

### DIFF
--- a/docs/api/cozy-client/classes/hasmany.md
+++ b/docs/api/cozy-client/classes/hasmany.md
@@ -352,7 +352,29 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:151](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L151)
+[packages/cozy-client/src/associations/HasMany.js:174](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L174)
+
+***
+
+### addTargetRelationships
+
+▸ **addTargetRelationships**(`idsArg`): `void`
+
+Update target document with relationships
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `idsArg` | `string`\[] | The ids to add as a relationship |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:147](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L147)
 
 ***
 
@@ -392,7 +414,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:241](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L241)
+[packages/cozy-client/src/associations/HasMany.js:256](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L256)
 
 ***
 
@@ -460,7 +482,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:192](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L192)
+[packages/cozy-client/src/associations/HasMany.js:207](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L207)
 
 ***
 
@@ -504,7 +526,29 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:172](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L172)
+[packages/cozy-client/src/associations/HasMany.js:193](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L193)
+
+***
+
+### removeTargetRelationships
+
+▸ **removeTargetRelationships**(`idsArg`): `void`
+
+Remove relationships from target document
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `idsArg` | `string`\[] | The ids to remove from the target relationships |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:184](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L184)
 
 ***
 
@@ -518,7 +562,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:183](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L183)
+[packages/cozy-client/src/associations/HasMany.js:198](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L198)
 
 ***
 
@@ -539,7 +583,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:213](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L213)
+[packages/cozy-client/src/associations/HasMany.js:228](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L228)
 
 ***
 
@@ -572,7 +616,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:217](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L217)
+[packages/cozy-client/src/associations/HasMany.js:232](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L232)
 
 ***
 
@@ -593,7 +637,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:206](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L206)
+[packages/cozy-client/src/associations/HasMany.js:221](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L221)
 
 ***
 
@@ -615,7 +659,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:274](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L274)
+[packages/cozy-client/src/associations/HasMany.js:289](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L289)
 
 ***
 
@@ -636,7 +680,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:283](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L283)
+[packages/cozy-client/src/associations/HasMany.js:298](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L298)
 
 ***
 
@@ -662,7 +706,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:260](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L260)
+[packages/cozy-client/src/associations/HasMany.js:275](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L275)
 
 ***
 
@@ -684,7 +728,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:321](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L321)
+[packages/cozy-client/src/associations/HasMany.js:336](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L336)
 
 ***
 
@@ -707,7 +751,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:295](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L295)
+[packages/cozy-client/src/associations/HasMany.js:310](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L310)
 
 ***
 
@@ -730,7 +774,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:345](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L345)
+[packages/cozy-client/src/associations/HasMany.js:360](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L360)
 
 ***
 
@@ -752,4 +796,4 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:356](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L356)
+[packages/cozy-client/src/associations/HasMany.js:371](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L371)

--- a/docs/api/cozy-client/classes/hasmanytriggers.md
+++ b/docs/api/cozy-client/classes/hasmanytriggers.md
@@ -297,7 +297,33 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:151](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L151)
+[packages/cozy-client/src/associations/HasMany.js:174](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L174)
+
+***
+
+### addTargetRelationships
+
+▸ **addTargetRelationships**(`idsArg`): `void`
+
+Update target document with relationships
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `idsArg` | `string`\[] | The ids to add as a relationship |
+
+*Returns*
+
+`void`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[addTargetRelationships](hasmany.md#addtargetrelationships)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:147](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L147)
 
 ***
 
@@ -345,7 +371,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:241](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L241)
+[packages/cozy-client/src/associations/HasMany.js:256](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L256)
 
 ***
 
@@ -429,7 +455,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:192](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L192)
+[packages/cozy-client/src/associations/HasMany.js:207](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L207)
 
 ***
 
@@ -481,7 +507,33 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:172](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L172)
+[packages/cozy-client/src/associations/HasMany.js:193](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L193)
+
+***
+
+### removeTargetRelationships
+
+▸ **removeTargetRelationships**(`idsArg`): `void`
+
+Remove relationships from target document
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `idsArg` | `string`\[] | The ids to remove from the target relationships |
+
+*Returns*
+
+`void`
+
+*Inherited from*
+
+[HasMany](hasmany.md).[removeTargetRelationships](hasmany.md#removetargetrelationships)
+
+*Defined in*
+
+[packages/cozy-client/src/associations/HasMany.js:184](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L184)
 
 ***
 
@@ -499,7 +551,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:183](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L183)
+[packages/cozy-client/src/associations/HasMany.js:198](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L198)
 
 ***
 
@@ -524,7 +576,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:213](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L213)
+[packages/cozy-client/src/associations/HasMany.js:228](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L228)
 
 ***
 
@@ -561,7 +613,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:217](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L217)
+[packages/cozy-client/src/associations/HasMany.js:232](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L232)
 
 ***
 
@@ -586,7 +638,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:206](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L206)
+[packages/cozy-client/src/associations/HasMany.js:221](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L221)
 
 ***
 
@@ -612,7 +664,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:274](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L274)
+[packages/cozy-client/src/associations/HasMany.js:289](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L289)
 
 ***
 
@@ -637,7 +689,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:283](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L283)
+[packages/cozy-client/src/associations/HasMany.js:298](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L298)
 
 ***
 
@@ -692,7 +744,7 @@ having for the 'konnector' worker, and then filter them based on their
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:321](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L321)
+[packages/cozy-client/src/associations/HasMany.js:336](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L336)
 
 ***
 
@@ -719,7 +771,7 @@ having for the 'konnector' worker, and then filter them based on their
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:295](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L295)
+[packages/cozy-client/src/associations/HasMany.js:310](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L310)
 
 ***
 
@@ -746,7 +798,7 @@ having for the 'konnector' worker, and then filter them based on their
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:345](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L345)
+[packages/cozy-client/src/associations/HasMany.js:360](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L360)
 
 ***
 
@@ -772,4 +824,4 @@ having for the 'konnector' worker, and then filter them based on their
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:356](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L356)
+[packages/cozy-client/src/associations/HasMany.js:371](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L371)

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -1754,6 +1754,16 @@ describe('file creation', () => {
   it('should support creating a file with references', async () => {
     const { client } = setup()
     jest.spyOn(client, 'requestMutation')
+    client.stackClient.fetchJSON = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: {
+          _id: '1337'
+        }
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: 1, type: 'io.cozy.files' }]
+      })
     await client.create(
       'io.cozy.files',
       {
@@ -1766,6 +1776,9 @@ describe('file creation', () => {
         icons: [{ _id: 1, _type: 'io.cozy.files' }]
       }
     )
+    client.stackClient.fetchJSON = jest.fn().mockResolvedValue({
+      data: [{ id: '1337', type: 'io.cozy.files' }]
+    })
     const requestMutationCalls = client.requestMutation.mock.calls
     const lastCall = requestMutationCalls[requestMutationCalls.length - 1]
     expect(lastCall[0]).toEqual(

--- a/packages/cozy-client/src/associations/HasMany.js
+++ b/packages/cozy-client/src/associations/HasMany.js
@@ -140,20 +140,15 @@ class HasMany extends Association {
   }
 
   /**
-   * Add a referenced document by id. You need to call save()
-   * in order to synchronize your document with the store.
+   * Update target document with relationships
    *
-   * @todo We shouldn't create the array of relationship manually since
-   * it'll not be present in the store as well.
-   * We certainly should use something like `updateRelationship`
-   *
+   * @param {string[]} idsArg - The ids to add as a relationship
    */
-  addById(idsArg) {
+  addTargetRelationships(idsArg) {
     if (!this.target.relationships) this.target.relationships = {}
     if (!this.target.relationships[this.name]) {
       this.target.relationships[this.name] = { data: [] }
     }
-
     const ids = Array.isArray(idsArg) ? idsArg : [idsArg]
 
     const newRelations = ids
@@ -165,18 +160,38 @@ class HasMany extends Association {
 
     this.target.relationships[this.name].data.push(...newRelations)
     this.updateMetaCount()
+  }
 
+  /**
+   * Add a referenced document by id. You need to call save()
+   * in order to synchronize your document with the store.
+   *
+   * @todo We shouldn't create the array of relationship manually since
+   * it'll not be present in the store as well.
+   * We certainly should use something like `updateRelationship`
+   *
+   */
+  addById(idsArg) {
+    this.addTargetRelationships(idsArg)
     return this.save(this.target)
   }
 
-  removeById(idsArg) {
+  /**
+   * Remove relationships from target document
+   *
+   * @param {string[]} idsArg - The ids to remove from the target relationships
+   */
+  removeTargetRelationships(idsArg) {
     const ids = Array.isArray(idsArg) ? idsArg : [idsArg]
 
     this.target.relationships[this.name].data = this.target.relationships[
       this.name
     ].data.filter(({ _id }) => !ids.includes(_id))
     this.updateMetaCount()
+  }
 
+  removeById(idsArg) {
+    this.removeTargetRelationships(idsArg)
     return this.save(this.target)
   }
 

--- a/packages/cozy-client/src/associations/HasManyFiles.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.js
@@ -63,7 +63,7 @@ export default class HasManyFiles extends HasMany {
     }))
     await this.mutate(this.addReferences(relations))
 
-    await super.addById(ids)
+    this.addTargetRelationships(ids)
   }
 
   async removeById(idsArg) {
@@ -74,7 +74,7 @@ export default class HasManyFiles extends HasMany {
     }))
     await this.mutate(this.removeReferences(references))
 
-    await super.removeById(ids)
+    this.removeTargetRelationships(ids)
   }
 
   addReferences(referencedDocs) {

--- a/packages/cozy-client/src/associations/HasManyFiles.spec.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.spec.js
@@ -73,7 +73,6 @@ describe('HasManyFiles', () => {
       mutationType: 'ADD_REFERENCES_TO',
       referencedDocuments: [{ _type: DOCTYPE_FILES, _id: 4 }]
     })
-    expect(save).toHaveBeenCalled()
   })
 
   it('adds multiple relations', async () => {
@@ -92,7 +91,6 @@ describe('HasManyFiles', () => {
         { _type: DOCTYPE_FILES, _id: 5 }
       ]
     })
-    expect(save).toHaveBeenCalled()
   })
 
   it('removes relations', async () => {
@@ -103,7 +101,6 @@ describe('HasManyFiles', () => {
       mutationType: 'REMOVE_REFERENCES_TO',
       referencedDocuments: [{ _type: DOCTYPE_FILES, _id: 2 }]
     })
-    expect(save).toHaveBeenCalled()
   })
 
   it('adds multiple relations', async () => {
@@ -117,7 +114,6 @@ describe('HasManyFiles', () => {
         { _type: DOCTYPE_FILES, _id: 2 }
       ]
     })
-    expect(save).toHaveBeenCalled()
   })
 
   it('add wrong file relations', () => {

--- a/packages/cozy-client/types/associations/HasMany.d.ts
+++ b/packages/cozy-client/types/associations/HasMany.d.ts
@@ -102,6 +102,12 @@ declare class HasMany extends Association {
      */
     remove(docsArg: CozyClientDocument[]): CozyClientDocument;
     /**
+     * Update target document with relationships
+     *
+     * @param {string[]} idsArg - The ids to add as a relationship
+     */
+    addTargetRelationships(idsArg: string[]): void;
+    /**
      * Add a referenced document by id. You need to call save()
      * in order to synchronize your document with the store.
      *
@@ -111,6 +117,12 @@ declare class HasMany extends Association {
      *
      */
     addById(idsArg: any): any;
+    /**
+     * Remove relationships from target document
+     *
+     * @param {string[]} idsArg - The ids to remove from the target relationships
+     */
+    removeTargetRelationships(idsArg: string[]): void;
     removeById(idsArg: any): any;
     updateMetaCount(): void;
     getRelationship(): any;

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -57,6 +57,10 @@ const normalizeFile = file => ({
   ...file.attributes
 })
 
+const normalizeReferences = references => {
+  return references.map(ref => ({ _type: ref.type, _id: ref.id }))
+}
+
 const sanitizeFileName = name => name && name.trim()
 
 /**
@@ -203,13 +207,16 @@ class FileCollection extends DocumentCollection {
    * @param  {Array}  documents       An array of JSON documents having a `_type` and `_id` field.
    * @returns {object}                The JSON API conformant response.
    */
-  addReferencedBy(document, documents) {
+  async addReferencedBy(document, documents) {
     const refs = documents.map(d => ({ id: d._id, type: d._type }))
-    return this.stackClient.fetchJSON(
+    const resp = await this.stackClient.fetchJSON(
       'POST',
       uri`/files/${document._id}/relationships/referenced_by`,
       { data: refs }
     )
+    return {
+      data: normalizeReferences(resp.data)
+    }
   }
 
   /**
@@ -224,13 +231,16 @@ class FileCollection extends DocumentCollection {
    * @param  {Array}  documents       An array of JSON documents having a `_type` and `_id` field.
    * @returns {object}                The JSON API conformant response.
    */
-  removeReferencedBy(document, documents) {
+  async removeReferencedBy(document, documents) {
     const refs = documents.map(d => ({ id: d._id, type: d._type }))
-    return this.stackClient.fetchJSON(
+    const resp = await this.stackClient.fetchJSON(
       'DELETE',
       uri`/files/${document._id}/relationships/referenced_by`,
       { data: refs }
     )
+    return {
+      data: normalizeReferences(resp.data)
+    }
   }
 
   /**
@@ -245,13 +255,16 @@ class FileCollection extends DocumentCollection {
    * @param  {Array}  documents       An array of JSON files having an `_id` field.
    * @returns {object}                The JSON API conformant response.
    */
-  addReferencesTo(document, documents) {
+  async addReferencesTo(document, documents) {
     const refs = documents.map(d => ({ id: d._id, type: 'io.cozy.files' }))
-    return this.stackClient.fetchJSON(
+    const resp = await this.stackClient.fetchJSON(
       'POST',
       uri`/data/${document._type}/${document._id}/relationships/references`,
       { data: refs }
     )
+    return {
+      data: normalizeReferences(resp.data)
+    }
   }
 
   /**
@@ -266,13 +279,16 @@ class FileCollection extends DocumentCollection {
    * @param  {Array}  documents       An array of JSON files having an `_id` field.
    * @returns {object}                The JSON API conformant response.
    */
-  removeReferencesTo(document, documents) {
+  async removeReferencesTo(document, documents) {
     const refs = documents.map(d => ({ id: d._id, type: 'io.cozy.files' }))
-    return this.stackClient.fetchJSON(
+    const resp = await this.stackClient.fetchJSON(
       'DELETE',
       uri`/data/${document._type}/${document._id}/relationships/references`,
       { data: refs }
     )
+    return {
+      data: normalizeReferences(resp.data)
+    }
   }
 
   /**

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -352,6 +352,9 @@ describe('FileCollection', () => {
 
     beforeEach(() => {
       spy.mockClear()
+      spy.mockReturnValue({
+        data: [{ id: '123', type: 'io.cozy.files' }]
+      })
     })
 
     const file = {
@@ -366,7 +369,8 @@ describe('FileCollection', () => {
           _type: 'io.cozy.photos.albums'
         }
       ]
-      await collection.addReferencedBy(file, refs)
+      const res = await collection.addReferencedBy(file, refs)
+      expect(res.data).toEqual([file])
       expect(spy).toMatchSnapshot()
     })
     it('should remove a reference', async () => {
@@ -376,7 +380,8 @@ describe('FileCollection', () => {
           _type: 'io.cozy.photos.albums'
         }
       ]
-      await collection.removeReferencedBy(file, refs)
+      const res = await collection.removeReferencedBy(file, refs)
+      expect(res.data).toEqual([file])
       expect(spy).toMatchSnapshot()
     })
   })

--- a/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
+++ b/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
@@ -94,7 +94,14 @@ exports[`FileCollection referencedBy should add a reference 1`] = `
   "results": Array [
     Object {
       "type": "return",
-      "value": undefined,
+      "value": Object {
+        "data": Array [
+          Object {
+            "id": "123",
+            "type": "io.cozy.files",
+          },
+        ],
+      },
     },
   ],
 }
@@ -119,7 +126,14 @@ exports[`FileCollection referencedBy should remove a reference 1`] = `
   "results": Array [
     Object {
       "type": "return",
-      "value": undefined,
+      "value": Object {
+        "data": Array [
+          Object {
+            "id": "123",
+            "type": "io.cozy.files",
+          },
+        ],
+      },
     },
   ],
 }


### PR DESCRIPTION
We had two issues with files relationships:
* When adding/removing the answer from the stack is `{type, id}`, which was causing an issue in the store as we always expect a `_type`.
* When adding/removing, we call the dedicated stack routes from HasManyFiles, but we were trying to save the file again from HasMany association, which is useless (it's only relevant for relationships different from io.cozy.files)