### PR TITLE
Encrypted attribute in io.cozy.files

### DIFF
--- a/docs/api/cozy-client/interfaces/models.file.FileUploadOptions.md
+++ b/docs/api/cozy-client/interfaces/models.file.FileUploadOptions.md
@@ -14,7 +14,7 @@ Erase / rename
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:455](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L455)
+[packages/cozy-client/src/models/file.js:465](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L465)
 
 ***
 
@@ -26,7 +26,7 @@ The file Content-Type
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:454](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L454)
+[packages/cozy-client/src/models/file.js:464](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L464)
 
 ***
 
@@ -38,7 +38,7 @@ The dirId to upload the file to
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:452](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L452)
+[packages/cozy-client/src/models/file.js:462](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L462)
 
 ***
 
@@ -50,7 +50,7 @@ An object containing the metadata to attach
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:453](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L453)
+[packages/cozy-client/src/models/file.js:463](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L463)
 
 ***
 
@@ -62,4 +62,4 @@ The file name to upload
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:451](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L451)
+[packages/cozy-client/src/models/file.js:461](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L461)

--- a/docs/api/cozy-client/modules/models.file.md
+++ b/docs/api/cozy-client/modules/models.file.md
@@ -40,7 +40,7 @@ Upload a file on a mobile
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:559](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L559)
+[packages/cozy-client/src/models/file.js:569](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L569)
 
 ***
 
@@ -65,7 +65,7 @@ file object with path attribute
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:126](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L126)
+[packages/cozy-client/src/models/file.js:136](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L136)
 
 ***
 
@@ -86,7 +86,7 @@ file object with path attribute
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:605](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L605)
+[packages/cozy-client/src/models/file.js:615](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L615)
 
 ***
 
@@ -111,7 +111,7 @@ The files found by the rules
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:246](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L246)
+[packages/cozy-client/src/models/file.js:256](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L256)
 
 ***
 
@@ -135,7 +135,7 @@ Generate a file name for a revision
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:441](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L441)
+[packages/cozy-client/src/models/file.js:451](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L451)
 
 ***
 
@@ -159,7 +159,7 @@ A filename with the right suffix
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:416](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L416)
+[packages/cozy-client/src/models/file.js:426](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L426)
 
 ***
 
@@ -185,7 +185,7 @@ The full path of the file in the cozy
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:304](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L304)
+[packages/cozy-client/src/models/file.js:314](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L314)
 
 ***
 
@@ -209,7 +209,7 @@ id of the parent folder, if any
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:140](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L140)
+[packages/cozy-client/src/models/file.js:150](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L150)
 
 ***
 
@@ -233,7 +233,7 @@ A description of the status
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:152](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L152)
+[packages/cozy-client/src/models/file.js:162](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L162)
 
 ***
 
@@ -257,7 +257,7 @@ A doctype
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:172](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L172)
+[packages/cozy-client/src/models/file.js:182](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L182)
 
 ***
 
@@ -281,7 +281,7 @@ The mime-type of the target file, or an empty string is the target is not a file
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:162](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L162)
+[packages/cozy-client/src/models/file.js:172](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L172)
 
 ***
 
@@ -301,7 +301,7 @@ The mime-type of the target file, or an empty string is the target is not a file
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:585](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L585)
+[packages/cozy-client/src/models/file.js:595](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L595)
 
 ***
 
@@ -325,7 +325,7 @@ Whether the file's metadata attribute exists
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:293](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L293)
+[packages/cozy-client/src/models/file.js:303](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L303)
 
 ***
 
@@ -345,7 +345,7 @@ Whether the file's metadata attribute exists
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:577](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L577)
+[packages/cozy-client/src/models/file.js:587](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L587)
 
 ***
 
@@ -366,6 +366,28 @@ Whether the file's metadata attribute exists
 *Defined in*
 
 [packages/cozy-client/src/models/file.js:46](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L46)
+
+***
+
+### isEncrypted
+
+▸ **isEncrypted**(`file`): `boolean`
+
+Whether the file is client-side encrypted
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `IOCozyFile` | io.cozy.files document |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/models/file.js:74](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L74)
 
 ***
 
@@ -405,7 +427,7 @@ Whether the file's metadata attribute exists
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:596](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L596)
+[packages/cozy-client/src/models/file.js:606](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L606)
 
 ***
 
@@ -447,7 +469,7 @@ Whether the file is supported by Only Office
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:74](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L74)
+[packages/cozy-client/src/models/file.js:84](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L84)
 
 ***
 
@@ -468,7 +490,7 @@ Whether the file is supported by Only Office
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:569](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L569)
+[packages/cozy-client/src/models/file.js:579](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L579)
 
 ***
 
@@ -490,7 +512,7 @@ Whether the file is referenced by an album
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:268](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L268)
+[packages/cozy-client/src/models/file.js:278](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L278)
 
 ***
 
@@ -514,7 +536,7 @@ Returns whether the file is a shortcut to a sharing
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:192](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L192)
+[packages/cozy-client/src/models/file.js:202](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L202)
 
 ***
 
@@ -538,7 +560,7 @@ Returns whether the sharing shortcut is new
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:217](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L217)
+[packages/cozy-client/src/models/file.js:227](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L227)
 
 ***
 
@@ -560,7 +582,7 @@ Returns whether the file is a shortcut to a sharing
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:182](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L182)
+[packages/cozy-client/src/models/file.js:192](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L192)
 
 ***
 
@@ -582,7 +604,7 @@ Returns whether the sharing shortcut is new
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:206](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L206)
+[packages/cozy-client/src/models/file.js:216](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L216)
 
 ***
 
@@ -604,7 +626,7 @@ true if the file is a shortcut
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:99](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L99)
+[packages/cozy-client/src/models/file.js:109](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L109)
 
 ***
 
@@ -633,7 +655,7 @@ Move file to destination.
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:328](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L328)
+[packages/cozy-client/src/models/file.js:338](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L338)
 
 ***
 
@@ -659,7 +681,7 @@ full normalized object
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:112](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L112)
+[packages/cozy-client/src/models/file.js:122](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L122)
 
 ***
 
@@ -686,7 +708,7 @@ The overrided file
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:383](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L383)
+[packages/cozy-client/src/models/file.js:393](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L393)
 
 ***
 
@@ -708,7 +730,7 @@ Read a file on a mobile
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:512](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L512)
+[packages/cozy-client/src/models/file.js:522](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L522)
 
 ***
 
@@ -734,7 +756,7 @@ The saved file
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:232](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L232)
+[packages/cozy-client/src/models/file.js:242](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L242)
 
 ***
 
@@ -758,7 +780,7 @@ But we want to exclude .txt and .md because the CozyUI Viewer can already show t
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:89](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L89)
+[packages/cozy-client/src/models/file.js:99](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L99)
 
 ***
 
@@ -815,4 +837,4 @@ If there is a conflict, then we apply the conflict strategy : `erase` or `rename
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:473](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L473)
+[packages/cozy-client/src/models/file.js:483](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L483)

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -2048,6 +2048,7 @@ Attributes used for file creation
 | name | <code>string</code> | Name of the created file. |
 | lastModifiedDate | <code>Date</code> | Can be used to set the last modified date of a file. |
 | executable | <code>boolean</code> | Whether or not the file is executable |
+| encrypted | <code>boolean</code> | Whether or not the file is client-side encrypted |
 | metadata | <code>object</code> | io.cozy.files.metadata to attach to the file |
 
 <a name="FileDocument"></a>

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -1800,7 +1800,7 @@ describe('file creation', () => {
     expect(doc._id).toEqual('1337')
     expect(client.stackClient.fetchJSON).toHaveBeenCalledWith(
       'POST',
-      '/files/folder-id?Name=toto.pdf&Type=file&Executable=false&MetadataID=&Size=12',
+      '/files/folder-id?Name=toto.pdf&Type=file&Executable=false&Encrypted=false&MetadataID=&Size=12',
       'file-content',
       {
         headers: { 'Content-Type': 'text/plain', 'Content-Length': '12' },

--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -66,6 +66,16 @@ export const isNote = file => {
 }
 
 /**
+ * Whether the file is client-side encrypted
+ *
+ * @param {IOCozyFile} file - io.cozy.files document
+ * @returns {boolean}
+ */
+export const isEncrypted = file => {
+  return !!file.encrypted
+}
+
+/**
  * Whether the file is supported by Only Office
  *
  * @param {IOCozyFile} file - io.cozy.file document

--- a/packages/cozy-client/src/models/file.spec.js
+++ b/packages/cozy-client/src/models/file.spec.js
@@ -231,6 +231,18 @@ describe('File Model', () => {
     })
   })
 
+  describe('encryption', () => {
+    it('should return when a file is encrypted or not', () => {
+      const encryptedFile = {
+        name: 'encryptedfile.txt',
+        encrypted: true
+      }
+      const plaintextFile = { name: 'plaintext.txt', mime: 'text' }
+      expect(fileModel.isEncrypted(encryptedFile)).toBe(true)
+      expect(fileModel.isEncrypted(plaintextFile)).toBe(false)
+    })
+  })
+
   describe('splitFilename', () => {
     it.each`
       opts                                       | result

--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -158,8 +158,11 @@ import { QueryDefinition } from './queries/dsl'
  * @property {FilesDoctype} _type - Doctype of the file
  * @property {string} name - Name of the file
  * @property {object} metadata - Metadata of the file
- * @property {object} type - Type of the file
- * @property {object} class - Class of the file
+ * @property {string} type - Type of the file
+ * @property {string} class - Class of the file
+ * @property {string} mime - Mime of the file
+ * @property {boolean} executable - Whether or not the file is executable
+ * @property {boolean} encrypted - Whether or not the file is client-side encrypted
  * @typedef {CozyClientDocument & FileDocument} IOCozyFile - An io.cozy.files document
  */
 

--- a/packages/cozy-client/types/models/file.d.ts
+++ b/packages/cozy-client/types/models/file.d.ts
@@ -29,6 +29,7 @@ export function splitFilename(file: IOCozyFile): object;
 export function isFile(file: IOCozyFile): boolean;
 export function isDirectory(file: IOCozyFile): boolean;
 export function isNote(file: IOCozyFile): boolean;
+export function isEncrypted(file: IOCozyFile): boolean;
 export function isOnlyOfficeFile(file: IOCozyFile): boolean;
 export function shouldBeOpenedByOnlyOffice(file: IOCozyFile): boolean;
 export function isShortcut(file: IOCozyFile): boolean;

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -184,11 +184,23 @@ export type FileDocument = {
     /**
      * - Type of the file
      */
-    type: object;
+    type: string;
     /**
      * - Class of the file
      */
-    class: object;
+    class: string;
+    /**
+     * - Mime of the file
+     */
+    mime: string;
+    /**
+     * - Whether or not the file is executable
+     */
+    executable: boolean;
+    /**
+     * - Whether or not the file is client-side encrypted
+     */
+    encrypted: boolean;
 };
 /**
  * - An io.cozy.files document

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -701,7 +701,7 @@ describe('FileCollection', () => {
         checksum: 'a6dabd99832b270468e254814df2ed20'
       }
       const result = await collection.updateFile(data, params)
-      const expectedPath = `/files/59140416-b95f?Name=mydoc.epub&Type=file&Executable=false&UpdatedAt=${new Date(
+      const expectedPath = `/files/59140416-b95f?Name=mydoc.epub&Type=file&Executable=false&Encrypted=false&UpdatedAt=${new Date(
         data.lastModified
       ).toISOString()}&CreatedAt=${new Date(data.lastModified).toISOString()}`
       const expectedOptions = {
@@ -740,7 +740,7 @@ describe('FileCollection', () => {
         metadata: { type: 'bill' }
       }
       const result = await collection.updateFile(data, params)
-      const expectedPath = `/files/59140416-b95f?Name=mydoc.epub&Type=file&Executable=false&MetadataID=${metadataId}&UpdatedAt=${new Date(
+      const expectedPath = `/files/59140416-b95f?Name=mydoc.epub&Type=file&Executable=false&Encrypted=false&MetadataID=${metadataId}&UpdatedAt=${new Date(
         data.lastModified
       ).toISOString()}&CreatedAt=${new Date(data.lastModified).toISOString()}`
       const expectedOptions = {
@@ -773,7 +773,7 @@ describe('FileCollection', () => {
         contentLength: 1234
       }
       const result = await collection.updateFile(data, params)
-      const expectedPath = `/files/59140416-b95f?Name=mydoc.epub&Type=file&Executable=false&Size=1234&UpdatedAt=${new Date(
+      const expectedPath = `/files/59140416-b95f?Name=mydoc.epub&Type=file&Executable=false&Encrypted=false&Size=1234&UpdatedAt=${new Date(
         data.lastModified
       ).toISOString()}&CreatedAt=${new Date(data.lastModified).toISOString()}`
       const expectedOptions = {
@@ -808,7 +808,7 @@ describe('FileCollection', () => {
 
       data = new File([''], 'mydoc.epub')
       await collection.updateFile(data, params)
-      const expectedPath = `/files/59140416-b95f?Name=mydoc.epub&Type=file&Executable=false&UpdatedAt=${new Date(
+      const expectedPath = `/files/59140416-b95f?Name=mydoc.epub&Type=file&Executable=false&Encrypted=false&UpdatedAt=${new Date(
         data.lastModified
       ).toISOString()}&CreatedAt=${new Date(data.lastModified).toISOString()}`
 
@@ -833,7 +833,7 @@ describe('FileCollection', () => {
 
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'PUT',
-        `/files/59140416-b95f?Name=mydoc.epub&Type=file&Executable=false`,
+        `/files/59140416-b95f?Name=mydoc.epub&Type=file&Executable=false&Encrypted=false`,
         data,
         expectedOptions
       )
@@ -970,7 +970,7 @@ describe('FileCollection', () => {
     it('should create a file without metadata', async () => {
       const params = { dirId }
       const result = await collection.createFile(data, params)
-      const expectedPath = `/files/${dirId}?Name=mydoc.epub&Type=file&Executable=false&MetadataID=&Size=&UpdatedAt=${new Date(
+      const expectedPath = `/files/${dirId}?Name=mydoc.epub&Type=file&Executable=false&Encrypted=false&MetadataID=&Size=&UpdatedAt=${new Date(
         data.lastModified
       ).toISOString()}&CreatedAt=${new Date(data.lastModified).toISOString()}`
       const expectedOptions = {
@@ -1006,7 +1006,7 @@ describe('FileCollection', () => {
         metadata: { type: 'bill' }
       }
       const result = await collection.createFile(data, params)
-      const expectedPath = `/files/${dirId}?Name=mydoc.epub&Type=file&Executable=false&MetadataID=${metadataId}&Size=&UpdatedAt=${new Date(
+      const expectedPath = `/files/${dirId}?Name=mydoc.epub&Type=file&Executable=false&Encrypted=false&MetadataID=${metadataId}&Size=&UpdatedAt=${new Date(
         data.lastModified
       ).toISOString()}&CreatedAt=${new Date(data.lastModified).toISOString()}`
       const expectedOptions = {
@@ -1033,7 +1033,7 @@ describe('FileCollection', () => {
     it('should send the file size via querystring and headers', async () => {
       const params = { dirId, contentLength }
       const result = await collection.createFile(data, params)
-      const expectedPath = `/files/${dirId}?Name=mydoc.epub&Type=file&Executable=false&MetadataID=&Size=${String(
+      const expectedPath = `/files/${dirId}?Name=mydoc.epub&Type=file&Executable=false&Encrypted=false&MetadataID=&Size=${String(
         contentLength
       )}&UpdatedAt=${new Date(
         data.lastModified


### PR DESCRIPTION
This introduces the `encrypted` field in the io.cozy.files, used to determine if a file is client-side encrypted.

Note this `encrypted` attribute will be simply ignored by the stack as long as this [PR](https://github.com/cozy/cozy-stack/pull/3378) isn't merged.