### PR TITLE
fix: Handle query limit for first and last paginated query

### DIFF
--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -85,10 +85,18 @@ export const sortAndLimitDocsIds = (
       : []
     evaluatedIds = sorter(docs).map(properId)
   }
-  if (queryState.definition.limit) {
-    evaluatedIds = queryState.definition.limit
-      ? evaluatedIds.slice(0, count * fetchedPagesCount)
-      : evaluatedIds
+  const limit = queryState.definition.limit
+  if (limit) {
+    let sliceCount
+    if (count < limit) {
+      // When there are less results than the limit, this is either the first
+      // or last paginated query.
+      sliceCount =
+        fetchedPagesCount > 1 ? limit * (fetchedPagesCount - 1) + count : count
+    } else {
+      sliceCount = limit * fetchedPagesCount
+    }
+    evaluatedIds = evaluatedIds.slice(0, sliceCount)
   }
   return evaluatedIds
 }

--- a/packages/cozy-client/src/store/queries.spec.js
+++ b/packages/cozy-client/src/store/queries.spec.js
@@ -427,4 +427,36 @@ describe('sortAndLimitDocsIds', () => {
     )
     expect(ids2).toEqual(['doc2', 'doc1'])
   })
+
+  it('should correctly handle count inferior to limit', () => {
+    const query1 = Q('io.cozy.files')
+      .sortBy([{ name: 'asc' }])
+      .limitBy(2)
+
+    const ids1 = sortAndLimitDocsIds(
+      { definition: query1.toDefinition() },
+      docs,
+      ['doc1', 'doc2'],
+      {
+        count: 1,
+        fetchedPagesCount: 1
+      }
+    )
+    expect(ids1.length).toEqual(1)
+
+    const query2 = Q('io.cozy.files')
+      .sortBy([{ name: 'asc' }])
+      .limitBy(2)
+
+    const ids2 = sortAndLimitDocsIds(
+      { definition: query2.toDefinition() },
+      docs,
+      ['doc1', 'doc2', 'doc3'],
+      {
+        count: 1,
+        fetchedPagesCount: 2
+      }
+    )
+    expect(ids2.length).toEqual(3)
+  })
 })


### PR DESCRIPTION
When enforcing the query limit in the store, we relied on the query
count to slice the docs. However, the count can be inferior to the
limit for the fisrt and last paginated query, leading to issues with
the slice.