### PR TITLE
Feat/throw error

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -511,16 +511,24 @@ Returns the cozy client from the context
 
 Fetches a queryDefinition and returns the queryState
 
+**`property`** {object} as - Name for the query \[required]
+
+**`property`** {boolean} enabled - If set to false, the query won't be executed
+
+**`property`** {object} fetchPolicy - Fetch policy
+
+**`property`** {object} singleDocData - If true, the "data" returned will be
+a single doc instead of an array for single doc queries. Defaults to false for backward
+compatibility but will be set to true in the future.
+
+**`property`** {Function} onError - Callback if the query is errored
+
 *Parameters*
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `queryDefinition` | `any` | Definition created with Q() |
-| `options` | `Object` | Options |
-| `options.as` | `any` | Name for the query \[required] |
-| `options.enabled` | `boolean` | If set to false, the query won't be executed |
-| `options.fetchPolicy` | `any` | Fetch policy |
-| `options.singleDocData` | `any` | If true, the "data" returned will be a single doc instead of an array for single doc queries. Defaults to false for backward compatibility but will be set to true in the future. |
+| `queryDefinition` | [`QueryDefinition`](classes/querydefinition.md) | Definition created with Q() |
+| `options` | `any` | - |
 
 *Returns*
 
@@ -528,7 +536,7 @@ Fetches a queryDefinition and returns the queryState
 
 *Defined in*
 
-[packages/cozy-client/src/hooks/useQuery.js:36](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hooks/useQuery.js#L36)
+[packages/cozy-client/src/hooks/useQuery.js:38](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hooks/useQuery.js#L38)
 
 ***
 

--- a/docs/api/cozy-client/classes/cozyclient.md
+++ b/docs/api/cozy-client/classes/cozyclient.md
@@ -83,7 +83,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1519](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1519)
+[packages/cozy-client/src/CozyClient.js:1527](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1527)
 
 ***
 
@@ -148,6 +148,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 | `autoHydrate` | `boolean` | - |
 | `client` | `any` | - |
 | `oauth` | `any` | - |
+| `onError` | `Function` | Default callback if a query is errored |
 | `onTokenRefresh` | `Function` | - |
 | `stackClient` | `any` | - |
 | `store` | `boolean` | If set to false, the client will not instantiate a Redux store automatically. Use this if you want to merge cozy-client's store with your own redux store. See [here](https://docs.cozy.io/en/cozy-client/react-integration/#1b-use-your-own-redux-store) for more information. |
@@ -197,7 +198,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1495](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1495)
+[packages/cozy-client/src/CozyClient.js:1503](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1503)
 
 ***
 
@@ -207,7 +208,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1428](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1428)
+[packages/cozy-client/src/CozyClient.js:1436](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1436)
 
 ***
 
@@ -237,7 +238,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1226](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1226)
+[packages/cozy-client/src/CozyClient.js:1234](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1234)
 
 ***
 
@@ -342,7 +343,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1361](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1361)
+[packages/cozy-client/src/CozyClient.js:1369](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1369)
 
 ***
 
@@ -358,7 +359,7 @@ Returns whether the client has been revoked on the server
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1442](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1442)
+[packages/cozy-client/src/CozyClient.js:1450](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1450)
 
 ***
 
@@ -442,7 +443,7 @@ If `oauth` options are passed, stackClient is an OAuthStackClient.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1476](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1476)
+[packages/cozy-client/src/CozyClient.js:1484](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1484)
 
 ***
 
@@ -487,7 +488,7 @@ The document that has been deleted
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1547](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1547)
+[packages/cozy-client/src/CozyClient.js:1555](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1555)
 
 ***
 
@@ -573,7 +574,7 @@ Makes sure that the query exists in the store
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1433](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1433)
+[packages/cozy-client/src/CozyClient.js:1441](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1441)
 
 ***
 
@@ -623,7 +624,7 @@ Query state
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1322](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1322)
+[packages/cozy-client/src/CozyClient.js:1330](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1330)
 
 ***
 
@@ -658,7 +659,7 @@ Query state
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1202](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1202)
+[packages/cozy-client/src/CozyClient.js:1210](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1210)
 
 ***
 
@@ -702,7 +703,7 @@ Creates an association that is linked to the store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1209](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1209)
+[packages/cozy-client/src/CozyClient.js:1217](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1217)
 
 ***
 
@@ -716,7 +717,7 @@ Creates an association that is linked to the store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1529](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1529)
+[packages/cozy-client/src/CozyClient.js:1537](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1537)
 
 ***
 
@@ -740,7 +741,7 @@ Array of documents or null if the collection does not exist.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1245](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1245)
+[packages/cozy-client/src/CozyClient.js:1253](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1253)
 
 ***
 
@@ -765,7 +766,7 @@ Document or null if the object does not exist.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1262](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1262)
+[packages/cozy-client/src/CozyClient.js:1270](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1270)
 
 ***
 
@@ -820,7 +821,7 @@ One or more mutation to execute
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1129](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1129)
+[packages/cozy-client/src/CozyClient.js:1137](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1137)
 
 ***
 
@@ -836,7 +837,7 @@ getInstanceOptions - Returns current instance options, such as domain or app slu
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1556](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1556)
+[packages/cozy-client/src/CozyClient.js:1564](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1564)
 
 ***
 
@@ -863,7 +864,7 @@ Get a query from the internal store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1283](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1283)
+[packages/cozy-client/src/CozyClient.js:1291](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1291)
 
 ***
 
@@ -892,7 +893,7 @@ the store up, which in turn will update the `<Query>`s and re-render the data.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1225](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1225)
+[packages/cozy-client/src/CozyClient.js:1233](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1233)
 
 ***
 
@@ -906,7 +907,7 @@ the store up, which in turn will update the `<Query>`s and re-render the data.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1536](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1536)
+[packages/cozy-client/src/CozyClient.js:1544](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1544)
 
 ***
 
@@ -928,7 +929,7 @@ Sets public attribute and emits event related to revocation
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1447](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1447)
+[packages/cozy-client/src/CozyClient.js:1455](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1455)
 
 ***
 
@@ -950,7 +951,7 @@ Emits event when token is refreshed
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1458](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1458)
+[packages/cozy-client/src/CozyClient.js:1466](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1466)
 
 ***
 
@@ -976,7 +977,7 @@ the relationship
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1172](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1172)
+[packages/cozy-client/src/CozyClient.js:1180](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1180)
 
 ***
 
@@ -1001,7 +1002,7 @@ Instead, the relationships will have null documents.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1149](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1149)
+[packages/cozy-client/src/CozyClient.js:1157](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1157)
 
 ***
 
@@ -1022,7 +1023,7 @@ Instead, the relationships will have null documents.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1183](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1183)
+[packages/cozy-client/src/CozyClient.js:1191](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1191)
 
 ***
 
@@ -1036,7 +1037,7 @@ Instead, the relationships will have null documents.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1345](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1345)
+[packages/cozy-client/src/CozyClient.js:1353](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1353)
 
 ***
 
@@ -1058,7 +1059,7 @@ loadInstanceOptionsFromDOM - Loads the dataset injected by the Stack in web page
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1567](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1567)
+[packages/cozy-client/src/CozyClient.js:1575](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1575)
 
 ***
 
@@ -1139,7 +1140,7 @@ and working.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1195](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1195)
+[packages/cozy-client/src/CozyClient.js:1203](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1203)
 
 ***
 
@@ -1160,7 +1161,7 @@ and working.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:971](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L971)
+[packages/cozy-client/src/CozyClient.js:979](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L979)
 
 ***
 
@@ -1186,7 +1187,7 @@ Mutate a document
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:989](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L989)
+[packages/cozy-client/src/CozyClient.js:997](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L997)
 
 ***
 
@@ -1282,7 +1283,7 @@ All documents matching the query
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:936](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L936)
+[packages/cozy-client/src/CozyClient.js:944](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L944)
 
 ***
 
@@ -1316,7 +1317,7 @@ All documents matching the query
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1543](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1543)
+[packages/cozy-client/src/CozyClient.js:1551](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1551)
 
 ***
 
@@ -1342,7 +1343,7 @@ Contains the fetched token and the client information.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1339](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1339)
+[packages/cozy-client/src/CozyClient.js:1347](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1347)
 
 ***
 
@@ -1463,7 +1464,7 @@ Contains the fetched token and the client information.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1392](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1392)
+[packages/cozy-client/src/CozyClient.js:1400](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1400)
 
 ***
 
@@ -1483,7 +1484,7 @@ Contains the fetched token and the client information.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1113](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1113)
+[packages/cozy-client/src/CozyClient.js:1121](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1121)
 
 ***
 
@@ -1556,7 +1557,29 @@ set some data in the store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1588](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1588)
+[packages/cozy-client/src/CozyClient.js:1596](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1596)
+
+***
+
+### setOnError
+
+▸ **setOnError**(`onError`): `void`
+
+At any time put an error function
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `onError` | `Function` |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1608](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1608)
 
 ***
 
@@ -1594,7 +1617,7 @@ use options.force = true.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1418](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1418)
+[packages/cozy-client/src/CozyClient.js:1426](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1426)
 
 ***
 
@@ -1618,7 +1641,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1355](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1355)
+[packages/cozy-client/src/CozyClient.js:1363](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1363)
 
 ***
 
@@ -1632,7 +1655,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1595](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1595)
+[packages/cozy-client/src/CozyClient.js:1615](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1615)
 
 ***
 
@@ -1715,7 +1738,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:964](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L964)
+[packages/cozy-client/src/CozyClient.js:972](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L972)
 
 ***
 

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -102,6 +102,7 @@ const DOC_UPDATE = 'update'
  * @property {boolean} [autoHydrate]
  * @property {object} [oauth]
  * @property {Function} [onTokenRefresh]
+ * @property {Function} [onError] - Default callback if a query is errored
  * @property  {Link}         [link]   - Backward compatibility
  * @property  {Array<Link>}  [links]  - List of links
  * @property  {object}       [schema] - Schema description for each doctypes
@@ -919,7 +920,15 @@ client.query(Q('io.cozy.bills'))`)
       return response
     } catch (error) {
       this.dispatch(receiveQueryError(queryId, error))
-      throw error
+      // specific onError
+      if (options.onError) {
+        options.onError(error)
+        // defaulted onError
+      } else if (this.options.onError) {
+        this.options.onError(error)
+      } else {
+        throw error
+      }
     }
   }
 
@@ -1589,6 +1598,18 @@ instantiation of the client.`
     Object.entries(data).forEach(([doctype, data]) => {
       this.dispatch(receiveQueryResult(null, { data }))
     })
+  }
+
+  /**
+   * At any time put an error function
+   *
+   * @param {Function} [onError] - Set a callback for queries which are errored
+   */
+  setOnError(onError) {
+    if (this.options && this.options.onError) {
+      throw new Error('On Error is already defined')
+    }
+    this.options.onError = onError
   }
 
   toJSON() {

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -102,7 +102,6 @@ const DOC_UPDATE = 'update'
  * @property {boolean} [autoHydrate]
  * @property {object} [oauth]
  * @property {Function} [onTokenRefresh]
- * @property {Function} [onTokenRefresh]
  * @property  {Link}         [link]   - Backward compatibility
  * @property  {Array<Link>}  [links]  - List of links
  * @property  {object}       [schema] - Schema description for each doctypes

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -162,7 +162,6 @@ describe('CozyClient initialization', () => {
       })
     }
     const client = await CozyClient.fromOldOAuthClient(oldClient)
-    console.log({ stackClient: client.stackClient })
     expect(client.stackClient.uri).toBe(url)
     expect(client.stackClient.oauthOptions.clientID).toBe(oauth.clientID)
     expect(client.stackClient.token.accessToken).toBe(token.accessToken)
@@ -1400,6 +1399,54 @@ describe('CozyClient', () => {
       const lastDispatchCall = dispatchCalls[dispatchCalls.length - 1]
       expect(lastDispatchCall[0]).toEqual(
         receiveQueryResult('allTodos', fakeResponse)
+      )
+    })
+
+    const setupOnError = () => {
+      const error = new TypeError('Failed to fetch')
+      requestHandler.mockReturnValueOnce(Promise.reject(error))
+      const onError = jest.fn().mockReturnValueOnce(() => true)
+      return onError
+    }
+
+    it('should call onError callback when an error is thrown. Callback passed as argument', async () => {
+      const onError = setupOnError()
+
+      await client.query(query, { as: 'allTodos', onError })
+      expect(onError).toBeCalled()
+    })
+
+    it('should call onError callback when an error is catched. It is passed during instantiation', async () => {
+      const onError = setupOnError()
+      const client = new CozyClient({ onError })
+
+      await client.query(query, { as: 'allTodos' })
+      expect(onError).toBeCalled()
+    })
+
+    it('should call onError callback when an error is catched. It is passed with setOnError', async () => {
+      const onError = setupOnError()
+      client.setOnError(onError)
+
+      await client.query(query, { as: 'allTodos' })
+      expect(onError).toBeCalled()
+    })
+
+    it('should throw an error when we call setOnError twice (or several times)', async () => {
+      const client = new CozyClient({})
+      const onError = () => true
+
+      const funcShouldThrow = () => client.setOnError(onError)
+      expect(funcShouldThrow).not.toThrow()
+      expect(funcShouldThrow).toThrow('On Error is already defined')
+    })
+
+    it('should throw an error when there is no onError callback', async () => {
+      const error = new TypeError('Failed to fetch')
+      requestHandler.mockReturnValueOnce(Promise.reject(error))
+
+      await expect(client.query(query, { as: 'allTodos' })).rejects.toThrow(
+        'Failed to fetch'
       )
     })
   })

--- a/packages/cozy-client/src/hooks/useQuery.js
+++ b/packages/cozy-client/src/hooks/useQuery.js
@@ -5,6 +5,7 @@ import useClient from './useClient'
 import logger from '../logger'
 import { UseQueryReturnValue } from '../types'
 import { clientContext } from '../context'
+import { QueryDefinition } from '../queries/dsl'
 
 const useSelector = createSelectorHook(clientContext)
 
@@ -21,15 +22,16 @@ const generateFetchMoreQueryDefinition = queryResult => {
 /**
  * Fetches a queryDefinition and returns the queryState
  *
- * @param  {object} queryDefinition - Definition created with Q()
+ * @param  {QueryDefinition} queryDefinition - Definition created with Q()
  *
- * @param  {object} options - Options
- * @param  {object} options.as - Name for the query [required]
- * @param  {boolean} options.enabled - If set to false, the query won't be executed
- * @param  {object} options.fetchPolicy - Fetch policy
- * @param  {object} options.singleDocData - If true, the "data" returned will be
+ * @typedef {object} UseQueryOptions
+ * @property  {object} as - Name for the query [required]
+ * @property  {boolean} enabled - If set to false, the query won't be executed
+ * @property  {object} fetchPolicy - Fetch policy
+ * @property  {object} singleDocData - If true, the "data" returned will be
  * a single doc instead of an array for single doc queries. Defaults to false for backward
  * compatibility but will be set to true in the future.
+ * @property {Function} onError - Callback if the query is errored
  *
  * @returns {UseQueryReturnValue}
  */

--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -78,7 +78,8 @@ import { QueryDefinition } from './queries/dsl'
  * @property {string} [as] - Name of the query
  * @property {Function} [fetchPolicy] - Fetch policy to bypass fetching based on what's already inside the state. See "Fetch policies"
  * @property {AutoUpdateOptions} [autoUpdate] - Options for the query auto update
- * @property {string} [options.update] - Does not seem to be used
+ * @property {string} [update] - Does not seem to be used
+ * @property {Function} [onError] - Callback when the query is errored
  */
 
 /**

--- a/packages/cozy-client/types/CozyClient.d.ts
+++ b/packages/cozy-client/types/CozyClient.d.ts
@@ -11,6 +11,10 @@ export type ClientOptions = {
     oauth?: object;
     onTokenRefresh?: Function;
     /**
+     * - Default callback if a query is errored
+     */
+    onError?: Function;
+    /**
      * - Schema description for each doctypes
      */
     schema?: object;
@@ -39,7 +43,7 @@ export type ClientOptions = {
  * @property {boolean} [autoHydrate]
  * @property {object} [oauth]
  * @property {Function} [onTokenRefresh]
- * @property {Function} [onTokenRefresh]
+ * @property {Function} [onError] - Default callback if a query is errored
  * @property  {Link}         [link]   - Backward compatibility
  * @property  {Array<Link>}  [links]  - List of links
  * @property  {object}       [schema] - Schema description for each doctypes
@@ -146,6 +150,10 @@ declare class CozyClient {
         autoHydrate?: boolean;
         oauth?: object;
         onTokenRefresh?: Function;
+        /**
+         * - Default callback if a query is errored
+         */
+        onError?: Function;
         /**
          * - If set to false, the client will not instantiate a Redux store automatically. Use this if you want to merge cozy-client's store with your own redux store. See [here](https://docs.cozy.io/en/cozy-client/react-integration/#1b-use-your-own-redux-store) for more information.
          */
@@ -640,6 +648,12 @@ declare class CozyClient {
      * @param {object} data - Data that is inserted in the store. Shape: { doctype: [data] }
      */
     setData(data: object): void;
+    /**
+     * At any time put an error function
+     *
+     * @param {Function} [onError] - Set a callback for queries which are errored
+     */
+    setOnError(onError?: Function): void;
     toJSON(): SnapshotClient;
 }
 declare namespace CozyClient {

--- a/packages/cozy-client/types/hooks/useQuery.d.ts
+++ b/packages/cozy-client/types/hooks/useQuery.d.ts
@@ -2,23 +2,47 @@ export function useQueries(querySpecs: any): {};
 export default useQuery;
 /**
  * Fetches a queryDefinition and returns the queryState
+ */
+export type UseQueryOptions = {
+    /**
+     * - Name for the query [required]
+     */
+    as: object;
+    /**
+     * - If set to false, the query won't be executed
+     */
+    enabled: boolean;
+    /**
+     * - Fetch policy
+     */
+    fetchPolicy: object;
+    /**
+     * - If true, the "data" returned will be
+     * a single doc instead of an array for single doc queries. Defaults to false for backward
+     * compatibility but will be set to true in the future.
+     */
+    singleDocData: object;
+    /**
+     * - Callback if the query is errored
+     */
+    onError: Function;
+};
+/**
+ * Fetches a queryDefinition and returns the queryState
  *
- * @param  {object} queryDefinition - Definition created with Q()
+ * @param  {QueryDefinition} queryDefinition - Definition created with Q()
  *
- * @param  {object} options - Options
- * @param  {object} options.as - Name for the query [required]
- * @param  {boolean} options.enabled - If set to false, the query won't be executed
- * @param  {object} options.fetchPolicy - Fetch policy
- * @param  {object} options.singleDocData - If true, the "data" returned will be
+ * @typedef {object} UseQueryOptions
+ * @property  {object} as - Name for the query [required]
+ * @property  {boolean} enabled - If set to false, the query won't be executed
+ * @property  {object} fetchPolicy - Fetch policy
+ * @property  {object} singleDocData - If true, the "data" returned will be
  * a single doc instead of an array for single doc queries. Defaults to false for backward
  * compatibility but will be set to true in the future.
+ * @property {Function} onError - Callback if the query is errored
  *
  * @returns {UseQueryReturnValue}
  */
-declare function useQuery(queryDefinition: object, options: {
-    as: object;
-    enabled: boolean;
-    fetchPolicy: object;
-    singleDocData: object;
-}): UseQueryReturnValue;
+declare function useQuery(queryDefinition: QueryDefinition, options: any): UseQueryReturnValue;
+import { QueryDefinition } from "../queries/dsl";
 import { UseQueryReturnValue } from "../types";

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -64,6 +64,10 @@ export type QueryOptions = {
      * - Does not seem to be used
      */
     update?: string;
+    /**
+     * - Callback when the query is errored
+     */
+    onError?: Function;
 };
 export type FetchMoreAble = {
     fetchMore: Function;


### PR DESCRIPTION
We can now pass an onError callback to CozyClient.
This callback can be defined globally when creating
the client

new CozyClient({..., onError: (e) => alert(e)})
or with client.setOnError(cb)

Or it can be defined locally:
client.query(QDef, {..., onError: (e) => alert(e)})
useQuery(QDef, {..., onError: (e) => alert(e)})
