### PR TITLE
feat: Add warning when selector fields are not indexed

### DIFF
--- a/packages/cozy-stack-client/src/ContactsCollection.spec.js
+++ b/packages/cozy-stack-client/src/ContactsCollection.spec.js
@@ -32,6 +32,9 @@ describe('ContactsCollection', () => {
     const col = new ContactsCollection('io.cozy.contacts', stackClient)
     return { stackClient, col }
   }
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
 
   it('should use a special route for the myself contact', async () => {
     const { col, stackClient } = setup()

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -452,6 +452,12 @@ The returned documents are paginated by the stack.
 
     sort = transformSort(sort)
 
+    if (!indexedFields && selector) {
+      console.warn(
+        'Selector fields should be manually indexed to prevent unexpected behaviour'
+      )
+    }
+
     indexedFields = indexedFields
       ? indexedFields
       : getIndexFields({ sort, selector })

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -116,6 +116,7 @@ describe('DocumentCollection', () => {
 
     beforeAll(() => {
       client.fetchJSON.mockResolvedValue(NORMAL_RESPONSE_FIXTURE)
+      jest.spyOn(console, 'warn').mockImplementation(() => {})
     })
 
     it('should call the right route', async () => {
@@ -1302,6 +1303,12 @@ describe('DocumentCollection', () => {
   })
   describe('toMangoOptions', () => {
     const collection = new DocumentCollection('io.cozy.todos', client)
+    let warnSpy
+
+    beforeEach(() => {
+      jest.resetAllMocks()
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    })
 
     it('should correctly build the indexName', () => {
       const selector = {
@@ -1370,6 +1377,14 @@ describe('DocumentCollection', () => {
         indexedFields
       })
       expect(opts.sort).toEqual([{ name: 'asc' }, { date: 'asc' }])
+    })
+    it('should raise warning when there is a selector and no indexFields', () => {
+      collection.toMangoOptions({ name: 'toto' }, {})
+      expect(warnSpy).toHaveBeenCalled()
+    })
+    it('should not raise warning when there is a selector and indexFields', () => {
+      collection.toMangoOptions({ name: 'toto' }, { indexedFields: ['name'] })
+      expect(warnSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -96,6 +96,7 @@ describe('FileCollection', () => {
 
     beforeAll(() => {
       client.fetchJSON.mockResolvedValue(FIND_RESPONSE)
+      jest.spyOn(console, 'warn').mockImplementation(() => {})
     })
 
     afterAll(() => {


### PR DESCRIPTION
When no indexFields option is given in a query definition, the fields to
index are automatically generated to create the index.
However, this might be dangerous as the indexed fields might actually
not entirely comply with the query objective.