### PR TITLE
fix: Call `onTokenRefresh()` after `setToken()` when refreshing token

### DIFF
--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -219,6 +219,7 @@ class CozyStackClient {
       )
     }
     const newToken = new AppToken(token)
+    this.setToken(newToken)
     this.onTokenRefresh(newToken)
     return newToken
   }
@@ -241,13 +242,11 @@ class CozyStackClient {
         errors.EXPIRED_TOKEN.test(e.message) ||
         errors.INVALID_TOKEN.test(e.message)
       ) {
-        let token
         try {
-          token = await this.refreshToken()
+          await this.refreshToken()
         } catch (refreshError) {
           throw e
         }
-        this.setToken(token)
         return await this.fetchJSONWithCurrentToken(method, path, body, options)
       } else {
         throw e

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -496,6 +496,8 @@ class OAuthClient extends CozyStackClient {
       ...result
     })
 
+    this.setToken(newToken)
+
     if (this.onTokenRefresh && typeof this.onTokenRefresh === 'function') {
       this.onTokenRefresh(newToken)
     }

--- a/packages/cozy-stack-client/src/OAuthClient.spec.js
+++ b/packages/cozy-stack-client/src/OAuthClient.spec.js
@@ -222,6 +222,52 @@ describe('OAuthClient', () => {
     })
   })
 
+  describe('fetchJSON', () => {
+    it('should call onTokenRefresh after setToken when refreshing the current token', async () => {
+      const client = new OAuthClient({
+        ...REGISTERED_CLIENT_INIT_OPTIONS,
+        oauth: {
+          ...REGISTERED_CLIENT_INIT_OPTIONS.oauth,
+          token: new AccessToken({
+            tokenType: 'type',
+            accessToken: 'accessToken-abcd',
+            refreshToken: 'refresh-789',
+            scope: 'io.cozy.todos'
+          })
+        },
+        onTokenRefresh: jest.fn()
+      })
+      jest.spyOn(client, 'onTokenRefresh')
+      jest.spyOn(client, 'setToken')
+      global.fetch
+        .mockResponseOnce(() => {
+          return Promise.resolve({
+            headers: {
+              'content-type': 'application/json; charset=UTF-8'
+            },
+            body: JSON.stringify({
+              error: 'Expired token'
+            }),
+            ok: false,
+            status: 403,
+            statusText: '',
+            type: 'default',
+            url: 'http://cozy.tools:8080/settings/capabilities'
+          })
+        })
+        .once([FAKE_APP_HTML, { status: 200 }])
+        .once([JSON.stringify({ res: 'ok' }), { status: 200 }])
+      await client.fetchJSON('GET', '/test')
+
+      expect(client.onTokenRefresh).toHaveBeenCalled()
+      expect(client.setToken).toHaveBeenCalled()
+      const onTokenRefreshOrder =
+        client.onTokenRefresh.mock.invocationCallOrder[0]
+      const setTokenOrder = client.setToken.mock.invocationCallOrder[0]
+      expect(setTokenOrder).toBeLessThan(onTokenRefreshOrder)
+    })
+  })
+
   describe('getAccessToken', () => {
     it('should return the current access token', () => {
       client = new OAuthClient(REGISTERED_CLIENT_INIT_OPTIONS)
@@ -235,3 +281,28 @@ describe('OAuthClient', () => {
     })
   })
 })
+
+const FAKE_DATA_COZY = JSON.stringify({
+  app: {
+    editor: 'Cozy',
+    icon: 'icon.svg',
+    name: 'Accueil',
+    prefix: 'Cozy',
+    slug: 'home'
+  },
+  domain: 'test.mycozy.cloud',
+  locale: 'fr',
+  token: 'SOME_TOKEN',
+  tracking: false
+})
+
+const FAKE_APP_HTML = `<!DOCTYPE html><html lang="fr"><head><meta charset="utf-8"><title>Cozy Home</title>
+  <link rel="icon" href="//test.mycozy.cloud/assets/favicon.f56cf1d03b.ico">
+  <link rel="icon" type="image/png" href="//test.mycozy.cloud/assets/favicon-16x16.192a16308f.png" sizes="16x16">
+  <link rel="icon" type="image/png" href="//test.mycozy.cloud/assets/favicon-32x32.9f958fa2c7.png" sizes="32x32">
+  <link rel="apple-touch-icon" sizes="180x180" href="//test.mycozy.cloud/assets/apple-touch-icon.a0e0ae4102.png"/>
+    <link rel="manifest" href="/manifest.json" crossorigin="use-credentials"><meta name="msapplication-TileColor" content="#2b5797"><meta name="theme-color" content="#ffffff"><meta name="viewport" content="width=device-width,height=device-height,initial-scale=1,viewport-fit=cover"><link rel="stylesheet" href="vendors/home.c451e5ac76c8377b20c5.0.min.css"><link rel="stylesheet" href="app/home.cbb1b1050b936df11fbd.min.css"><link rel="stylesheet" type="text/css" href="//test.mycozy.cloud/assets/styles/theme.faa4e12bdc.css"> <script src="//test.mycozy.cloud/assets/js/cozy-client.605c649bc3.min.js"></script> 
+<link rel="stylesheet" type="text/css" href="//test.mycozy.cloud/assets/fonts/fonts.33109548ca.css">
+<link rel="stylesheet" type="text/css" href="//test.mycozy.cloud/assets/css/cozy-bar.6effa2d88c.min.css">
+<script src="//test.mycozy.cloud/assets/js/cozy-bar.f99c08ee53.min.js"></script></head><body><div role="application" data-cozy='${FAKE_DATA_COZY}'><script src="vendors/home.a664629f1a5622ccb459.js"></script><script src="app/home.455bbc269323b2c64382.js"></script><script src="//test.mycozy.cloud/assets/js/piwik.js" async></script></div></body></html>
+`


### PR DESCRIPTION
Previous `fetchJSON` and `refreshToken` implementation called
`onTokenRefresh()` before `setToken()`, which would result to emitting
`tokenRefreshed` event with cozy-client not being updated yet

___

Related PR:

- https://github.com/cozy/cozy-react-native/pull/313

___

TODO:

- [x] Test tokenRefresh on web apps
- [x] Test tokenRefresh on react-native