### PR TITLE
feat: Use lib alias for safetynet

### DIFF
--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -66,7 +66,7 @@
     "cozy-ui": ">34.0.0",
     "react": "^16.7.0",
     "react-native": "^0.65.0",
-    "react-native-google-safetynet": "0.0.4",
+    "react-native-google-safetynet": "npm:cozy-react-native-google-safetynet@^1.0.0",
     "react-native-inappbrowser-reborn": "^3.5.1",
     "react-native-ios11-devicecheck": "https://github.com/cozy/react-native-devicecheck#app-attest-v0.1"
   },


### PR DESCRIPTION
This modifies the compileSdkVersion from 27 to 28 to avoid a compile bug when looking for sdk28 components