### PR TITLE
feat: Support client.save for files 

### DIFF
--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -457,15 +457,28 @@ class FileCollection extends DocumentCollection {
   }
 
   /***
-   * Update the io.cozy.files
-   * Used by StackLink to support CozyClient.save({file})
+   * Updates an existing file or directory
+   *
+   * Used by StackLink to support CozyClient.save({file}).
+   * Update the binary file if a `data` param is passed. Only updates
+   * attributes otherwise.
+   *
    * @param {FileAttributes} file - The file with its new content
+   * @param {File|Blob|string|ArrayBuffer} attributes.data Will be used as content of the updated file
    * @returns {FileAttributes} Updated document
    * @throws {Error} - explaining reason why update failed
    */
-
-  async update(file) {
-    return this.updateAttributes(file.id, file)
+  async update(attributes) {
+    const { data, ...updateFileOptions } = attributes
+    const fileId = attributes.id || attributes._id
+    if (data) {
+      if (attributes.type === 'directory') {
+        throw new Error('You cannot pass a data object for a directory')
+      }
+      updateFileOptions.fileId = fileId
+      return this.updateFile(data, updateFileOptions)
+    }
+    return this.updateAttributes(fileId, attributes)
   }
 
   /**

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -75,7 +75,8 @@ const CONTENT_TYPE_OCTET_STREAM = 'application/octet-stream'
  */
 const normalizeFile = file => ({
   ...normalizeDoc(file, 'io.cozy.files'),
-  ...file.attributes
+  ...file.attributes,
+  _rev: file?.meta?.rev // Beware of JSON-API
 })
 
 /**

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -506,6 +506,55 @@ describe('FileCollection', () => {
     })
   })
 
+  describe('update', () => {
+    const client = new CozyStackClient()
+    const collection = new FileCollection('io.cozy.files', client)
+
+    const spyUpdateFile = jest.spyOn(collection, 'updateFile')
+    const spyUpdateAttributes = jest.spyOn(collection, 'updateAttributes')
+
+    beforeEach(() => {
+      spyUpdateFile.mockReturnValue()
+      spyUpdateAttributes.mockReturnValue()
+    })
+
+    it('should update file when a data param is passed', async () => {
+      const atts = {
+        fileId: '123',
+        type: 'file',
+        name: 'thoughts.txt',
+        data: new Blob()
+      }
+      await collection.update(atts)
+      expect(spyUpdateFile).toHaveBeenCalled()
+    })
+    it('should fail when a data param is passed for a directory', async () => {
+      expect.assertions(1)
+      try {
+        const atts = {
+          fileId: '123',
+          type: 'directory',
+          name: 'dirdir',
+          data: new Blob()
+        }
+        await collection.update(atts)
+      } catch (error) {
+        expect(error.message).toEqual(
+          'You cannot pass a data object for a directory'
+        )
+      }
+    })
+    it('should update attributes when no data param is passed', async () => {
+      const atts = {
+        _id: '123',
+        type: 'file',
+        name: 'thoughts.txt'
+      }
+      await collection.update(atts)
+      expect(spyUpdateAttributes).toHaveBeenCalledWith(atts._id, atts)
+    })
+  })
+
   describe('updateAttributes', () => {
     beforeEach(() => {
       client.fetchJSON.mockReturnValue({ data: [] })


### PR DESCRIPTION
When updating a file we might either want to update its CouchDB
attributes, e.g. the name, or the binary itself.
To do so, the app used to go through the collection, and call `.update`
for attributes or `.updateFile` to update the binary.
It is now possible to directly use `client.save` for both cases. When a
`data` attribute is passed to the document, is is considered as a binary
update.