### PR TITLE
fix: Return meta after file's referenced_by update

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -510,11 +510,11 @@ files associated to a specific document
     * [.forceFileDownload](#FileCollection+forceFileDownload)
     * [.get(id)](#FileCollection+get) ⇒ <code>Object</code>
     * [.find(selector, options)](#FileCollection+find) ⇒ <code>Object</code>
-    * [.findReferencedBy(document, options)](#FileCollection+findReferencedBy) ⇒ <code>object</code>
-    * [.addReferencedBy(document, documents)](#FileCollection+addReferencedBy) ⇒ <code>object</code>
-    * [.removeReferencedBy(document, documents)](#FileCollection+removeReferencedBy) ⇒ <code>object</code>
-    * [.addReferencesTo(document, documents)](#FileCollection+addReferencesTo) ⇒ <code>object</code>
-    * [.removeReferencesTo(document, documents)](#FileCollection+removeReferencesTo) ⇒ <code>object</code>
+    * [.findReferencedBy(document, options)](#FileCollection+findReferencedBy) ⇒ <code>Object</code>
+    * [.addReferencedBy(document, documents)](#FileCollection+addReferencedBy) ⇒ <code>Object</code>
+    * [.removeReferencedBy(document, documents)](#FileCollection+removeReferencedBy) ⇒ <code>Object</code>
+    * [.addReferencesTo(document, documents)](#FileCollection+addReferencesTo) ⇒
+    * [.removeReferencesTo(document, documents)](#FileCollection+removeReferencesTo) ⇒
     * [.destroy(file)](#FileCollection+destroy) ⇒ <code>Promise</code>
     * [.emptyTrash()](#FileCollection+emptyTrash)
     * [.restore(id)](#FileCollection+restore) ⇒ <code>Promise</code>
@@ -581,11 +581,11 @@ The returned documents are paginated by the stack.
 
 <a name="FileCollection+findReferencedBy"></a>
 
-### fileCollection.findReferencedBy(document, options) ⇒ <code>object</code>
+### fileCollection.findReferencedBy(document, options) ⇒ <code>Object</code>
 async findReferencedBy - Returns the list of files referenced by a document — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
-**Returns**: <code>object</code> - The JSON API conformant response.  
+**Returns**: <code>Object</code> - The JSON API conformant response.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -597,7 +597,7 @@ async findReferencedBy - Returns the list of files referenced by a document — 
 
 <a name="FileCollection+addReferencedBy"></a>
 
-### fileCollection.addReferencedBy(document, documents) ⇒ <code>object</code>
+### fileCollection.addReferencedBy(document, documents) ⇒ <code>Object</code>
 Add referenced_by documents to a file — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#post-filesfile-idrelationshipsreferenced_by
 
  For example, to have an album referenced by a file:
@@ -606,7 +606,7 @@ addReferencedBy({_id: 123, _type: "io.cozy.files", name: "cozy.jpg"}, [{_id: 456
 ```
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
-**Returns**: <code>object</code> - The JSON API conformant response.  
+**Returns**: <code>Object</code> - The JSON API conformant response.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -615,7 +615,7 @@ addReferencedBy({_id: 123, _type: "io.cozy.files", name: "cozy.jpg"}, [{_id: 456
 
 <a name="FileCollection+removeReferencedBy"></a>
 
-### fileCollection.removeReferencedBy(document, documents) ⇒ <code>object</code>
+### fileCollection.removeReferencedBy(document, documents) ⇒ <code>Object</code>
 Remove referenced_by documents from a file — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#delete-filesfile-idrelationshipsreferenced_by
 
  For example, to remove an album reference from a file:
@@ -624,7 +624,7 @@ Remove referenced_by documents from a file — see https://docs.cozy.io/en/cozy-
 ```
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
-**Returns**: <code>object</code> - The JSON API conformant response.  
+**Returns**: <code>Object</code> - The JSON API conformant response.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -633,7 +633,7 @@ Remove referenced_by documents from a file — see https://docs.cozy.io/en/cozy-
 
 <a name="FileCollection+addReferencesTo"></a>
 
-### fileCollection.addReferencesTo(document, documents) ⇒ <code>object</code>
+### fileCollection.addReferencesTo(document, documents) ⇒
 Add files references to a document — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#post-datatypedoc-idrelationshipsreferences
 
  For example, to add a photo to an album:
@@ -642,7 +642,7 @@ Add files references to a document — see https://docs.cozy.io/en/cozy-stack/re
 ```
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
-**Returns**: <code>object</code> - The JSON API conformant response.  
+**Returns**: 204 No Content  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -651,7 +651,7 @@ Add files references to a document — see https://docs.cozy.io/en/cozy-stack/re
 
 <a name="FileCollection+removeReferencesTo"></a>
 
-### fileCollection.removeReferencesTo(document, documents) ⇒ <code>object</code>
+### fileCollection.removeReferencesTo(document, documents) ⇒
 Remove files references to a document — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#delete-datatypedoc-idrelationshipsreferences
 
  For example, to remove a photo from an album:
@@ -660,7 +660,7 @@ Remove files references to a document — see https://docs.cozy.io/en/cozy-stack
 ```
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
-**Returns**: <code>object</code> - The JSON API conformant response.  
+**Returns**: 204 No Content  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -58,7 +58,9 @@ const normalizeFile = file => ({
 })
 
 const normalizeReferences = references => {
-  return references.map(ref => ({ _type: ref.type, _id: ref.id }))
+  return references
+    ? references.map(ref => ({ _type: ref.type, _id: ref.id }))
+    : []
 }
 
 const sanitizeFileName = name => name && name.trim()
@@ -184,7 +186,7 @@ class FileCollection extends DocumentCollection {
     const path = querystring.buildURL(url, params)
     const resp = await this.stackClient.fetchJSON('GET', path)
     return {
-      data: resp.data.map(f => normalizeFile(f)),
+      data: normalizeReferences(resp.data),
       included: resp.included ? resp.included.map(f => normalizeFile(f)) : [],
       next: has(resp, 'links.next'),
       meta: resp.meta,

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -171,7 +171,7 @@ class FileCollection extends DocumentCollection {
    * @param  {number} options.skip    For skip-based pagination, the number of referenced files to skip.
    * @param  {number} options.limit   For pagination, the number of results to return.
    * @param  {object} options.cursor  For cursor-based pagination, the index cursor.
-   * @returns {object}                The JSON API conformant response.
+   * @returns {{data, included, meta, skip, next, bookmark}} The JSON API conformant response.
    */
   async findReferencedBy(document, { skip = 0, limit, cursor } = {}) {
     const params = {
@@ -200,9 +200,9 @@ class FileCollection extends DocumentCollection {
    * addReferencedBy({_id: 123, _type: "io.cozy.files", name: "cozy.jpg"}, [{_id: 456, _type: "io.cozy.photos.albums", name: "Happy Cloud"}])
    * ```
    *
-   * @param  {FileDocument} document        A JSON representing the file
+   * @param  {FileDocument} document  A JSON representing the file
    * @param  {Array}  documents       An array of JSON documents having a `_type` and `_id` field.
-   * @returns {object}                The JSON API conformant response.
+   * @returns {{data, meta}}          The JSON API conformant response.
    */
   async addReferencedBy(document, documents) {
     const refs = documents.map(d => ({ id: d._id, type: d._type }))
@@ -212,7 +212,8 @@ class FileCollection extends DocumentCollection {
       { data: refs }
     )
     return {
-      data: normalizeReferences(resp.data)
+      data: normalizeReferences(resp.data),
+      meta: resp.meta
     }
   }
 
@@ -226,7 +227,7 @@ class FileCollection extends DocumentCollection {
    *
    * @param  {object} document        A JSON representing the file
    * @param  {Array}  documents       An array of JSON documents having a `_type` and `_id` field.
-   * @returns {object}                The JSON API conformant response.
+   * @returns {{data, meta}}          The JSON API conformant response.
    */
   async removeReferencedBy(document, documents) {
     const refs = documents.map(d => ({ id: d._id, type: d._type }))
@@ -236,7 +237,8 @@ class FileCollection extends DocumentCollection {
       { data: refs }
     )
     return {
-      data: normalizeReferences(resp.data)
+      data: normalizeReferences(resp.data),
+      meta: resp.meta
     }
   }
 
@@ -250,7 +252,7 @@ class FileCollection extends DocumentCollection {
    *
    * @param  {object} document        A JSON representing a document, with at least a `_type` and `_id` field.
    * @param  {Array}  documents       An array of JSON files having an `_id` field.
-   * @returns {object}                The JSON API conformant response.
+   * @returns 204 No Content
    */
   async addReferencesTo(document, documents) {
     const refs = documents.map(d => ({ id: d._id, type: 'io.cozy.files' }))
@@ -271,7 +273,7 @@ class FileCollection extends DocumentCollection {
    *
    * @param  {object} document        A JSON representing a document, with at least a `_type` and `_id` field.
    * @param  {Array}  documents       An array of JSON files having an `_id` field.
-   * @returns {object}                The JSON API conformant response.
+   * @returns 204 No Content
    */
   async removeReferencesTo(document, documents) {
     const refs = documents.map(d => ({ id: d._id, type: 'io.cozy.files' }))

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -353,7 +353,8 @@ describe('FileCollection', () => {
     beforeEach(() => {
       spy.mockClear()
       spy.mockReturnValue({
-        data: [{ id: '123', type: 'io.cozy.files' }]
+        data: [{ id: '123', type: 'io.cozy.files' }],
+        meta: { rev: '2-xxx', count: 1 }
       })
     })
 
@@ -371,6 +372,7 @@ describe('FileCollection', () => {
       ]
       const res = await collection.addReferencedBy(file, refs)
       expect(res.data).toEqual([file])
+      expect(res.meta).not.toBeNull()
       expect(spy).toMatchSnapshot()
     })
     it('should remove a reference', async () => {
@@ -382,6 +384,7 @@ describe('FileCollection', () => {
       ]
       const res = await collection.removeReferencedBy(file, refs)
       expect(res.data).toEqual([file])
+      expect(res.meta).not.toBeNull()
       expect(spy).toMatchSnapshot()
     })
   })

--- a/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
+++ b/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
@@ -101,6 +101,10 @@ exports[`FileCollection referencedBy should add a reference 1`] = `
             "type": "io.cozy.files",
           },
         ],
+        "meta": Object {
+          "count": 1,
+          "rev": "2-xxx",
+        },
       },
     },
   ],
@@ -133,6 +137,10 @@ exports[`FileCollection referencedBy should remove a reference 1`] = `
             "type": "io.cozy.files",
           },
         ],
+        "meta": Object {
+          "count": 1,
+          "rev": "2-xxx",
+        },
       },
     },
   ],

--- a/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
+++ b/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
@@ -67,8 +67,15 @@ exports[`FileCollection findReferencedBy should pass all the filters 1`] = `
     Object {
       "type": "return",
       "value": Object {
-        "data": Array [],
-        "meta": Object {},
+        "data": Array [
+          Object {
+            "id": "album-1",
+            "type": "io.cozy.photos.albums",
+          },
+        ],
+        "meta": Object {
+          "count": 1,
+        },
       },
     },
   ],
@@ -97,8 +104,8 @@ exports[`FileCollection referencedBy should add a reference 1`] = `
       "value": Object {
         "data": Array [
           Object {
-            "id": "123",
-            "type": "io.cozy.files",
+            "id": "456",
+            "type": "io.cozy.photos.albums",
           },
         ],
         "meta": Object {
@@ -131,15 +138,10 @@ exports[`FileCollection referencedBy should remove a reference 1`] = `
     Object {
       "type": "return",
       "value": Object {
-        "data": Array [
-          Object {
-            "id": "123",
-            "type": "io.cozy.files",
-          },
-        ],
+        "data": null,
         "meta": Object {
-          "count": 1,
-          "rev": "2-xxx",
+          "count": 0,
+          "rev": "3-xxx",
         },
       },
     },


### PR DESCRIPTION
After updating a file's `referenced_by` attribute, `cozy-stack` will
not only return the updated file but also a `meta` object containing
the file's new revision and the file's new references count.

Fixes a regression introduced by https://github.com/cozy/cozy-client/pull/1048