### PR TITLE
fix: Cozy-Client runs on node

### DIFF
--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -47,7 +47,7 @@
     "@testing-library/react-hooks": "3.7.0",
     "babel-plugin-search-and-replace": "1.1.0",
     "btoa": "1.2.1",
-    "cozy-device-helper": "1.12.0",
+    "cozy-device-helper": "2.1.0",
     "cozy-flags": "2.8.6",
     "cozy-logger": "1.7.0",
     "cozy-ui": "48.0.0",
@@ -62,7 +62,7 @@
     "typescript": "4.1.5"
   },
   "peerDependencies": {
-    "cozy-device-helper": ">1.12.0",
+    "cozy-device-helper": ">=2.1.0",
     "cozy-flags": ">2.8.6",
     "cozy-logger": ">1.7.0",
     "cozy-ui": ">34.0.0",

--- a/packages/cozy-pouch-link/package.json
+++ b/packages/cozy-pouch-link/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@babel/cli": "7.12.8",
     "@cozy/minilog": "1.0.0",
-    "cozy-device-helper": "1.12.0",
+    "cozy-device-helper": "2.1.0",
     "jest-localstorage-mock": "2.4.19",
     "parcel": "1.12.4",
     "pouchdb-adapter-memory": "7.2.2",
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "@cozy/minilog": "1.0.0",
-    "cozy-device-helper": "^1.12.0"
+    "cozy-device-helper": ">=2.1.0"
   },
   "scripts": {
     "build": "../../bin/build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4694,10 +4694,10 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-cozy-device-helper@1.12.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-1.12.0.tgz#619a24b0d3caf2d3f616a1524daef7c7b71eab7a"
-  integrity sha512-7pFbltgkD8rSO0PEf8pd6aBB37RUnNYH7fb3pkbcvo5rk4quCfSLREV94gZwXxowzP4vjZcAumTM09DfI42mJA==
+cozy-device-helper@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-2.1.0.tgz#6e94215ecf7831093eeb6b260923262cb7331f81"
+  integrity sha512-FhiplXS7R4kY7FobGDbmR6GSWMcgrZMnjDz2DcHVyX2sSNewVKk71zRh0vWeWuJRraoXpd32n8B327SjERkEXw==
   dependencies:
     lodash "^4.17.19"
 


### PR DESCRIPTION
BREAKING CHANGE: We need to upgrade cozy-device-helper
in order to be able to run cozy-client within a node
context. So let's upgrade it.

You need to install cozy-device-helper >= 2.1.0 in
your app.