### PR TITLE
fix: UseQuery returns fetch method

### DIFF
--- a/packages/cozy-client/src/hooks/useQuery.js
+++ b/packages/cozy-client/src/hooks/useQuery.js
@@ -84,7 +84,15 @@ const useQuery = (queryDefinition, options) => {
     return client.query(generateFetchMoreQueryDefinition(queryState), { as })
   }, [as, client])
 
-  return { ...queryState, fetchMore: fetchMore }
+  const fetch = useCallback(() => {
+    return client.query(definition, options)
+  }, [client, definition, options])
+
+  return {
+    ...queryState,
+    fetchMore: fetchMore,
+    fetch: fetch
+  }
 }
 
 export const useQueries = querySpecs => {

--- a/packages/cozy-client/src/hooks/useQuery.spec.jsx
+++ b/packages/cozy-client/src/hooks/useQuery.spec.jsx
@@ -52,6 +52,46 @@ describe('use query', () => {
     })
   })
 
+  it('should share the same API than ObservableQuery', () => {
+    const {
+      hookResult: {
+        result: { current }
+      }
+    } = setupQuery({
+      queryOptions: {
+        as: 'simpsons'
+      },
+      queryDefinition: () => Q('io.cozy.simpsons')
+    })
+    expect(current).toMatchObject({
+      data: [
+        expect.objectContaining({ name: 'Homer' }),
+        expect.objectContaining({ name: 'Marge' })
+      ],
+      definition: expect.objectContaining({
+        doctype: 'io.cozy.simpsons'
+      })
+    })
+
+    expect(Object.keys(current)).toEqual(
+      expect.objectContaining([
+        'id',
+        'definition',
+        'fetchStatus',
+        'lastFetch',
+        'lastUpdate',
+        'lastErrorUpdate',
+        'lastError',
+        'hasMore',
+        'count',
+        'data',
+        'bookmark',
+        'options',
+        'fetchMore',
+        'fetch'
+      ])
+    )
+  })
   it('should query through the client in context', () => {
     const { client } = setupQuery({
       queryOptions: {


### PR DESCRIPTION
fetch was missing from the API. So making
a request from <Query or with queryConnect
didn't share the same API than useQuery.

So let's fix it.

https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/ObservableQuery.js#L49-L51