### PR TITLE
refactor: Defines ddoc and name index

### DIFF
--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -432,7 +432,9 @@ class PouchLink extends CozyLink {
       const index = await db.createIndex({
         index: {
           fields
-        }
+        },
+        ddoc: `${name}`,
+        name: `${name}`
       })
       this.indexes[absName] = index
       return index

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -588,7 +588,11 @@ describe('CozyPouchLink', () => {
         .where({})
         .sortBy([{ name: 'asc' }])
       await link.request(query)
-      expect(spy).toHaveBeenCalledWith({ index: { fields: ['name'] } })
+      expect(spy).toHaveBeenCalledWith({
+        index: { fields: ['name'] },
+        ddoc: 'by_name',
+        name: 'by_name'
+      })
     })
 
     it('uses indexFields if provided', async () => {
@@ -597,7 +601,11 @@ describe('CozyPouchLink', () => {
       link.ensureIndex(TODO_DOCTYPE, {
         indexedFields: ['myIndex']
       })
-      expect(spy).toHaveBeenCalledWith({ index: { fields: ['myIndex'] } })
+      expect(spy).toHaveBeenCalledWith({
+        index: { fields: ['myIndex'] },
+        ddoc: 'by_myIndex',
+        name: 'by_myIndex'
+      })
     })
 
     it('uses the specified index', async () => {

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -518,6 +518,7 @@ class DocumentCollection {
     }
     if (indexName) {
       indexDef.ddoc = indexName
+      indexDef.name = indexName
     }
     if (partialFilter) {
       indexDef.index.partial_filter_selector = partialFilter


### PR DESCRIPTION
When creating indexes with `createIndex` in Cozy Pouch Link, it's more readable to have a correct `ddoc` and `name` instead of `idx-asdfsd ...`

name: name of the index, auto-generated if you don’t include it
ddoc : design document name (i.e. the part after '_design/'), auto-generated if you don’t include it

More details on [PouchDB API](https://pouchdb.com/api.html)