### PR TITLE
fix: Use fetchOwnPermissions instead of deprecated getOwnPermissions

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -176,6 +176,9 @@ not.</p>
 <dd><p>Attributes representing a design doc</p>
 </dd>
 <dt><a href="#Permission">Permission</a> ⇒ <code><a href="#Permission">Permission</a></code></dt>
+<dd><p>async getOwnPermissions - deprecated: please use fetchOwnPermissions instead</p>
+</dd>
+<dt><a href="#Permission">Permission</a> ⇒ <code><a href="#Permission">Permission</a></code></dt>
 <dd><p>async fetchOwnPermissions - Fetches permissions</p>
 </dd>
 <dt><a href="#Rule">Rule</a> : <code>object</code></dt>
@@ -2200,6 +2203,13 @@ Attributes representing a design doc
 | language | <code>string</code> | The index language. Can be 'query' for mango index or 'javascript' for views. |
 | views | <code>object</code> | Views definition, i.e. the index. |
 
+<a name="Permission"></a>
+
+## Permission ⇒ [<code>Permission</code>](#Permission)
+async getOwnPermissions - deprecated: please use fetchOwnPermissions instead
+
+**Kind**: global typedef  
+**Returns**: [<code>Permission</code>](#Permission) - permission  
 <a name="Permission"></a>
 
 ## Permission ⇒ [<code>Permission</code>](#Permission)

--- a/packages/cozy-client/src/models/permission.js
+++ b/packages/cozy-client/src/models/permission.js
@@ -51,7 +51,7 @@ export function isReadOnly(perm, options = {}) {
  */
 export async function fetchOwn(client) {
   const collection = client.collection('io.cozy.permissions')
-  const data = await collection.getOwnPermissions()
+  const data = await collection.fetchOwnPermissions()
   const permissions = get(data, 'data.attributes.permissions')
   if (!permissions) throw `Can't get self permissions`
   return Object.values(permissions)

--- a/packages/cozy-client/src/models/permission.spec.js
+++ b/packages/cozy-client/src/models/permission.spec.js
@@ -42,7 +42,7 @@ function setupClient(verbs = [], ids = ['first', 'other']) {
   return {
     query: async data => data,
     collection: () => ({
-      getOwnPermissions: async () => ({
+      fetchOwnPermissions: async () => ({
         data: {
           id: '9385e37389cb9f71a230168f245df2f8',
           _id: '9385e37389cb9f71a230168f245df2f8',

--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -194,12 +194,20 @@ class PermissionCollection extends DocumentCollection {
     }
   }
 
+  /**
+   * async getOwnPermissions - deprecated: please use fetchOwnPermissions instead
+   *
+   * @typedef {object} Permission
+   *
+   * @returns {Permission} permission
+   */
   async getOwnPermissions() {
     console.warn(
       'getOwnPermissions is deprecated, please use fetchOwnPermissions instead'
     )
     return this.fetchOwnPermissions()
   }
+
   /**
    * async fetchOwnPermissions - Fetches permissions
    *


### PR DESCRIPTION
- prevent warnings in app consuming permission