### PR TITLE
fix(documents): Reducer should assign new object for concerned doctype

### DIFF
--- a/packages/cozy-client/src/store/documents.js
+++ b/packages/cozy-client/src/store/documents.js
@@ -151,16 +151,16 @@ export const getCollectionFromSlice = (state = {}, doctype) => {
 }
 
 /*
-  This method has been created in order to get a returned object 
-  in `data` with the full set on information coming potentially from 
-  ìncluded`
+  This method has been created in order to get a returned object
+  in `data` with the full set on information coming potentially from
+  `included`
 
-  This method should be somewhere else. The `document` shall not be 
-  deal with included / data and so on. 
+  This method should be somewhere else. The `document` shall not be
+  dealt with included / data and so on.
 
-  This method takes data and included and merge both sources 
-  together. It should be always up to date. The returned object 
-  will be as full of informations as it can be.
+  This method takes `data` and `included` and merge both sources
+  together. It should be always up-to-date. The returned object
+  will be as full of information as it can be.
 */
 export const extractAndMergeDocument = (data, updatedStateWithIncluded) => {
   const doctype = data[0]._type
@@ -172,8 +172,9 @@ export const extractAndMergeDocument = (data, updatedStateWithIncluded) => {
   const sortedData = keyBy(data, properId)
 
   let mergedData = Object.assign({}, updatedStateWithIncluded)
+  mergedData[doctype] = Object.assign({}, updatedStateWithIncluded[doctype])
+
   Object.values(sortedData).map(data => {
-    if (!mergedData[doctype]) mergedData[doctype] = {}
     const id = properId(data)
     if (mergedData[doctype][id]) {
       mergedData[doctype][id] = {

--- a/packages/cozy-client/src/store/documents.spec.js
+++ b/packages/cozy-client/src/store/documents.spec.js
@@ -4,23 +4,25 @@ import {
 } from './documents'
 
 describe('extractAndMerge', () => {
-  it('should return the right data', () => {
-    const data = {
-      0: {
-        id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
-        _id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
-        type: 'io.cozy.files',
-        _type: 'io.cozy.files'
-      },
-      1: {
-        id: 'b6ff135b34e041ffb2d4a4865f3e235f',
-        type: 'io.cozy.files',
-        _type: 'io.cozy.files',
-        _id: 'b6ff135b34e041ffb2d4a4865f3e235f'
-      }
+  const data = {
+    0: {
+      id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
+      _id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
+      type: 'io.cozy.files',
+      _type: 'io.cozy.files',
+      blabla: 'new field'
+    },
+    1: {
+      id: 'b6ff135b34e041ffb2d4a4865f3e235f',
+      type: 'io.cozy.files',
+      _type: 'io.cozy.files',
+      _id: 'b6ff135b34e041ffb2d4a4865f3e235f',
+      blibli: 'another new field'
     }
-    const updatedStateWithIncluded = {
-      0: {
+  }
+  const updatedStateWithIncluded = {
+    'io.cozy.files': {
+      b6ff135b34e041ffb2d4a4865f3e0a53: {
         attributes: {
           type: 'file',
           name: 'IMG_0016.PNG',
@@ -38,7 +40,7 @@ describe('extractAndMerge', () => {
         type: 'io.cozy.files',
         _type: 'io.cozy.files'
       },
-      1: {
+      b6ff135b34e041ffb2d4a4865f3e235f: {
         attributes: {
           type: 'file',
           name: 'IMG_0054.PNG',
@@ -57,65 +59,112 @@ describe('extractAndMerge', () => {
         _type: 'io.cozy.files'
       }
     }
+  }
+
+  it('should return the right data', () => {
     const returnedDatas = extractAndMergeDocument(
       data,
       updatedStateWithIncluded
     )
 
     const manuallyMergedData = {
-      '0': {
-        _id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
-        _type: 'io.cozy.files',
-        attributes: {
-          dir_id: '7d2f9c24cd345ce3171bf71f401e80c6',
-          name: 'IMG_0016.PNG',
-          type: 'file'
-        },
-        id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
-        links: { self: '/files/b6ff135b34e041ffb2d4a4865f3e0a53' },
-        meta: { rev: '5-87840eceaab358e38aa8b6bb0d4577b1' },
-        relationships: {
-          parent: {
-            links: { related: '/files/7d2f9c24cd345ce3171bf71f401e80c6' }
-          }
-        },
-        type: 'io.cozy.files'
-      },
-      '1': {
-        _id: 'b6ff135b34e041ffb2d4a4865f3e235f',
-        _type: 'io.cozy.files',
-        attributes: {
-          dir_id: '7d2f9c24cd345ce3171bf71f401e80c6',
-          name: 'IMG_0054.PNG',
-          type: 'file'
-        },
-        id: 'b6ff135b34e041ffb2d4a4865f3e235f',
-        links: { self: '/files/b6ff135b34e041ffb2d4a4865f3e235f' },
-        meta: { rev: '5-ca91c0dc02dafb38eb56070c1d80d62c' },
-        relationships: {
-          parent: {
-            links: { related: '/files/7d2f9c24cd345ce3171bf71f401e80c6' }
-          }
-        },
-        type: 'io.cozy.files'
-      },
       'io.cozy.files': {
         b6ff135b34e041ffb2d4a4865f3e0a53: {
           _id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
           _type: 'io.cozy.files',
+          attributes: {
+            dir_id: '7d2f9c24cd345ce3171bf71f401e80c6',
+            name: 'IMG_0016.PNG',
+            type: 'file'
+          },
+          blabla: 'new field',
           id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
+          links: { self: '/files/b6ff135b34e041ffb2d4a4865f3e0a53' },
+          meta: { rev: '5-87840eceaab358e38aa8b6bb0d4577b1' },
+          relationships: {
+            parent: {
+              links: { related: '/files/7d2f9c24cd345ce3171bf71f401e80c6' }
+            }
+          },
           type: 'io.cozy.files'
         },
         b6ff135b34e041ffb2d4a4865f3e235f: {
           _id: 'b6ff135b34e041ffb2d4a4865f3e235f',
           _type: 'io.cozy.files',
+          attributes: {
+            dir_id: '7d2f9c24cd345ce3171bf71f401e80c6',
+            name: 'IMG_0054.PNG',
+            type: 'file'
+          },
+          blibli: 'another new field',
           id: 'b6ff135b34e041ffb2d4a4865f3e235f',
+          links: { self: '/files/b6ff135b34e041ffb2d4a4865f3e235f' },
+          meta: { rev: '5-ca91c0dc02dafb38eb56070c1d80d62c' },
+          relationships: {
+            parent: {
+              links: { related: '/files/7d2f9c24cd345ce3171bf71f401e80c6' }
+            }
+          },
           type: 'io.cozy.files'
         }
       }
     }
     expect(returnedDatas).toEqual(manuallyMergedData)
   })
+
+  it(
+    'should assign a new object for doctype of document to update' +
+      'in order to allow selector to recompute their data when documents are updated',
+    () => {
+      const returnedDatas = extractAndMergeDocument(
+        data,
+        updatedStateWithIncluded
+      )
+
+      // Then
+      expect(
+        returnedDatas['io.cozy.files'] ===
+          updatedStateWithIncluded['io.cozy.files']
+      ).toBeFalsy()
+    }
+  )
+
+  it(
+    'should assign a new object for doctype of document to update' +
+      'even if the mergedData is the same, because reselect createSelector update ' +
+      'according to object reference, not only value',
+    () => {
+      const dataAlreadyIncludedInUpdatedStateWithIncluded = {
+        0: {
+          id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
+          _id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
+          type: 'io.cozy.files',
+          _type: 'io.cozy.files'
+        },
+        1: {
+          id: 'b6ff135b34e041ffb2d4a4865f3e235f',
+          type: 'io.cozy.files',
+          _type: 'io.cozy.files',
+          _id: 'b6ff135b34e041ffb2d4a4865f3e235f'
+        }
+      }
+
+      const returnedDatas = extractAndMergeDocument(
+        dataAlreadyIncludedInUpdatedStateWithIncluded,
+        updatedStateWithIncluded
+      )
+
+      // Then
+      expect(
+        returnedDatas['io.cozy.files'] ===
+          updatedStateWithIncluded['io.cozy.files']
+      ).toBeFalsy()
+
+      expect(returnedDatas['io.cozy.files']).toEqual(
+        updatedStateWithIncluded['io.cozy.files']
+      )
+    }
+  )
 })
 
 describe('mergeDocumentsWithRelationships', () => {


### PR DESCRIPTION
In Banks, we noticed the reference of the state.cozy.documents[doctype]
does not change when we refetch more transaction.

This was dued to extractAndMergeDocument that created a new
mergedData object but providing again the same properties.

Our property that got updated, from 1000 documents to 1500, was still
inside the same reference, so reselect did not recompute after store
got updated, and users faced this bug while moving from home page with
reimbursements, users see old reimbursements from home/transactions
instead of seeing the full reimbursements fetched on Reimbursements page.


when removing memoize options and adding `console.log('documents', documents ? Object.keys(documents).length : 0)` inside documentSelector line 72 => https://github.com/cozy/cozy-banks/blob/master/src/selectors/index.js#L72

![Capture d’écran 2022-02-09 à 16 17 30](https://user-images.githubusercontent.com/8363334/153231064-f18c5cdd-189b-4f80-9a53-8c019051d312.png)

