### PR TITLE
fix(filename): Get illegal characters from file name and returns them

### DIFF
--- a/docs/api/cozy-client/modules/models.file.md
+++ b/docs/api/cozy-client/modules/models.file.md
@@ -518,7 +518,7 @@ Move file to destination.
 | :------ | :------ | :------ | :------ |
 | `client` | [`CozyClient`](../classes/cozyclient.md) | `undefined` | The CozyClient instance |
 | `fileId` | `string` | `undefined` | The file's id (required) |
-| `destination` | `Object` | `undefined` |  |
+| `destination` | `Object` | `undefined` | The destination object containing: |
 | `destination.folderId` | `string` | `undefined` | The destination folder's id (required) |
 | `destination.path` | `string` | `undefined` | The file's path after the move (optional, used to optimize performance in case of conflict) |
 | `force` | `boolean` | `false` | Whether we should overwrite, i.e. put to trash, the destination in case of conflict (defaults to false). |

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -64,6 +64,9 @@ through OAuth.</p>
 <dt><a href="#isDocumentUpdateConflict">isDocumentUpdateConflict</a> ⇒ <code>boolean</code></dt>
 <dd><p>Helper to identify a document conflict</p>
 </dd>
+<dt><a href="#getIllegalCharacters">getIllegalCharacters</a> ⇒ <code>string</code></dt>
+<dd><p>Get the list of illegal characters in the file name</p>
+</dd>
 <dt><a href="#getIndexFields">getIndexFields</a> ⇒ <code>Array</code></dt>
 <dd><p>Compute fields that should be indexed for a mango
 query to work</p>
@@ -92,10 +95,6 @@ See <a href="https://docs.cozy.io/en/cozy-stack/sharing-design/#description-of-a
 </dd>
 <dt><a href="#getAccessToken">getAccessToken()</a> ⇒ <code>string</code></dt>
 <dd><p>Get the app token string</p>
-</dd>
-<dt><a href="#sanitizeAttributes">sanitizeAttributes(attributes)</a> ⇒ <code><a href="#FileAttributes">FileAttributes</a></code> | <code><a href="#DirectoryAttributes">DirectoryAttributes</a></code></dt>
-<dd><p>Sanitize Attribute for an io.cozy.files</p>
-<p>Currently juste the name</p>
 </dd>
 <dt><a href="#garbageCollect">garbageCollect()</a></dt>
 <dd><p>Delete outdated results from cache</p>
@@ -745,6 +744,10 @@ Creates directory or file.
 - Used by StackLink to support CozyClient.create('io.cozy.files', options)
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
+**Throws**:
+
+- <code>Error</code> - explaining reason why creation failed
+
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -758,6 +761,10 @@ updateFile - Updates a file's data
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
 **Returns**: <code>object</code> - Updated document  
+**Throws**:
+
+- <code>Error</code> - explaining reason why update failed
+
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1650,6 +1657,19 @@ Helper to identify a document conflict
 | --- | --- | --- |
 | error | <code>Error</code> | An error |
 
+<a name="getIllegalCharacters"></a>
+
+## getIllegalCharacters ⇒ <code>string</code>
+Get the list of illegal characters in the file name
+
+**Kind**: global constant  
+**Returns**: <code>string</code> - illegal characters separated by spaces  
+**Access**: public  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| name | <code>string</code> | the file name |
+
 <a name="getIndexFields"></a>
 
 ## getIndexFields ⇒ <code>Array</code>
@@ -1735,19 +1755,6 @@ Get the app token string
 **Kind**: global function  
 **Returns**: <code>string</code> - token  
 **See**: CozyStackClient.getAccessToken  
-<a name="sanitizeAttributes"></a>
-
-## sanitizeAttributes(attributes) ⇒ [<code>FileAttributes</code>](#FileAttributes) \| [<code>DirectoryAttributes</code>](#DirectoryAttributes)
-Sanitize Attribute for an io.cozy.files
-
-Currently juste the name
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| attributes | [<code>FileAttributes</code>](#FileAttributes) \| [<code>DirectoryAttributes</code>](#DirectoryAttributes) | Attributes of the created file/directory |
-
 <a name="garbageCollect"></a>
 
 ## garbageCollect()

--- a/packages/cozy-client/src/__tests__/fixtures.js
+++ b/packages/cozy-client/src/__tests__/fixtures.js
@@ -84,7 +84,8 @@ export const FILE_1 = {
   _id: 1,
   _rev: '3-bd9bb7286a094842b954d9e86429090d',
   _type: 'io.cozy.files',
-  label: 'File 1'
+  label: 'File 1',
+  name: 'New document name'
 }
 export const FILE_2 = {
   _id: 2,

--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -22,7 +22,7 @@ const FILENAME_WITH_EXTENSION_REGEX = /(.+)(\..*)$/
  * @returns {object}  {filename, extension}
  */
 export const splitFilename = file => {
-  if (!isString(file.name)) throw new Error('file should have a name property ')
+  if (!isString(file.name)) throw new Error('file should have a name property')
 
   if (file.type === 'file') {
     const match = file.name.match(FILENAME_WITH_EXTENSION_REGEX)
@@ -318,7 +318,7 @@ export const getFullpath = async (client, dirId, name) => {
  *
  * @param {CozyClient} client             - The CozyClient instance
  * @param   {string} fileId               - The file's id (required)
- * @param   {object} destination
+ * @param   {object} destination          - The destination object containing:
  * @param   {string} destination.folderId - The destination folder's id (required)
  * @param   {string} destination.path     - The file's path after the move (optional, used to optimize performance in case of conflict)
  * @param   {boolean} force               - Whether we should overwrite, i.e. put to trash, the destination in case of conflict (defaults to false).

--- a/packages/cozy-client/src/models/file.spec.js
+++ b/packages/cozy-client/src/models/file.spec.js
@@ -212,7 +212,9 @@ describe('File Model', () => {
     }
 
     it('should throw an error if the file is not correct', () => {
-      expect(() => fileModel.splitFilename({})).toThrow()
+      expect(() => fileModel.splitFilename({})).toThrow(
+        'file should have a name property'
+      )
       expect(() => fileModel.splitFilename({ name: null })).toThrow()
       expect(() => fileModel.splitFilename({ name: '' })).not.toThrow()
     })

--- a/packages/cozy-client/types/__tests__/fixtures.d.ts
+++ b/packages/cozy-client/types/__tests__/fixtures.d.ts
@@ -103,6 +103,7 @@ export namespace FILE_1 {
     export { _type_6 as _type };
     const label_6: string;
     export { label_6 as label };
+    export const name: string;
 }
 export namespace FILE_2 {
     const _id_7: number;

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -173,6 +173,67 @@ describe('FileCollection', () => {
     })
   })
 
+  describe('create', () => {
+    it('file - should throw illegal characters errors when invalid file name', async () => {
+      expect.assertions(1)
+      try {
+        await collection.create({ name: 'incorrect/filename' })
+      } catch (error) {
+        expect(error.message).toEqual(
+          'Invalid filename containing illegal character(s): /'
+        )
+      }
+    })
+    it('file - should throw missing name errors when name is multiple spaces', async () => {
+      expect.assertions(1)
+      try {
+        await collection.create({ name: '   ' })
+      } catch (error) {
+        expect(error.message).toEqual('Missing name argument')
+      }
+    })
+
+    it('file - should throw incorrect file name errors when name is forbidden', async () => {
+      expect.assertions(1)
+      try {
+        await collection.create({ name: '..' })
+      } catch (error) {
+        expect(error.message).toEqual('Invalid filename: ..')
+      }
+    })
+
+    it('directory - should throw illegal characters errors when invalid file name', async () => {
+      expect.assertions(1)
+      try {
+        await collection.create({
+          name: 'incorrect/filename',
+          type: 'directory'
+        })
+      } catch (error) {
+        expect(error.message).toEqual(
+          'Invalid filename containing illegal character(s): /'
+        )
+      }
+    })
+    it('directory - should throw missing name errors when name is multiple spaces', async () => {
+      expect.assertions(1)
+      try {
+        await collection.create({ name: '   ', type: 'directory' })
+      } catch (error) {
+        expect(error.message).toEqual('Missing name argument')
+      }
+    })
+
+    it('directory - should throw incorrect file name errors when name is forbidden', async () => {
+      expect.assertions(1)
+      try {
+        await collection.create({ name: '..', type: 'directory' })
+      } catch (error) {
+        expect(error.message).toEqual('Invalid filename: ..')
+      }
+    })
+  })
+
   describe('createDirectory', () => {
     const NEW_DIR = {
       name: 'notes',
@@ -454,9 +515,56 @@ describe('FileCollection', () => {
       client.fetchJSON.mockClear()
     })
 
+    it('should not fetch json when file name is not valid', async () => {
+      try {
+        await collection.updateAttributes('42', {
+          dir_id: '123',
+          name: 'incorrect / name'
+        })
+      } catch (error) {
+        expect(client.fetchJSON.mock.calls.length).toEqual(0)
+      }
+    })
+
+    it('should throw error when file name contains illegal characters', async () => {
+      try {
+        await collection.updateAttributes('42', {
+          dir_id: '123',
+          name: 'incorrect / name'
+        })
+      } catch (error) {
+        expect(error.message).toEqual(
+          'Invalid filename containing illegal character(s): /'
+        )
+      }
+    })
+
+    it('should throw error when file name is forbidden', async () => {
+      try {
+        await collection.updateAttributes('42', {
+          dir_id: '123',
+          name: '.'
+        })
+      } catch (error) {
+        expect(error.message).toEqual('Invalid filename: .')
+      }
+    })
+
+    it('should throw error when file name is only space', async () => {
+      try {
+        await collection.updateAttributes('42', {
+          dir_id: '123',
+          name: '    '
+        })
+      } catch (error) {
+        expect(error.message).toEqual('Missing name argument')
+      }
+    })
+
     it('should call the right route', async () => {
       await collection.updateAttributes('42', {
-        dir_id: '123'
+        dir_id: '123',
+        name: 'correct-name'
       })
       expect(client.fetchJSON.mock.calls.length).toBeGreaterThan(0)
       expect(
@@ -528,6 +636,62 @@ describe('FileCollection', () => {
 
     afterEach(() => {
       client.fetchJSON.mockClear()
+    })
+
+    it('should not fetch json when file name is not valid', async () => {
+      try {
+        const data = new File([''], 'mydoc.epub')
+        const params = {
+          fileId: '59140416-b95f',
+          name: '/'
+        }
+        await collection.updateFile(data, params)
+      } catch (error) {
+        expect(client.fetchJSON.mock.calls.length).toEqual(0)
+      }
+    })
+
+    it('should throw error when file name contains illegal characters', async () => {
+      try {
+        const data = new File([''], 'mydoc.epub')
+        const params = {
+          fileId: '59140416-b95f',
+          name: 'illegal/characters'
+        }
+        await collection.updateFile(data, params)
+      } catch (error) {
+        expect(error.message).toEqual(
+          'Invalid filename containing illegal character(s): /'
+        )
+      }
+    })
+
+    it('should throw error when file name is forbidden', async () => {
+      try {
+        const data = new File([''], 'mydoc.epub')
+        const params = {
+          fileId: '59140416-b95f',
+          name: '..'
+        }
+        await collection.updateFile(data, params)
+      } catch (error) {
+        expect(error.message).toEqual('Invalid filename: ..')
+      }
+    })
+
+    it('should throw error when file name is only space', async () => {
+      try {
+        const data = new File([''], 'mydoc.epub')
+        const params = {
+          fileId: '59140416-b95f',
+          checksum: 'a6dabd99832b270468e254814df2ed20',
+          metadata: { type: 'bill' },
+          name: ' '
+        }
+        await collection.updateFile(data, params)
+      } catch (error) {
+        expect(error.message).toEqual('Missing name argument')
+      }
     })
 
     it('should update a file without metadata', async () => {

--- a/packages/cozy-stack-client/src/ShortcutsCollection.js
+++ b/packages/cozy-stack-client/src/ShortcutsCollection.js
@@ -1,5 +1,6 @@
 import DocumentCollection from './DocumentCollection'
 import { uri } from './utils'
+import { getIllegalCharacters } from './getIllegalCharacter'
 
 export const SHORTCUTS_DOCTYPE = 'io.cozy.files.shortcuts'
 
@@ -14,14 +15,30 @@ class ShortcutsCollection extends DocumentCollection {
    * @param {string} attributes.name Filename
    * @param {string} attributes.url Shortcut's URL
    * @param {string} attributes.dir_id dir_id where to create the shortcut
+   * @throws {Error} - explaining reason why creation failed
    */
   async create(attributes) {
     if (!attributes.type) {
       attributes.type = SHORTCUTS_DOCTYPE
     }
-    if (!attributes.name || !attributes.url || !attributes.dir_id) {
+    if (
+      !attributes.name ||
+      !attributes.name.trim() ||
+      !attributes.url ||
+      !attributes.dir_id
+    ) {
       throw new Error(
         'you need at least a name, an url and a dir_id attributes to create a shortcut'
+      )
+    }
+    const name = attributes.name.trim()
+    if (name === '.' || name === '..') {
+      throw new Error(`Invalid filename: ${name}`)
+    }
+    const illegalCharacters = getIllegalCharacters(name)
+    if (illegalCharacters.length) {
+      throw new Error(
+        `Invalid filename containing illegal character(s): ${illegalCharacters}`
       )
     }
     const path = uri`/shortcuts`

--- a/packages/cozy-stack-client/src/ShortcutsCollection.spec.js
+++ b/packages/cozy-stack-client/src/ShortcutsCollection.spec.js
@@ -54,6 +54,57 @@ describe('ShortcutsCollection', () => {
     it('throws an error if all required attributes are not there', async () => {
       await expect(collection.create({})).rejects.toThrow()
     })
+
+    it('should throw error when file name is incorrect', async () => {
+      try {
+        await collection.create({
+          dir_id: '629fb233be550a21174ac8e19f003e4a',
+          name: 'cozy/url',
+          url: 'https://cozy/io'
+        })
+      } catch (error) {
+        expect(error.message).toEqual(
+          'Invalid filename containing illegal character(s): /'
+        )
+      }
+    })
+    it('should throw error when file name is incorrect', async () => {
+      try {
+        await collection.create({
+          dir_id: '629fb233be550a21174ac8e19f003e4a',
+          name: '..',
+          url: 'https://cozy/io'
+        })
+      } catch (error) {
+        expect(error.message).toEqual('Invalid filename: ..')
+      }
+    })
+    it('should throw error when name is space', async () => {
+      try {
+        await collection.create({
+          dir_id: '629fb233be550a21174ac8e19f003e4a',
+          name: '   ',
+          url: 'https://cozy/io'
+        })
+      } catch (error) {
+        expect(error.message).toEqual(
+          'you need at least a name, an url and a dir_id attributes to create a shortcut'
+        )
+      }
+    })
+    it('should throw error when name is undefined', async () => {
+      try {
+        await collection.create({
+          dir_id: '629fb233be550a21174ac8e19f003e4a',
+          name: undefined,
+          url: 'https://cozy/io'
+        })
+      } catch (error) {
+        expect(error.message).toEqual(
+          'you need at least a name, an url and a dir_id attributes to create a shortcut'
+        )
+      }
+    })
   })
 
   describe('get', () => {

--- a/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
+++ b/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
@@ -207,6 +207,7 @@ Array [
     "data": Object {
       "attributes": Object {
         "dir_id": "123",
+        "name": "correct-name",
       },
       "id": "42",
       "type": "io.cozy.files",

--- a/packages/cozy-stack-client/src/getIllegalCharacter.js
+++ b/packages/cozy-stack-client/src/getIllegalCharacter.js
@@ -1,0 +1,12 @@
+/**
+ * Get the list of illegal characters in the file name
+ *
+ * @public
+ * @param {string} name - the file name
+ * @returns {string} illegal characters separated by spaces
+ */
+export const getIllegalCharacters = name => {
+  const FILENAME_ILLEGAL_CHARACTERS = /\/|\x00|\n|\r/g // eslint-disable-line no-control-regex
+  const match = name.match(FILENAME_ILLEGAL_CHARACTERS)
+  return match ? match.join(' ') : ''
+}

--- a/packages/cozy-stack-client/src/getIllegalCharacter.spec.js
+++ b/packages/cozy-stack-client/src/getIllegalCharacter.spec.js
@@ -1,0 +1,34 @@
+import { getIllegalCharacters } from './getIllegalCharacter'
+
+describe('getIllegalCharacters', () => {
+  it('should return empty string when no illegal characters found', () => {
+    const name =
+      'Valid file name with #@&"\'()§è!çà)-°_^¨*$€ù%`£=+:;.,?∞…÷≠≤<>•ë“‘{¶«Çø}æê®†Úºîœπ‡Ò∂ƒﬁÌÏÈ¬µ‹≈©◊ß~ '
+    expect(getIllegalCharacters(name)).toEqual('')
+  })
+
+  it('should return illegal characters split with spaces when illegal characters found', () => {
+    const name = 'Invalid file name with / and / and \x00 and \n and \r'
+    expect(getIllegalCharacters(name)).toEqual('/ / \x00 \n \r')
+  })
+
+  it('should return illegal characters split with spaces when / found', () => {
+    const name = 'Invalid file name with /'
+    expect(getIllegalCharacters(name)).toEqual('/')
+  })
+
+  it('should return illegal characters split with spaces when \x00 found', () => {
+    const name = 'Invalid file name with \x00'
+    expect(getIllegalCharacters(name)).toEqual('\x00')
+  })
+
+  it('should return illegal characters split with spaces when \n found', () => {
+    const name = 'Invalid file name with \n'
+    expect(getIllegalCharacters(name)).toEqual('\n')
+  })
+
+  it('should return illegal characters split with spaces when \r found', () => {
+    const name = 'Invalid file name with \r'
+    expect(getIllegalCharacters(name)).toEqual('\r')
+  })
+})


### PR DESCRIPTION
To alert in Drive when filename contains illegal characters instead of 'the name already exists'

[waiting for equivalent MR in cozy-drive](https://github.com/cozy/cozy-drive/pull/2442)