### PR TITLE
fix: Lodash.merge is not creating a new object

### DIFF
--- a/packages/cozy-client/src/store/documents.js
+++ b/packages/cozy-client/src/store/documents.js
@@ -178,7 +178,7 @@ export const extractAndMergeDocument = (data, updatedStateWithIncluded) => {
   Object.values(sortedData).map(data => {
     const id = properId(data)
     if (mergedData[doctype][id]) {
-      mergedData[doctype][id] = merge(mergedData[doctype][id], data)
+      mergedData[doctype][id] = merge({}, mergedData[doctype][id], data)
     } else {
       mergedData[doctype][id] = data
     }

--- a/packages/cozy-client/src/store/documents.spec.js
+++ b/packages/cozy-client/src/store/documents.spec.js
@@ -148,7 +148,24 @@ describe('extractAndMerge', () => {
       ).toBeFalsy()
     }
   )
+  it(
+    'should assign a new object for doctype[id] of document to update' +
+      'in order to allow selector to recompute their data when documents are updated',
+    () => {
+      const returnedDatas = extractAndMergeDocument(
+        data,
+        updatedStateWithIncluded
+      )
 
+      // Then
+      expect(
+        returnedDatas['io.cozy.files']['b6ff135b34e041ffb2d4a4865f3e0a53'] ===
+          updatedStateWithIncluded['io.cozy.files'][
+            'b6ff135b34e041ffb2d4a4865f3e0a53'
+          ]
+      ).toBeFalsy()
+    }
+  )
   it(
     'should assign a new object for doctype of document to update' +
       'even if the mergedData is the same, because reselect createSelector update ' +


### PR DESCRIPTION
By not creating a new object, we kept the same
referencial equality and then some components
that checked this equality was not re-rendering.

