### PR TITLE
fix: References routes do not return content

### DIFF
--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -254,14 +254,11 @@ class FileCollection extends DocumentCollection {
    */
   async addReferencesTo(document, documents) {
     const refs = documents.map(d => ({ id: d._id, type: 'io.cozy.files' }))
-    const resp = await this.stackClient.fetchJSON(
+    return this.stackClient.fetchJSON(
       'POST',
       uri`/data/${document._type}/${document._id}/relationships/references`,
       { data: refs }
     )
-    return {
-      data: normalizeReferences(resp.data)
-    }
   }
 
   /**
@@ -278,14 +275,11 @@ class FileCollection extends DocumentCollection {
    */
   async removeReferencesTo(document, documents) {
     const refs = documents.map(d => ({ id: d._id, type: 'io.cozy.files' }))
-    const resp = await this.stackClient.fetchJSON(
+    return this.stackClient.fetchJSON(
       'DELETE',
       uri`/data/${document._type}/${document._id}/relationships/references`,
       { data: refs }
     )
-    return {
-      data: normalizeReferences(resp.data)
-    }
   }
 
   /**

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -386,6 +386,43 @@ describe('FileCollection', () => {
     })
   })
 
+  describe('referencesTo', () => {
+    const client = new CozyStackClient()
+    const collection = new FileCollection('io.cozy.files', client)
+
+    beforeEach(() => {
+      client.fetchJSON.mockReturnValue({})
+    })
+
+    const file = {
+      _type: 'io.cozy.files',
+      _id: '123'
+    }
+    const refs = [
+      {
+        _id: '456',
+        name: 'Greatest album'
+      }
+    ]
+
+    it('should add a reference', async () => {
+      await collection.addReferencesTo(file, refs)
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        '/data/io.cozy.files/123/relationships/references',
+        { data: [{ id: '456', type: 'io.cozy.files' }] }
+      )
+    })
+    it('should remove a reference', async () => {
+      await collection.removeReferencesTo(file, refs)
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'DELETE',
+        '/data/io.cozy.files/123/relationships/references',
+        { data: [{ id: '456', type: 'io.cozy.files' }] }
+      )
+    })
+  })
+
   describe('updateAttributes', () => {
     beforeEach(() => {
       client.fetchJSON.mockReturnValue({ data: [] })


### PR DESCRIPTION
In https://github.com/cozy/cozy-client/pull/1048, we mistakenly assumed
the `/relationships/references` routes return a data object, but only the
`/relationships/referenced_by` routes do so.
See https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs