### PR TITLE
feat: Add DACC model

### DIFF
--- a/packages/cozy-client/src/models/dacc.js
+++ b/packages/cozy-client/src/models/dacc.js
@@ -1,0 +1,73 @@
+import log from 'cozy-logger'
+import { DACCMeasure } from '../types'
+
+/**
+ * Throw an errror if a DACC parameter is incorrect.
+ *
+ * @param { DACCMeasure} measure - The DACC measure
+ */
+export const checkMeasureParams = measure => {
+  const {
+    createdBy,
+    measureName,
+    startDate,
+    value,
+    group1,
+    group2,
+    group3
+  } = measure
+
+  if (!createdBy || typeof createdBy !== 'string') {
+    throw new Error('Missing or wrong type parameter: createdBy')
+  }
+  if (!measureName || typeof measureName !== 'string') {
+    throw new Error('Missing or wrong type parameter: measureName')
+  }
+  if (!startDate) {
+    throw new Error('Missing parameter: startDate')
+  }
+  const parsedDate = new Date(Date.parse(startDate))
+  if (!parsedDate.toISOString().startsWith(startDate)) {
+    throw new Error('Date should be in YYYY-MM-DD format')
+  }
+  if (!value || typeof value !== 'number') {
+    throw new Error('Missing or wrong type parameter: value')
+  }
+  if (
+    (group1 &&
+      (typeof group1 !== 'object' || Object.keys(group1).length === 0)) ||
+    (group2 &&
+      (typeof group2 !== 'object' || Object.keys(group2).length === 0)) ||
+    (group3 && (typeof group3 !== 'object' || Object.keys(group3).length === 0))
+  ) {
+    throw new Error('Groups should be key-value objects')
+  }
+  if ((group3 && (!group2 || !group1)) || (group2 && !group1)) {
+    throw new Error('Group order must be respected')
+  }
+}
+
+/**
+ * Send measures to a DACC through a remote doctype
+ *
+ * @param {object} client - The CozyClient instance
+ * @param {string} remoteDoctype - The remote doctype to use
+ * @param {DACCMeasure} measure - The DACC measure
+ */
+export const sendMeasureToDACC = async (client, remoteDoctype, measure) => {
+  try {
+    checkMeasureParams(measure)
+
+    await client
+      .getStackClient()
+      .fetchJSON('POST', `/remote/${remoteDoctype}`, {
+        data: JSON.stringify(measure)
+      })
+  } catch (error) {
+    log(
+      'error',
+      `Error while sending measure to remote doctype: ${error.message}`
+    )
+    throw error
+  }
+}

--- a/packages/cozy-client/src/models/dacc.spec.js
+++ b/packages/cozy-client/src/models/dacc.spec.js
@@ -1,0 +1,99 @@
+import { checkMeasureParams } from './dacc'
+
+describe('dacc', () => {
+  const measure = {
+    value: 42,
+    measureName: 'theanswer',
+    startDate: '2022-01-01',
+    createdBy: 'DeepThought'
+  }
+
+  it('should not throw when all params are corrects', () => {
+    expect(() => checkMeasureParams(measure)).not.toThrow()
+  })
+
+  it('should not throw when all params are corrects with groups', () => {
+    const measureWithGroups = {
+      ...measure,
+      group1: { a: 1 },
+      group2: { b: 1 },
+      group3: { c: 1 }
+    }
+    expect(() => checkMeasureParams(measureWithGroups)).not.toThrow()
+  })
+
+  it('should throw an error when createdBy is missing or malformed', () => {
+    expect(() => checkMeasureParams({ ...measure, createdBy: null })).toThrow()
+    expect(() => checkMeasureParams({ ...measure, createdBy: 123 })).toThrow()
+  })
+
+  it('should throw an error when value is missing or malformed', () => {
+    expect(() => checkMeasureParams({ ...measure, value: null })).toThrow()
+    expect(() =>
+      checkMeasureParams({ ...measure, value: 'notacorrectvalue' })
+    ).toThrow()
+  })
+
+  it('should throw an error when measureName is missing or malformed', () => {
+    expect(() =>
+      checkMeasureParams({ ...measure, measureName: null })
+    ).toThrow()
+    expect(() => checkMeasureParams({ ...measure, measureName: 10 })).toThrow()
+  })
+
+  it('should throw an error when startDate is missing or malformed', () => {
+    expect(() => checkMeasureParams({ ...measure, startDate: null })).toThrow()
+    expect(() => checkMeasureParams({ ...measure, startDate: 123 })).toThrow()
+    expect(() =>
+      checkMeasureParams({ ...measure, startDate: '01 January 2012' })
+    ).toThrow()
+    expect(() =>
+      checkMeasureParams({ ...measure, startDate: '2022:01:01' })
+    ).toThrow()
+  })
+
+  it('should throw an error when groups are not objects', () => {
+    expect(() => checkMeasureParams({ ...measure, group1: '123' })).toThrow()
+    expect(() =>
+      checkMeasureParams({ ...measure, group1: { a: 1 }, group2: '456' })
+    ).toThrow()
+    expect(() =>
+      checkMeasureParams({
+        ...measure,
+        group1: { a: 1 },
+        group2: { b: 1 },
+        group3: '789'
+      })
+    ).toThrow()
+  })
+
+  it('should throw an error when groups are empty objects', () => {
+    expect(() => checkMeasureParams({ ...measure, group1: {} })).toThrow()
+    expect(() =>
+      checkMeasureParams({ ...measure, group1: { a: 1 }, group2: {} })
+    ).toThrow()
+    expect(() =>
+      checkMeasureParams({
+        ...measure,
+        group1: { a: 1 },
+        group2: { b: 1 },
+        group3: {}
+      })
+    ).toThrow()
+  })
+
+  it('should throw an error when groups order is not respected', () => {
+    expect(() => checkMeasureParams({ ...measure, group2: { b: 1 } })).toThrow()
+    expect(() => checkMeasureParams({ ...measure, group3: { c: 1 } })).toThrow()
+    expect(() =>
+      checkMeasureParams({
+        ...measure,
+        group1: { a: 1 },
+        group3: { c: 1 }
+      })
+    ).toThrow()
+    expect(() =>
+      checkMeasureParams({ ...measure, group2: { b: 1 }, group3: { c: 1 } })
+    ).toThrow()
+  })
+})

--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -303,13 +303,15 @@ import { QueryDefinition } from './queries/dsl'
 
 /**
  * @typedef {object} DACCMeasure
- * @property {string} measureName
- * @property {string} startDate
- * @property {string} createdBy
- * @property {number} value
- * @property {object} group1
- * @property {object} group2
- * @property {object} group3
+ * See https://github.com/cozy/DACC
+ *
+ * @property {string} measureName - It must match an existing measure name on the DACC server
+ * @property {string} startDate - Start of the aggregation period. Should be in YYYY-MM-DD format
+ * @property {number} value - The measured value on the aggregation period
+ * @property {string} createdBy - The slug of the app creating the measure
+ * @property {object} group1 - Should be a {key: value} where the key is set in the measure definition.
+ * @property {object} group2 - Should be a {key: value} where the key is set in the measure definition.
+ * @property {object} group3 - Should be a {key: value} where the key is set in the measure definition.
  */
 
 /**

--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -302,6 +302,17 @@ import { QueryDefinition } from './queries/dsl'
  */
 
 /**
+ * @typedef {object} DACCMeasure
+ * @property {string} measureName
+ * @property {string} startDate
+ * @property {string} createdBy
+ * @property {number} value
+ * @property {object} group1
+ * @property {object} group2
+ * @property {object} group3
+ */
+
+/**
  * Receives the URL to present to the user as a parameter, and should return a promise that resolves with the URL the user was redirected to after accepting the permissions.
  *
  * @callback OpenURLCallback


### PR DESCRIPTION
This provides an API to send measures to the DACC through a remote
doctype and check the parameters to ensure their correctness.