### PR TITLE
fix: Make a correct deep merge on objects.

### DIFF
--- a/packages/cozy-client/src/store.spec.js
+++ b/packages/cozy-client/src/store.spec.js
@@ -188,48 +188,6 @@ describe('Store', () => {
       spy.mockRestore()
     })
 
-    it('should store a new doc received in a mutation result', () => {
-      store.dispatch(
-        receiveMutationResult('foo', {
-          data: [TODO_1]
-        })
-      )
-      expect(
-        getDocumentFromState(store.getState(), 'io.cozy.todos', TODO_1._id)
-      ).toEqual(TODO_1)
-    })
-
-    it('should store an updated doc received in a mutation result', () => {
-      store.dispatch(
-        receiveMutationResult('foo', {
-          data: [TODO_1]
-        })
-      )
-      store.dispatch(
-        receiveMutationResult('bar', {
-          data: [{ ...TODO_1, label: 'Buy croissants' }]
-        })
-      )
-      expect(
-        getDocumentFromState(store.getState(), 'io.cozy.todos', TODO_1._id)
-          .label
-      ).toBe('Buy croissants')
-    })
-
-    it('it should store documents with included from a mutation result', () => {
-      store.dispatch(
-        receiveMutationResult('foo', {
-          data: [...TODO_WITH_RELATION.relationships.attachments.files],
-          included: [FILE_1, FILE_2]
-        })
-      )
-
-      expect(
-        getDocumentFromState(store.getState(), 'io.cozy.files', FILE_1._id)
-          .label
-      ).toBe(FILE_1.label)
-    })
-
     it('should respect the query limit', () => {
       const query = new Q({
         doctype: 'io.cozy.todos',
@@ -305,6 +263,48 @@ describe('Store', () => {
         { _id: 'todo_4', label: 'Run a semi-marathon' },
         { _id: 'todo_2', label: 'Check email' }
       ])
+    })
+
+    it('should store a new doc received in a mutation result', () => {
+      store.dispatch(
+        receiveMutationResult('foo', {
+          data: [TODO_1]
+        })
+      )
+      expect(
+        getDocumentFromState(store.getState(), 'io.cozy.todos', TODO_1._id)
+      ).toEqual(TODO_1)
+    })
+
+    it('should store an updated doc received in a mutation result', () => {
+      store.dispatch(
+        receiveMutationResult('foo', {
+          data: [TODO_1]
+        })
+      )
+      store.dispatch(
+        receiveMutationResult('bar', {
+          data: [{ ...TODO_1, label: 'Buy croissants' }]
+        })
+      )
+      expect(
+        getDocumentFromState(store.getState(), 'io.cozy.todos', TODO_1._id)
+          .label
+      ).toBe('Buy croissants')
+    })
+
+    it('it should store documents with included from a mutation result', () => {
+      store.dispatch(
+        receiveMutationResult('foo', {
+          data: [...TODO_WITH_RELATION.relationships.attachments.files],
+          included: [FILE_1, FILE_2]
+        })
+      )
+
+      expect(
+        getDocumentFromState(store.getState(), 'io.cozy.files', FILE_1._id)
+          .label
+      ).toBe(FILE_1.label)
     })
 
     describe('deletion', () => {

--- a/packages/cozy-client/src/store/documents.js
+++ b/packages/cozy-client/src/store/documents.js
@@ -2,6 +2,7 @@ import keyBy from 'lodash/keyBy'
 import get from 'lodash/get'
 import isEqual from 'lodash/isEqual'
 import omit from 'lodash/omit'
+import merge from 'lodash/merge'
 
 import logger from '../logger'
 
@@ -177,10 +178,7 @@ export const extractAndMergeDocument = (data, updatedStateWithIncluded) => {
   Object.values(sortedData).map(data => {
     const id = properId(data)
     if (mergedData[doctype][id]) {
-      mergedData[doctype][id] = {
-        ...mergedData[doctype][id],
-        ...data
-      }
+      mergedData[doctype][id] = merge(mergedData[doctype][id], data)
     } else {
       mergedData[doctype][id] = data
     }

--- a/packages/cozy-client/src/store/documents.spec.js
+++ b/packages/cozy-client/src/store/documents.spec.js
@@ -10,7 +10,10 @@ describe('extractAndMerge', () => {
       _id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
       type: 'io.cozy.files',
       _type: 'io.cozy.files',
-      blabla: 'new field'
+      blabla: 'new field',
+      cozyMedata: {
+        created_at: '123456'
+      }
     },
     1: {
       id: 'b6ff135b34e041ffb2d4a4865f3e235f',
@@ -38,7 +41,10 @@ describe('extractAndMerge', () => {
           }
         },
         type: 'io.cozy.files',
-        _type: 'io.cozy.files'
+        _type: 'io.cozy.files',
+        cozyMedata: {
+          updated_at: '987654'
+        }
       },
       b6ff135b34e041ffb2d4a4865f3e235f: {
         attributes: {
@@ -78,6 +84,10 @@ describe('extractAndMerge', () => {
             type: 'file'
           },
           blabla: 'new field',
+          cozyMedata: {
+            created_at: '123456',
+            updated_at: '987654'
+          },
           id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
           links: { self: '/files/b6ff135b34e041ffb2d4a4865f3e0a53' },
           meta: { rev: '5-87840eceaab358e38aa8b6bb0d4577b1' },

--- a/packages/cozy-client/src/store/documents.spec.js
+++ b/packages/cozy-client/src/store/documents.spec.js
@@ -11,8 +11,11 @@ describe('extractAndMerge', () => {
       type: 'io.cozy.files',
       _type: 'io.cozy.files',
       blabla: 'new field',
-      cozyMedata: {
-        created_at: '123456'
+      cozyMetadata: {
+        created_at: '123456',
+        updatedByApps: {
+          slug: 'drive'
+        }
       }
     },
     1: {
@@ -42,8 +45,11 @@ describe('extractAndMerge', () => {
         },
         type: 'io.cozy.files',
         _type: 'io.cozy.files',
-        cozyMedata: {
-          updated_at: '987654'
+        cozyMetadata: {
+          updated_at: '987654',
+          updatedByApps: {
+            date: '2019-06-11T01:02:03Z'
+          }
         }
       },
       b6ff135b34e041ffb2d4a4865f3e235f: {
@@ -84,9 +90,13 @@ describe('extractAndMerge', () => {
             type: 'file'
           },
           blabla: 'new field',
-          cozyMedata: {
+          cozyMetadata: {
             created_at: '123456',
-            updated_at: '987654'
+            updated_at: '987654',
+            updatedByApps: {
+              slug: 'drive',
+              date: '2019-06-11T01:02:03Z'
+            }
           },
           id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
           links: { self: '/files/b6ff135b34e041ffb2d4a4865f3e0a53' },


### PR DESCRIPTION
When we merge object with the spread operator, it
doesn't make a deep merge, it replace the second
level.

Exemple:
```js
d1 = {a: 1, b: {b1: 1}}
d2 =  {c: 3, b: {b2: 2}}
merge = {...d1, ...d2}
// merge = { a: 1, b: { b2: 2 }, c: 3 }
```

This is not what we want in this case. We want a
fully merged object, not a replace. We expect the
result to be:
```
// mege = { a : 1, b { b1: 1, b2: 2}, c: 3}
```

To achieve that, we use lodash merge!

Fix #1175

(credits to @paultranvan for the finding!) 