### PR TITLE
Fix partial filter

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -58,6 +58,9 @@ through OAuth.</p>
 <dt><a href="#isIndexConflictError">isIndexConflictError</a> ⇒ <code>boolean</code></dt>
 <dd><p>Helper to identify an index conflict</p>
 </dd>
+<dt><a href="#isIndexNotUsedWarning">isIndexNotUsedWarning</a> ⇒ <code>boolean</code></dt>
+<dd><p>Helper to identify a not used index</p>
+</dd>
 <dt><a href="#isNoUsableIndexError">isNoUsableIndexError</a> ⇒ <code>boolean</code></dt>
 <dd><p>Helper to identify a no usable index error</p>
 </dd>
@@ -83,8 +86,11 @@ through OAuth.</p>
 query to work</p>
 </dd>
 <dt><a href="#isInconsistentIndex">isInconsistentIndex</a> ⇒ <code>boolean</code></dt>
-<dd><p>Check if an index is in an inconsistent state, i.e. its name
-contains the indexed attributes which are not in correct order.</p>
+<dd><p>Check if an index is in an inconsistent state, i.e. it evaluates one of these:</p>
+<ul>
+<li>its name contains the indexed attributes which are not in correct order</li>
+<li>it contains a partial filter, but the fields are not in the name</li>
+</ul>
 </dd>
 <dt><a href="#isMatchingIndex">isMatchingIndex</a> ⇒ <code>boolean</code></dt>
 <dd><p>Check if an index is matching the given fields</p>
@@ -1738,6 +1744,18 @@ Helper to identify an index conflict
 | --- | --- | --- |
 | error | <code>Error</code> | An error |
 
+<a name="isIndexNotUsedWarning"></a>
+
+## isIndexNotUsedWarning ⇒ <code>boolean</code>
+Helper to identify a not used index
+
+**Kind**: global constant  
+**Returns**: <code>boolean</code> - Whether or not this is a not used index warning  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| warning | <code>string</code> | The warning returned by CouchDB |
+
 <a name="isNoUsableIndexError"></a>
 
 ## isNoUsableIndexError ⇒ <code>boolean</code>
@@ -1834,8 +1852,9 @@ query to work
 <a name="isInconsistentIndex"></a>
 
 ## isInconsistentIndex ⇒ <code>boolean</code>
-Check if an index is in an inconsistent state, i.e. its name
-contains the indexed attributes which are not in correct order.
+Check if an index is in an inconsistent state, i.e. it evaluates one of these:
+- its name contains the indexed attributes which are not in correct order
+- it contains a partial filter, but the fields are not in the name
 
 **Kind**: global constant  
 **Returns**: <code>boolean</code> - True if the index is inconsistent  

--- a/packages/cozy-stack-client/src/Collection.js
+++ b/packages/cozy-stack-client/src/Collection.js
@@ -41,6 +41,18 @@ export const isIndexConflictError = error => {
 }
 
 /**
+ * Helper to identify a not used index
+ *
+ * @param {string} warning - The warning returned by CouchDB
+ * @returns {boolean} Whether or not this is a not used index warning
+ */
+export const isIndexNotUsedWarning = warning => {
+  return warning.match(
+    /was not used because it does not contain a valid index for this query/
+  )
+}
+
+/**
  * Helper to identify a no usable index error
  *
  * @param {Error} error - An error

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -438,7 +438,7 @@ class DocumentCollection {
   }
 
   toMangoOptions(selector, options = {}) {
-    let { sort, indexedFields } = options
+    let { sort, indexedFields, partialFilter } = options
     const { fields, skip = 0, limit, bookmark } = options
 
     sort = transformSort(sort)
@@ -446,8 +446,15 @@ class DocumentCollection {
     indexedFields = indexedFields
       ? indexedFields
       : getIndexFields({ sort, selector })
+
+    const partialFilterFields = partialFilter
+      ? getIndexFields({ partialFilter })
+      : null
     const indexName =
-      options.indexId || `_design/${getIndexNameFromFields(indexedFields)}`
+      options.indexId ||
+      `_design/${getIndexNameFromFields(indexedFields, {
+        partialFilterFields
+      })}`
     if (sort) {
       const sortOrders = uniq(
         sort.map(sortOption => head(Object.values(sortOption)))

--- a/packages/cozy-stack-client/src/mangoIndex.spec.js
+++ b/packages/cozy-stack-client/src/mangoIndex.spec.js
@@ -107,6 +107,26 @@ describe('inconsistent index', () => {
     expect(isInconsistentIndex(index1)).toBe(false)
     expect(isInconsistentIndex(index2)).toBe(false)
   })
+  it('should not detect consistent index with partial filter', () => {
+    const index = buildDesignDoc(
+      { bar: 'asc', foo: 'asc' },
+      {
+        id: '_design/by_bar_and_foo_filter_trashed',
+        partialFilter: { trashed: { $ne: false } }
+      }
+    )
+    expect(isInconsistentIndex(index)).toBe(false)
+  })
+  it('should detect index with partial filter but without fields in name', () => {
+    const index = buildDesignDoc(
+      { bar: 'asc', foo: 'asc' },
+      {
+        id: '_design/by_bar_and_foo',
+        partialFilter: { trashed: { $ne: false } }
+      }
+    )
+    expect(isInconsistentIndex(index)).toBe(true)
+  })
 })
 
 describe('getIndexFields', () => {


### PR DESCRIPTION
When a partial filter is defined and the index is not created yet,
CouchDB might fallback on another existing index and return a warning
saying the specified index was not used.
This is not what we want, because the existing index might not actually
use the partial filter and make a full-scan on the index to evaluate
it.