### PR TITLE
fix: Use regex supported by Safari

### DIFF
--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -415,15 +415,15 @@ export const overrideFileForPath = async (client, dirPath, file, metadata) => {
  */
 export const generateNewFileNameOnConflict = filenameWithoutExtension => {
   //Check if the string ends by _1
-  const regex = new RegExp('(?<=_)([0-9]+)$') // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Assertions#other_assertions
+  const regex = new RegExp('(_)([0-9]+)$')
   const matches = filenameWithoutExtension.match(regex)
   if (matches) {
-    let versionNumber = parseInt(matches[1])
+    let versionNumber = parseInt(matches[2])
     //increment versionNumber
     versionNumber++
     const newFilenameWithoutExtension = filenameWithoutExtension.replace(
-      regex,
-      `${versionNumber}`
+      new RegExp('(_)([0-9]+)$'),
+      `_${versionNumber}`
     )
     return newFilenameWithoutExtension
   } else {


### PR DESCRIPTION
This king of regex was not supported by Safari.
Let's revert it

This reverts commit 3d7cce2a8f7e185edfd86b137e13401dd561abcc.