### PR TITLE
fix: Add id in CozyClientDocument for RealTime

### DIFF
--- a/packages/cozy-client/src/RealTimeQueries.jsx
+++ b/packages/cozy-client/src/RealTimeQueries.jsx
@@ -16,6 +16,7 @@ import { CouchDBDocument, CozyClientDocument, Doctype, Mutation } from './types'
  */
 const normalizeDoc = (couchDBDoc, doctype) => {
   return {
+    id: couchDBDoc._id,
     _type: doctype,
     ...couchDBDoc
   }

--- a/packages/cozy-client/src/RealTimeQueries.spec.jsx
+++ b/packages/cozy-client/src/RealTimeQueries.spec.jsx
@@ -38,6 +38,7 @@ describe('RealTimeQueries', () => {
         definition: {
           document: {
             _id: 'mock-created',
+            id: 'mock-created',
             _type: 'io.cozy.files',
             type: 'file'
           },
@@ -47,6 +48,7 @@ describe('RealTimeQueries', () => {
         response: {
           data: {
             _id: 'mock-created',
+            id: 'mock-created',
             _type: 'io.cozy.files',
             type: 'file'
           }
@@ -60,6 +62,7 @@ describe('RealTimeQueries', () => {
       definition: {
         document: {
           _id: 'mock-updated',
+          id: 'mock-updated',
           _type: 'io.cozy.files',
           type: 'file'
         },
@@ -69,6 +72,7 @@ describe('RealTimeQueries', () => {
       response: {
         data: {
           _id: 'mock-updated',
+          id: 'mock-updated',
           _type: 'io.cozy.files',
           type: 'file'
         }
@@ -81,6 +85,7 @@ describe('RealTimeQueries', () => {
       definition: {
         document: {
           _id: 'mock-deleted',
+          id: 'mock-deleted',
           _type: 'io.cozy.files',
           type: 'file',
           _deleted: true
@@ -91,6 +96,7 @@ describe('RealTimeQueries', () => {
       response: {
         data: {
           _id: 'mock-deleted',
+          id: 'mock-deleted',
           _type: 'io.cozy.files',
           type: 'file',
           _deleted: true
@@ -118,6 +124,7 @@ describe('RealTimeQueries', () => {
         definition: {
           document: {
             _id: 'mock-created',
+            id: 'mock-created',
             _type: 'io.cozy.oauth.clients',
             client_kind: 'desktop',
             client_name: 'Cozy Drive (hostname)'
@@ -128,6 +135,7 @@ describe('RealTimeQueries', () => {
         response: {
           data: {
             _id: 'mock-created',
+            id: 'mock-created',
             _type: 'io.cozy.oauth.clients',
             client_kind: 'desktop',
             client_name: 'Cozy Drive (hostname)'

--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -113,6 +113,7 @@ import { QueryDefinition } from './queries/dsl'
 /**
  * @typedef {object} CozyClientDocument - A document
  * @property {string} [_id] - Id of the document
+ * @property {string} [id] - Id of the document
  * @property {string} [_type] - Type of the document
  * @property {string} [_rev] - Current revision of the document
  * @property {boolean} [_deleted] - When the document has been deleted

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -100,6 +100,10 @@ export type CozyClientDocument = {
      */
     _id?: string;
     /**
+     * - Id of the document
+     */
+    id?: string;
+    /**
      * - Type of the document
      */
     _type?: string;


### PR DESCRIPTION
Although we tend to rely on the `_id` for all documents, we sometimes
also rely on `id`, which is a legacy that we encounter in some apps such
as Drive. Therefore, e23239fc2a17f8362a74dabdda0e3f816dfc6eb2 introduced
a regression in Drive as the `id` was missing.