### PR TITLE
Feat/handle www authenticate header error

### DIFF
--- a/packages/cozy-stack-client/src/CozyStackClient.spec.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.spec.js
@@ -259,7 +259,11 @@ describe('CozyStackClient', () => {
     const client = new CozyStackClient(FAKE_INIT_OPTIONS)
 
     beforeAll(() => {
-      global.fetch = require('jest-fetch-mock')
+      global.fetch = jestFetchMock
+    })
+
+    beforeEach(() => {
+      fetch.resetMocks()
       fetch.mockResponse(JSON.stringify(FAKE_RESPONSE), {
         headers: { 'Content-Type': 'application/json' }
       })

--- a/packages/cozy-stack-client/src/CozyStackClient.spec.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.spec.js
@@ -365,6 +365,39 @@ describe('CozyStackClient', () => {
       )
     })
 
+    it('should try to refresh the current token when received an expired token response', async () => {
+      const client = new CozyStackClient(FAKE_INIT_OPTIONS)
+      global.fetch
+        .mockResponseOnce(() => {
+          return Promise.resolve({
+            headers: {
+              'content-type': 'application/json; charset=UTF-8'
+            },
+            body: JSON.stringify({
+              error: 'Expired token'
+            }),
+            ok: false,
+            status: 403,
+            statusText: '',
+            type: 'default',
+            url: 'http://cozy.tools:8080/settings/capabilities'
+          })
+        })
+        .once([FAKE_APP_HTML, { status: 200 }])
+        .once([JSON.stringify({ res: 'ok' }), { status: 200 }])
+      await client.fetchJSON('GET', '/test')
+      const token = client.getAccessToken()
+      expect(token).toEqual(FAKE_APP_TOKEN)
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${FAKE_APP_TOKEN}`
+          })
+        })
+      )
+    })
+
     it('should not change option header even if we recall the method after an expired token for instance', async () => {
       jest.spyOn(client, 'fetchJSONWithCurrentToken')
       fetch.mockRejectedValueOnce({ message: 'Expired token' })

--- a/packages/cozy-stack-client/src/errors.js
+++ b/packages/cozy-stack-client/src/errors.js
@@ -8,6 +8,27 @@ export default {
   INVALID_TOKEN
 }
 
+const getWwwAuthenticateErrorMessage = response => {
+  const invalidTokenRegex = /invalid_token/
+  const expiredTokenRegex = /access token expired/
+  const wwwAuthenticateHeader =
+    response.headers && response.headers.get('www-authenticate')
+
+  if (!wwwAuthenticateHeader) {
+    return undefined
+  }
+
+  if (expiredTokenRegex.test(wwwAuthenticateHeader)) {
+    return 'Expired token'
+  }
+
+  if (invalidTokenRegex.test(wwwAuthenticateHeader)) {
+    return 'Invalid token'
+  }
+
+  return undefined
+}
+
 export class FetchError extends Error {
   constructor(response, reason) {
     super()
@@ -21,9 +42,12 @@ export class FetchError extends Error {
     this.status = response.status
     this.reason = reason
 
+    let wwwAuthenticateErrorMessage = getWwwAuthenticateErrorMessage(response)
+
     Object.defineProperty(this, 'message', {
       value:
         reason.message ||
+        wwwAuthenticateErrorMessage ||
         (typeof reason === 'string' ? reason : JSON.stringify(reason))
     })
   }


### PR DESCRIPTION
In cozy/cozy-stack@2d1e27652c76fb9cfb66751019f40ee9a1ae64d1 we
introduced `WWW-Authenticate` header usage to notify that the token
expired

CozyStackClient is now able to refresh its token when
`WWW-Authenticate` is set with expired token error