### PR TITLE
Feat/flagship certification

### DIFF
--- a/docs/api/cozy-client/classes/cozyclient.md
+++ b/docs/api/cozy-client/classes/cozyclient.md
@@ -43,7 +43,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:122](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L122)
+[packages/cozy-client/src/CozyClient.js:124](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L124)
 
 ## Properties
 
@@ -53,7 +53,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:156](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L156)
+[packages/cozy-client/src/CozyClient.js:158](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L158)
 
 ***
 
@@ -63,7 +63,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:179](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L179)
+[packages/cozy-client/src/CozyClient.js:181](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L181)
 
 ***
 
@@ -73,7 +73,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:175](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L175)
+[packages/cozy-client/src/CozyClient.js:177](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L177)
 
 ***
 
@@ -83,7 +83,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1527](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1527)
+[packages/cozy-client/src/CozyClient.js:1534](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1534)
 
 ***
 
@@ -93,7 +93,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:163](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L163)
+[packages/cozy-client/src/CozyClient.js:165](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L165)
 
 ***
 
@@ -103,7 +103,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:162](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L162)
+[packages/cozy-client/src/CozyClient.js:164](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L164)
 
 ***
 
@@ -113,7 +113,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:470](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L470)
+[packages/cozy-client/src/CozyClient.js:472](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L472)
 
 ***
 
@@ -123,7 +123,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:172](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L172)
+[packages/cozy-client/src/CozyClient.js:174](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L174)
 
 ***
 
@@ -133,7 +133,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:447](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L447)
+[packages/cozy-client/src/CozyClient.js:449](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L449)
 
 ***
 
@@ -158,7 +158,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:158](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L158)
+[packages/cozy-client/src/CozyClient.js:160](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L160)
 
 ***
 
@@ -168,7 +168,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:184](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L184)
+[packages/cozy-client/src/CozyClient.js:186](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L186)
 
 ***
 
@@ -178,7 +178,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:160](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L160)
+[packages/cozy-client/src/CozyClient.js:162](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L162)
 
 ***
 
@@ -188,7 +188,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:177](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L177)
+[packages/cozy-client/src/CozyClient.js:179](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L179)
 
 ***
 
@@ -198,7 +198,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1503](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1503)
+[packages/cozy-client/src/CozyClient.js:1510](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1510)
 
 ***
 
@@ -208,7 +208,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1436](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1436)
+[packages/cozy-client/src/CozyClient.js:1443](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1443)
 
 ***
 
@@ -218,7 +218,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:197](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L197)
+[packages/cozy-client/src/CozyClient.js:199](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L199)
 
 ***
 
@@ -238,7 +238,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1234](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1234)
+[packages/cozy-client/src/CozyClient.js:1236](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1236)
 
 ***
 
@@ -283,7 +283,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:450](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L450)
+[packages/cozy-client/src/CozyClient.js:452](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L452)
 
 ***
 
@@ -303,7 +303,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:406](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L406)
+[packages/cozy-client/src/CozyClient.js:408](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L408)
 
 ***
 
@@ -323,7 +323,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:547](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L547)
+[packages/cozy-client/src/CozyClient.js:549](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L549)
 
 ***
 
@@ -343,7 +343,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1369](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1369)
+[packages/cozy-client/src/CozyClient.js:1376](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1376)
 
 ***
 
@@ -359,7 +359,7 @@ Returns whether the client has been revoked on the server
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1450](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1450)
+[packages/cozy-client/src/CozyClient.js:1457](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1457)
 
 ***
 
@@ -384,7 +384,7 @@ Collection corresponding to the doctype
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:539](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L539)
+[packages/cozy-client/src/CozyClient.js:541](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L541)
 
 ***
 
@@ -422,7 +422,7 @@ await client.create('io.cozy.todos', {
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:594](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L594)
+[packages/cozy-client/src/CozyClient.js:596](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L596)
 
 ***
 
@@ -443,7 +443,7 @@ If `oauth` options are passed, stackClient is an OAuthStackClient.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1484](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1484)
+[packages/cozy-client/src/CozyClient.js:1491](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1491)
 
 ***
 
@@ -468,7 +468,7 @@ The document that has been deleted
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:836](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L836)
+[packages/cozy-client/src/CozyClient.js:838](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L838)
 
 ***
 
@@ -488,7 +488,7 @@ The document that has been deleted
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1555](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1555)
+[packages/cozy-client/src/CozyClient.js:1562](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1562)
 
 ***
 
@@ -514,7 +514,7 @@ a method from cozy-client
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:224](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L224)
+[packages/cozy-client/src/CozyClient.js:226](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L226)
 
 ***
 
@@ -536,7 +536,7 @@ a method from cozy-client
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:656](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L656)
+[packages/cozy-client/src/CozyClient.js:658](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L658)
 
 ***
 
@@ -560,7 +560,7 @@ Makes sure that the query exists in the store
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:857](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L857)
+[packages/cozy-client/src/CozyClient.js:859](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L859)
 
 ***
 
@@ -574,7 +574,7 @@ Makes sure that the query exists in the store
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1441](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1441)
+[packages/cozy-client/src/CozyClient.js:1448](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1448)
 
 ***
 
@@ -597,7 +597,7 @@ Makes sure that the query exists in the store
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:543](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L543)
+[packages/cozy-client/src/CozyClient.js:545](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L545)
 
 ***
 
@@ -624,7 +624,7 @@ Query state
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1330](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1330)
+[packages/cozy-client/src/CozyClient.js:1332](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1332)
 
 ***
 
@@ -645,7 +645,7 @@ Query state
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:556](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L556)
+[packages/cozy-client/src/CozyClient.js:558](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L558)
 
 ***
 
@@ -659,7 +659,7 @@ Query state
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1210](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1210)
+[packages/cozy-client/src/CozyClient.js:1212](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1212)
 
 ***
 
@@ -680,7 +680,7 @@ Query state
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:563](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L563)
+[packages/cozy-client/src/CozyClient.js:565](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L565)
 
 ***
 
@@ -703,7 +703,7 @@ Creates an association that is linked to the store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1217](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1217)
+[packages/cozy-client/src/CozyClient.js:1219](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1219)
 
 ***
 
@@ -717,7 +717,7 @@ Creates an association that is linked to the store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1537](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1537)
+[packages/cozy-client/src/CozyClient.js:1544](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1544)
 
 ***
 
@@ -741,7 +741,7 @@ Array of documents or null if the collection does not exist.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1253](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1253)
+[packages/cozy-client/src/CozyClient.js:1255](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1255)
 
 ***
 
@@ -766,7 +766,7 @@ Document or null if the object does not exist.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1270](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1270)
+[packages/cozy-client/src/CozyClient.js:1272](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1272)
 
 ***
 
@@ -801,7 +801,7 @@ One or more mutation to execute
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:749](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L749)
+[packages/cozy-client/src/CozyClient.js:751](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L751)
 
 ***
 
@@ -821,7 +821,7 @@ One or more mutation to execute
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1137](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1137)
+[packages/cozy-client/src/CozyClient.js:1139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1139)
 
 ***
 
@@ -837,7 +837,7 @@ getInstanceOptions - Returns current instance options, such as domain or app slu
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1564](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1564)
+[packages/cozy-client/src/CozyClient.js:1571](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1571)
 
 ***
 
@@ -864,7 +864,7 @@ Get a query from the internal store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1291](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1291)
+[packages/cozy-client/src/CozyClient.js:1293](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1293)
 
 ***
 
@@ -893,7 +893,7 @@ the store up, which in turn will update the `<Query>`s and re-render the data.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1233](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1233)
+[packages/cozy-client/src/CozyClient.js:1235](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1235)
 
 ***
 
@@ -907,7 +907,7 @@ the store up, which in turn will update the `<Query>`s and re-render the data.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1544](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1544)
+[packages/cozy-client/src/CozyClient.js:1551](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1551)
 
 ***
 
@@ -929,7 +929,7 @@ Sets public attribute and emits event related to revocation
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1455](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1455)
+[packages/cozy-client/src/CozyClient.js:1462](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1462)
 
 ***
 
@@ -951,7 +951,7 @@ Emits event when token is refreshed
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1466](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1466)
+[packages/cozy-client/src/CozyClient.js:1473](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1473)
 
 ***
 
@@ -977,7 +977,7 @@ the relationship
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1180](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1180)
+[packages/cozy-client/src/CozyClient.js:1182](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1182)
 
 ***
 
@@ -1002,7 +1002,7 @@ Instead, the relationships will have null documents.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1157](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1157)
+[packages/cozy-client/src/CozyClient.js:1159](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1159)
 
 ***
 
@@ -1023,7 +1023,7 @@ Instead, the relationships will have null documents.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1191](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1191)
+[packages/cozy-client/src/CozyClient.js:1193](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1193)
 
 ***
 
@@ -1037,7 +1037,7 @@ Instead, the relationships will have null documents.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1353](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1353)
+[packages/cozy-client/src/CozyClient.js:1355](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1355)
 
 ***
 
@@ -1059,7 +1059,7 @@ loadInstanceOptionsFromDOM - Loads the dataset injected by the Stack in web page
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1575](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1575)
+[packages/cozy-client/src/CozyClient.js:1582](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1582)
 
 ***
 
@@ -1093,7 +1093,7 @@ Emits
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:439](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L439)
+[packages/cozy-client/src/CozyClient.js:441](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L441)
 
 ***
 
@@ -1116,7 +1116,7 @@ Emits
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:486](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L486)
+[packages/cozy-client/src/CozyClient.js:488](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L488)
 
 ***
 
@@ -1140,7 +1140,7 @@ and working.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1203](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1203)
+[packages/cozy-client/src/CozyClient.js:1205](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1205)
 
 ***
 
@@ -1161,7 +1161,7 @@ and working.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:979](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L979)
+[packages/cozy-client/src/CozyClient.js:981](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L981)
 
 ***
 
@@ -1187,7 +1187,7 @@ Mutate a document
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:997](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L997)
+[packages/cozy-client/src/CozyClient.js:999](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L999)
 
 ***
 
@@ -1207,7 +1207,7 @@ Mutate a document
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:225](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L225)
+[packages/cozy-client/src/CozyClient.js:227](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L227)
 
 ***
 
@@ -1229,7 +1229,7 @@ Dehydrates and adds metadata before saving a document
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:720](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L720)
+[packages/cozy-client/src/CozyClient.js:722](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L722)
 
 ***
 
@@ -1256,7 +1256,7 @@ executes its query when mounted if no fetch policy has been indicated.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:880](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L880)
+[packages/cozy-client/src/CozyClient.js:882](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L882)
 
 ***
 
@@ -1283,7 +1283,7 @@ All documents matching the query
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:944](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L944)
+[packages/cozy-client/src/CozyClient.js:946](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L946)
 
 ***
 
@@ -1317,7 +1317,7 @@ All documents matching the query
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1551](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1551)
+[packages/cozy-client/src/CozyClient.js:1558](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1558)
 
 ***
 
@@ -1343,7 +1343,7 @@ Contains the fetched token and the client information.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1347](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1347)
+[packages/cozy-client/src/CozyClient.js:1349](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1349)
 
 ***
 
@@ -1357,7 +1357,7 @@ Contains the fetched token and the client information.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:410](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L410)
+[packages/cozy-client/src/CozyClient.js:412](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L412)
 
 ***
 
@@ -1425,7 +1425,7 @@ client.plugins.alerts
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:275](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L275)
+[packages/cozy-client/src/CozyClient.js:277](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L277)
 
 ***
 
@@ -1445,7 +1445,7 @@ client.plugins.alerts
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:226](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L226)
+[packages/cozy-client/src/CozyClient.js:228](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L228)
 
 ***
 
@@ -1464,7 +1464,7 @@ Contains the fetched token and the client information.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1400](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1400)
+[packages/cozy-client/src/CozyClient.js:1407](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1407)
 
 ***
 
@@ -1484,7 +1484,7 @@ Contains the fetched token and the client information.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1121](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1121)
+[packages/cozy-client/src/CozyClient.js:1123](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1123)
 
 ***
 
@@ -1507,7 +1507,7 @@ Create or update a document on the server
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:616](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L616)
+[packages/cozy-client/src/CozyClient.js:618](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L618)
 
 ***
 
@@ -1533,7 +1533,7 @@ Saves multiple documents in one batch
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:634](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L634)
+[packages/cozy-client/src/CozyClient.js:636](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L636)
 
 ***
 
@@ -1557,7 +1557,7 @@ set some data in the store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1596](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1596)
+[packages/cozy-client/src/CozyClient.js:1603](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1603)
 
 ***
 
@@ -1579,7 +1579,7 @@ At any time put an error function
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1608](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1608)
+[packages/cozy-client/src/CozyClient.js:1615](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1615)
 
 ***
 
@@ -1617,7 +1617,7 @@ use options.force = true.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1426](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1426)
+[packages/cozy-client/src/CozyClient.js:1433](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1433)
 
 ***
 
@@ -1641,7 +1641,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1363](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1363)
+[packages/cozy-client/src/CozyClient.js:1365](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1365)
 
 ***
 
@@ -1655,7 +1655,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1615](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1615)
+[packages/cozy-client/src/CozyClient.js:1622](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1622)
 
 ***
 
@@ -1676,7 +1676,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:821](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L821)
+[packages/cozy-client/src/CozyClient.js:823](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L823)
 
 ***
 
@@ -1698,7 +1698,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:846](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L846)
+[packages/cozy-client/src/CozyClient.js:848](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L848)
 
 ***
 
@@ -1718,7 +1718,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:605](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L605)
+[packages/cozy-client/src/CozyClient.js:607](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L607)
 
 ***
 
@@ -1738,7 +1738,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:972](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L972)
+[packages/cozy-client/src/CozyClient.js:974](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L974)
 
 ***
 
@@ -1764,7 +1764,7 @@ the DOM.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:373](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L373)
+[packages/cozy-client/src/CozyClient.js:375](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L375)
 
 ***
 
@@ -1788,7 +1788,7 @@ environment variables
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:345](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L345)
+[packages/cozy-client/src/CozyClient.js:347](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L347)
 
 ***
 
@@ -1812,7 +1812,7 @@ a client with a cookie-based instance of cozy-client-js.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:299](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L299)
+[packages/cozy-client/src/CozyClient.js:301](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L301)
 
 ***
 
@@ -1840,7 +1840,7 @@ An instance of a client, configured from the old client
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:317](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L317)
+[packages/cozy-client/src/CozyClient.js:319](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L319)
 
 ***
 
@@ -1874,4 +1874,4 @@ There are at the moment only 2 hooks available.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:815](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L815)
+[packages/cozy-client/src/CozyClient.js:817](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L817)

--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -67,7 +67,8 @@
     "react": "^16.7.0",
     "react-native": "^0.65.0",
     "react-native-google-safetynet": "0.0.4",
-    "react-native-inappbrowser-reborn": "^3.5.1"
+    "react-native-inappbrowser-reborn": "^3.5.1",
+    "react-native-ios11-devicecheck": "https://github.com/cozy/react-native-devicecheck#app-attest-v0.1"
   },
   "sideEffects": false
 }

--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -66,6 +66,7 @@
     "cozy-ui": ">34.0.0",
     "react": "^16.7.0",
     "react-native": "^0.65.0",
+    "react-native-google-safetynet": "0.0.4",
     "react-native-inappbrowser-reborn": "^3.5.1"
   },
   "sideEffects": false

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -65,6 +65,8 @@ import { QueryIDGenerator } from './store/queries'
 import stringify from 'json-stable-stringify'
 import PromiseCache from './promise-cache'
 
+import { certifyFlagship } from './flagship-certification/flagship-certification'
+
 const ensureArray = arr => (Array.isArray(arr) ? arr : [arr])
 
 const deprecatedHandler = msg => ({
@@ -1363,6 +1365,11 @@ client.query(Q('io.cozy.bills'))`)
   async startOAuthFlow(openURLCallback) {
     const stackClient = this.getStackClient()
     await stackClient.register()
+
+    if (stackClient.oauthOptions.shouldRequireFlagshipPermissions) {
+      await certifyFlagship(stackClient.oauthOptions.certificationConfig, this)
+    }
+
     return this.authorize(openURLCallback)
   }
 

--- a/packages/cozy-client/src/flagship-certification/README.md
+++ b/packages/cozy-client/src/flagship-certification/README.md
@@ -1,0 +1,86 @@
+# Flagship certification
+
+Flagship certification is the process of verifying that the current running app is a genuine Cozy application.
+
+This verification is done by querying an app certificate from the app store (Apple AppStore or Google Play) and sending  the resulting certificate to `cozy-stack`. Then `cozy-stack` will be able to an analyze the certificate and conclude if the app is genuine or not.
+
+## Nomenclature
+
+- `flagship`: refers to the Cozy main application
+- `store certification`: process of verifying app's genuineness through the platform's store 
+- `attestation`: result from the `store certification`
+- `challenge`: unique token given to the app by `cozy-stack` that may be encrypted in the `attestation` as a proof of authenticity
+- `nonce`: data type used to store the `challenge` token
+- `SafetyNet`: Google's implementation of the `store certification`
+- `AppAttest`: Apple's implementation of the `store certification`
+
+## Android certification
+
+Android certification is based on [SafetyNet](https://developer.android.com/training/safetynet/index.html).
+
+This process requires to query a `challenge` from `cozy-stack` and to use it to init the `store certification` process through `SafetyNet`. Then the received `attestation` is send to `cozy-stack` for verification.
+
+The resulting `attestation` is in the form of a `JSON Web Signature` that embbed the following `JSON`:
+```json
+{
+    "apkCertificateDigestSha256": [
+        "base64 encoded, SHA-256 hash of the certificate used to sign requesting app="
+    ],
+    "apkDigestSha256": "kNv83tJLFqwliYQ/6HUPCeGkBzLLCX/nvT+EF3OEB2I=",
+    "apkPackageName": "com.package.name.of.requesting.app",
+    "basicIntegrity": true,
+    "ctsProfileMatch": true, 
+    "evaluationType": "BASIC",
+    "nonce": "R2Rra24fVm5xa2Mg",
+    "timestampMs": 9860437986543
+}
+```
+
+The `attestation`'s content is described in the SafetyNet's documentation: https://developer.android.com/training/safetynet/attestation#use-response-server
+
+## iOS certification
+
+iOS certification is based on [AppAttest](https://developer.apple.com/documentation/devicecheck).
+
+This process requires to query a `challenge` from `cozy-stack` and to use it to init the `store certification` process through `AppAttest`. Then the received `attestation` is send to `cozy-stack` for verification.
+
+The resulting `attestation` is in the form of a `base64` token.
+
+The `attestation`'s content is described in the `AppAttest`'s documentation: https://developer.apple.com/documentation/devicecheck/validating_apps_that_connect_to_your_server#3576643
+
+## Client's configuration
+
+In order to configure `flagship` certification on an app, the OAuth property of `cozy-client` must contain `shouldRequireFlagshipPermissions` property set to `true` and `certificationConfig` property filled with required API keys.
+
+Example of `cozy-client` configuration:
+```js
+const client = await initClient(uri, {
+    scope: [
+      'io.cozy.apps'
+    ],
+    oauth: {
+      redirectURI: 'REDIRECT_URI',
+      softwareID: 'YOUR_APP_ID',
+      clientKind: 'mobile',
+      clientName: 'YOUR_APP_NAME',
+      shouldRequireFlagshipPermissions: true,
+      certificationConfig: {
+        androidSafetyNetApiKey: 'YOUR_GOOGLE_SAFETY_NET_API_KEY'
+      }
+    },
+```
+
+## Stacks' configuration
+
+In order to certify an app, the `cozy-stack` needs to have the following data:
+- App's package name
+  - The app's package name is set on the react-native project
+  - It should be put in `flagship.apk_package_names` in the `cozy-stack`'s configuration file
+- iOS app's id
+  - The iOS app's id is the concatenation of the developper team's id and the app's package name as defined in the XCode project
+  - If team's id is `ABCDEFGHIJ` and package name is `io.cozy.some_app` then the resulting app's id should be `ABCDEFGHIJ.io.cozy.some_app`
+  - It should be put in `flagship.apple_app_ids` in the `cozy-stack`'s configuration file
+- Android app's certificate digest
+  - The Android certificate digest can be found in the Google Play app's Console, in `Configuration/App integrity` page
+  - The certificate digest is the `App signing key certificate` in SHA-256 format converted from HEX to base64
+  - It should be put in `flagship.apk_certificate_digests` in the `cozy-stack`'s configuration file

--- a/packages/cozy-client/src/flagship-certification/README.md
+++ b/packages/cozy-client/src/flagship-certification/README.md
@@ -82,5 +82,15 @@ In order to certify an app, the `cozy-stack` needs to have the following data:
   - It should be put in `flagship.apple_app_ids` in the `cozy-stack`'s configuration file
 - Android app's certificate digest
   - The Android certificate digest can be found in the Google Play app's Console, in `Configuration/App integrity` page
+    - On local dev environment, the dev certificate location is:
+      - On a ReactNative project: `<project_root>/android/app/debug.keystore`
+      - On an Android Studio project:
+        - On OSX: `~/.android/debug.keystore`
+        - On Windows: `%UserProfile%\.android\debug.keystore`
+      - On a Xamarin Project:
+        - On OSX: `~/.local/share/Xamarin/Mono for Android/debug.keystore`
+        - On Windows: `%LocalAppData%\Xamarin\Mono for Android\debug.keystore`
+    - To extract the certificat digest from local dev certificate:
+      - `keytool -list -v -keystore ./android/app/debug.keystore -alias androiddebugkey -storepass android -keypass android | grep "SHA256: " | cut -d " " -f 3 | xxd -r -p | openssl base64`
   - The certificate digest is the `App signing key certificate` in SHA-256 format converted from HEX to base64
   - It should be put in `flagship.apk_certificate_digests` in the `cozy-stack`'s configuration file

--- a/packages/cozy-client/src/flagship-certification/flagship-certification.js
+++ b/packages/cozy-client/src/flagship-certification/flagship-certification.js
@@ -1,0 +1,93 @@
+import CozyClient from '../CozyClient'
+
+import { getAppAttestationFromStore } from './store-attestation'
+
+/**
+ * Request a challenge from the Stack that can be used to request the app attestation from the app store
+ *
+ * @param {CozyClient} client - the CozyClient instance
+ * @returns {Promise<string>} - the Nonce string returned by the stack
+ */
+const getStackChallenge = async client => {
+  try {
+    const stackClient = client.getStackClient()
+
+    const result = await stackClient.fetchJSON(
+      'POST',
+      `/auth/clients/${stackClient.oauthOptions.clientID}/challenge`,
+      null,
+      {
+        headers: {
+          Authorization: stackClient.registrationAccessTokenToAuthHeader()
+        }
+      }
+    )
+
+    return result.nonce
+  } catch (e) {
+    throw new Error(
+      '[FLAGSHIP_CERTIFICATION] Something went wrong while requesting a challenge from CozyStack:\n' +
+        e.message
+    )
+  }
+}
+
+/**
+ * Give the app attestation to the Stack
+ *
+ * @param {AttestationResult} appAttestation - the app attestation that was returned by the app store
+ * @param {string} nonce - the Nonce string retrieved from the stack
+ * @param {CozyClient} client - the CozyClient instance
+ */
+const giveAppAttestationToStack = async (appAttestation, nonce, client) => {
+  try {
+    const { platform, attestation, keyId } = appAttestation
+
+    const stackClient = client.getStackClient()
+
+    await stackClient.fetchJSON(
+      'POST',
+      `/auth/clients/${stackClient.oauthOptions.clientID}/attestation`,
+      {
+        platform: platform,
+        attestation: attestation,
+        challenge: nonce,
+        keyId: keyId
+      },
+      {
+        headers: {
+          Authorization: stackClient.registrationAccessTokenToAuthHeader()
+        }
+      }
+    )
+  } catch (e) {
+    throw new Error(
+      '[FLAGSHIP_CERTIFICATION] Something went wrong while giving attestation to CozyStack:\n' +
+        e.message
+    )
+  }
+}
+
+/**
+ * Verify app's identity and integrity so the Stack can trust it
+ * Verification is done on Stack side by using information from the app's store (Google Play or Apple AppStore)
+ *
+ * @param {CertificationConfig} certificationConfig - the required configuration to access the stores API
+ * @param {CozyClient} client - the CozyClient instance
+ */
+export const certifyFlagship = async (certificationConfig, client) => {
+  if (!certificationConfig) {
+    throw new Error(
+      '[FLAGSHIP_CERTIFICATION] Certification configuration is not set'
+    )
+  }
+
+  const stackChallengeNonce = await getStackChallenge(client)
+
+  const appAttestation = await getAppAttestationFromStore(
+    stackChallengeNonce,
+    certificationConfig
+  )
+
+  await giveAppAttestationToStack(appAttestation, stackChallengeNonce, client)
+}

--- a/packages/cozy-client/src/flagship-certification/store-attestation.android.js
+++ b/packages/cozy-client/src/flagship-certification/store-attestation.android.js
@@ -1,0 +1,31 @@
+//@ts-ignore
+import RNGoogleSafetyNet from 'react-native-google-safetynet'
+
+/**
+ * Retrieve the app's attestation from the Google Play store
+ *
+ * @param {string} nonce - the Nonce string retrieved from the stack
+ * @param {CertificationConfig} certificationConfig - Configuration to access the stores certification API
+ * @returns {Promise<AttestationResult>} the app's attestation
+ */
+export const getAppAttestationFromStore = async (
+  nonce,
+  certificationConfig
+) => {
+  try {
+    const attestationResult = await RNGoogleSafetyNet.sendAttestationRequestJWT(
+      nonce,
+      certificationConfig.androidSafetyNetApiKey
+    )
+
+    return {
+      platform: 'android',
+      attestation: attestationResult
+    }
+  } catch (e) {
+    throw new Error(
+      '[FLAGSHIP_CERTIFICATION] Something went wrong while requesting an attestation from Google Safetynet:\n' +
+        e.message
+    )
+  }
+}

--- a/packages/cozy-client/src/flagship-certification/store-attestation.ios.js
+++ b/packages/cozy-client/src/flagship-certification/store-attestation.ios.js
@@ -1,0 +1,31 @@
+//@ts-ignore
+import RNIOS11DeviceCheck from 'react-native-ios11-devicecheck'
+
+/**
+ * Retrieve the app's attestation from the Apple AppStore
+ *
+ * @param {string} nonce - the Nonce string retrieved from the stack
+ * @param {CertificationConfig} certificationConfig - Configuration to access the stores certification API
+ * @returns {Promise<AttestationResult>} the app's attestation
+ */
+export const getAppAttestationFromStore = async (
+  nonce,
+  certificationConfig
+) => {
+  try {
+    const keyId = await RNIOS11DeviceCheck.generateKey()
+
+    const attestKey = await RNIOS11DeviceCheck.attestKey(keyId, nonce)
+
+    return {
+      platform: 'ios',
+      attestation: attestKey,
+      keyId: keyId
+    }
+  } catch (e) {
+    throw new Error(
+      '[FLAGSHIP_CERTIFICATION] Something went wrong while requesting an attestation from Apple DeviceCheck:\n' +
+        e.message
+    )
+  }
+}

--- a/packages/cozy-client/src/flagship-certification/store-attestation.js
+++ b/packages/cozy-client/src/flagship-certification/store-attestation.js
@@ -1,0 +1,15 @@
+/**
+ * Retrieve the app's attestation from the app's store
+ * /!\ This is a mock implementation that should never be called
+ *
+ * @param {string} nonce - the Nonce string retrieved from the stack
+ * @param {CertificationConfig} certificationConfig - Configuration to access the stores certification API
+ * @returns {Promise<AttestationResult>} the app's attestation
+ */
+const validateAppMock = async (nonce, certificationConfig) => {
+  throw new Error(
+    `validateApp can only be called from a React Native container`
+  )
+}
+
+export const getAppAttestationFromStore = validateAppMock

--- a/packages/cozy-client/src/flagship-certification/typedefs.js
+++ b/packages/cozy-client/src/flagship-certification/typedefs.js
@@ -1,0 +1,23 @@
+/**
+ * A JSON Web Signature
+ * @typedef {string} jws
+ */
+
+/**
+ * A JSON Web Signature
+ * @typedef {string} base64string
+ */
+
+/**
+ * An app attestation from the app store
+ * @typedef {object} AttestationResult
+ * @property {string} platform
+ * @property {jws|base64string} attestation
+ * @property {string} [keyId]
+ */
+
+/**
+ * Configuration to access the stores certification API
+ * @typedef {object} CertificationConfig
+ * @property {string} androidSafetyNetApiKey
+ */

--- a/packages/cozy-client/types/flagship-certification/flagship-certification.d.ts
+++ b/packages/cozy-client/types/flagship-certification/flagship-certification.d.ts
@@ -1,0 +1,2 @@
+export function certifyFlagship(certificationConfig: CertificationConfig, client: CozyClient): Promise<void>;
+import CozyClient from "../CozyClient";

--- a/packages/cozy-client/types/flagship-certification/store-attestation.android.d.ts
+++ b/packages/cozy-client/types/flagship-certification/store-attestation.android.d.ts
@@ -1,0 +1,1 @@
+export function getAppAttestationFromStore(nonce: string, certificationConfig: CertificationConfig): Promise<AttestationResult>;

--- a/packages/cozy-client/types/flagship-certification/store-attestation.d.ts
+++ b/packages/cozy-client/types/flagship-certification/store-attestation.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Retrieve the app's attestation from the app's store
+ * /!\ This is a mock implementation that should never be called
+ *
+ * @param {string} nonce - the Nonce string retrieved from the stack
+ * @param {CertificationConfig} certificationConfig - Configuration to access the stores certification API
+ * @returns {Promise<AttestationResult>} the app's attestation
+ */
+export function getAppAttestationFromStore(nonce: string, certificationConfig: CertificationConfig): Promise<AttestationResult>;

--- a/packages/cozy-client/types/flagship-certification/store-attestation.ios.d.ts
+++ b/packages/cozy-client/types/flagship-certification/store-attestation.ios.d.ts
@@ -1,0 +1,1 @@
+export function getAppAttestationFromStore(nonce: string, certificationConfig: CertificationConfig): Promise<AttestationResult>;

--- a/packages/cozy-client/types/flagship-certification/typedefs.d.ts
+++ b/packages/cozy-client/types/flagship-certification/typedefs.d.ts
@@ -1,0 +1,22 @@
+/**
+ * A JSON Web Signature
+ */
+type jws = string;
+/**
+ * A JSON Web Signature
+ */
+type base64string = string;
+/**
+ * An app attestation from the app store
+ */
+type AttestationResult = {
+    platform: string;
+    attestation: jws | base64string;
+    keyId?: string;
+};
+/**
+ * Configuration to access the stores certification API
+ */
+type CertificationConfig = {
+    androidSafetyNetApiKey: string;
+};

--- a/packages/cozy-client/types/models/permission.d.ts
+++ b/packages/cozy-client/types/models/permission.d.ts
@@ -52,7 +52,7 @@ export type Document = {
     _type: string;
     type: string;
 };
-export type PermissionVerb = "DELETE" | "PUT" | "POST" | "GET" | "ALL" | "PATCH";
+export type PermissionVerb = "POST" | "DELETE" | "PUT" | "GET" | "ALL" | "PATCH";
 export type PermissionItem = {
     /**
      * - ALL, GET, PUT, PATCH, DELETE, POST…


### PR DESCRIPTION
Add ability to register to `cozy-stack` as a Cozy flagship app

Consumer app can now init `cozy-client` with
`oauth.shouldRequireFlagshipPermissions` set to `true` in order to
register itself as a flagship app

When doing this, the OAuth process can now query respective platform's
stores in order to get an attestation of genuineness that can be
analysed by `cozy-stack`

This mechanism requires to be in a ReactNative environment

____

Related PR : https://github.com/cozy/cozy-react-native/pull/56
____

Todo:

- [x] Implement Android SafetyNet
- [x] Implement iOS DeviceCheck
- [x] Document the process
- [x] Drop commit `tests: TEMPORARY LOGS`