### PR TITLE
feat: Add deleteFileId* functions

### DIFF
--- a/docs/api/cozy-client/modules/models.file.md
+++ b/docs/api/cozy-client/modules/models.file.md
@@ -20,6 +20,48 @@
 
 ## Functions
 
+### deleteFileById
+
+▸ `Const` **deleteFileById**(`client`, `fileId`): `Promise`<`void`>
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`CozyClient`](../classes/cozyclient.md) | Instance of CozyClient |
+| `fileId` | `string` | Id of io.cozy.files document |
+
+*Returns*
+
+`Promise`<`void`>
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:617](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L617)
+
+***
+
+### deleteFileByIds
+
+▸ `Const` **deleteFileByIds**(`client`, `fileIds`): `Promise`<`void`>
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`CozyClient`](../classes/cozyclient.md) | Instance of CozyClient |
+| `fileIds` | `string`\[] | Array of ids of io.cozy.files document |
+
+*Returns*
+
+`Promise`<`void`>
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:633](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L633)
+
+***
+
 ### doMobileUpload
 
 ▸ `Const` **doMobileUpload**(`client`, `fileURL`, `options`): `Promise`<`any`>

--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -609,3 +609,37 @@ export const fetchBlobFileById = async (client, fileId) => {
 
   return fileBlob
 }
+
+/**
+ * @param {CozyClient} client - Instance of CozyClient
+ * @param {string} fileId - Id of io.cozy.files document
+ */
+export const deleteFileById = async (client, fileId) => {
+  try {
+    const { data: ioCozyFile } = await client.query(
+      Q(DOCTYPE_FILES).getById(fileId)
+    )
+
+    await client.destroy(ioCozyFile)
+  } catch (error) {
+    throw error
+  }
+}
+
+/**
+ * @param {CozyClient} client - Instance of CozyClient
+ * @param {string[]} fileIds - Array of ids of io.cozy.files document
+ */
+export const deleteFileByIds = async (client, fileIds) => {
+  try {
+    const { data: ioCozyFiles } = await client.query(
+      Q(DOCTYPE_FILES).getByIds(fileIds)
+    )
+
+    for (const ioCozyFile of ioCozyFiles) {
+      await client.destroy(ioCozyFile)
+    }
+  } catch (error) {
+    throw error
+  }
+}

--- a/packages/cozy-client/types/models/file.d.ts
+++ b/packages/cozy-client/types/models/file.d.ts
@@ -62,6 +62,8 @@ export function hasQualifications(file: IOCozyFile): boolean;
 export function hasCertifications(file: IOCozyFile): boolean;
 export function isFromKonnector(file: IOCozyFile): boolean;
 export function fetchBlobFileById(client: CozyClient, fileId: string): Promise<Blob>;
+export function deleteFileById(client: CozyClient, fileId: string): Promise<void>;
+export function deleteFileByIds(client: CozyClient, fileIds: string[]): Promise<void>;
 export type FileUploadOptions = {
     /**
      * - The file name to upload


### PR DESCRIPTION
Avoid the app to have to fetch the document if it has only its ID, to be able to delete it