### PR TITLE
fix(client): Explicit type of file class and type that should be string

### DIFF
--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -170,11 +170,11 @@ export type FileDocument = {
     /**
      * - Type of the file
      */
-    type: object;
+    type: string;
     /**
      * - Class of the file
      */
-    class: object;
+    class: string;
 };
 /**
  * - An io.cozy.files document


### PR DESCRIPTION
Apparently:

![Capture d’écran 2022-02-14 à 16 52 21](https://user-images.githubusercontent.com/8363334/153898168-a607b026-d380-44b0-af15-ae1764836413.png)
