### PR TITLE
feat: Add FileCollection.fetchChanges() method

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -157,6 +157,19 @@ Deleted and design docs are filtered by default, thus documents are retrieved in
 <dt><a href="#OAuthClient">OAuthClient</a> : <code>object</code></dt>
 <dd><p>Document representing a io.cozy.oauth.clients</p>
 </dd>
+<dt><a href="#FetchChangesReturnValue">FetchChangesReturnValue</a> ⇒ <code><a href="#FetchChangesReturnValue">FetchChangesReturnValue</a></code></dt>
+<dd><p>Use cozy-stack&#39;s _changes API for io.cozy.files
+Design docs are filtered by default, thus documents are retrieved in the
+response (includeDocs is set to true in the parameters of _changes).
+Deleted and trashed documents can be filtered on demand and files&#39; paths
+can be requested as well.</p>
+<p>Since deleted and trashed documents are skipped by cozy-stack rather than
+CouchDB, when either option is set to true, the response can contain less
+documents than the defined limit. Thus one should rely solely on the
+<code>pending</code> result attribute to determine if more documents can be fetched or
+not.</p>
+<p>You should use fetchChangesRaw to call CouchDB&#39;s _changes API.</p>
+</dd>
 <dt><a href="#JobDocument">JobDocument</a> : <code>object</code></dt>
 <dd><p>Document representing a io.cozy.jobs</p>
 </dd>
@@ -2113,6 +2126,45 @@ Updates the OAuth informations
 Reset the current OAuth client
 
 **Kind**: instance method of [<code>OAuthClient</code>](#OAuthClient)  
+<a name="FetchChangesReturnValue"></a>
+
+## FetchChangesReturnValue ⇒ [<code>FetchChangesReturnValue</code>](#FetchChangesReturnValue)
+Use cozy-stack's _changes API for io.cozy.files
+Design docs are filtered by default, thus documents are retrieved in the
+response (includeDocs is set to true in the parameters of _changes).
+Deleted and trashed documents can be filtered on demand and files' paths
+can be requested as well.
+
+Since deleted and trashed documents are skipped by cozy-stack rather than
+CouchDB, when either option is set to true, the response can contain less
+documents than the defined limit. Thus one should rely solely on the
+`pending` result attribute to determine if more documents can be fetched or
+not.
+
+You should use fetchChangesRaw to call CouchDB's _changes API.
+
+**Kind**: global typedef  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| couchOptions | <code>CouchOptions</code> | Couch options for changes |
+| options | <code>FetchChangesOptions</code> | Further options on the returned documents. By default, it is set to                                        { includeFilePath: false, skipDeleted: false, skipTrashed: false } |
+
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| since | <code>string</code> | Bookmark telling CouchDB from which point in time should changes be returned |
+| limit | <code>number</code> | The maximum number of returned documents for one call |
+| includeDocs | <code>boolean</code> | Whether or not complete documents should be returned |
+| fields | <code>Array.&lt;string&gt;</code> | The list of fields that should be returned for each document |
+| includeFilePath | <code>boolean</code> | Whether to include the path of file changes (needs includeDocs to be true) |
+| skipDeleted | <code>boolean</code> | Whether to skip changes for deleted documents |
+| skipTrashed | <code>boolean</code> | Whether to skip changes for trashed documents (needs includeDocs to be true) |
+| newLastSeq | <code>string</code> |  |
+| pending | <code>boolean</code> |  |
+| documents | <code>Array.&lt;object&gt;</code> |  |
+
 <a name="JobDocument"></a>
 
 ## JobDocument : <code>object</code>

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -2,9 +2,10 @@ import mime from 'mime/lite'
 import has from 'lodash/has'
 import get from 'lodash/get'
 import pick from 'lodash/pick'
+import pickBy from 'lodash/pickBy'
+
 import DocumentCollection, { normalizeDoc } from './DocumentCollection'
 import { uri, slugify, formatBytes } from './utils'
-import * as querystring from './querystring'
 import { FetchError } from './errors'
 import { dontThrowNotFoundError } from './Collection'
 
@@ -100,6 +101,13 @@ const dirName = path => {
   return path.substring(0, lastIndex)
 }
 
+const buildURL = (path, params) => {
+  const urlParams = new URLSearchParams(pickBy(params))
+  const stringParams = urlParams.toString()
+
+  return stringParams ? `${path}?${stringParams}` : path
+}
+
 /**
  * Implements `DocumentCollection` API along with specific methods for
  * `io.cozy.files`.
@@ -182,9 +190,9 @@ class FileCollection extends DocumentCollection {
       'page[cursor]': cursor,
       sort: 'datetime'
     }
-    const url = uri`/data/${document._type}/${document._id}/relationships/references`
-    const path = querystring.buildURL(url, params)
-    const resp = await this.stackClient.fetchJSON('GET', path)
+    const path = uri`/data/${document._type}/${document._id}/relationships/references`
+    const url = buildURL(path, params)
+    const resp = await this.stackClient.fetchJSON('GET', url)
     return {
       data: normalizeReferences(resp.data),
       included: resp.included ? resp.included.map(f => normalizeFile(f)) : [],
@@ -664,9 +672,9 @@ class FileCollection extends DocumentCollection {
 
   async statById(id, options = {}) {
     const params = pick(options, ['page[limit]', 'page[skip]', 'page[cursor]'])
-    const url = uri`/files/${id}`
-    const path = querystring.buildURL(url, params)
-    const resp = await this.stackClient.fetchJSON('GET', path)
+    const path = uri`/files/${id}`
+    const url = buildURL(path, params)
+    const resp = await this.stackClient.fetchJSON('GET', url)
     return {
       data: normalizeFile(resp.data),
       included: resp.included && resp.included.map(f => normalizeFile(f)),
@@ -968,9 +976,9 @@ class FileCollection extends DocumentCollection {
       'page[cursor]': cursor,
       sort: 'id'
     }
-    const url = uri`/data/${oauthClient._type}/${oauthClient._id}/relationships/not_synchronizing`
-    const path = querystring.buildURL(url, params)
-    const resp = await this.stackClient.fetchJSON('GET', path)
+    const path = uri`/data/${oauthClient._type}/${oauthClient._id}/relationships/not_synchronizing`
+    const url = buildURL(path, params)
+    const resp = await this.stackClient.fetchJSON('GET', url)
     return {
       data: resp.data.map(f => normalizeFile(f)),
       included: resp.included ? resp.included.map(f => normalizeFile(f)) : [],

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -67,7 +67,7 @@ describe('FileCollection', () => {
       })
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'GET',
-        '/files/42?page[limit]=200&page[skip]=50&page[cursor]=abc123'
+        '/files/42?page%5Blimit%5D=200&page%5Bskip%5D=50&page%5Bcursor%5D=abc123'
       )
     })
 


### PR DESCRIPTION
We introduce a new method to fetch `io.cozy.files` changes from the
Cozy which does not go directly to CouchDB but uses the new
`cozy-stack` `/files/_changes` route.

This new route allows us to filter out trashed and deleted files from
the returned changes without using the CouchDB `selector` parameter
which can make queries really slow if the Cozy has lots of deleted
documents and thus time out.
This will be especially useful for the Desktop client.

This route has other benefits such as requesting specific fields or
for the path of files (i.e. as opposed to directories).
It also comes with limitations such as not being able to request
changes on specific documents via their ids.

This change is based on https://github.com/cozy/cozy-stack/pull/3200
and as such should probably not be merged until this PR makes its
way into production.