### PR TITLE
feat: Add at least _id when selecting fields

### DIFF
--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -474,7 +474,9 @@ class PouchLink extends CozyLink {
       const findOpts = {
         sort,
         selector: mergedSelector,
-        fields,
+        // same selector as Document Collection. We force _id.
+        // Fix https://github.com/cozy/cozy-client/issues/985
+        fields: fields ? [...fields, '_id', '_type', 'class'] : undefined,
         limit,
         skip
       }

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -317,6 +317,26 @@ describe('CozyPouchLink', () => {
         expectedMergedSelector
       )
     })
+
+    it("should add _id in the selected fields since CozyClient' store needs it", async () => {
+      find.mockReturnValue({ docs: [TODO_3, TODO_4] })
+      await setup()
+      link.pouches.isSynced = jest.fn().mockReturnValue(true)
+      const db = link.getPouch(TODO_DOCTYPE)
+      await db.bulkDocs(docs.map(x => omit(x, '_type')))
+      const query = Q(TODO_DOCTYPE)
+        .where({ label: { $gt: null }, done: true })
+        .indexFields(['done', 'label'])
+        .sortBy([{ done: 'asc' }, { label: 'asc' }])
+        .select(['label'])
+      await link.request(query)
+      expect(find).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          fields: ['label', '_id', '_type', 'class']
+        })
+      )
+    })
   })
 
   describe('mutations', () => {


### PR DESCRIPTION
Since CozyClient's code rely on _id to store the data
let's request it automatically.

We do the same thing in StackClient.

Fix #985