### PR TITLE
fix: Check the correct path to get the warning

### DIFF
--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -262,11 +262,8 @@ class DocumentCollection {
     let resp
     try {
       resp = await this.fetchDocumentsWithMango(path, selector, options)
-      if (
-        resp.warning &&
-        options.partialFilter &&
-        isIndexNotUsedWarning(resp.warning)
-      ) {
+      const warning = resp.warning || resp.meta?.warning
+      if (warning && options.partialFilter && isIndexNotUsedWarning(warning)) {
         // This warning might happen when an index including a partial filter
         // is not created yet.
         throw new Error('no_index')

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -573,13 +573,40 @@ describe('DocumentCollection', () => {
       ).resolves.toBe(FIND_RESPONSE_FIXTURE)
     })
 
-    it('should not throw an error when a warning is returned and a partial filter is defined', async () => {
+    it('should not throw an error when a warning is returned in resp.warning and a partial filter is defined', async () => {
       client.fetchJSON.mockRestore()
       client.fetchJSON
         .mockResolvedValueOnce({
           rows: [],
           warning:
             '_design/by_label was not used because it does not contain a valid index for this query'
+        })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce(FIND_RESPONSE_FIXTURE)
+        .mockResolvedValueOnce(FIND_RESPONSE_FIXTURE)
+      const collection = new DocumentCollection('io.cozy.todos', client)
+      await expect(
+        collection.findWithMango(
+          'fakepath',
+          { label: 'work' },
+          {
+            indexedFields: ['label'],
+            partialFilter: { done: { $exists: true } }
+          }
+        )
+      ).resolves.toBe(FIND_RESPONSE_FIXTURE)
+    })
+
+    it('should not throw an error when a warning is returned in resp.meta.warning and a partial filter is defined', async () => {
+      client.fetchJSON.mockRestore()
+      client.fetchJSON
+        .mockResolvedValueOnce({
+          rows: [],
+          meta: {
+            warning:
+              '_design/by_label was not used because it does not contain a valid index for this query'
+          }
         })
         .mockResolvedValueOnce({ rows: [] })
         .mockResolvedValueOnce({})


### PR DESCRIPTION
We were checking only in resp.warning, but we can also have this warning in resp.meta.warning. 

We now handle the both case