### PR TITLE
fix(stack-client): Fetch icon url when no appData and slug is passed

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -1839,8 +1839,8 @@ or using preloaded url when blob not needed
 | stackClient.oauthOptions | <code>object</code> |  | oauthOptions used to detect fetching mechanism |
 | opts | <code>object</code> |  | Options |
 | opts.type | <code>string</code> |  | Options type |
-| opts.slug | <code>string</code> |  | Options slug |
-| opts.appData | <code>object</code> \| <code>string</code> |  | Apps data - io.cozy.apps or Slug - string |
+| opts.slug | <code>string</code> \| <code>undefined</code> |  | Options slug |
+| opts.appData | <code>object</code> \| <code>string</code> \| <code>undefined</code> |  | Apps data - io.cozy.apps or Slug - string |
 | [opts.priority] | <code>string</code> | <code>&quot;&#x27;stack&#x27;&quot;</code> | Options priority |
 
 <a name="garbageCollect"></a>

--- a/packages/cozy-stack-client/src/getIconURL.js
+++ b/packages/cozy-stack-client/src/getIconURL.js
@@ -3,16 +3,17 @@ import memoize, { ErrorReturned } from './memoize'
 /**
  * Get Icon source Url
  *
- * @param  {object|string}  app - Apps data - io.cozy.apps or Slug - string
+ * @param  {object}  app - Apps data - io.cozy.apps
+ * @param  {string}  slug - Slug - string
  * @param  {string|undefined} domain - Host to use in the origin (e.g. cozy.tools)
  * @param  {string} protocol - Url protocol (e.g. http / https)
  * @returns {string}  Source Url of icon
  * @private
  * @throws {Error} When cannot fetch or get icon source
  */
-const loadIcon = async (app, domain, protocol) => {
+const loadIcon = async (app, slug, domain, protocol) => {
   if (!domain) throw new Error('Cannot fetch icon: missing domain')
-  const source = _getAppIconURL(app, domain, protocol)
+  const source = _getAppIconURL(app, slug, domain, protocol)
   if (!source) {
     throw new Error(`Cannot get icon source for app ${app.name}`)
   }
@@ -22,27 +23,30 @@ const loadIcon = async (app, domain, protocol) => {
 /**
  * Get App Icon URL
  *
- * @param  {object|string}  app - Apps data - io.cozy.apps or Slug - string
+ * @param  {object}  app - Apps data - io.cozy.apps or Slug - string
+ * @param  {string}  slug - Slug - string
  * @param  {string|undefined} domain - Host to use in the origin (e.g. cozy.tools)
  * @param  {string} protocol - Url protocol (e.g. http / https)
  * @private
  * @returns {string|null}  App Icon URL
  */
-const _getAppIconURL = (app, domain, protocol) => {
-  const path = (app && app.links && app.links.icon) || _getRegistryIconPath(app)
+const _getAppIconURL = (app, slug, domain, protocol) => {
+  const path =
+    (app && app.links && app.links.icon) || _getRegistryIconPath(app, slug)
   return path ? `${protocol}//${domain}${path}` : null
 }
 
 /**
  * Get Registry Icon Path
  *
- * @param  {object|string}  app - Apps data - io.cozy.apps or Slug - string
+ * @param  {object}  app - Apps data - io.cozy.apps or Slug - string
+ * @param  {string}  slug - Slug - string
  * @returns {string|undefined}  Registry icon path
  * @private
  */
-const _getRegistryIconPath = app => {
-  if (typeof app === 'string') {
-    return `/registry/${app}/icon`
+const _getRegistryIconPath = (app, slug) => {
+  if (slug) {
+    return `/registry/${slug}/icon`
   }
 
   return (
@@ -130,8 +134,8 @@ const fetchAppOrKonnectorViaRegistry = (stackClient, type, slug) =>
  * @param  {object}  stackClient.oauthOptions - oauthOptions used to detect fetching mechanism
  * @param  {object} opts - Options
  * @param  {string} opts.type - Options type
- * @param  {string} opts.slug - Options slug
- * @param  {object|string}  opts.appData - Apps data - io.cozy.apps or Slug - string
+ * @param  {string|undefined} opts.slug - Options slug
+ * @param  {object|string|undefined}  opts.appData - Apps data - io.cozy.apps
  * @param  {string} [opts.priority='stack'] - Options priority
  * @returns {Promise<string>|string} DOMString containing URL source or a URL representing the Blob .
  * @private
@@ -181,7 +185,7 @@ export const _getIconURL = async (stackClient, opts) => {
   } else {
     try {
       const { host: domain, protocol } = new URL(stackClient.uri)
-      return loadIcon(appData, domain, protocol)
+      return loadIcon(appData, slug, domain, protocol)
     } catch (error) {
       throw new Error(
         `Cannot fetch icon: invalid stackClient.uri: ${error.message}`
@@ -198,8 +202,8 @@ export const _getIconURL = async (stackClient, opts) => {
  * @param  {object}  stackClient.oauthOptions - oauthOptions used to detect fetching mechanism
  * @param  {object} opts - Options
  * @param  {string} opts.type - Options type
- * @param  {string} opts.slug - Options slug
- * @param  {object|string}  opts.appData - Apps data - io.cozy.apps or Slug - string
+ * @param  {string|undefined} opts.slug - Options slug
+ * @param  {object|string|undefined}  opts.appData - Apps data - io.cozy.apps or Slug - string
  * @param  {string} [opts.priority='stack'] - Options priority
  * @returns {Promise<string>|string} DOMString containing URL source or a URL representing the Blob or ErrorReturned
  */

--- a/packages/cozy-stack-client/src/getIconURL.spec.js
+++ b/packages/cozy-stack-client/src/getIconURL.spec.js
@@ -205,6 +205,7 @@ describe('get icon', () => {
 
     it('should return url from registry if app data not containing icon path', async () => {
       defaultOpts.appData = { latest_version: { version: '3' }, slug: 'slug' }
+      defaultOpts.slug = undefined
       const url = await getIconURL(stackClient, defaultOpts)
       expect(url).toEqual('http://cozy.tools:8080/registry/slug/3/icon')
     })
@@ -217,16 +218,30 @@ describe('get icon', () => {
 
     it('should catch occurring error and returns nothing - ErrorReturned', async () => {
       defaultOpts.appData = { latest_version: undefined, slug: 'slug' }
+      defaultOpts.slug = undefined
       const url = await getIconURL(stackClient, defaultOpts)
       expect(url).toEqual(new ErrorReturned())
     })
 
-    it('should return url from appData if appData is a SLUG', async () => {
-      defaultOpts.appData = 'appData-that-is-a-slug'
+    it('should return url from slug if appData is  undefined and there is a slug', async () => {
+      defaultOpts.appData = undefined
+      defaultOpts.slug = 'slug'
       const url = await getIconURL(stackClient, defaultOpts)
-      expect(url).toEqual(
-        'http://cozy.tools:8080/registry/appData-that-is-a-slug/icon'
-      )
+      expect(url).toEqual('http://cozy.tools:8080/registry/slug/icon')
+    })
+
+    it('should return url from slug if appData is  version latest_version but there is a slug', async () => {
+      defaultOpts.appData = { latest_version: { version: '3' }, slug: 'slug' }
+      defaultOpts.slug = 'slug'
+      const url = await getIconURL(stackClient, defaultOpts)
+      expect(url).toEqual('http://cozy.tools:8080/registry/slug/icon')
+    })
+
+    it('should return url from appData, links, icon if defined, even if slug defined', async () => {
+      defaultOpts.appData = { links: { icon: '/path/to/icon' } }
+      defaultOpts.slug = 'slug'
+      const url = await getIconURL(stackClient, defaultOpts)
+      expect(url).toEqual('http://cozy.tools:8080/path/to/icon')
     })
   })
 })


### PR DESCRIPTION
some AppIcon contains only a slug, so appData was undefined, breaking Home icons used by konnectors