### PR TITLE
feat: Add `deconstructCozyWebLinkWithSlug` to extract data from Cozy url

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -190,6 +190,33 @@ Creates a client suitable for use in tests
 
 ***
 
+### deconstructCozyWebLinkWithSlug
+
+▸ **deconstructCozyWebLinkWithSlug**(`webLink`, `subDomainType?`): `CozyLinkData`
+
+Deconstruct the given link in order to retrieve useful data like Cozy's name, domain, or slug
+
+The given link MUST contain a slug
+
+*Parameters*
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `webLink` | `string` | `undefined` | link to deconstruct. It should be a link from a Cozy and containing a slug |
+| `subDomainType` | `SubdomainType` | `'flat'` | - |
+
+*Returns*
+
+`CozyLinkData`
+
+Deconstructed link
+
+*Defined in*
+
+[packages/cozy-client/src/helpers.js:90](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L90)
+
+***
+
 ### dehydrate
 
 ▸ **dehydrate**(`document`): `Object`
@@ -206,7 +233,7 @@ Creates a client suitable for use in tests
 
 *Defined in*
 
-[packages/cozy-client/src/helpers.js:3](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L3)
+[packages/cozy-client/src/helpers.js:5](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L5)
 
 ***
 
@@ -241,7 +268,7 @@ Generated URL
 
 *Defined in*
 
-[packages/cozy-client/src/helpers.js:51](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L51)
+[packages/cozy-client/src/helpers.js:53](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L53)
 
 ***
 
@@ -541,7 +568,7 @@ The root Cozy URL
 
 *Defined in*
 
-[packages/cozy-client/src/helpers.js:199](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L199)
+[packages/cozy-client/src/helpers.js:242](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L242)
 
 ***
 

--- a/docs/api/cozy-client/classes/InvalidCozyUrlError.md
+++ b/docs/api/cozy-client/classes/InvalidCozyUrlError.md
@@ -26,7 +26,7 @@ Error.constructor
 
 *Defined in*
 
-[packages/cozy-client/src/helpers.js:88](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L88)
+[packages/cozy-client/src/helpers.js:131](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L131)
 
 ## Properties
 
@@ -36,4 +36,4 @@ Error.constructor
 
 *Defined in*
 
-[packages/cozy-client/src/helpers.js:91](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L91)
+[packages/cozy-client/src/helpers.js:134](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L134)

--- a/docs/api/cozy-client/classes/InvalidProtocolError.md
+++ b/docs/api/cozy-client/classes/InvalidProtocolError.md
@@ -26,7 +26,7 @@ Error.constructor
 
 *Defined in*
 
-[packages/cozy-client/src/helpers.js:80](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L80)
+[packages/cozy-client/src/helpers.js:123](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L123)
 
 ## Properties
 
@@ -36,4 +36,4 @@ Error.constructor
 
 *Defined in*
 
-[packages/cozy-client/src/helpers.js:83](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L83)
+[packages/cozy-client/src/helpers.js:126](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers.js#L126)

--- a/packages/cozy-client/src/helpers.js
+++ b/packages/cozy-client/src/helpers.js
@@ -1,5 +1,7 @@
 import { Association } from './associations'
 
+import { CozyLinkData, SubdomainType } from './types'
+
 export const dehydrate = document => {
   const dehydrated = Object.entries(document).reduce(
     (documentArg, [key, value]) => {
@@ -74,6 +76,47 @@ export const generateWebLink = ({
   }
 
   return url.toString()
+}
+
+/**
+ * Deconstruct the given link in order to retrieve useful data like Cozy's name, domain, or slug
+ *
+ * The given link MUST contain a slug
+ *
+ * @param {string} webLink - link to deconstruct. It should be a link from a Cozy and containing a slug
+ * @param {SubdomainType} [subDomainType=flat] - whether the cozy is using flat or nested subdomains.
+ * @returns {CozyLinkData} Deconstructed link
+ */
+export const deconstructCozyWebLinkWithSlug = (
+  webLink,
+  subDomainType = 'flat'
+) => {
+  const url = new URL(webLink)
+
+  const slug =
+    subDomainType === 'nested'
+      ? url.host.split('.')[0]
+      : url.host.split('.')[0].split('-')[1]
+
+  const cozyName =
+    subDomainType === 'nested'
+      ? url.host.split('.')[1]
+      : url.host.split('.')[0].split('-')[0]
+
+  const cozyBaseDomain = url.host
+    .split('.')
+    .slice(subDomainType === 'nested' ? 2 : 1)
+    .join('.')
+
+  return {
+    cozyBaseDomain,
+    cozyName,
+    pathname: url.pathname,
+    hash: url.hash,
+    protocol: url.protocol,
+    searchParams: url.searchParams.toString(),
+    slug
+  }
 }
 
 export class InvalidProtocolError extends Error {

--- a/packages/cozy-client/src/helpers.spec.js
+++ b/packages/cozy-client/src/helpers.spec.js
@@ -1,6 +1,7 @@
 import { enableFetchMocks, disableFetchMocks } from 'jest-fetch-mock'
 
 import {
+  deconstructCozyWebLinkWithSlug,
   dehydrate,
   generateWebLink,
   rootCozyUrl,
@@ -148,6 +149,83 @@ describe('generateWebLink', () => {
       })
     ).toEqual(`https://drive.alice.cozy.tools/public/#/files/432432`)
   })
+})
+
+describe('deconstructWebLink', () => {
+  it.each([
+    [
+      'https://claude-notes.mycozy.cloud',
+      'flat',
+      {
+        protocol: 'https:',
+        cozyName: 'claude',
+        cozyBaseDomain: 'mycozy.cloud',
+        pathname: '/',
+        hash: '',
+        searchParams: '',
+        slug: 'notes'
+      }
+    ],
+    [
+      'http://alice-drive.cozy.tools:8080',
+      'flat',
+      {
+        protocol: 'http:',
+        cozyName: 'alice',
+        cozyBaseDomain: 'cozy.tools:8080',
+        pathname: '/',
+        hash: '',
+        searchParams: '',
+        slug: 'drive'
+      }
+    ],
+    [
+      'https://photo.claude.custome-domain.fr',
+      'nested',
+      {
+        protocol: 'https:',
+        cozyName: 'claude',
+        cozyBaseDomain: 'custome-domain.fr',
+        pathname: '/',
+        hash: '',
+        searchParams: '',
+        slug: 'photo'
+      }
+    ],
+    [
+      'http://drive.cozy.tools:8080/#/folder/SOME_FOLDER_ID',
+      'nested',
+      {
+        protocol: 'http:',
+        cozyName: 'cozy',
+        cozyBaseDomain: 'tools:8080',
+        pathname: '/',
+        hash: '#/folder/SOME_FOLDER_ID',
+        searchParams: '',
+        slug: 'drive'
+      }
+    ],
+    [
+      'http://notes.cozy.tools:8080/public/?id=SOME_FOLDER_ID&sharecode=SOME_SHARECODE',
+      'nested',
+      {
+        protocol: 'http:',
+        cozyName: 'cozy',
+        cozyBaseDomain: 'tools:8080',
+        pathname: '/public/',
+        hash: '',
+        searchParams: 'id=SOME_FOLDER_ID&sharecode=SOME_SHARECODE',
+        slug: 'notes'
+      }
+    ]
+  ])(
+    'should deconstruct %p link with %p subdomain type',
+    (link, subdomainType, result) => {
+      expect(deconstructCozyWebLinkWithSlug(link, subdomainType)).toEqual(
+        result
+      )
+    }
+  )
 })
 
 describe('rootCozyUrl', () => {

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -24,6 +24,7 @@ export {
   getReferencedById
 } from './associations/helpers'
 export {
+  deconstructCozyWebLinkWithSlug,
   dehydrate,
   generateWebLink,
   rootCozyUrl,

--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -380,4 +380,26 @@ import { QueryDefinition } from './queries/dsl'
  * @property {string} [codeChallenge]
  */
 
+/**
+ * Subdomain type for a Cozy. Can be flat or nested subdomains
+ *
+ * Example of 'flat' domain: https://claude-notes.somedomain.fr
+ * Example of 'nested' domain: https://notes.claude.somedomain.fr
+ *
+ * @typedef {'flat'|'nested'} SubdomainType
+ */
+
+/**
+ * Represents the different parts of a deconstructed Cozy link
+ *
+ * @typedef {object} CozyLinkData
+ * @property {string} cozyBaseDomain - The Cozy's domain (i.e. 'mycozy.cloud')
+ * @property {string} cozyName - The Cozy's name (i.e. 'claude')
+ * @property {string} [hash] - The link's path (i.e. '#/folder/SOME_FOLDER_ID')
+ * @property {string} [pathname] - The link's path (i.e. '/public/')
+ * @property {string} protocol - The link's protocol (i.e. 'https')
+ * @property {string} [searchParams] - The link's searchParams (i.e. 'id=SOME_FOLDER_ID&sharecode=SOME_SHARECODE')
+ * @property {string} slug - The link's slug (i.e. 'drive' or 'notes)
+ */
+
 export default {}

--- a/packages/cozy-client/types/helpers.d.ts
+++ b/packages/cozy-client/types/helpers.d.ts
@@ -7,6 +7,7 @@ export function generateWebLink({ cozyUrl, searchParams: searchParamsOption, pat
     slug: string;
     subDomainType: string;
 }): string;
+export function deconstructCozyWebLinkWithSlug(webLink: string, subDomainType?: SubdomainType): CozyLinkData;
 export class InvalidProtocolError extends Error {
     constructor(url: any);
     url: any;
@@ -16,3 +17,5 @@ export class InvalidCozyUrlError extends Error {
     url: any;
 }
 export function rootCozyUrl(url: URL): Promise<URL>;
+import { SubdomainType } from "./types";
+import { CozyLinkData } from "./types";

--- a/packages/cozy-client/types/index.d.ts
+++ b/packages/cozy-client/types/index.d.ts
@@ -19,6 +19,6 @@ export { manifest, models };
 export { QueryDefinition, Q, Mutations, MutationTypes, getDoctypeFromOperation } from "./queries/dsl";
 export { Association, HasMany, HasOne, HasOneInPlace, HasManyInPlace, HasManyTriggers } from "./associations";
 export { isReferencedBy, isReferencedById, getReferencedBy, getReferencedById } from "./associations/helpers";
-export { dehydrate, generateWebLink, rootCozyUrl, InvalidCozyUrlError, InvalidProtocolError } from "./helpers";
+export { deconstructCozyWebLinkWithSlug, dehydrate, generateWebLink, rootCozyUrl, InvalidCozyUrlError, InvalidProtocolError } from "./helpers";
 export { cancelable, isQueryLoading, hasQueryBeenLoaded } from "./utils";
 export { queryConnect, queryConnectFlat, withClient } from "./hoc";

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -477,4 +477,44 @@ export type PKCECodes = {
     codeVerifier?: string;
     codeChallenge?: string;
 };
+/**
+ * Subdomain type for a Cozy. Can be flat or nested subdomains
+ *
+ * Example of 'flat' domain: https://claude-notes.somedomain.fr
+ * Example of 'nested' domain: https://notes.claude.somedomain.fr
+ */
+export type SubdomainType = "flat" | "nested";
+/**
+ * Represents the different parts of a deconstructed Cozy link
+ */
+export type CozyLinkData = {
+    /**
+     * - The Cozy's domain (i.e. 'mycozy.cloud')
+     */
+    cozyBaseDomain: string;
+    /**
+     * - The Cozy's name (i.e. 'claude')
+     */
+    cozyName: string;
+    /**
+     * - The link's path (i.e. '#/folder/SOME_FOLDER_ID')
+     */
+    hash?: string;
+    /**
+     * - The link's path (i.e. '/public/')
+     */
+    pathname?: string;
+    /**
+     * - The link's protocol (i.e. 'https')
+     */
+    protocol: string;
+    /**
+     * - The link's searchParams (i.e. 'id=SOME_FOLDER_ID&sharecode=SOME_SHARECODE')
+     */
+    searchParams?: string;
+    /**
+     * - The link's slug (i.e. 'drive' or 'notes)
+     */
+    slug: string;
+};
 import { QueryDefinition } from "./queries/dsl";


### PR DESCRIPTION
Sometimes we have to manipulate Cozy's URLs as strings and we want to
deconstruct them to retrieve data like slug, or Cozy's name

This is the case on `cozy-notes` as we can retrieve a `returnUrl` from
the URL's searchParams. In a mobile app, we wan't to extract the target
slug from the `returnUrl` so we can call `openApp()` for this slug

In order to ease the process, `deconstructCozyWebLinkWithSlug()`
requires the Cozy's URL to contain a slug

Without knowing if the URL contains a slug or not, it would be not
possible to correctly extract data from the URL as we can't guess if a
part of the URL should be a subdomain, or if it contains a slug

___

Related PRs:

- https://github.com/cozy/cozy-notes/pull/318
- https://github.com/cozy/cozy-ui/pull/2206