### PR TITLE
fix(refresh-token): Fetch refresh token on a specific route

### DIFF
--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -187,7 +187,7 @@ class CozyStackClient {
       throw new Error('Not in a web context, cannot refresh token')
     }
 
-    const response = await fetch('/', options)
+    const response = await fetch('/?refreshToken', options)
 
     if (!response.ok) {
       throw new Error(


### PR DESCRIPTION
This allows service-worker not to cache this call

Because fetching '/' means fetching '/index.html'
that is cached by service-worker
This prevents error on Home+Drive
when user stays connected for more than 24 hours