### PR TITLE
feat: Add getSharingLink function

### DIFF
--- a/docs/api/cozy-client/modules/models.md
+++ b/docs/api/cozy-client/modules/models.md
@@ -13,6 +13,7 @@
 *   [instance](models.instance.md)
 *   [note](models.note.md)
 *   [permission](models.permission.md)
+*   [sharing](models.sharing.md)
 *   [timeseries](models.timeseries.md)
 *   [trigger](models.trigger.md)
 *   [utils](models.utils.md)
@@ -25,7 +26,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/index.js:16](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/index.js#L16)
+[packages/cozy-client/src/models/index.js:17](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/index.js#L17)
 
 ***
 
@@ -35,4 +36,4 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/index.js:15](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/index.js#L15)
+[packages/cozy-client/src/models/index.js:16](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/index.js#L16)

--- a/docs/api/cozy-client/modules/models.sharing.md
+++ b/docs/api/cozy-client/modules/models.sharing.md
@@ -1,0 +1,31 @@
+[cozy-client](../README.md) / [models](models.md) / sharing
+
+# Namespace: sharing
+
+[models](models.md).sharing
+
+## Functions
+
+### getSharingLink
+
+▸ **getSharingLink**(`client`, `filesIds`, `isFlatDomain`): `Promise`<`string`>
+
+Generate Sharing link for one or many files
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`CozyClient`](../classes/CozyClient.md) | Instance of CozyClient |
+| `filesIds` | `string`\[] | Array of io.cozy.files ids |
+| `isFlatDomain` | `boolean` | - |
+
+*Returns*
+
+`Promise`<`string`>
+
+Shared link
+
+*Defined in*
+
+[packages/cozy-client/src/models/sharing.js:13](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/sharing.js#L13)

--- a/packages/cozy-client/src/const.js
+++ b/packages/cozy-client/src/const.js
@@ -1,3 +1,4 @@
 export const REGISTRATION_ABORT = 'REGISTRATION_ABORT'
 
 export const DOCTYPE_FILES = 'io.cozy.files'
+export const DOCTYPE_PERMISSIONS = 'io.cozy.permissions'

--- a/packages/cozy-client/src/models/index.js
+++ b/packages/cozy-client/src/models/index.js
@@ -10,6 +10,7 @@ import * as utils from './utils'
 import * as contact from './contact'
 import * as document from './document'
 import * as timeseries from './timeseries'
+import * as sharing from './sharing'
 
 // For backward compatibility before 9.0.0
 const triggers = trigger
@@ -29,5 +30,6 @@ export {
   utils,
   contact,
   document,
-  timeseries
+  timeseries,
+  sharing
 }

--- a/packages/cozy-client/src/models/sharing.js
+++ b/packages/cozy-client/src/models/sharing.js
@@ -1,0 +1,31 @@
+import { DOCTYPE_FILES, DOCTYPE_PERMISSIONS } from '../const'
+import CozyClient from '../CozyClient'
+import { generateWebLink } from '../helpers'
+
+/**
+ * Generate Sharing link for one or many files
+ *
+ * @param {CozyClient} client - Instance of CozyClient
+ * @param {string[]} filesIds - Array of io.cozy.files ids
+ * @param {boolean} [isFlatDomain] -
+ * @returns {Promise<string>} Shared link
+ */
+export const getSharingLink = async (client, filesIds, isFlatDomain) => {
+  const PERMS = {
+    _type: DOCTYPE_PERMISSIONS,
+    permissions: {
+      files: { type: DOCTYPE_FILES, values: filesIds, verbs: ['GET'] }
+    }
+  }
+  const { data: sharedLink } = await client.save(PERMS)
+
+  const webLink = generateWebLink({
+    cozyUrl: client.getStackClient().uri,
+    searchParams: [['sharecode', sharedLink?.attributes?.shortcodes?.code]],
+    pathname: '/public',
+    slug: 'drive',
+    subDomainType: isFlatDomain ? 'flat' : 'nested'
+  })
+
+  return webLink
+}

--- a/packages/cozy-client/src/models/sharing.spec.js
+++ b/packages/cozy-client/src/models/sharing.spec.js
@@ -1,0 +1,53 @@
+import { getSharingLink } from './sharing'
+
+describe('getSharingLink', () => {
+  const mockSharecode = { attributes: { shortcodes: { code: 'shortcode' } } }
+  const mockClient = {
+    save: jest.fn(() => ({ data: mockSharecode })),
+    getStackClient: jest.fn(() => ({ uri: 'http://cozy.cloud' }))
+  }
+  const mockFiles = [
+    { id: 'fileId01', name: 'File 01' },
+    { id: 'fileId02', name: 'File 02' }
+  ]
+
+  it('should generate the right share link if "isFlatDomain" param is not defined', async () => {
+    const sharingLink = await getSharingLink(mockClient, mockFiles)
+
+    expect(sharingLink).toBe(
+      'http://drive.cozy.cloud/public?sharecode=shortcode#/'
+    )
+  })
+
+  it('should generate the right share link to a nested cozy', async () => {
+    const isFlatDomain = false
+    const sharingLink = await getSharingLink(
+      mockClient,
+      mockFiles,
+      isFlatDomain
+    )
+
+    expect(sharingLink).toBe(
+      'http://drive.cozy.cloud/public?sharecode=shortcode#/'
+    )
+  })
+
+  it('should generate the right share link to a flat cozy', async () => {
+    const isFlatDomain = true
+    const sharingLink = await getSharingLink(
+      mockClient,
+      mockFiles,
+      isFlatDomain
+    )
+
+    expect(sharingLink).toBe(
+      'http://cozy-drive.cloud/public?sharecode=shortcode#/'
+    )
+  })
+
+  it('should generate the right share link with an correct sharecode', async () => {
+    const sharingLink = await getSharingLink(mockClient, mockFiles)
+
+    expect(sharingLink).toContain('sharecode=shortcode')
+  })
+})

--- a/packages/cozy-client/types/const.d.ts
+++ b/packages/cozy-client/types/const.d.ts
@@ -1,2 +1,3 @@
 export const REGISTRATION_ABORT: "REGISTRATION_ABORT";
 export const DOCTYPE_FILES: "io.cozy.files";
+export const DOCTYPE_PERMISSIONS: "io.cozy.permissions";

--- a/packages/cozy-client/types/models/index.d.ts
+++ b/packages/cozy-client/types/models/index.d.ts
@@ -12,4 +12,5 @@ import * as utils from "./utils";
 import * as contact from "./contact";
 import * as document from "./document";
 import * as timeseries from "./timeseries";
-export { trigger, instance, applications, file, folder, note, account, permission, utils, contact, document, timeseries };
+import * as sharing from "./sharing";
+export { trigger, instance, applications, file, folder, note, account, permission, utils, contact, document, timeseries, sharing };

--- a/packages/cozy-client/types/models/sharing.d.ts
+++ b/packages/cozy-client/types/models/sharing.d.ts
@@ -1,0 +1,2 @@
+export function getSharingLink(client: CozyClient, filesIds: string[], isFlatDomain?: boolean): Promise<string>;
+import CozyClient from "../CozyClient";


### PR DESCRIPTION
Added `getSharingLink` function to generate a sharing link for one or more files.
This function already exists in different libraries like `cozy-sharing` or `cozy-mespapiers-lib`, and soon in `cozy-ui`.
So I think it's good to centralize it in `cozy-client`.