### PR TITLE
fix: Re-export associations helpers

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -284,6 +284,57 @@ Generated URL
 
 ***
 
+### getReferencedBy
+
+▸ `Const` **getReferencedBy**(`file`, `referencedBy`): `Reference`\[]
+
+Get array of reference by an specific doctype
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `IOCozyFile` | io.cozy.files document |
+| `referencedBy` | `string` | Doctype where document is referenced |
+
+*Returns*
+
+`Reference`\[]
+
+Array of references found
+
+*Defined in*
+
+[packages/cozy-client/src/associations/helpers.js:134](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/helpers.js#L134)
+
+***
+
+### getReferencedById
+
+▸ `Const` **getReferencedById**(`file`, `referencedBy`, `referencedId`): `Reference`\[]
+
+Get array of reference by an specific doctype and a specific Id of that reference
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `IOCozyFile` | io.cozy.files document |
+| `referencedBy` | `string` | Doctype where document is referenced |
+| `referencedId` | `string` | Id of the referenced document |
+
+*Returns*
+
+`Reference`\[]
+
+Array of the reference found
+
+*Defined in*
+
+[packages/cozy-client/src/associations/helpers.js:148](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/helpers.js#L148)
+
+***
+
 ### hasQueryBeenLoaded
 
 ▸ `Const` **hasQueryBeenLoaded**(`col`): `any`
@@ -326,6 +377,57 @@ is loading.
 *Defined in*
 
 [packages/cozy-client/src/utils.js:37](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/utils.js#L37)
+
+***
+
+### isReferencedBy
+
+▸ `Const` **isReferencedBy**(`file`, `referencedBy`): `boolean`
+
+Checks if the file is referenced by a specific doctype
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `IOCozyFile` | io.cozy.files document |
+| `referencedBy` | `string` | Doctype where document is referenced |
+
+*Returns*
+
+`boolean`
+
+If a reference is found
+
+*Defined in*
+
+[packages/cozy-client/src/associations/helpers.js:102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/helpers.js#L102)
+
+***
+
+### isReferencedById
+
+▸ `Const` **isReferencedById**(`file`, `referencedBy`, `referencedId`): `boolean`
+
+Checks if the file is referenced by a specific doctype and a specific Id of that reference
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `IOCozyFile` | io.cozy.files document |
+| `referencedBy` | `string` | Doctype where document is referenced |
+| `referencedId` | `string` | Id of the referenced document |
+
+*Returns*
+
+`boolean`
+
+If a reference is found
+
+*Defined in*
+
+[packages/cozy-client/src/associations/helpers.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/helpers.js#L117)
 
 ***
 

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -17,6 +17,12 @@ export {
   HasManyInPlace,
   HasManyTriggers
 } from './associations'
+export {
+  isReferencedBy,
+  isReferencedById,
+  getReferencedBy,
+  getReferencedById
+} from './associations/helpers'
 export { dehydrate, generateWebLink } from './helpers'
 export { cancelable, isQueryLoading, hasQueryBeenLoaded } from './utils'
 export { getQueryFromState } from './store'

--- a/packages/cozy-client/types/index.d.ts
+++ b/packages/cozy-client/types/index.d.ts
@@ -18,6 +18,7 @@ import * as models from "./models";
 export { manifest, models };
 export { QueryDefinition, Q, Mutations, MutationTypes, getDoctypeFromOperation } from "./queries/dsl";
 export { Association, HasMany, HasOne, HasOneInPlace, HasManyInPlace, HasManyTriggers } from "./associations";
+export { isReferencedBy, isReferencedById, getReferencedBy, getReferencedById } from "./associations/helpers";
 export { dehydrate, generateWebLink } from "./helpers";
 export { cancelable, isQueryLoading, hasQueryBeenLoaded } from "./utils";
 export { queryConnect, queryConnectFlat, withClient } from "./hoc";


### PR DESCRIPTION
On this PR #1076, the association helpers exports from the cozy-client index are missing