### PR TITLE
fix: Delete File

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -2277,6 +2277,7 @@ Document representing a io.cozy.files
 | attributes | [<code>FileAttributes</code>](#FileAttributes) | Attributes of the file |
 | meta | <code>object</code> | Meta |
 | relationships | <code>object</code> | Relationships |
+| referenced_by | <code>object</code> | Referenced by |
 
 <a name="Stream"></a>
 

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -308,10 +308,13 @@ class FileCollection extends DocumentCollection {
    * @returns {Promise<{data, meta}>}          The JSON API conformant response.
    */
   async removeReferencedBy(document, documents) {
-    const refs = documents.map(d => ({ id: d._id, type: d._type }))
+    const refs = documents.map(d => ({
+      id: d._id || d.id,
+      type: d._type || d.type
+    }))
     const resp = await this.stackClient.fetchJSON(
       'DELETE',
-      uri`/files/${document._id}/relationships/referenced_by`,
+      uri`/files/${document._id || document.id}/relationships/referenced_by`,
       { data: refs }
     )
     return {


### PR DESCRIPTION
- We should not remove the reference before
deleting the file. cozy-stack needs to know
if the document was shared before moving it
to the Trash in order to revoke the sharing

- Use the route to remove all the referenced_by
by doing only one request instead of one by
reference.