### PR TITLE
fix: CozyClient can be used in a node env

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -93,7 +93,7 @@ const referencesUnsupportedError = relationshipClassName => {
 }
 
 const securiseUri = uri => {
-  if (uri && window['cozy']?.isSecureProtocol) {
+  if (uri && window && window['cozy']?.isSecureProtocol) {
     const secureUrl = new URL(uri)
     secureUrl.protocol = 'https:'
 

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -280,6 +280,19 @@ describe('CozyClient initialization', () => {
       expect(client.options.uri).toBe('http://cozy.tools')
     })
 
+    it('should not secure the URL if window is undefined (node env)', () => {
+      let windowSpy = jest.spyOn(window, 'window', 'get')
+      windowSpy.mockImplementation(() => undefined)
+      const client = new CozyClient({
+        uri: 'http://cozy.tools',
+        schema: '',
+        token: 'SOME_TOKEN'
+      })
+
+      expect(client.options.uri).toBe('http://cozy.tools')
+      windowSpy.mockRestore()
+    })
+
     describe('capabilities', () => {
       it('should instanciate Client with capabilities', () => {
         const options = {


### PR DESCRIPTION
We should not rely on `window` since CozyClient can be used in a Node env. 

This commit https://github.com/cozy/cozy-client/commit/3a9d557bbf70f6c7a30acbdad225000b40a23215 introduced a regression for our app's services.  