### PR TITLE
feat: Add rootCozyUrl helper

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -19,6 +19,8 @@ cozy-client
 *   [HasManyTriggers](classes/hasmanytriggers.md)
 *   [HasOne](classes/hasone.md)
 *   [HasOneInPlace](classes/hasoneinplace.md)
+*   [InvalidCozyUrlError](classes/invalidcozyurlerror.md)
+*   [InvalidProtocolError](classes/invalidprotocolerror.md)
 *   [Query](classes/query.md)
 *   [QueryDefinition](classes/querydefinition.md)
 *   [Registry](classes/registry.md)
@@ -482,6 +484,64 @@ if there are N queries, only 1 extra level of nesting is introduced.
 *Defined in*
 
 [packages/cozy-client/src/hoc.jsx:89](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hoc.jsx#L89)
+
+***
+
+### rootCozyUrl
+
+▸ `Const` **rootCozyUrl**(`url`): `Promise`<`URL`>
+
+rootCozyUrl - Get the root URL of a Cozy from more precise ones
+
+The goal is to allow users to use any URL copied from their browser as their
+Cozy URL rather than trying to explain to them what we expect (e.g. when
+requesting the Cozy URL to connect an app).
+If we can't get the root URL either because there's no Cozy or the domain
+does not exist or anything else, we'll throw an InvalidCozyUrlError.
+Also, since we communicate only via HTTP or HTTPS, we'll throw an
+InvalidProtocolError if any other protocol is used.
+
+This function expects a fully qualified URL thus with a protocol and a valid
+hostname. If your application accepts Cozy intances as input (e.g. `claude`
+when the Cozy can be found at `https://claude.mycozy.cloud`), it is your
+responsibility to add the appropriate domain to the hostname before calling
+this function.
+
+Examples:
+
+1.  getting the root URL when your user gives you its instance name
+
+const userInput = 'claude'
+const rootUrl = await rootCozyUrl(new URL(`https://${userInput}.mycozy.cloud`))
+// → returns new URL('https://claude.mycozy.cloud')
+
+2.  getting the root URL when your user gives you a Cozy Drive URL
+
+const userInput = 'https://claude-drive.mycozy.cloud/#/folder/io.cozy.files.root-dir'
+const rootUrl = await rootCozyUrl(new URL(userInput))
+// → returns new URL('https://claude.mycozy.cloud')
+
+3.  getting the root URL when the Cozy uses nested sub-domains
+
+const userInput = 'http://photos.camille.nimbus.com:8080/#/album/1234567890'
+const rootCozyUrl = await rootCozyUrl(new URL(userInput))
+// → returns new URL('http://camille.nimbus.com:8080')
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `url` | `URL` | The URL from which we'll try to get the root Cozy URL |
+
+*Returns*
+
+`Promise`<`URL`>
+
+The root Cozy URL
+
+*Defined in*
+
+[packages/cozy-client/src/helpers.js:199](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L199)
 
 ***
 

--- a/docs/api/cozy-client/classes/invalidcozyurlerror.md
+++ b/docs/api/cozy-client/classes/invalidcozyurlerror.md
@@ -1,0 +1,39 @@
+[cozy-client](../README.md) / InvalidCozyUrlError
+
+# Class: InvalidCozyUrlError
+
+## Hierarchy
+
+*   `Error`
+
+    ↳ **`InvalidCozyUrlError`**
+
+## Constructors
+
+### constructor
+
+• **new InvalidCozyUrlError**(`url`)
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `url` | `any` |
+
+*Overrides*
+
+Error.constructor
+
+*Defined in*
+
+[packages/cozy-client/src/helpers.js:87](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L87)
+
+## Properties
+
+### url
+
+• **url**: `any`
+
+*Defined in*
+
+[packages/cozy-client/src/helpers.js:89](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L89)

--- a/docs/api/cozy-client/classes/invalidprotocolerror.md
+++ b/docs/api/cozy-client/classes/invalidprotocolerror.md
@@ -1,0 +1,39 @@
+[cozy-client](../README.md) / InvalidProtocolError
+
+# Class: InvalidProtocolError
+
+## Hierarchy
+
+*   `Error`
+
+    ↳ **`InvalidProtocolError`**
+
+## Constructors
+
+### constructor
+
+• **new InvalidProtocolError**(`url`)
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `url` | `any` |
+
+*Overrides*
+
+Error.constructor
+
+*Defined in*
+
+[packages/cozy-client/src/helpers.js:79](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L79)
+
+## Properties
+
+### url
+
+• **url**: `any`
+
+*Defined in*
+
+[packages/cozy-client/src/helpers.js:81](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L81)

--- a/packages/cozy-client/src/helpers.js
+++ b/packages/cozy-client/src/helpers.js
@@ -75,3 +75,163 @@ export const generateWebLink = ({
 
   return url.toString()
 }
+
+export class InvalidProtocolError extends Error {
+  constructor(url) {
+    super(`Invalid URL protocol ${url.protocol}`)
+
+    this.url = url
+  }
+}
+
+export class InvalidCozyUrlError extends Error {
+  constructor(url) {
+    super(`URL ${url.toString()} does not seem to be a valid Cozy URL`)
+
+    this.url = url
+  }
+}
+
+/* uri - Returns a well formed URL origin from a protocol, a hostname and a port
+ *
+ * If the protocol and/or port are omitted from the argument, the function will
+ * default to HTTPS and omit the port in the returned origin.
+ *
+ * @param {object} url          Object of URL elements
+ * @param {string} url.protocol Protocol to use in the origin (e.g. http)
+ * @param {string} url.hostname Hostname to use in the origin (e.g. claude.mycozy.cloud)
+ * @param {string} url.port     Port to use in the origin (e.g. 8080)
+ *
+ * @returns {string} Generated URL origin
+ */
+const uri = ({ protocol, hostname, port }) => {
+  return (
+    (protocol !== '' ? `${protocol}//` : 'https://') +
+    hostname +
+    (port !== '' ? `:${port}` : '')
+  )
+}
+
+/* wellKnownUrl - Returns a valid URL string to a Well Known password change page
+ *
+ * The built URL will point to the origin generated from the given protocol,
+ * hostname and port.
+ *
+ * @param {object} url          Object of URL elements
+ * @param {string} url.protocol Protocol to use in the origin (e.g. http)
+ * @param {string} url.hostname Hostname to use in the origin (e.g. claude.mycozy.cloud)
+ * @param {string} url.port     Port to use in the origin (e.g. 8080)
+ *
+ * @returns {string} Generated Well Known password change URL string
+ */
+const wellKnownUrl = url => uri(url) + '/.well-known/change-password'
+
+/* isValidOrigin - Checks whether a given URL is a valid Cozy origin
+ *
+ * This method tries to fetch the Well Known change password page of the Cozy
+ * supposedly at the given origin. This allows us to determine whether the given
+ * origin is the root URL of a Cozy or not via the status of the response:
+ * - a 200 response status means there's an actual Well Known password change
+ *   page accessible from the given origin so we suppose it's a valid Cozy
+ *   origin (i.e. it could be another site altogether though)
+ * - a 401 response status means the pointed page requires authentication so the
+ *   origin is probably pointing to a Cozy app
+ * - another status means there aren't any Cozy behind to the given origin
+ *
+ * @param {object} url          Object of URL elements
+ * @param {string} url.protocol Protocol to use in the origin (e.g. http)
+ * @param {string} url.hostname Hostname to use in the origin (e.g. claude.mycozy.cloud)
+ * @param {string} url.port     Port to use in the origin (e.g. 8080)
+ *
+ * @returns {Promise<boolean>} True if we believe there's a Cozy behind the given origin
+ * @throws {InvalidCozyUrlError} Thrown when we know for sure there aren't any Cozy behind the given origin
+ */
+const isValidOrigin = async url => {
+  const { status } = await fetch(wellKnownUrl(url))
+
+  if (status === 404) {
+    throw new InvalidCozyUrlError(url)
+  }
+  return status === 200
+}
+
+/**
+ * rootCozyUrl - Get the root URL of a Cozy from more precise ones
+ *
+ * The goal is to allow users to use any URL copied from their browser as their
+ * Cozy URL rather than trying to explain to them what we expect (e.g. when
+ * requesting the Cozy URL to connect an app).
+ * If we can't get the root URL either because there's no Cozy or the domain
+ * does not exist or anything else, we'll throw an InvalidCozyUrlError.
+ * Also, since we communicate only via HTTP or HTTPS, we'll throw an
+ * InvalidProtocolError if any other protocol is used.
+ *
+ * This function expects a fully qualified URL thus with a protocol and a valid
+ * hostname. If your application accepts Cozy intances as input (e.g. `claude`
+ * when the Cozy can be found at `https://claude.mycozy.cloud`), it is your
+ * responsibility to add the appropriate domain to the hostname before calling
+ * this function.
+ *
+ * Examples:
+ *
+ * 1. getting the root URL when your user gives you its instance name
+ *
+ *   const userInput = 'claude'
+ *   const rootUrl = await rootCozyUrl(new URL(`https://${userInput}.mycozy.cloud`))
+ *   // → returns new URL('https://claude.mycozy.cloud')
+ *
+ * 2. getting the root URL when your user gives you a Cozy Drive URL
+ *
+ *   const userInput = 'https://claude-drive.mycozy.cloud/#/folder/io.cozy.files.root-dir'
+ *   const rootUrl = await rootCozyUrl(new URL(userInput))
+ *   // → returns new URL('https://claude.mycozy.cloud')
+ *
+ * 3. getting the root URL when the Cozy uses nested sub-domains
+ *
+ *   const userInput = 'http://photos.camille.nimbus.com:8080/#/album/1234567890'
+ *   const rootCozyUrl = await rootCozyUrl(new URL(userInput))
+ *   // → returns new URL('http://camille.nimbus.com:8080')
+ *
+ * @param {URL} url The URL from which we'll try to get the root Cozy URL
+ *
+ * @returns {Promise<URL>} The root Cozy URL
+ */
+export const rootCozyUrl = async url => {
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new InvalidProtocolError(url)
+  }
+
+  // If the entered URL is good, use it
+  if (await isValidOrigin(url)) {
+    return url
+  }
+
+  // If the entered URL's lowest sub-domain contains a dash, remove it and
+  // what follows and try the new resulting url.
+  if (/^[^.-][^.]+-[^.-]+\./.test(url.hostname)) {
+    const [subDomain, ...domain] = url.hostname.split('.')
+    const hostname = [subDomain.replace(/-.+/, ''), ...domain].join('.')
+
+    if (
+      await isValidOrigin({ protocol: url.protocol, hostname, port: url.port })
+    ) {
+      return new URL(uri({ protocol: url.protocol, hostname, port: url.port }))
+    }
+  }
+
+  // Try to remove the first sub-domain in case its a nested app name
+  // eslint-disable-next-line no-unused-vars
+  const hostname = url.hostname
+    .split('.')
+    .splice(1)
+    .join('.')
+  if (
+    await isValidOrigin({ protocol: url.protocol, hostname, port: url.port })
+  ) {
+    return new URL(uri({ protocol: url.protocol, hostname, port: url.port }))
+  }
+
+  // At this point, we've tried everything we could to correct the user's URL
+  // without success. So bail out and let the user provide a valid one.
+  throw new InvalidCozyUrlError(url)
+}

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -23,7 +23,13 @@ export {
   getReferencedBy,
   getReferencedById
 } from './associations/helpers'
-export { dehydrate, generateWebLink } from './helpers'
+export {
+  dehydrate,
+  generateWebLink,
+  rootCozyUrl,
+  InvalidCozyUrlError,
+  InvalidProtocolError
+} from './helpers'
 export { cancelable, isQueryLoading, hasQueryBeenLoaded } from './utils'
 export { getQueryFromState } from './store'
 export { default as Registry } from './registry'

--- a/packages/cozy-client/src/index.node.js
+++ b/packages/cozy-client/src/index.node.js
@@ -17,7 +17,13 @@ export {
   HasManyInPlace,
   HasManyTriggers
 } from './associations'
-export { dehydrate, generateWebLink } from './helpers'
+export {
+  dehydrate,
+  generateWebLink,
+  rootCozyUrl,
+  InvalidCozyUrlError,
+  InvalidProtocolError
+} from './helpers'
 export { cancelable } from './utils'
 export { getQueryFromState } from './store'
 export { default as Registry } from './registry'

--- a/packages/cozy-client/types/helpers.d.ts
+++ b/packages/cozy-client/types/helpers.d.ts
@@ -7,3 +7,12 @@ export function generateWebLink({ cozyUrl, searchParams: searchParamsOption, pat
     slug: string;
     subDomainType: string;
 }): string;
+export class InvalidProtocolError extends Error {
+    constructor(url: any);
+    url: any;
+}
+export class InvalidCozyUrlError extends Error {
+    constructor(url: any);
+    url: any;
+}
+export function rootCozyUrl(url: URL): Promise<URL>;

--- a/packages/cozy-client/types/index.d.ts
+++ b/packages/cozy-client/types/index.d.ts
@@ -19,6 +19,6 @@ export { manifest, models };
 export { QueryDefinition, Q, Mutations, MutationTypes, getDoctypeFromOperation } from "./queries/dsl";
 export { Association, HasMany, HasOne, HasOneInPlace, HasManyInPlace, HasManyTriggers } from "./associations";
 export { isReferencedBy, isReferencedById, getReferencedBy, getReferencedById } from "./associations/helpers";
-export { dehydrate, generateWebLink } from "./helpers";
+export { dehydrate, generateWebLink, rootCozyUrl, InvalidCozyUrlError, InvalidProtocolError } from "./helpers";
 export { cancelable, isQueryLoading, hasQueryBeenLoaded } from "./utils";
 export { queryConnect, queryConnectFlat, withClient } from "./hoc";

--- a/packages/cozy-client/types/index.node.d.ts
+++ b/packages/cozy-client/types/index.node.d.ts
@@ -13,4 +13,4 @@ import * as models from "./models";
 export { manifest, models };
 export { QueryDefinition, Mutations, MutationTypes, getDoctypeFromOperation, Q } from "./queries/dsl";
 export { Association, HasMany, HasOne, HasOneInPlace, HasManyInPlace, HasManyTriggers } from "./associations";
-export { dehydrate, generateWebLink } from "./helpers";
+export { dehydrate, generateWebLink, rootCozyUrl, InvalidCozyUrlError, InvalidProtocolError } from "./helpers";


### PR DESCRIPTION
To help our users connect our applications to their Cozy, we want them
to be able to simply use any URL of their Cozy copied from their
browser as their Cozy URL (e.g.
`https://claude-drive.mycozy.cloud/#/folder/io.cozy.files.root-dir`).

Without this help, we would not recognize the above URL as a valid
Cozy URL and would refuse to attempt the connection.

The new `rootCozyUrl` helper will reduce it down to the user's Cozy
URL (e.g. `https://claude.mycozy.cloud`) and return it or reject if:
- the domain does not exist
- the provided protocol is not HTTP or HTTPS
- no instance could be found with the resulting URL

Since our applications can be connected to a self-hosted Cozy, we also
handle URL ports.