### PR TITLE
feat: Be more explicit on query warning messages

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -52,7 +52,7 @@ cozy-client
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:454](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L454)
+[packages/cozy-client/src/queries/dsl.js:462](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L462)
 
 ***
 
@@ -76,7 +76,7 @@ cozy-client
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:442](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L442)
+[packages/cozy-client/src/queries/dsl.js:450](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L450)
 
 ***
 
@@ -130,7 +130,7 @@ query definitions.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:338](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L338)
+[packages/cozy-client/src/queries/dsl.js:346](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L346)
 
 ***
 
@@ -259,7 +259,7 @@ Generated URL
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:418](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L418)
+[packages/cozy-client/src/queries/dsl.js:426](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L426)
 
 ***
 

--- a/docs/api/cozy-client/classes/querydefinition.md
+++ b/docs/api/cozy-client/classes/querydefinition.md
@@ -187,7 +187,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:235](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L235)
+[packages/cozy-client/src/queries/dsl.js:243](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L243)
 
 ***
 
@@ -211,7 +211,7 @@ It is useful to warn the developer when a partial index might be used.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:108](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L108)
+[packages/cozy-client/src/queries/dsl.js:114](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L114)
 
 ***
 
@@ -264,7 +264,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:129](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L129)
+[packages/cozy-client/src/queries/dsl.js:137](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L137)
 
 ***
 
@@ -288,7 +288,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:142](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L142)
+[packages/cozy-client/src/queries/dsl.js:150](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L150)
 
 ***
 
@@ -313,7 +313,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:218](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L218)
+[packages/cozy-client/src/queries/dsl.js:226](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L226)
 
 ***
 
@@ -337,7 +337,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:175](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L175)
+[packages/cozy-client/src/queries/dsl.js:183](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L183)
 
 ***
 
@@ -361,7 +361,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:231](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L231)
+[packages/cozy-client/src/queries/dsl.js:239](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L239)
 
 ***
 
@@ -388,7 +388,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:248](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L248)
+[packages/cozy-client/src/queries/dsl.js:256](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L256)
 
 ***
 
@@ -415,7 +415,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:286](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L286)
+[packages/cozy-client/src/queries/dsl.js:294](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L294)
 
 ***
 
@@ -444,7 +444,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:268](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L268)
+[packages/cozy-client/src/queries/dsl.js:276](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L276)
 
 ***
 
@@ -470,7 +470,7 @@ You can find more information about partial indexes [here](https://docs.cozy.io/
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:189](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L189)
+[packages/cozy-client/src/queries/dsl.js:197](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L197)
 
 ***
 
@@ -494,7 +494,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:301](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L301)
+[packages/cozy-client/src/queries/dsl.js:309](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L309)
 
 ***
 
@@ -518,7 +518,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:165](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L165)
+[packages/cozy-client/src/queries/dsl.js:173](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L173)
 
 ***
 
@@ -542,7 +542,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:199](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L199)
+[packages/cozy-client/src/queries/dsl.js:207](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L207)
 
 ***
 
@@ -573,7 +573,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:305](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L305)
+[packages/cozy-client/src/queries/dsl.js:313](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L313)
 
 ***
 
@@ -598,4 +598,4 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:153](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L153)
+[packages/cozy-client/src/queries/dsl.js:161](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L161)

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -562,7 +562,7 @@ client.query(Q('io.cozy.bills'))`)
 
   get(doctype, id) {
     console.warn(
-      'client.get(doctype, id) is deprecated, please use Q(doctype).getById(id) to build the same query.'
+      `client.get(${doctype}, id) is deprecated, please use Q(${doctype}).getById(id) to build the same query.`
     )
     return new QueryDefinition({ doctype, id })
   }

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -84,13 +84,19 @@ class QueryDefinition {
       return
     }
     if (_sort.length > fieldsToIndex.length) {
-      console.warn('You should not sort on non-indexed fields')
+      console.warn(
+        `You should not sort on non-indexed fields.\n
+        Sort: ${JSON.stringify(_sort)}\n
+        Indexed fields: ${fieldsToIndex}`
+      )
       return
     }
     for (let i = 0; i < _sort.length; i++) {
       if (Object.keys(_sort[i])[0] !== fieldsToIndex[i]) {
         console.warn(
-          'The sort order should be the same than the indexed fields'
+          `The sort order should be the same than the indexed fields.\n
+          Sort: ${JSON.stringify(_sort)}\n
+          Indexed fields: ${fieldsToIndex}\n`
         )
         return
       }
@@ -109,13 +115,15 @@ class QueryDefinition {
     const hasExistsFalse = findKey(selector, ['$exists', false])
     if (hasExistsFalse) {
       console.warn(
-        'The "$exists: false" predicate should be defined as a partial index for better performance'
+        `The "$exists: false" predicate should be defined as a partial index for better performance.\n
+        Selector: ${selector}`
       )
     }
     const hasNe = findKey(selector, '$ne')
     if (hasNe) {
       console.info(
-        'The use of the $ne operator is more efficient with a partial index.'
+        `The use of the $ne operator is more efficient with a partial index.\n
+        Selector: ${selector}`
       )
     }
   }


### PR DESCRIPTION
This is useful to know which query is involved by a warning message