### PR TITLE
feat: Add Manual to Job creation

### DIFF
--- a/packages/cozy-stack-client/src/JobCollection.js
+++ b/packages/cozy-stack-client/src/JobCollection.js
@@ -39,17 +39,19 @@ class JobCollection {
    * Creates a job
    *
    * @param  {string} workerType - Ex: "konnector"
-   * @param  {object} args - Ex: {"slug": "my-konnector", "trigger": "trigger-id"}
-   * @param  {object} options - creation options
+   * @param  {object} [args={}] - Ex: {"slug": "my-konnector", "trigger": "trigger-id"}
+   * @param  {object} [options={}] - creation options
+   * @param  {boolean} [manual=false] -  Manual execution
    * @returns {object} createdJob
    */
-  create(workerType, args, options) {
+  create(workerType, args = {}, options = {}, manual = false) {
     return this.stackClient.fetchJSON('POST', `/jobs/queue/${workerType}`, {
       data: {
         type: JOBS_DOCTYPE,
         attributes: {
-          arguments: args || {},
-          options: options || {}
+          arguments: args,
+          options: options,
+          manual
         }
       }
     })
@@ -59,7 +61,6 @@ class JobCollection {
    * Return a normalized job, given its id
    *
    * @param {string} id - id of the job
-   *
    * @returns {JobDocument}
    */
   async get(id) {

--- a/packages/cozy-stack-client/src/JobCollection.spec.js
+++ b/packages/cozy-stack-client/src/JobCollection.spec.js
@@ -13,7 +13,7 @@ describe('job collection', () => {
     col = new JobCollection(stackClient)
   })
 
-  it('should call the right route when creating', async () => {
+  it('should call the right route when creating & defaulting manual to false', async () => {
     await col.create('service', {
       message: {
         name: 'categorization',
@@ -27,6 +27,35 @@ describe('job collection', () => {
         data: {
           attributes: {
             arguments: { message: { name: 'categorization', slug: 'banks' } },
+            manual: false,
+            options: {}
+          },
+          type: 'io.cozy.jobs'
+        }
+      }
+    )
+  })
+
+  it('should call the right route when creating & set manual to true', async () => {
+    await col.create(
+      'service',
+      {
+        message: {
+          name: 'categorization',
+          slug: 'banks'
+        }
+      },
+      {},
+      true
+    )
+    expect(stackClient.fetchJSON).toHaveBeenCalledWith(
+      'POST',
+      '/jobs/queue/service',
+      {
+        data: {
+          attributes: {
+            arguments: { message: { name: 'categorization', slug: 'banks' } },
+            manual: true,
             options: {}
           },
           type: 'io.cozy.jobs'


### PR DESCRIPTION
We had the capacity to launch trigger `manually`. But there was no way to create a `manual` job. 

Since https://github.com/cozy/cozy-stack/pull/3308 we can create the job with the `manual` argument. 

What is this `manual` stuff? By default, jobs are queued and the gozy-worker enqueue the jobs progressively. But sometimes, we need to run a job as quick as possible since the user is currently waiting for the response of the job. To achieve that, we have this concept of `manual` job. The job is still async, but not in the `global` queue. 

This is needed when we want to launch the banking connector to get a temporary token in order to create the account on the BI's side. 