### PR TITLE
Feat/improve inapp browser

### DIFF
--- a/packages/cozy-client/src/authentication/mobile.native.js
+++ b/packages/cozy-client/src/authentication/mobile.native.js
@@ -34,7 +34,7 @@ export const authenticateWithReactNativeInAppBrowser = async url => {
       enableBarCollapsing: false,
       // Android Properties
       showTitle: true,
-      toolbarColor: '#6200EE',
+      toolbarColor: '#8e9094',
       secondaryToolbarColor: 'black',
       enableUrlBarHiding: true,
       enableDefaultShare: true,

--- a/packages/cozy-client/src/authentication/mobile.native.js
+++ b/packages/cozy-client/src/authentication/mobile.native.js
@@ -29,6 +29,7 @@ export const authenticateWithReactNativeInAppBrowser = async url => {
       enableUrlBarHiding: true,
       enableDefaultShare: true,
       forceCloseOnRedirection: false,
+      showInRecents: true,
       // Specify full animation resource identifier(package:anim/name)
       // or only resource name(in case of animation bundled with app).
       animations: {


### PR DESCRIPTION
This PR does:
- Fix a bug that would close the InAppBrowser when application is sent to background
- Add a promise rejection when we detect that the user closed the InAppBrowser or the `/authorize` dialog (in the HTML view)
- Edit the InAppBrowser's header color from violet to gray

### Before
<img width="492" alt="image" src="https://user-images.githubusercontent.com/1884255/159057076-6eeb4dc7-7dc8-4c7e-a7e4-e622c9e07f44.png">

### After
<img width="492" alt="image" src="https://user-images.githubusercontent.com/1884255/159056895-3522fdf7-59bb-4908-8236-1186e3f9b901.png">

___

Related PR: https://github.com/cozy/cozy-react-native/pull/108