### PR TITLE
feat: Add method to fetch DACC aggregates

### DIFF
--- a/docs/api/cozy-client/interfaces/models.dacc.Params.md
+++ b/docs/api/cozy-client/interfaces/models.dacc.Params.md
@@ -1,0 +1,43 @@
+[cozy-client](../README.md) / [models](../modules/models.md) / [dacc](../modules/models.dacc.md) / Params
+
+# Interface: Params<>
+
+[models](../modules/models.md).[dacc](../modules/models.dacc.md).Params
+
+The unformatted DACC aggregate params
+
+## Properties
+
+### endDate
+
+• **endDate**: `string`
+
+The measure end date
+
+*Defined in*
+
+[packages/cozy-client/src/models/dacc.js:98](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L98)
+
+***
+
+### measureName
+
+• **measureName**: `string`
+
+The measure name
+
+*Defined in*
+
+[packages/cozy-client/src/models/dacc.js:96](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L96)
+
+***
+
+### startDate
+
+• **startDate**: `string`
+
+The measure start date
+
+*Defined in*
+
+[packages/cozy-client/src/models/dacc.js:97](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L97)

--- a/docs/api/cozy-client/modules/models.dacc.md
+++ b/docs/api/cozy-client/modules/models.dacc.md
@@ -4,7 +4,39 @@
 
 [models](models.md).dacc
 
+## Interfaces
+
+*   [Params](../interfaces/models.dacc.Params.md)
+
 ## Functions
+
+### buildAggregateParams
+
+▸ **buildAggregateParams**(`params`): `DACCAggregatesParams`
+
+Build parameters to request DACC aggregate
+
+**`property`** {string} \[measureName] - The measure name
+
+**`property`** {string} \[startDate]   - The measure start date
+
+**`property`** {string} \[endDate]     - The measure end date
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `params` | [`Params`](../interfaces/models.dacc.Params.md) | The unformatted DACC aggregate params |
+
+*Returns*
+
+`DACCAggregatesParams`
+
+*Defined in*
+
+[packages/cozy-client/src/models/dacc.js:103](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L103)
+
+***
 
 ### checkMeasureParams
 
@@ -24,7 +56,53 @@ Throw an errror if a DACC parameter is incorrect.
 
 *Defined in*
 
-[packages/cozy-client/src/models/dacc.js:9](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L9)
+[packages/cozy-client/src/models/dacc.js:25](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L25)
+
+***
+
+### fetchAggregatesFromDACC
+
+▸ **fetchAggregatesFromDACC**(`client`, `remoteDoctype`, `params`): `Promise`<`void`>
+
+Send measures to a DACC through a remote doctype
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`CozyClient`](../classes/CozyClient.md) | The CozyClient instance |
+| `remoteDoctype` | `string` | The remote doctype to use |
+| `params` | `DACCAggregatesParams` | The request params |
+
+*Returns*
+
+`Promise`<`void`>
+
+*Defined in*
+
+[packages/cozy-client/src/models/dacc.js:127](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L127)
+
+***
+
+### isCorrectDateFormat
+
+▸ **isCorrectDateFormat**(`date`): `boolean`
+
+Check whether or not the given date is in YYYY-MM-DD format
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `date` | `string` | The date to check |
+
+*Returns*
+
+`boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/models/dacc.js:11](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L11)
 
 ***
 
@@ -38,7 +116,7 @@ Send measures to a DACC through a remote doctype
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `client` | `any` | The CozyClient instance |
+| `client` | [`CozyClient`](../classes/CozyClient.md) | The CozyClient instance |
 | `remoteDoctype` | `string` | The remote doctype to use |
 | `measure` | `DACCMeasure` | The DACC measure |
 
@@ -48,4 +126,4 @@ Send measures to a DACC through a remote doctype
 
 *Defined in*
 
-[packages/cozy-client/src/models/dacc.js:57](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L57)
+[packages/cozy-client/src/models/dacc.js:72](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L72)

--- a/packages/cozy-client/src/models/dacc.js
+++ b/packages/cozy-client/src/models/dacc.js
@@ -1,10 +1,17 @@
 import log from 'cozy-logger'
 import { DACCMeasure, DACCAggregatesParams } from '../types'
+import CozyClient from '../CozyClient'
 
+/**
+ * Check whether or not the given date is in YYYY-MM-DD format
+ *
+ * @param {string} date - The date to check
+ * @returns {boolean}
+ */
 export const isCorrectDateFormat = date => {
   try {
     const parsedDate = new Date(Date.parse(date))
-    return parsedDate.toISOString().startsWith(date)
+    return !!parsedDate.toISOString().startsWith(date)
   } catch (err) {
     return false
   }
@@ -58,7 +65,7 @@ export const checkMeasureParams = measure => {
 /**
  * Send measures to a DACC through a remote doctype
  *
- * @param {object} client - The CozyClient instance
+ * @param {CozyClient} client - The CozyClient instance
  * @param {string} remoteDoctype - The remote doctype to use
  * @param {DACCMeasure} measure - The DACC measure
  */
@@ -81,6 +88,18 @@ export const sendMeasureToDACC = async (client, remoteDoctype, measure) => {
   }
 }
 
+/**
+ * Build parameters to request DACC aggregate
+ *
+ *
+ * @typedef Params - The unformatted DACC aggregate params
+ * @property {string} [measureName] - The measure name
+ * @property {string} [startDate]   - The measure start date
+ * @property {string} [endDate]     - The measure end date
+ *
+ * @param {Params} params - The unformatted DACC aggregate params
+ * @returns {DACCAggregatesParams}
+ */
 export const buildAggregateParams = params => {
   const { measureName } = params
   if (!measureName || typeof measureName !== 'string') {
@@ -89,6 +108,10 @@ export const buildAggregateParams = params => {
   const startDate = params.startDate || new Date(0).toISOString()
   const endDate = params.endDate || new Date(Date.now()).toISOString()
   if (!isCorrectDateFormat(startDate) || !isCorrectDateFormat(endDate)) {
+    log(
+      'error',
+      `Date should be in YYYY-MM-DD format but received: startDate: ${startDate} | endDate: ${endDate}`
+    )
     throw new Error('Date should be in YYYY-MM-DD format')
   }
   return { measureName, startDate, endDate }
@@ -97,7 +120,7 @@ export const buildAggregateParams = params => {
 /**
  * Send measures to a DACC through a remote doctype
  *
- * @param {object} client - The CozyClient instance
+ * @param {CozyClient} client - The CozyClient instance
  * @param {string} remoteDoctype - The remote doctype to use
  * @param {DACCAggregatesParams} params - The request params
  */

--- a/packages/cozy-client/src/models/dacc.js
+++ b/packages/cozy-client/src/models/dacc.js
@@ -61,7 +61,8 @@ export const sendMeasureToDACC = async (client, remoteDoctype, measure) => {
     await client
       .getStackClient()
       .fetchJSON('POST', `/remote/${remoteDoctype}`, {
-        data: JSON.stringify(measure)
+        data: JSON.stringify(measure),
+        path: 'measure'
       })
   } catch (error) {
     log(

--- a/packages/cozy-client/src/models/dacc.js
+++ b/packages/cozy-client/src/models/dacc.js
@@ -1,5 +1,14 @@
 import log from 'cozy-logger'
-import { DACCMeasure } from '../types'
+import { DACCMeasure, DACCAggregatesParams } from '../types'
+
+export const isCorrectDateFormat = date => {
+  try {
+    const parsedDate = new Date(Date.parse(date))
+    return parsedDate.toISOString().startsWith(date)
+  } catch (err) {
+    return false
+  }
+}
 
 /**
  * Throw an errror if a DACC parameter is incorrect.
@@ -26,8 +35,7 @@ export const checkMeasureParams = measure => {
   if (!startDate) {
     throw new Error('Missing parameter: startDate')
   }
-  const parsedDate = new Date(Date.parse(startDate))
-  if (!parsedDate.toISOString().startsWith(startDate)) {
+  if (!isCorrectDateFormat(startDate)) {
     throw new Error('Date should be in YYYY-MM-DD format')
   }
   if (typeof value !== 'number') {
@@ -68,6 +76,48 @@ export const sendMeasureToDACC = async (client, remoteDoctype, measure) => {
     log(
       'error',
       `Error while sending measure to remote doctype: ${error.message}`
+    )
+    throw error
+  }
+}
+
+export const buildAggregateParams = params => {
+  const { measureName } = params
+  if (!measureName || typeof measureName !== 'string') {
+    throw new Error('Missing or wrong type parameter: measureName')
+  }
+  const startDate = params.startDate || new Date(0).toISOString()
+  const endDate = params.endDate || new Date(Date.now()).toISOString()
+  if (!isCorrectDateFormat(startDate) || !isCorrectDateFormat(endDate)) {
+    throw new Error('Date should be in YYYY-MM-DD format')
+  }
+  return { measureName, startDate, endDate }
+}
+
+/**
+ * Send measures to a DACC through a remote doctype
+ *
+ * @param {object} client - The CozyClient instance
+ * @param {string} remoteDoctype - The remote doctype to use
+ * @param {DACCAggregatesParams} params - The request params
+ */
+export const fetchAggregatesFromDACC = async (
+  client,
+  remoteDoctype,
+  params
+) => {
+  try {
+    const aggregateParams = buildAggregateParams(params)
+    await client
+      .getStackClient()
+      .fetchJSON('POST', `/remote/${remoteDoctype}`, {
+        data: JSON.stringify(aggregateParams),
+        path: 'aggregate'
+      })
+  } catch (error) {
+    log(
+      'error',
+      `Error while fetching aggregates to remote doctype: ${error.message}`
     )
     throw error
   }

--- a/packages/cozy-client/src/models/dacc.spec.js
+++ b/packages/cozy-client/src/models/dacc.spec.js
@@ -1,6 +1,6 @@
-import { checkMeasureParams } from './dacc'
+import { checkMeasureParams, buildAggregateParams } from './dacc'
 
-describe('dacc', () => {
+describe('checkMeasureParams', () => {
   const measure = {
     value: 42,
     measureName: 'theanswer',
@@ -102,5 +102,39 @@ describe('dacc', () => {
     expect(() =>
       checkMeasureParams({ ...measure, group2: { b: 1 }, group3: { c: 1 } })
     ).toThrow()
+  })
+})
+
+describe('buildAggregateParams', () => {
+  beforeAll(() => {
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementation(() => new Date(2022, 5, 1).valueOf())
+  })
+  it('should throw if measure name is not correct', () => {
+    expect(() => buildAggregateParams({})).toThrow()
+    expect(() => buildAggregateParams({ measurName: 42 })).toThrow()
+  })
+
+  it('should throw if dates are not correct', () => {
+    expect(() =>
+      buildAggregateParams({
+        measureName: 'test',
+        startDate: 'Lundi 10 août 2021'
+      })
+    ).toThrow()
+    expect(() =>
+      buildAggregateParams({
+        measureName: 'test',
+        endDate: 'Lundi 10 août 2021'
+      })
+    ).toThrow()
+  })
+  it('should build date if not provided', () => {
+    expect(buildAggregateParams({ measureName: 'test' })).toEqual({
+      measureName: 'test',
+      startDate: '1970-01-01T00:00:00.000Z',
+      endDate: new Date(2022, 5, 1).toISOString()
+    })
   })
 })

--- a/packages/cozy-client/src/models/dacc.spec.js
+++ b/packages/cozy-client/src/models/dacc.spec.js
@@ -130,11 +130,29 @@ describe('buildAggregateParams', () => {
       })
     ).toThrow()
   })
-  it('should build date if not provided', () => {
+  it('should build dates if none provided', () => {
     expect(buildAggregateParams({ measureName: 'test' })).toEqual({
       measureName: 'test',
       startDate: '1970-01-01T00:00:00.000Z',
       endDate: new Date(2022, 5, 1).toISOString()
+    })
+  })
+  it('should build dates if startDate provided', () => {
+    expect(
+      buildAggregateParams({ measureName: 'test', startDate: '2021-08-10' })
+    ).toEqual({
+      measureName: 'test',
+      startDate: '2021-08-10',
+      endDate: new Date(2022, 5, 1).toISOString()
+    })
+  })
+  it('should build dates if endDate provided', () => {
+    expect(
+      buildAggregateParams({ measureName: 'test', endDate: '2022-05-02' })
+    ).toEqual({
+      measureName: 'test',
+      startDate: '1970-01-01T00:00:00.000Z',
+      endDate: '2022-05-02'
     })
   })
 })

--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -323,6 +323,15 @@ import { QueryDefinition } from './queries/dsl'
  */
 
 /**
+ * @typedef {object} DACCAggregatesParams
+ * See https://github.com/cozy/DACC
+ *
+ * @property {string} measureName - It must match an existing measure name on the DACC server
+ * @property {string} startDate - Start of the aggregation period. Should be in YYYY-MM-DD format
+ * @property {string} endDate - End of the aggregation period. Should be in YYYY-MM-DD format
+ */
+
+/**
  * Receives the URL to present to the user as a parameter, and should return a promise that resolves with the URL the user was redirected to after accepting the permissions.
  *
  * @callback OpenURLCallback

--- a/packages/cozy-client/types/models/dacc.d.ts
+++ b/packages/cozy-client/types/models/dacc.d.ts
@@ -1,11 +1,25 @@
-export function isCorrectDateFormat(date: any): boolean;
+export function isCorrectDateFormat(date: string): boolean;
 export function checkMeasureParams(measure: DACCMeasure): void;
-export function sendMeasureToDACC(client: object, remoteDoctype: string, measure: DACCMeasure): Promise<void>;
-export function buildAggregateParams(params: any): {
-    measureName: string;
-    startDate: any;
-    endDate: any;
+export function sendMeasureToDACC(client: CozyClient, remoteDoctype: string, measure: DACCMeasure): Promise<void>;
+export function buildAggregateParams(params: Params): DACCAggregatesParams;
+export function fetchAggregatesFromDACC(client: CozyClient, remoteDoctype: string, params: DACCAggregatesParams): Promise<void>;
+/**
+ * - The unformatted DACC aggregate params
+ */
+export type Params = {
+    /**
+     * - The measure name
+     */
+    measureName?: string;
+    /**
+     * - The measure start date
+     */
+    startDate?: string;
+    /**
+     * - The measure end date
+     */
+    endDate?: string;
 };
-export function fetchAggregatesFromDACC(client: object, remoteDoctype: string, params: DACCAggregatesParams): Promise<void>;
 import { DACCMeasure } from "../types";
+import CozyClient from "../CozyClient";
 import { DACCAggregatesParams } from "../types";

--- a/packages/cozy-client/types/models/dacc.d.ts
+++ b/packages/cozy-client/types/models/dacc.d.ts
@@ -1,3 +1,11 @@
+export function isCorrectDateFormat(date: any): boolean;
 export function checkMeasureParams(measure: DACCMeasure): void;
 export function sendMeasureToDACC(client: object, remoteDoctype: string, measure: DACCMeasure): Promise<void>;
+export function buildAggregateParams(params: any): {
+    measureName: string;
+    startDate: any;
+    endDate: any;
+};
+export function fetchAggregatesFromDACC(client: object, remoteDoctype: string, params: DACCAggregatesParams): Promise<void>;
 import { DACCMeasure } from "../types";
+import { DACCAggregatesParams } from "../types";

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -391,6 +391,23 @@ export type DACCMeasure = {
     group3: object;
 };
 /**
+ * See https://github.com/cozy/DACC
+ */
+export type DACCAggregatesParams = {
+    /**
+     * - It must match an existing measure name on the DACC server
+     */
+    measureName: string;
+    /**
+     * - Start of the aggregation period. Should be in YYYY-MM-DD format
+     */
+    startDate: string;
+    /**
+     * - End of the aggregation period. Should be in YYYY-MM-DD format
+     */
+    endDate: string;
+};
+/**
  * Receives the URL to present to the user as a parameter, and should return a promise that resolves with the URL the user was redirected to after accepting the permissions.
  */
 export type OpenURLCallback = (url: string) => any;


### PR DESCRIPTION
This will be useful for apps aiming to fetch aggregates from the DACC, e.g. coachCO2.
Also, it copes with the remote-doctype change: https://github.com/cozy/cozy-doctypes/pull/201/files