### PR TITLE
fix: Correct fr locale 'facture d'énergie' in cozy-client

### DIFF
--- a/packages/cozy-client/src/models/document/locales/fr.json
+++ b/packages/cozy-client/src/models/document/locales/fr.json
@@ -71,7 +71,7 @@
       "phone_invoice": "Facture de téléphone",
       "isp_invoice": "Facture d'internet",
       "telecom_invoice": "Facture de télécom",
-      "energy_invoice": "Facture d'électricité",
+      "energy_invoice": "Facture d'énergie",
       "water_invoice": "Facture d'eau",
       "web_service_invoice": "Facture de service web",
       "appliance_invoice": "Facture d'électroménager",


### PR DESCRIPTION
energy_invoice is not only for electricity, correction the fr locale, english one is OK.