### PR TITLE
fix: Generate FileCollection URLs with querystring

### DIFF
--- a/docs/api/cozy-client/classes/querydefinition.md
+++ b/docs/api/cozy-client/classes/querydefinition.md
@@ -17,13 +17,13 @@ from a Cozy. `QueryDefinition`s are sent to links.
 | :------ | :------ | :------ |
 | `options` | `Object` | Initial options for the query definition |
 | `options.bookmark` | `string` | - |
-| `options.cursor` | `Cursor` | - |
+| `options.cursor` | `CouchDBViewCursor` | - |
 | `options.doctype` | `string` | - |
-| `options.fields` | `any`\[] | - |
+| `options.fields` | `string`\[] | - |
 | `options.id` | `string` | - |
-| `options.ids` | `any`\[] | - |
+| `options.ids` | `string`\[] | - |
 | `options.includes` | `string`\[] | - |
-| `options.indexedFields` | `any`\[] | - |
+| `options.indexedFields` | `string`\[] | - |
 | `options.limit` | `number` | - |
 | `options.partialFilter` | `any` | - |
 | `options.referenced` | `string` | - |
@@ -49,7 +49,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 ### cursor
 
-• **cursor**: `Cursor`
+• **cursor**: `CouchDBViewCursor`
 
 *Defined in*
 
@@ -69,7 +69,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 ### fields
 
-• **fields**: `any`\[]
+• **fields**: `string`\[]
 
 *Defined in*
 
@@ -89,7 +89,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 ### ids
 
-• **ids**: `any`\[]
+• **ids**: `string`\[]
 
 *Defined in*
 
@@ -109,7 +109,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 ### indexedFields
 
-• **indexedFields**: `any`\[]
+• **indexedFields**: `string`\[]
 
 *Defined in*
 
@@ -434,7 +434,7 @@ Use the last docid of each query as startkey_docid to paginate or leave blank fo
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `cursor` | `Cursor` | The cursor for pagination. |
+| `cursor` | `CouchDBViewCursor` | The cursor for pagination. |
 
 *Returns*
 
@@ -557,13 +557,13 @@ The QueryDefinition object.
 | Name | Type |
 | :------ | :------ |
 | `bookmark` | `string` |
-| `cursor` | `Cursor` |
+| `cursor` | `CouchDBViewCursor` |
 | `doctype` | `string` |
-| `fields` | `any`\[] |
+| `fields` | `string`\[] |
 | `id` | `string` |
-| `ids` | `any`\[] |
+| `ids` | `string`\[] |
 | `includes` | `string`\[] |
-| `indexedFields` | `any`\[] |
+| `indexedFields` | `string`\[] |
 | `limit` | `number` |
 | `partialFilter` | `any` |
 | `referenced` | `string` |

--- a/docs/api/cozy-client/modules/models.folder.md
+++ b/docs/api/cozy-client/modules/models.folder.md
@@ -30,7 +30,7 @@
 
 ### createFolderWithReference
 
-▸ `Const` **createFolderWithReference**(`client`, `path`, `document`): `Promise`<`IOCozyFile`>
+▸ `Const` **createFolderWithReference**(`client`, `path`, `document`): `Promise`<`IOCozyFolder`>
 
 Create a folder with a reference to the given document
 
@@ -44,7 +44,7 @@ Create a folder with a reference to the given document
 
 *Returns*
 
-`Promise`<`IOCozyFile`>
+`Promise`<`IOCozyFolder`>
 
 Folder document
 
@@ -56,7 +56,7 @@ Folder document
 
 ### ensureMagicFolder
 
-▸ `Const` **ensureMagicFolder**(`client`, `id`, `path`): `Promise`<`IOCozyFile`>
+▸ `Const` **ensureMagicFolder**(`client`, `id`, `path`): `Promise`<`IOCozyFolder`>
 
 Returns a "Magic Folder", given its id. See https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.apps/#special-iocozyapps-doctypes
 
@@ -70,7 +70,7 @@ Returns a "Magic Folder", given its id. See https://docs.cozy.io/en/cozy-doctype
 
 *Returns*
 
-`Promise`<`IOCozyFile`>
+`Promise`<`IOCozyFolder`>
 
 Folder document
 
@@ -82,7 +82,7 @@ Folder document
 
 ### getReferencedFolder
 
-▸ `Const` **getReferencedFolder**(`client`, `document`): `Promise`<`IOCozyFile`>
+▸ `Const` **getReferencedFolder**(`client`, `document`): `Promise`<`IOCozyFolder`>
 
 Returns the most recent folder referenced by the given document
 
@@ -95,7 +95,7 @@ Returns the most recent folder referenced by the given document
 
 *Returns*
 
-`Promise`<`IOCozyFile`>
+`Promise`<`IOCozyFolder`>
 
 Folder referenced by the given document
 

--- a/docs/api/cozy-pouch-link.md
+++ b/docs/api/cozy-pouch-link.md
@@ -505,7 +505,7 @@ Get the database name based on prefix and doctype
 
 | Param | Type | Description |
 | --- | --- | --- |
-| } | <code>string</code> | prefix - The URL prefix |
+| prefix | <code>string</code> | The URL prefix |
 | doctype | <code>string</code> | The database doctype |
 
 <a name="getPrefix"></a>
@@ -526,9 +526,9 @@ Get the URI prefix
 **Kind**: global function  
 **Returns**: <code>string</code> - alias  
 
-| Param | Type |
-| --- | --- |
-| query | <code>QueryDefinition</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| query | <code>QueryDefinition</code> | The query definition whose name we're getting |
 
 <a name="SyncStatus"></a>
 

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -137,15 +137,14 @@ See <a href="https://docs.cozy.io/en/cozy-stack/sharing-design/#description-of-a
 ## Typedefs
 
 <dl>
-<dt><a href="#CouchOptionsRaw">CouchOptionsRaw</a> : <code>object</code></dt>
-<dd><p>Calls _changes route from CouchDB
-No further treatment is done contrary to fetchchanges</p>
-</dd>
 <dt><a href="#FetchChangesReturnValue">FetchChangesReturnValue</a> ⇒ <code><a href="#FetchChangesReturnValue">FetchChangesReturnValue</a></code></dt>
 <dd><p>Use Couch _changes API
 Deleted and design docs are filtered by default, thus documents are retrieved in the response
 (include_docs is set to true in the parameters of _changes).</p>
 <p>You should use fetchChangesRaw to have low level control on _changes parameters.</p>
+</dd>
+<dt><a href="#CouchDBViewCursor">CouchDBViewCursor</a> : <code>Array.&lt;string&gt;</code> | <code>string</code></dt>
+<dd><p>Cursor used for Mango queries pagination</p>
 </dd>
 <dt><a href="#DirectoryAttributes">DirectoryAttributes</a> : <code>object</code></dt>
 <dd><p>Attributes used for directory creation</p>
@@ -178,6 +177,10 @@ not.</p>
 <dt><a href="#JobDocument">JobDocument</a> : <code>object</code></dt>
 <dd><p>Document representing a io.cozy.jobs</p>
 </dd>
+<dt><a href="#MangoPartialFilter">MangoPartialFilter</a> : <code>object</code></dt>
+<dd></dd>
+<dt><a href="#MangoQueryOptions">MangoQueryOptions</a> : <code>object</code></dt>
+<dd></dd>
 <dt><a href="#DesignDoc">DesignDoc</a> : <code>object</code></dt>
 <dd><p>Attributes representing a design doc</p>
 </dd>
@@ -366,11 +369,12 @@ Abstracts a collection of documents of the same doctype, providing CRUD methods 
     * [.create(doc)](#DocumentCollection+create)
     * [.update(document)](#DocumentCollection+update)
     * [.destroy(doc)](#DocumentCollection+destroy)
-    * [.updateAll(docs)](#DocumentCollection+updateAll)
+    * [.updateAll(rawDocs)](#DocumentCollection+updateAll)
     * [.destroyAll(docs)](#DocumentCollection+destroyAll)
     * [.fetchAllMangoIndexes()](#DocumentCollection+fetchAllMangoIndexes) ⇒ <code>Array</code>
     * [.destroyIndex(index)](#DocumentCollection+destroyIndex) ⇒ <code>object</code>
     * [.copyIndex(existingIndex, newIndexName)](#DocumentCollection+copyIndex) ⇒ <code>object</code>
+    * [.fetchChangesRaw(couchOptions)](#DocumentCollection+fetchChangesRaw)
 
 <a name="DocumentCollection+all"></a>
 
@@ -462,14 +466,14 @@ Destroys a document
 
 <a name="DocumentCollection+updateAll"></a>
 
-### documentCollection.updateAll(docs)
+### documentCollection.updateAll(rawDocs)
 Updates several documents in one batch
 
 **Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| docs | <code>Array.&lt;Document&gt;</code> | Documents to be updated |
+| rawDocs | <code>Array.&lt;Document&gt;</code> | Documents to be updated |
 
 <a name="DocumentCollection+destroyAll"></a>
 
@@ -517,6 +521,22 @@ having to recompute the existing index.
 | existingIndex | <code>object</code> | The design doc to copy |
 | newIndexName | <code>string</code> | The name of the copy |
 
+<a name="DocumentCollection+fetchChangesRaw"></a>
+
+### documentCollection.fetchChangesRaw(couchOptions)
+Calls _changes route from CouchDB
+No further treatment is done contrary to fetchchanges
+
+**Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
+**See**: https://docs.couchdb.org/en/stable/api/database/changes.html  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| couchOptions | <code>object</code> | Couch options for changes https://kutt.it/5r7MNQ |
+| [couchOptions.since] | <code>string</code> | Bookmark telling CouchDB from which point in time should changes be returned |
+| [couchOptions.doc_ids] | <code>Array.&lt;string&gt;</code> | Only return changes for a subset of documents |
+| [couchOptions.includeDocs] | <code>boolean</code> | Includes full documents as part of results |
+
 <a name="FileCollection"></a>
 
 ## FileCollection
@@ -536,8 +556,8 @@ files associated to a specific document
     * [.findReferencedBy(document, options)](#FileCollection+findReferencedBy) ⇒ <code>Object</code>
     * [.addReferencedBy(document, documents)](#FileCollection+addReferencedBy) ⇒ <code>Object</code>
     * [.removeReferencedBy(document, documents)](#FileCollection+removeReferencedBy) ⇒ <code>Object</code>
-    * [.addReferencesTo(document, documents)](#FileCollection+addReferencesTo) ⇒
-    * [.removeReferencesTo(document, documents)](#FileCollection+removeReferencesTo) ⇒
+    * [.addReferencesTo(document, documents)](#FileCollection+addReferencesTo)
+    * [.removeReferencesTo(document, documents)](#FileCollection+removeReferencesTo)
     * [.destroy(file)](#FileCollection+destroy) ⇒ <code>Promise</code>
     * [.emptyTrash()](#FileCollection+emptyTrash)
     * [.restore(id)](#FileCollection+restore) ⇒ <code>Promise</code>
@@ -549,15 +569,15 @@ files associated to a specific document
     * [.fetchFileContentById(id)](#FileCollection+fetchFileContentById)
     * [.getBeautifulSize(file, decimal)](#FileCollection+getBeautifulSize)
     * [.isChildOf(child, parent)](#FileCollection+isChildOf) ⇒ <code>boolean</code>
-    * [.statById(id, [options])](#FileCollection+statById) ⇒ <code>object</code>
+    * [.statById(id, options)](#FileCollection+statById) ⇒ <code>object</code>
     * [.createDirectoryByPath(path)](#FileCollection+createDirectoryByPath) ⇒ <code>object</code>
     * [.createFileMetadata(attributes)](#FileCollection+createFileMetadata) ⇒ <code>object</code>
     * [.updateMetadataAttribute(id, metadata)](#FileCollection+updateMetadataAttribute) ⇒ <code>object</code>
     * [.getFileTypeFromName(name)](#FileCollection+getFileTypeFromName) ⇒ <code>string</code>
     * [.doUpload(dataArg, path, options, method)](#FileCollection+doUpload)
     * [.findNotSynchronizedDirectories(oauthClient, options)](#FileCollection+findNotSynchronizedDirectories) ⇒ <code>Array.&lt;(object\|IOCozyFolder)&gt;</code>
-    * [.addNotSynchronizedDirectories(oauthClient, directories)](#FileCollection+addNotSynchronizedDirectories) ⇒
-    * [.removeNotSynchronizedDirectories(oauthClient, directories)](#FileCollection+removeNotSynchronizedDirectories) ⇒
+    * [.addNotSynchronizedDirectories(oauthClient, directories)](#FileCollection+addNotSynchronizedDirectories)
+    * [.removeNotSynchronizedDirectories(oauthClient, directories)](#FileCollection+removeNotSynchronizedDirectories)
 
 <a name="FileCollection+forceFileDownload"></a>
 
@@ -600,7 +620,7 @@ The returned documents are paginated by the stack.
 | Param | Type | Description |
 | --- | --- | --- |
 | selector | <code>object</code> | The Mango selector. |
-| options | <code>Object</code> | The query options. |
+| options | [<code>MangoQueryOptions</code>](#MangoQueryOptions) | The query options |
 
 <a name="FileCollection+findReferencedBy"></a>
 
@@ -614,9 +634,9 @@ async findReferencedBy - Returns the list of files referenced by a document — 
 | --- | --- | --- |
 | document | <code>object</code> | A JSON representing a document, with at least a `_type` and `_id` field. |
 | options | <code>object</code> | Additional options |
-| options.skip | <code>number</code> | For skip-based pagination, the number of referenced files to skip. |
-| options.limit | <code>number</code> | For pagination, the number of results to return. |
-| options.cursor | <code>object</code> | For cursor-based pagination, the index cursor. |
+| [options.skip] | <code>number</code> \| <code>null</code> | For skip-based pagination, the number of referenced files to skip. |
+| [options.limit] | <code>number</code> \| <code>null</code> | For pagination, the number of results to return. |
+| [options.cursor] | [<code>CouchDBViewCursor</code>](#CouchDBViewCursor) \| <code>null</code> | For cursor-based pagination, the index cursor. |
 
 <a name="FileCollection+addReferencedBy"></a>
 
@@ -656,7 +676,7 @@ Remove referenced_by documents from a file — see https://docs.cozy.io/en/cozy-
 
 <a name="FileCollection+addReferencesTo"></a>
 
-### fileCollection.addReferencesTo(document, documents) ⇒
+### fileCollection.addReferencesTo(document, documents)
 Add files references to a document — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#post-datatypedoc-idrelationshipsreferences
 
  For example, to add a photo to an album:
@@ -665,16 +685,15 @@ Add files references to a document — see https://docs.cozy.io/en/cozy-stack/re
 ```
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
-**Returns**: 204 No Content  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | document | <code>object</code> | A JSON representing a document, with at least a `_type` and `_id` field. |
-| documents | <code>Array</code> | An array of JSON files having an `_id` field. |
+| documents | <code>Array</code> | An array of JSON files having an `_id` field. Returns 204 No Content |
 
 <a name="FileCollection+removeReferencesTo"></a>
 
-### fileCollection.removeReferencesTo(document, documents) ⇒
+### fileCollection.removeReferencesTo(document, documents)
 Remove files references to a document — see https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/#delete-datatypedoc-idrelationshipsreferences
 
  For example, to remove a photo from an album:
@@ -683,12 +702,11 @@ Remove files references to a document — see https://docs.cozy.io/en/cozy-stack
 ```
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
-**Returns**: 204 No Content  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | document | <code>object</code> | A JSON representing a document, with at least a `_type` and `_id` field. |
-| documents | <code>Array</code> | An array of JSON files having an `_id` field. |
+| documents | <code>Array</code> | An array of JSON files having an `_id` field. Returns 204 No Content |
 
 <a name="FileCollection+destroy"></a>
 
@@ -839,19 +857,19 @@ Checks if the file belongs to the parent's hierarchy.
 
 <a name="FileCollection+statById"></a>
 
-### fileCollection.statById(id, [options]) ⇒ <code>object</code>
+### fileCollection.statById(id, options) ⇒ <code>object</code>
 statById - Fetches the metadata about a document. For folders, the results include the list of child files and folders.
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
 **Returns**: <code>object</code> - A promise resolving to an object containing "data" (the document metadata), "included" (the child documents) and "links" (pagination informations)  
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| id | <code>string</code> |  | ID of the document |
-| [options] | <code>object</code> | <code>{}</code> | Description |
-| [options.page[limit]] | <code>number</code> |  | Max number of children documents to return |
-| [options.page[skip]] | <code>number</code> |  | Number of children documents to skip from the start |
-| [options.page[cursor]] | <code>string</code> |  | A cursor id for pagination |
+| Param | Type | Description |
+| --- | --- | --- |
+| id | <code>string</code> | ID of the document |
+| options | <code>object</code> \| <code>null</code> | Pagination options |
+| [options.page[limit]] | <code>number</code> \| <code>null</code> | For pagination, the number of results to return. |
+| [options.page[skip]] | <code>number</code> \| <code>null</code> | For skip-based pagination, the number of referenced files to skip. |
+| [options.page[cursor]] | [<code>CouchDBViewCursor</code>](#CouchDBViewCursor) \| <code>null</code> | For cursor-based pagination, the index cursor. |
 
 <a name="FileCollection+createDirectoryByPath"></a>
 
@@ -935,15 +953,15 @@ async findNotSynchronizedDirectories - Returns the list of directories not synch
 | Param | Type | Description |
 | --- | --- | --- |
 | oauthClient | [<code>OAuthClient</code>](#OAuthClient) | A JSON representing an OAuth client, with at least a `_type` and `_id` field. |
-| options | <code>object</code> | Additional options |
-| options.skip | <code>number</code> | For skip-based pagination, the number of referenced files to skip. |
-| options.limit | <code>number</code> | For pagination, the number of results to return. |
-| options.cursor | <code>object</code> | For cursor-based pagination, the index cursor. |
+| options | <code>object</code> \| <code>null</code> | Pagination options |
+| options.skip | <code>number</code> \| <code>null</code> | For skip-based pagination, the number of referenced files to skip. |
+| options.limit | <code>number</code> \| <code>null</code> | For pagination, the number of results to return. |
+| options.cursor | [<code>CouchDBViewCursor</code>](#CouchDBViewCursor) \| <code>null</code> | For cursor-based pagination, the index cursor. |
 | options.includeFiles | <code>boolean</code> | Include the whole file documents in the results list |
 
 <a name="FileCollection+addNotSynchronizedDirectories"></a>
 
-### fileCollection.addNotSynchronizedDirectories(oauthClient, directories) ⇒
+### fileCollection.addNotSynchronizedDirectories(oauthClient, directories)
 Add directory synchronization exclusions to an OAuth client — see https://docs.cozy.io/en/cozy-stack/not-synchronized-vfs/#post-datatypedoc-idrelationshipsnot_synchronizing
 
  For example, to exclude directory `/Photos` from `My Computer`'s desktop synchronization:
@@ -952,16 +970,15 @@ addNotSynchronizedDirectories({_id: 123, _type: "io.cozy.oauth.clients", clientN
 ```
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
-**Returns**: 204 No Content  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | oauthClient | [<code>OAuthClient</code>](#OAuthClient) | A JSON representing the OAuth client |
-| directories | <code>Array</code> | An array of JSON documents having a `_type` and `_id` fields and representing directories. |
+| directories | <code>Array</code> | An array of JSON documents having a `_type` and `_id` fields and representing directories. Returns 204 No Content |
 
 <a name="FileCollection+removeNotSynchronizedDirectories"></a>
 
-### fileCollection.removeNotSynchronizedDirectories(oauthClient, directories) ⇒
+### fileCollection.removeNotSynchronizedDirectories(oauthClient, directories)
 Remove directory synchronization exclusions from an OAuth client — see https://docs.cozy.io/en/cozy-stack/not-synchronized-vfs/#delete-datatypedoc-idrelationshipsnot_synchronizing
 
  For example, to re-include directory `/Photos` into `My Computer`'s desktop synchronization:
@@ -970,12 +987,11 @@ Remove directory synchronization exclusions from an OAuth client — see https:/
 ```
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
-**Returns**: 204 No Content  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | oauthClient | [<code>OAuthClient</code>](#OAuthClient) | A JSON representing the OAuth client |
-| directories | <code>Array</code> | An array of JSON documents having a `_type` and `_id` field and representing directories. |
+| directories | <code>Array</code> | An array of JSON documents having a `_type` and `_id` field and representing directories. Returns 204 No Content |
 
 <a name="NotesCollection"></a>
 
@@ -987,7 +1003,7 @@ Implements `DocumentCollection` API to interact with the /notes endpoint of the 
 * [NotesCollection](#NotesCollection)
     * [.all()](#NotesCollection+all) ⇒ <code>Object</code>
     * [.destroy(note)](#NotesCollection+destroy) ⇒ <code>Object</code>
-    * [.create(option)](#NotesCollection+create) ⇒ <code>Object</code>
+    * [.create(options)](#NotesCollection+create) ⇒ <code>Object</code>
     * [.fetchURL(note)](#NotesCollection+fetchURL) ⇒ <code>Object</code>
     * [.getDefaultSchema()](#NotesCollection+getDefaultSchema) ⇒ <code>object</code>
 
@@ -1008,12 +1024,12 @@ Destroys the note on the server
 
 | Param | Type | Description |
 | --- | --- | --- |
-| note | <code>io.cozy.notes</code> | The note document to destroy |
-| note._id | <code>string</code> | The note's id |
+| note | <code>object</code> | The io.cozy.notes document to destroy |
+| [note._id] | <code>string</code> | The note's id |
 
 <a name="NotesCollection+create"></a>
 
-### notesCollection.create(option) ⇒ <code>Object</code>
+### notesCollection.create(options) ⇒ <code>Object</code>
 Create a note
 
 **Kind**: instance method of [<code>NotesCollection</code>](#NotesCollection)  
@@ -1021,8 +1037,8 @@ Create a note
 
 | Param | Type | Description |
 | --- | --- | --- |
-| option | <code>object</code> |  |
-| option.dir_id | <code>string</code> | dir_id where to create the note |
+| options | <code>object</code> |  |
+| [options.dir_id] | <code>string</code> | dir_id where to create the note |
 
 <a name="NotesCollection+fetchURL"></a>
 
@@ -1035,8 +1051,8 @@ Returns the details to build the note's url
 
 | Param | Type | Description |
 | --- | --- | --- |
-| note | <code>io.cozy.notes</code> | The note document to open |
-| note._id | <code>string</code> | The note's id |
+| note | <code>object</code> | The io.cozy.notes document to open |
+| [note._id] | <code>string</code> | The note's id |
 
 <a name="NotesCollection+getDefaultSchema"></a>
 
@@ -1256,9 +1272,9 @@ Fetches all OAuth clients
 | Param | Type | Description |
 | --- | --- | --- |
 | options | <code>object</code> | Query options |
-| options.limit | <code>number</code> | For pagination, the number of results to return. |
-| options.bookmark | <code>object</code> | For cursor-based pagination, the index cursor. |
-| options.keys | <code>Array</code> | Ids of specific clients to return (within the current page), |
+| [options.limit] | <code>number</code> | For pagination, the number of results to return. |
+| [options.bookmark] | <code>string</code> | For bookmark-based pagination, the document _id to start from |
+| [options.keys] | <code>Array.&lt;string&gt;</code> | Ids of specific clients to return (within the current page), |
 
 <a name="OAuthClientsCollection+get"></a>
 
@@ -1282,7 +1298,7 @@ Destroys the OAuth client on the server
 
 | Param | Type | Description |
 | --- | --- | --- |
-| oauthClient | <code>io.cozy.oauth.clients</code> | The client document to destroy |
+| oauthClient | <code>object</code> | The io.cozy.oauth.clients document to destroy |
 
 <a name="PermissionCollection"></a>
 
@@ -1690,8 +1706,9 @@ Returns true when parameter has type directory, file or has _type io.cozy.files
 
 | Param | Type | Description |
 | --- | --- | --- |
-| type | <code>string</code> | The type of the file |
-| _type | <code>string</code> | The _type of the file |
+| doc | <code>object</code> | The document whose type is checked |
+| [doc._type] | <code>string</code> | The document's doctype |
+| [doc.type] | <code>&#x27;directory&#x27;</code> \| <code>&#x27;file&#x27;</code> | The io.cozy-files document type |
 
 <a name="isDirectory"></a>
 
@@ -1729,7 +1746,7 @@ query to work
 
 | Param | Type | Description |
 | --- | --- | --- |
-| options | <code>object</code> | Mango query options |
+| options | [<code>MangoQueryOptions</code>](#MangoQueryOptions) | Mango query options |
 
 <a name="isInconsistentIndex"></a>
 
@@ -1908,22 +1925,6 @@ Compute the RelationshipItem that can be referenced as a sharing recipient
 Get a uniform formatted URL and SSL information according to a provided URL
 
 **Kind**: global function  
-<a name="CouchOptionsRaw"></a>
-
-## CouchOptionsRaw : <code>object</code>
-Calls _changes route from CouchDB
-No further treatment is done contrary to fetchchanges
-
-**Kind**: global typedef  
-**See**: https://docs.couchdb.org/en/stable/api/database/changes.html  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| since | <code>string</code> | Bookmark telling CouchDB from which point in time should changes be returned |
-| doc_ids | <code>Array.&lt;string&gt;</code> | Only return changes for a subset of documents |
-| includeDocs | <code>boolean</code> | Includes full documents as part of results |
-| couchOptions | [<code>CouchOptionsRaw</code>](#CouchOptionsRaw) | Couch options for changes https://kutt.it/5r7MNQ |
-
 <a name="FetchChangesReturnValue"></a>
 
 ## FetchChangesReturnValue ⇒ [<code>FetchChangesReturnValue</code>](#FetchChangesReturnValue)
@@ -1937,20 +1938,26 @@ You should use fetchChangesRaw to have low level control on _changes parameters.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| since | <code>string</code> | Bookmark telling CouchDB from which point in time should changes be returned |
-| doc_ids | <code>Array.&lt;string&gt;</code> | Only return changes for a subset of documents |
-| couchOptions | <code>CouchOptions</code> | Couch options for changes |
-| options | <code>FetchChangesOptions</code> | Further options on the returned documents. By default, it is set to                                         { includeDesign: false, includeDeleted: false } |
+| couchOptions | <code>object</code> | Couch options for changes |
+| [couchOptions.since] | <code>string</code> | Bookmark telling CouchDB from which point in time should changes be returned |
+| [couchOptions.doc_ids] | <code>Array.&lt;string&gt;</code> | Only return changes for a subset of documents |
+| options | <code>object</code> | Further options on the returned documents. By default, it is set to { includeDesign: false, includeDeleted: false } |
+| [options.includeDesign] | <code>boolean</code> | Whether to include changes from design docs (needs include_docs to be true) |
+| [options.includeDeleted] | <code>boolean</code> | Whether to include changes for deleted documents (needs include_docs to be true) |
 
 **Properties**
 
-| Name | Type | Description |
-| --- | --- | --- |
-| includeDesign | <code>boolean</code> | Whether to include changes from design docs (needs include_docs to be true) |
-| includeDeleted | <code>boolean</code> | Whether to include changes for deleted documents (needs include_docs to be true) |
-| newLastSeq | <code>string</code> |  |
-| documents | <code>Array.&lt;object&gt;</code> |  |
+| Name | Type |
+| --- | --- |
+| newLastSeq | <code>string</code> | 
+| documents | <code>Array.&lt;object&gt;</code> | 
 
+<a name="CouchDBViewCursor"></a>
+
+## CouchDBViewCursor : <code>Array.&lt;string&gt;</code> \| <code>string</code>
+Cursor used for Mango queries pagination
+
+**Kind**: global typedef  
 <a name="DirectoryAttributes"></a>
 
 ## DirectoryAttributes : <code>object</code>
@@ -2246,6 +2253,27 @@ Document representing a io.cozy.jobs
 | _id | <code>string</code> | Id of the job |
 | attributes.state | <code>string</code> | state of the job. Can be 'errored', 'running', 'queued', 'done' |
 | attributes.error | <code>string</code> | Error message of the job if any |
+
+<a name="MangoPartialFilter"></a>
+
+## MangoPartialFilter : <code>object</code>
+**Kind**: global typedef  
+<a name="MangoQueryOptions"></a>
+
+## MangoQueryOptions : <code>object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| [sort] | <code>Array.&lt;object&gt;</code> | The sorting parameters |
+| [fields] | <code>Array.&lt;string&gt;</code> | The fields to return |
+| [limit] | <code>number</code> \| <code>null</code> | For pagination, the number of results to return |
+| [skip] | <code>number</code> \| <code>null</code> | For skip-based pagination, the number of referenced files to skip |
+| [indexId] | <code>string</code> \| <code>null</code> | The _id of the CouchDB index to use for this request |
+| [bookmark] | <code>string</code> \| <code>null</code> | For bookmark-based pagination, the document _id to start from |
+| [indexedFields] | <code>Array.&lt;string&gt;</code> |  |
+| [partialFilter] | [<code>MangoPartialFilter</code>](#MangoPartialFilter) \| <code>null</code> | An optional partial filter |
 
 <a name="DesignDoc"></a>
 

--- a/packages/cozy-client/src/RealTimeQueries.jsx
+++ b/packages/cozy-client/src/RealTimeQueries.jsx
@@ -26,6 +26,7 @@ const normalizeDoc = (couchDBDoc, doctype) => {
  * DispatchChange
  *
  * @param {CozyClient} client CozyClient instane
+ * @param {Doctype} doctype Doctype of the document to update
  * @param {CouchDBDocument} couchDBDoc Document to update
  * @param {Mutation} mutationDefinitionCreator Mutation to apply
  */

--- a/packages/cozy-client/src/flagship-certification/typedefs.js
+++ b/packages/cozy-client/src/flagship-certification/typedefs.js
@@ -1,23 +1,19 @@
 /**
- * A JSON Web Signature
- * @typedef {string} jws
+ * @typedef {string} jws - A JSON Web Signature
  */
 
 /**
- * A JSON Web Signature
- * @typedef {string} base64string
+ * @typedef {string} base64string - A JSON Web Signature
  */
 
 /**
- * An app attestation from the app store
- * @typedef {object} AttestationResult
+ * @typedef {object} AttestationResult - An app attestation from the app store
  * @property {string} platform
  * @property {jws|base64string} attestation
  * @property {string} [keyId]
  */
 
 /**
- * Configuration to access the stores certification API
- * @typedef {object} CertificationConfig
+ * @typedef {object} CertificationConfig - Configuration to access the stores certification API
  * @property {string} androidSafetyNetApiKey
  */

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -1,6 +1,6 @@
 import isArray from 'lodash/isArray'
 import findKey from 'lodash/findKey'
-import { Doctype } from '../types'
+import { CouchDBViewCursor, DocId, Doctype } from '../types'
 
 /**
  * @typedef PartialQueryDefinition
@@ -15,7 +15,7 @@ import { Doctype } from '../types'
  */
 
 /**
- * @typedef {Array} Cursor
+ * @typedef {object} MangoPartialFilter
  */
 
 /**
@@ -29,19 +29,19 @@ class QueryDefinition {
    * @class
    *
    * @param {object} options Initial options for the query definition
-   * @param {string} [options.doctype] - The doctype of the doc.
-   * @param {string} [options.id] - The id of the doc.
-   * @param {Array} [options.ids] - The ids of the docs.
-   * @param {object} [options.selector] - The selector to query the docs.
-   * @param {Array} [options.fields] - The fields to return.
-   * @param {Array} [options.indexedFields] - The fields to index.
-   * @param {object} [options.partialFilter] - The partial index definition to filter docs.
-   * @param {Array} [options.sort] - The sorting params.
+   * @param {Doctype} [options.doctype] - The doctype of the doc.
+   * @param {DocId|null} [options.id] - The id of the doc.
+   * @param {Array<DocId>} [options.ids] - The ids of the docs.
+   * @param {MangoSelector} [options.selector] - The selector to query the docs.
+   * @param {Array<string>} [options.fields] - The fields to return.
+   * @param {Array<string>} [options.indexedFields] - The fields to index.
+   * @param {MangoPartialFilter} [options.partialFilter] - The partial index definition to filter docs.
+   * @param {Array<object>} [options.sort] - The sorting params.
    * @param {Array<string>} [options.includes] - The docs to include.
-   * @param {string} [options.referenced] - The referenced document.
+   * @param {string|null} [options.referenced] - The referenced document.
    * @param {number|null} [options.limit] - The document's limit to return.
-   * @param {number} [options.skip] - The number of docs to skip.
-   * @param {Cursor} [options.cursor] - The cursor to paginate views.
+   * @param {number|null} [options.skip] - The number of docs to skip.
+   * @param {CouchDBViewCursor} [options.cursor] - The cursor to paginate views.
    * @param {string} [options.bookmark] - The bookmark to paginate mango queries.
    */
   constructor(options = {}) {
@@ -270,7 +270,7 @@ class QueryDefinition {
    * the starting document of the query, e.g. "file-id".
    * Use the last docid of each query as startkey_docid to paginate or leave blank for the first query.
    *
-   * @param {Cursor} cursor The cursor for pagination.
+   * @param {CouchDBViewCursor} cursor The cursor for pagination.
    * @returns {QueryDefinition}  The QueryDefinition object.
    */
   offsetCursor(cursor) {

--- a/packages/cozy-client/src/queries/dsl.spec.js
+++ b/packages/cozy-client/src/queries/dsl.spec.js
@@ -50,8 +50,9 @@ describe('QueryDefinition', () => {
     expect(withSkip.bookmark).toBeUndefined()
     expect(withSkip.cursor).toBeUndefined()
 
-    const withCursor = withSkip.offsetCursor('cursor-id')
-    expect(withCursor.cursor).toEqual('cursor-id')
+    const cursor = [['io.cozy.files', '1234'], 'xyz']
+    const withCursor = withSkip.offsetCursor(cursor)
+    expect(withCursor.cursor).toEqual(cursor)
     expect(withCursor.bookmark).toBeUndefined()
     expect(withCursor.skip).toBeUndefined()
 

--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -160,7 +160,7 @@ import { QueryDefinition } from './queries/dsl'
  * @property {string} name - Name of the folder
  * @property {object} metadata - Metadata of the folder
  * @property {object} type - Type of the folder
- * @typedef {CozyClientDocument & FileDocument} IOCozyFolder - An io.cozy.files document
+ * @typedef {CozyClientDocument & FolderDocument} IOCozyFolder - An io.cozy.files document
  */
 
 /**
@@ -244,6 +244,12 @@ import { QueryDefinition } from './queries/dsl'
  * @property {string} rev
  * @property {string?} error?
  * @property {string?} reason?
+ */
+
+/**
+ * @typedef {Array<string>|string} ViewKey
+ * @typedef {string} DocId
+ * @typedef {[ViewKey, DocId]} CouchDBViewCursor
  */
 
 /**

--- a/packages/cozy-client/types/flagship-certification/typedefs.d.ts
+++ b/packages/cozy-client/types/flagship-certification/typedefs.d.ts
@@ -1,13 +1,13 @@
 /**
- * A JSON Web Signature
+ * - A JSON Web Signature
  */
 type jws = string;
 /**
- * A JSON Web Signature
+ * - A JSON Web Signature
  */
 type base64string = string;
 /**
- * An app attestation from the app store
+ * - An app attestation from the app store
  */
 type AttestationResult = {
     platform: string;
@@ -15,7 +15,7 @@ type AttestationResult = {
     keyId?: string;
 };
 /**
- * Configuration to access the stores certification API
+ * - Configuration to access the stores certification API
  */
 type CertificationConfig = {
     androidSafetyNetApiKey: string;

--- a/packages/cozy-client/types/queries/dsl.d.ts
+++ b/packages/cozy-client/types/queries/dsl.d.ts
@@ -70,7 +70,7 @@ export type PartialQueryDefinition = {
     selector?: object;
 };
 export type MangoSelector = any;
-export type Cursor = any[];
+export type MangoPartialFilter = any;
 import { Doctype } from "../types";
 /**
  * @typedef PartialQueryDefinition
@@ -83,7 +83,7 @@ import { Doctype } from "../types";
  * @typedef {object} MangoSelector
  */
 /**
- * @typedef {Array} Cursor
+ * @typedef {object} MangoPartialFilter
  */
 /**
  * Chainable API to create query definitions to retrieve documents
@@ -96,50 +96,50 @@ export class QueryDefinition {
      * @class
      *
      * @param {object} options Initial options for the query definition
-     * @param {string} [options.doctype] - The doctype of the doc.
-     * @param {string} [options.id] - The id of the doc.
-     * @param {Array} [options.ids] - The ids of the docs.
-     * @param {object} [options.selector] - The selector to query the docs.
-     * @param {Array} [options.fields] - The fields to return.
-     * @param {Array} [options.indexedFields] - The fields to index.
-     * @param {object} [options.partialFilter] - The partial index definition to filter docs.
-     * @param {Array} [options.sort] - The sorting params.
+     * @param {Doctype} [options.doctype] - The doctype of the doc.
+     * @param {DocId|null} [options.id] - The id of the doc.
+     * @param {Array<DocId>} [options.ids] - The ids of the docs.
+     * @param {MangoSelector} [options.selector] - The selector to query the docs.
+     * @param {Array<string>} [options.fields] - The fields to return.
+     * @param {Array<string>} [options.indexedFields] - The fields to index.
+     * @param {MangoPartialFilter} [options.partialFilter] - The partial index definition to filter docs.
+     * @param {Array<object>} [options.sort] - The sorting params.
      * @param {Array<string>} [options.includes] - The docs to include.
-     * @param {string} [options.referenced] - The referenced document.
+     * @param {string|null} [options.referenced] - The referenced document.
      * @param {number|null} [options.limit] - The document's limit to return.
-     * @param {number} [options.skip] - The number of docs to skip.
-     * @param {Cursor} [options.cursor] - The cursor to paginate views.
+     * @param {number|null} [options.skip] - The number of docs to skip.
+     * @param {CouchDBViewCursor} [options.cursor] - The cursor to paginate views.
      * @param {string} [options.bookmark] - The bookmark to paginate mango queries.
      */
     constructor(options?: {
-        doctype: string;
-        id: string;
-        ids: any[];
-        selector: object;
-        fields: any[];
-        indexedFields: any[];
-        partialFilter: object;
-        sort: any[];
+        doctype: Doctype;
+        id: DocId | null;
+        ids: Array<DocId>;
+        selector: MangoSelector;
+        fields: Array<string>;
+        indexedFields: Array<string>;
+        partialFilter: MangoPartialFilter;
+        sort: Array<object>;
         includes: Array<string>;
-        referenced: string;
+        referenced: string | null;
         limit: number | null;
-        skip: number;
-        cursor: Cursor;
+        skip: number | null;
+        cursor: CouchDBViewCursor;
         bookmark: string;
     });
     doctype: string;
     id: string;
-    ids: any[];
+    ids: string[];
     selector: any;
-    fields: any[];
-    indexedFields: any[];
+    fields: string[];
+    indexedFields: string[];
     partialFilter: any;
     sort: any[];
     includes: string[];
     referenced: string;
     limit: number;
     skip: number;
-    cursor: Cursor;
+    cursor: CouchDBViewCursor;
     bookmark: string;
     /**
      * Checks if the sort order matches the index' fields order.
@@ -249,10 +249,10 @@ export class QueryDefinition {
      * the starting document of the query, e.g. "file-id".
      * Use the last docid of each query as startkey_docid to paginate or leave blank for the first query.
      *
-     * @param {Cursor} cursor The cursor for pagination.
+     * @param {CouchDBViewCursor} cursor The cursor for pagination.
      * @returns {QueryDefinition}  The QueryDefinition object.
      */
-    offsetCursor(cursor: Cursor): QueryDefinition;
+    offsetCursor(cursor: CouchDBViewCursor): QueryDefinition;
     /**
      * Use [bookmark](https://docs.couchdb.org/en/2.2.0/api/database/find.html#pagination) pagination.
      * Note this only applies for mango-queries (not views) and is way more efficient than skip pagination.
@@ -273,17 +273,17 @@ export class QueryDefinition {
     toDefinition(): {
         doctype: string;
         id: string;
-        ids: any[];
+        ids: string[];
         selector: any;
-        fields: any[];
-        indexedFields: any[];
+        fields: string[];
+        indexedFields: string[];
         partialFilter: any;
         sort: any[];
         includes: string[];
         referenced: string;
         limit: number;
         skip: number;
-        cursor: Cursor;
+        cursor: CouchDBViewCursor;
         bookmark: string;
     };
 }
@@ -296,4 +296,6 @@ declare const REMOVE_REFERENCES_TO: "REMOVE_REFERENCES_TO";
 declare const ADD_REFERENCED_BY: "ADD_REFERENCED_BY";
 declare const REMOVE_REFERENCED_BY: "REMOVE_REFERENCED_BY";
 declare const UPLOAD_FILE: "UPLOAD_FILE";
+import { CouchDBViewCursor } from "../types";
+import { DocId } from "../types";
 export {};

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -208,7 +208,7 @@ export type FolderDocument = {
 /**
  * - An io.cozy.files document
  */
-export type IOCozyFolder = CozyClientDocument & FileDocument;
+export type IOCozyFolder = CozyClientDocument & FolderDocument;
 /**
  * - An io.cozy.oauth.clients document
  */
@@ -299,6 +299,9 @@ export type CouchDBBulkResult = {
      */
     reason: string | null;
 };
+export type ViewKey = string | string[];
+export type DocId = string;
+export type CouchDBViewCursor = [string | string[], string];
 export type Theme = {
     id: string;
     label: string;

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -5,8 +5,10 @@ import get from 'lodash/get'
 import map from 'lodash/map'
 import zip from 'lodash/zip'
 import startsWith from 'lodash/startsWith'
-import Loop from './loop'
 import { isMobileApp } from 'cozy-device-helper'
+import { QueryDefinition } from 'cozy-client'
+
+import Loop from './loop'
 import logger from './logger'
 import { fetchRemoteLastSequence } from './remote'
 import { startReplication } from './startReplication'
@@ -16,7 +18,8 @@ import { getDatabaseName } from './utils'
 const DEFAULT_DELAY = 30 * 1000
 
 /**
- * @param {QueryDefinition} query
+ * @param {QueryDefinition} query The query definition whose name we're getting
+ *
  * @returns {string} alias
  */
 const getQueryAlias = query => {

--- a/packages/cozy-pouch-link/src/utils.js
+++ b/packages/cozy-pouch-link/src/utils.js
@@ -1,8 +1,9 @@
 /**
  * Get the database name based on prefix and doctype
  *
- * @param {string}} prefix - The URL prefix
+ * @param {string} prefix - The URL prefix
  * @param {string} doctype - The database doctype
+ *
  * @returns {string} The database name
  */
 export const getDatabaseName = (prefix, doctype) => {

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -5,6 +5,7 @@ import omit from 'lodash/omit'
 import head from 'lodash/head'
 import startsWith from 'lodash/startsWith'
 import qs from 'qs'
+import { MangoQueryOptions } from './mangoIndex'
 
 import Collection, {
   dontThrowNotFoundError,
@@ -209,8 +210,8 @@ class DocumentCollection {
    * name but the same definition. If yes, it means we found an old unamed
    * index, so we migrate it. If there is none, we create the new index.
    *
-   * @param {object} selector - The mango selector
-   * @param {object} options - The find options
+   * @param {object} selector The mango selector
+   * @param {MangoQueryOptions} options The find options
    * @private
    */
   async handleMissingIndex(selector, options) {
@@ -242,9 +243,10 @@ class DocumentCollection {
    * error is returned, the index is created and
    * the query run again.
    *
-   * @param {string} path - The route path
-   * @param {object} selector - The mango selector
-   * @param {object} options - The find options
+   * @param {string} path The route path
+   * @param {object} selector The mango selector
+   * @param {MangoQueryOptions} options The find options
+   *
    * @returns {object} - The find response
    * @private
    */
@@ -386,7 +388,7 @@ class DocumentCollection {
   /**
    * Updates several documents in one batch
    *
-   * @param  {Document[]} docs Documents to be updated
+   * @param  {Document[]} rawDocs Documents to be updated
    */
   async updateAll(rawDocs) {
     const stackClient = this.stackClient
@@ -612,8 +614,9 @@ class DocumentCollection {
    * This is useful to avoid creating new indexes having the
    * same definition of an existing one.
    *
-   * @param {object} selector - The query selector
-   * @param {object} options - The query options
+   * @param {object}            selector  The query selector
+   * @param {MangoQueryOptions} options   The find options
+   *
    * @returns {object} A matching index if it exists
    * @private
    */
@@ -644,12 +647,10 @@ class DocumentCollection {
    * Calls _changes route from CouchDB
    * No further treatment is done contrary to fetchchanges
    *
-   * @typedef {object} CouchOptionsRaw
-   * @param {string} since - Bookmark telling CouchDB from which point in time should changes be returned
-   * @param {Array<string>} doc_ids - Only return changes for a subset of documents
-   * @param {boolean} includeDocs - Includes full documents as part of results
-   *
-   * @param  {CouchOptionsRaw} couchOptions - Couch options for changes https://kutt.it/5r7MNQ
+   * @param {object} couchOptions - Couch options for changes https://kutt.it/5r7MNQ
+   * @param {string} [couchOptions.since] - Bookmark telling CouchDB from which point in time should changes be returned
+   * @param {Array<string>} [couchOptions.doc_ids] - Only return changes for a subset of documents
+   * @param {boolean} [couchOptions.includeDocs] - Includes full documents as part of results
    *
    * @see https://docs.couchdb.org/en/stable/api/database/changes.html
    */
@@ -681,17 +682,13 @@ class DocumentCollection {
    *
    * You should use fetchChangesRaw to have low level control on _changes parameters.
    *
-   * @typedef {object} CouchOptions
-   * @param {string} since - Bookmark telling CouchDB from which point in time should changes be returned
-   * @param {Array<string>} doc_ids - Only return changes for a subset of documents
+   * @param {object} couchOptions - Couch options for changes
+   * @param {string} [couchOptions.since] - Bookmark telling CouchDB from which point in time should changes be returned
+   * @param {Array<string>} [couchOptions.doc_ids] - Only return changes for a subset of documents
    *
-   * @typedef {object} FetchChangesOptions
-   * @property {boolean} includeDesign - Whether to include changes from design docs (needs include_docs to be true)
-   * @property {boolean} includeDeleted - Whether to include changes for deleted documents (needs include_docs to be true)
-   *
-   * @param  {CouchOptions} couchOptions - Couch options for changes
-   * @param  {FetchChangesOptions} options - Further options on the returned documents. By default, it is set to
-   *                                         { includeDesign: false, includeDeleted: false }
+   * @param {object} options - Further options on the returned documents. By default, it is set to { includeDesign: false, includeDeleted: false }
+   * @param {boolean} [options.includeDesign] - Whether to include changes from design docs (needs include_docs to be true)
+   * @param {boolean} [options.includeDeleted] - Whether to include changes for deleted documents (needs include_docs to be true)
    *
    * @typedef {object} FetchChangesReturnValue
    * @property {string} newLastSeq

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -3,7 +3,6 @@ import has from 'lodash/has'
 import get from 'lodash/get'
 import omit from 'lodash/omit'
 import pick from 'lodash/pick'
-import pickBy from 'lodash/pickBy'
 import { MangoQueryOptions } from './mangoIndex'
 
 import DocumentCollection, { normalizeDoc } from './DocumentCollection'
@@ -11,6 +10,7 @@ import { uri, slugify, formatBytes } from './utils'
 import { FetchError } from './errors'
 import { dontThrowNotFoundError } from './Collection'
 import { getIllegalCharacters } from './getIllegalCharacter'
+import * as querystring from './querystring'
 
 /**
  * Cursor used for Mango queries pagination
@@ -165,13 +165,6 @@ const dirName = path => {
   return path.substring(0, lastIndex)
 }
 
-const buildURL = (path, params) => {
-  const urlParams = new URLSearchParams(pickBy(params))
-  const stringParams = urlParams.toString()
-
-  return stringParams ? `${path}?${stringParams}` : path
-}
-
 /**
  * Implements `DocumentCollection` API along with specific methods for
  * `io.cozy.files`.
@@ -256,7 +249,7 @@ class FileCollection extends DocumentCollection {
       sort: 'datetime'
     }
     const path = uri`/data/${document._type}/${document._id}/relationships/references`
-    const url = buildURL(path, params)
+    const url = querystring.buildURL(path, params)
     const resp = await this.stackClient.fetchJSON('GET', url)
     return {
       data: normalizeReferences(resp.data),
@@ -740,7 +733,7 @@ class FileCollection extends DocumentCollection {
   async statById(id, options = {}) {
     const params = pick(options, ['page[limit]', 'page[skip]', 'page[cursor]'])
     const path = uri`/files/${id}`
-    const url = buildURL(path, params)
+    const url = querystring.buildURL(path, params)
     const resp = await this.stackClient.fetchJSON('GET', url)
     return {
       data: normalizeFile(resp.data),
@@ -1049,7 +1042,7 @@ class FileCollection extends DocumentCollection {
       sort: 'id'
     }
     const path = uri`/data/${oauthClient._type}/${oauthClient._id}/relationships/not_synchronizing`
-    const url = buildURL(path, params)
+    const url = querystring.buildURL(path, params)
     const resp = await this.stackClient.fetchJSON('GET', url)
     return {
       data: resp.data.map(f => normalizeFile(f)),
@@ -1173,7 +1166,7 @@ class FileCollection extends DocumentCollection {
       skip_trashed: opts.skipTrashed
     }
     const path = uri`/files/_changes`
-    const url = buildURL(path, params)
+    const url = querystring.buildURL(path, params)
     const {
       last_seq: newLastSeq,
       pending,

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -62,12 +62,12 @@ describe('FileCollection', () => {
       await collection.statById(42, {
         'page[skip]': 50,
         'page[limit]': 200,
-        'page[cursor]': 'abc123',
+        'page[cursor]': ['io.cozy.files', 'abc123'],
         ignoredOption: 'not-included'
       })
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'GET',
-        '/files/42?page%5Blimit%5D=200&page%5Bskip%5D=50&page%5Bcursor%5D=abc123'
+        '/files/42?page%5Blimit%5D=200&page%5Bskip%5D=50&page%5Bcursor%5D=io.cozy.files%2Cabc123'
       )
     })
 

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -67,7 +67,7 @@ describe('FileCollection', () => {
       })
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'GET',
-        '/files/42?page%5Blimit%5D=200&page%5Bskip%5D=50&page%5Bcursor%5D=io.cozy.files%2Cabc123'
+        '/files/42?page[limit]=200&page[skip]=50&page[cursor]=[%22io.cozy.files%22,%22abc123%22]'
       )
     })
 

--- a/packages/cozy-stack-client/src/NotesCollection.js
+++ b/packages/cozy-stack-client/src/NotesCollection.js
@@ -41,8 +41,8 @@ class NotesCollection extends DocumentCollection {
   /**
    * Destroys the note on the server
    *
-   * @param {io.cozy.notes} note     The note document to destroy
-   * @param {string}   note._id The note's id
+   * @param {object} note       The io.cozy.notes document to destroy
+   * @param {string} [note._id] The note's id
    *
    * @returns {{ data }} The deleted note
    */
@@ -56,8 +56,9 @@ class NotesCollection extends DocumentCollection {
   /**
    * Create a note
    *
-   * @param {object} option
-   * @param {string} option.dir_id dir_id where to create the note
+   * @param {object} options
+   * @param {string} [options.dir_id] dir_id where to create the note
+   *
    * @returns {{data, links, meta}} The JSON API conformant response.
    */
   async create({ dir_id }) {
@@ -82,8 +83,8 @@ class NotesCollection extends DocumentCollection {
    *
    * @see https://github.com/cozy/cozy-stack/blob/master/docs/notes.md#get-notesidopen
    *
-   * @param {io.cozy.notes} note The note document to open
-   * @param {string}   note._id The note's id
+   * @param {object} note       The io.cozy.notes document to open
+   * @param {string} [note._id] The note's id
    *
    * @returns {{ data }} The note's url details
    */

--- a/packages/cozy-stack-client/src/OAuthClientsCollection.js
+++ b/packages/cozy-stack-client/src/OAuthClientsCollection.js
@@ -27,11 +27,12 @@ class OAuthClientsCollection extends DocumentCollection {
   /**
    * Fetches all OAuth clients
    *
-   * @param  {object} options           Query options
-   * @param  {number} options.limit     For pagination, the number of results to return.
-   * @param  {object} options.bookmark  For cursor-based pagination, the index cursor.
-   * @param  {Array} options.keys       Ids of specific clients to return (within the current page),
-   * @returns {object}                  The JSON API conformant response.
+   * @param  {object}         options             Query options
+   * @param  {number}         [options.limit]     For pagination, the number of results to return.
+   * @param  {string}         [options.bookmark]  For bookmark-based pagination, the document _id to start from
+   * @param  {Array<string>}  [options.keys]      Ids of specific clients to return (within the current page),
+   *
+   * @returns {object} The JSON API conformant response.
    */
   async all(options = {}) {
     const { limit = 100, bookmark, keys } = options
@@ -103,7 +104,8 @@ class OAuthClientsCollection extends DocumentCollection {
   /**
    * Destroys the OAuth client on the server
    *
-   * @param {io.cozy.oauth.clients} oauthClient     The client document to destroy
+   * @param {object} oauthClient The io.cozy.oauth.clients document to destroy
+   *
    * @returns {{ data }} The deleted client
    */
   async destroy(oauthClient) {

--- a/packages/cozy-stack-client/src/mangoIndex.js
+++ b/packages/cozy-stack-client/src/mangoIndex.js
@@ -4,9 +4,27 @@ import get from 'lodash/get'
 import isEqual from 'lodash/isEqual'
 
 /**
+ * @typedef {object} MangoPartialFilter
+ */
+
+/**
+ * @typedef {object} MangoQueryOptions
+ *
+ * @property {Array<object>} [sort] The sorting parameters
+ * @property {Array<string>} [fields] The fields to return
+ * @property {number|null} [limit] For pagination, the number of results to return
+ * @property {number|null} [skip] For skip-based pagination, the number of referenced files to skip
+ * @property {string|null} [indexId] The _id of the CouchDB index to use for this request
+ * @property {string|null} [bookmark] For bookmark-based pagination, the document _id to start from
+ * @property {Array<string>} [indexedFields]
+ * @property {MangoPartialFilter|null} [partialFilter] An optional partial filter
+ */
+
+/**
  * Attributes representing a design doc
  *
  * @typedef {object} DesignDoc
+ *
  * @property {string} _id - Id of the design doc. Can be named, e.g. '_design/by_indexed_attribute' or not, e.g. '_design/12345'
  * @property {string} language - The index language. Can be 'query' for mango index or 'javascript' for views.
  * @property {object} views - Views definition, i.e. the index.
@@ -39,7 +57,8 @@ export const transformSort = sort => {
  * Compute fields that should be indexed for a mango
  * query to work
  *
- * @param  {object} options - Mango query options
+ * @param {MangoQueryOptions} options - Mango query options
+ *
  * @returns {Array} - Fields to index
  */
 export const getIndexFields = ({ selector, sort = [] }) => {

--- a/packages/cozy-stack-client/src/querystring.js
+++ b/packages/cozy-stack-client/src/querystring.js
@@ -1,5 +1,25 @@
 import pickBy from 'lodash/pickBy'
 
+/**
+ * Encode a value of any type into a URI search param compatible string with a specific treatment for arrays which will keep their brackets (they do not with standard `toString()` method).
+ *
+ * Examples:
+ *
+ *   encodeValues([['io.cozy.files', 'abcd1234'], '12345'])
+ *   // → '[[%22io.cozy.files%22,%22abcd1234%22],%2212345%22]'
+ *
+ *   encodeValues([['io.cozy.files', 'abcd1234'], '12345'].toString(), true)
+ *   // → '%22io.cozy.files%2Cabcd1234%2C12345%22'
+ *
+ *   encodeValues([['io.cozy.files', 'abcd1234'], '12345'].toString(), false)
+ *   // → 'io.cozy.files%2Cabcd1234%2C12345'
+ *
+ *   encodeValues('[1234]')
+ *   // → %5B1234%5D
+ *
+ * @function
+ * @private
+ */
 const encodeValues = (values, fromArray = false) => {
   if (Array.isArray(values)) {
     return '[' + values.map(v => encodeValues(v, true)).join(',') + ']'


### PR DESCRIPTION
When `FileCollection.fetchChanges()` was introduced, we found that
Arrays in query-string parameters were not URI encoded in the standard
way and we had our own URL generation function in the `querystring`
module.

Since the new method would pass a `fields` Array parameter which
needed to be encoded in the standard way, we decided to use
`URLSearchParams()` to encode the parameters.
While this would work for this particular parameter, this broke
pagination when a CouchDB view cursor would be used as this cursor is
an Array and needs the custom encoding.

Therefore, we're reverting the previous decision to use
`URLSearchParams` and go back to using our own `querystring` module to
generate URLs.
Since the `fields` parameter in the `fetchChanges()` method was in
fact already turned into a string before being passed to the URL
generation method, we don't need to do anything to keep it working.