### PR TITLE
refactor: Use logger instead of console

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -54,7 +54,7 @@ cozy-client
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:495](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L495)
+[packages/cozy-client/src/queries/dsl.js:496](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L496)
 
 ***
 
@@ -78,7 +78,7 @@ cozy-client
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:483](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L483)
+[packages/cozy-client/src/queries/dsl.js:484](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L484)
 
 ***
 
@@ -132,7 +132,7 @@ query definitions.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:379](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L379)
+[packages/cozy-client/src/queries/dsl.js:380](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L380)
 
 ***
 
@@ -158,7 +158,7 @@ Rejects with canceled: true as soon as cancel is called
 
 *Defined in*
 
-[packages/cozy-client/src/utils.js:14](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/utils.js#L14)
+[packages/cozy-client/src/utils.js:16](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/utils.js#L16)
 
 ***
 
@@ -288,7 +288,7 @@ Generated URL
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:459](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L459)
+[packages/cozy-client/src/queries/dsl.js:460](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L460)
 
 ***
 
@@ -382,7 +382,7 @@ Returns whether a query has been loaded at least once
 
 *Defined in*
 
-[packages/cozy-client/src/utils.js:48](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/utils.js#L48)
+[packages/cozy-client/src/utils.js:50](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/utils.js#L50)
 
 ***
 
@@ -405,7 +405,7 @@ is loading.
 
 *Defined in*
 
-[packages/cozy-client/src/utils.js:37](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/utils.js#L37)
+[packages/cozy-client/src/utils.js:39](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/utils.js#L39)
 
 ***
 
@@ -482,7 +482,7 @@ If a reference is found
 
 *Defined in*
 
-[packages/cozy-client/src/hoc.jsx:73](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hoc.jsx#L73)
+[packages/cozy-client/src/hoc.jsx:74](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hoc.jsx#L74)
 
 ***
 
@@ -510,7 +510,7 @@ if there are N queries, only 1 extra level of nesting is introduced.
 
 *Defined in*
 
-[packages/cozy-client/src/hoc.jsx:89](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hoc.jsx#L89)
+[packages/cozy-client/src/hoc.jsx:90](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hoc.jsx#L90)
 
 ***
 
@@ -762,7 +762,7 @@ Fetches a queryDefinition and run fetchMore on the query until the query is full
 
 *Defined in*
 
-[packages/cozy-client/src/hoc.jsx:15](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hoc.jsx#L15)
+[packages/cozy-client/src/hoc.jsx:16](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hoc.jsx#L16)
 
 ***
 
@@ -811,4 +811,4 @@ Fetches a queryDefinition and run fetchMore on the query until the query is full
 
 *Defined in*
 
-[packages/cozy-client/src/withMutations.jsx:23](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/withMutations.jsx#L23)
+[packages/cozy-client/src/withMutations.jsx:24](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/withMutations.jsx#L24)

--- a/docs/api/cozy-client/classes/HasMany.md
+++ b/docs/api/cozy-client/classes/HasMany.md
@@ -228,7 +228,7 @@ to do that, you can use .data.length.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:93](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L93)
+[packages/cozy-client/src/associations/HasMany.js:94](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L94)
 
 ***
 
@@ -248,7 +248,7 @@ Association.data
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:76](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L76)
+[packages/cozy-client/src/associations/HasMany.js:77](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L77)
 
 ***
 
@@ -262,7 +262,7 @@ Association.data
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:82](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L82)
+[packages/cozy-client/src/associations/HasMany.js:83](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L83)
 
 ***
 
@@ -280,7 +280,7 @@ Association.raw
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:69](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L69)
+[packages/cozy-client/src/associations/HasMany.js:70](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L70)
 
 ## Methods
 
@@ -304,7 +304,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:124](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L124)
+[packages/cozy-client/src/associations/HasMany.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L125)
 
 ***
 
@@ -331,7 +331,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:174](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L174)
+[packages/cozy-client/src/associations/HasMany.js:175](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L175)
 
 ***
 
@@ -353,7 +353,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:147](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L147)
+[packages/cozy-client/src/associations/HasMany.js:148](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L148)
 
 ***
 
@@ -373,7 +373,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:108](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L108)
+[packages/cozy-client/src/associations/HasMany.js:109](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L109)
 
 ***
 
@@ -393,7 +393,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:256](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L256)
+[packages/cozy-client/src/associations/HasMany.js:257](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L257)
 
 ***
 
@@ -413,7 +413,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:104](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L104)
+[packages/cozy-client/src/associations/HasMany.js:105](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L105)
 
 ***
 
@@ -433,7 +433,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:114](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L114)
+[packages/cozy-client/src/associations/HasMany.js:115](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L115)
 
 ***
 
@@ -447,7 +447,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:100](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L100)
+[packages/cozy-client/src/associations/HasMany.js:101](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L101)
 
 ***
 
@@ -461,7 +461,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:207](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L207)
+[packages/cozy-client/src/associations/HasMany.js:208](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L208)
 
 ***
 
@@ -485,7 +485,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:136](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L136)
+[packages/cozy-client/src/associations/HasMany.js:137](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L137)
 
 ***
 
@@ -505,7 +505,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:193](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L193)
+[packages/cozy-client/src/associations/HasMany.js:194](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L194)
 
 ***
 
@@ -527,7 +527,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:184](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L184)
+[packages/cozy-client/src/associations/HasMany.js:185](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L185)
 
 ***
 
@@ -541,7 +541,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:198](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L198)
+[packages/cozy-client/src/associations/HasMany.js:199](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L199)
 
 ***
 
@@ -562,7 +562,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:228](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L228)
+[packages/cozy-client/src/associations/HasMany.js:229](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L229)
 
 ***
 
@@ -595,7 +595,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:232](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L232)
+[packages/cozy-client/src/associations/HasMany.js:233](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L233)
 
 ***
 
@@ -616,7 +616,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:221](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L221)
+[packages/cozy-client/src/associations/HasMany.js:222](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L222)
 
 ***
 
@@ -638,7 +638,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:289](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L289)
+[packages/cozy-client/src/associations/HasMany.js:290](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L290)
 
 ***
 
@@ -659,7 +659,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:298](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L298)
+[packages/cozy-client/src/associations/HasMany.js:299](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L299)
 
 ***
 
@@ -685,7 +685,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:275](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L275)
+[packages/cozy-client/src/associations/HasMany.js:276](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L276)
 
 ***
 
@@ -707,7 +707,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:336](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L336)
+[packages/cozy-client/src/associations/HasMany.js:337](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L337)
 
 ***
 
@@ -730,7 +730,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:310](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L310)
+[packages/cozy-client/src/associations/HasMany.js:311](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L311)
 
 ***
 
@@ -753,7 +753,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:360](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L360)
+[packages/cozy-client/src/associations/HasMany.js:361](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L361)
 
 ***
 
@@ -775,4 +775,4 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:371](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L371)
+[packages/cozy-client/src/associations/HasMany.js:372](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L372)

--- a/docs/api/cozy-client/classes/HasManyTriggers.md
+++ b/docs/api/cozy-client/classes/HasManyTriggers.md
@@ -198,7 +198,7 @@ HasMany.count
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:93](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L93)
+[packages/cozy-client/src/associations/HasMany.js:94](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L94)
 
 ***
 
@@ -234,7 +234,7 @@ HasMany.hasMore
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:82](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L82)
+[packages/cozy-client/src/associations/HasMany.js:83](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L83)
 
 ***
 
@@ -252,7 +252,7 @@ HasMany.raw
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:69](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L69)
+[packages/cozy-client/src/associations/HasMany.js:70](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L70)
 
 ## Methods
 
@@ -280,7 +280,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:124](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L124)
+[packages/cozy-client/src/associations/HasMany.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L125)
 
 ***
 
@@ -311,7 +311,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:174](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L174)
+[packages/cozy-client/src/associations/HasMany.js:175](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L175)
 
 ***
 
@@ -337,7 +337,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:147](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L147)
+[packages/cozy-client/src/associations/HasMany.js:148](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L148)
 
 ***
 
@@ -361,7 +361,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:108](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L108)
+[packages/cozy-client/src/associations/HasMany.js:109](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L109)
 
 ***
 
@@ -385,7 +385,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:256](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L256)
+[packages/cozy-client/src/associations/HasMany.js:257](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L257)
 
 ***
 
@@ -409,7 +409,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:104](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L104)
+[packages/cozy-client/src/associations/HasMany.js:105](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L105)
 
 ***
 
@@ -433,7 +433,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:114](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L114)
+[packages/cozy-client/src/associations/HasMany.js:115](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L115)
 
 ***
 
@@ -451,7 +451,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:100](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L100)
+[packages/cozy-client/src/associations/HasMany.js:101](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L101)
 
 ***
 
@@ -469,7 +469,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:207](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L207)
+[packages/cozy-client/src/associations/HasMany.js:208](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L208)
 
 ***
 
@@ -497,7 +497,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:136](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L136)
+[packages/cozy-client/src/associations/HasMany.js:137](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L137)
 
 ***
 
@@ -521,7 +521,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:193](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L193)
+[packages/cozy-client/src/associations/HasMany.js:194](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L194)
 
 ***
 
@@ -547,7 +547,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:184](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L184)
+[packages/cozy-client/src/associations/HasMany.js:185](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L185)
 
 ***
 
@@ -565,7 +565,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:198](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L198)
+[packages/cozy-client/src/associations/HasMany.js:199](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L199)
 
 ***
 
@@ -590,7 +590,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:228](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L228)
+[packages/cozy-client/src/associations/HasMany.js:229](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L229)
 
 ***
 
@@ -627,7 +627,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:232](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L232)
+[packages/cozy-client/src/associations/HasMany.js:233](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L233)
 
 ***
 
@@ -652,7 +652,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:221](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L221)
+[packages/cozy-client/src/associations/HasMany.js:222](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L222)
 
 ***
 
@@ -678,7 +678,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:289](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L289)
+[packages/cozy-client/src/associations/HasMany.js:290](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L290)
 
 ***
 
@@ -703,7 +703,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:298](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L298)
+[packages/cozy-client/src/associations/HasMany.js:299](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L299)
 
 ***
 
@@ -758,7 +758,7 @@ having for the 'konnector' worker, and then filter them based on their
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:336](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L336)
+[packages/cozy-client/src/associations/HasMany.js:337](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L337)
 
 ***
 
@@ -785,7 +785,7 @@ having for the 'konnector' worker, and then filter them based on their
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:310](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L310)
+[packages/cozy-client/src/associations/HasMany.js:311](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L311)
 
 ***
 
@@ -812,7 +812,7 @@ having for the 'konnector' worker, and then filter them based on their
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:360](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L360)
+[packages/cozy-client/src/associations/HasMany.js:361](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L361)
 
 ***
 
@@ -838,4 +838,4 @@ having for the 'konnector' worker, and then filter them based on their
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:371](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L371)
+[packages/cozy-client/src/associations/HasMany.js:372](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L372)

--- a/docs/api/cozy-client/classes/HasOne.md
+++ b/docs/api/cozy-client/classes/HasOne.md
@@ -190,7 +190,7 @@ Association.data
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:12](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L12)
+[packages/cozy-client/src/associations/HasOne.js:13](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L13)
 
 ***
 
@@ -208,7 +208,7 @@ Association.raw
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:8](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L8)
+[packages/cozy-client/src/associations/HasOne.js:9](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L9)
 
 ## Methods
 
@@ -232,7 +232,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:41](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L41)
+[packages/cozy-client/src/associations/HasOne.js:42](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L42)
 
 ***
 
@@ -252,7 +252,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:89](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L89)
+[packages/cozy-client/src/associations/HasOne.js:90](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L90)
 
 ***
 
@@ -270,7 +270,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:51](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L51)
+[packages/cozy-client/src/associations/HasOne.js:52](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L52)
 
 ***
 
@@ -290,7 +290,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:75](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L75)
+[packages/cozy-client/src/associations/HasOne.js:76](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L76)
 
 ***
 
@@ -310,7 +310,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:56](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L56)
+[packages/cozy-client/src/associations/HasOne.js:57](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L57)
 
 ***
 
@@ -324,7 +324,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:82](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L82)
+[packages/cozy-client/src/associations/HasOne.js:83](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L83)
 
 ***
 
@@ -350,4 +350,4 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:27](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L27)
+[packages/cozy-client/src/associations/HasOne.js:28](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L28)

--- a/docs/api/cozy-client/classes/QueryDefinition.md
+++ b/docs/api/cozy-client/classes/QueryDefinition.md
@@ -33,7 +33,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:50](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L50)
+[packages/cozy-client/src/queries/dsl.js:51](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L51)
 
 ## Properties
 
@@ -43,7 +43,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:64](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L64)
+[packages/cozy-client/src/queries/dsl.js:65](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L65)
 
 ***
 
@@ -53,7 +53,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:63](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L63)
+[packages/cozy-client/src/queries/dsl.js:64](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L64)
 
 ***
 
@@ -63,7 +63,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:51](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L51)
+[packages/cozy-client/src/queries/dsl.js:52](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L52)
 
 ***
 
@@ -73,7 +73,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:55](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L55)
+[packages/cozy-client/src/queries/dsl.js:56](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L56)
 
 ***
 
@@ -83,7 +83,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:52](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L52)
+[packages/cozy-client/src/queries/dsl.js:53](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L53)
 
 ***
 
@@ -93,7 +93,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:53](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L53)
+[packages/cozy-client/src/queries/dsl.js:54](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L54)
 
 ***
 
@@ -103,7 +103,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:59](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L59)
+[packages/cozy-client/src/queries/dsl.js:60](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L60)
 
 ***
 
@@ -113,7 +113,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:56](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L56)
+[packages/cozy-client/src/queries/dsl.js:57](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L57)
 
 ***
 
@@ -123,7 +123,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:61](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L61)
+[packages/cozy-client/src/queries/dsl.js:62](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L62)
 
 ***
 
@@ -133,7 +133,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:57](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L57)
+[packages/cozy-client/src/queries/dsl.js:58](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L58)
 
 ***
 
@@ -143,7 +143,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:60](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L60)
+[packages/cozy-client/src/queries/dsl.js:61](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L61)
 
 ***
 
@@ -153,7 +153,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:54](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L54)
+[packages/cozy-client/src/queries/dsl.js:55](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L55)
 
 ***
 
@@ -163,7 +163,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:62](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L62)
+[packages/cozy-client/src/queries/dsl.js:63](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L63)
 
 ***
 
@@ -173,7 +173,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:58](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L58)
+[packages/cozy-client/src/queries/dsl.js:59](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L59)
 
 ## Methods
 
@@ -187,7 +187,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:276](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L276)
+[packages/cozy-client/src/queries/dsl.js:277](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L277)
 
 ***
 
@@ -209,7 +209,7 @@ Check if the selected fields are all included in the selectors
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L139)
+[packages/cozy-client/src/queries/dsl.js:140](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L140)
 
 ***
 
@@ -233,7 +233,7 @@ It is useful to warn the developer when a partial index might be used.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L117)
+[packages/cozy-client/src/queries/dsl.js:118](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L118)
 
 ***
 
@@ -262,7 +262,7 @@ See https://docs.cozy.io/en/tutorials/data/queries/#sort-data-with-mango
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:78](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L78)
+[packages/cozy-client/src/queries/dsl.js:79](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L79)
 
 ***
 
@@ -286,7 +286,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:166](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L166)
+[packages/cozy-client/src/queries/dsl.js:167](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L167)
 
 ***
 
@@ -310,7 +310,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:179](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L179)
+[packages/cozy-client/src/queries/dsl.js:180](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L180)
 
 ***
 
@@ -335,7 +335,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:259](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L259)
+[packages/cozy-client/src/queries/dsl.js:260](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L260)
 
 ***
 
@@ -359,7 +359,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:215](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L215)
+[packages/cozy-client/src/queries/dsl.js:216](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L216)
 
 ***
 
@@ -383,7 +383,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:272](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L272)
+[packages/cozy-client/src/queries/dsl.js:273](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L273)
 
 ***
 
@@ -410,7 +410,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:289](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L289)
+[packages/cozy-client/src/queries/dsl.js:290](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L290)
 
 ***
 
@@ -437,7 +437,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:327](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L327)
+[packages/cozy-client/src/queries/dsl.js:328](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L328)
 
 ***
 
@@ -466,7 +466,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:309](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L309)
+[packages/cozy-client/src/queries/dsl.js:310](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L310)
 
 ***
 
@@ -492,7 +492,7 @@ You can find more information about partial indexes [here](https://docs.cozy.io/
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:229](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L229)
+[packages/cozy-client/src/queries/dsl.js:230](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L230)
 
 ***
 
@@ -516,7 +516,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:342](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L342)
+[packages/cozy-client/src/queries/dsl.js:343](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L343)
 
 ***
 
@@ -540,7 +540,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:203](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L203)
+[packages/cozy-client/src/queries/dsl.js:204](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L204)
 
 ***
 
@@ -564,7 +564,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:240](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L240)
+[packages/cozy-client/src/queries/dsl.js:241](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L241)
 
 ***
 
@@ -595,7 +595,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:346](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L346)
+[packages/cozy-client/src/queries/dsl.js:347](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L347)
 
 ***
 
@@ -620,4 +620,4 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:190](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L190)
+[packages/cozy-client/src/queries/dsl.js:191](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L191)

--- a/docs/api/cozy-client/classes/StackLink.md
+++ b/docs/api/cozy-client/classes/StackLink.md
@@ -30,7 +30,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:59](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L59)
+[packages/cozy-client/src/StackLink.js:63](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L63)
 
 ## Properties
 
@@ -40,7 +40,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:66](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L66)
+[packages/cozy-client/src/StackLink.js:70](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L70)
 
 ## Methods
 
@@ -62,7 +62,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:111](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L111)
+[packages/cozy-client/src/StackLink.js:115](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L115)
 
 ***
 
@@ -82,7 +82,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:88](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L88)
+[packages/cozy-client/src/StackLink.js:92](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L92)
 
 ***
 
@@ -102,7 +102,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:69](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L69)
+[packages/cozy-client/src/StackLink.js:73](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L73)
 
 ***
 
@@ -128,7 +128,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:77](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L77)
+[packages/cozy-client/src/StackLink.js:81](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L81)
 
 ***
 
@@ -142,4 +142,4 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:73](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L73)
+[packages/cozy-client/src/StackLink.js:77](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L77)

--- a/docs/api/cozy-client/interfaces/models.file.FileUploadOptions.md
+++ b/docs/api/cozy-client/interfaces/models.file.FileUploadOptions.md
@@ -14,7 +14,7 @@ Erase / rename
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:465](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L465)
+[packages/cozy-client/src/models/file.js:466](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L466)
 
 ***
 
@@ -26,7 +26,7 @@ The file Content-Type
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:464](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L464)
+[packages/cozy-client/src/models/file.js:465](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L465)
 
 ***
 
@@ -38,7 +38,7 @@ The dirId to upload the file to
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:462](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L462)
+[packages/cozy-client/src/models/file.js:463](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L463)
 
 ***
 
@@ -50,7 +50,7 @@ An object containing the metadata to attach
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:463](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L463)
+[packages/cozy-client/src/models/file.js:464](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L464)
 
 ***
 
@@ -62,4 +62,4 @@ The file name to upload
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:461](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L461)
+[packages/cozy-client/src/models/file.js:462](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L462)

--- a/docs/api/cozy-client/interfaces/models.permission.Document.md
+++ b/docs/api/cozy-client/interfaces/models.permission.Document.md
@@ -14,7 +14,7 @@ Couchdb document like an io.cozy.files
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:10](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L10)
+[packages/cozy-client/src/models/permission.js:11](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L11)
 
 ***
 
@@ -24,7 +24,7 @@ Couchdb document like an io.cozy.files
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:12](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L12)
+[packages/cozy-client/src/models/permission.js:13](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L13)
 
 ***
 
@@ -34,7 +34,7 @@ Couchdb document like an io.cozy.files
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:11](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L11)
+[packages/cozy-client/src/models/permission.js:12](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L12)
 
 ***
 
@@ -44,4 +44,4 @@ Couchdb document like an io.cozy.files
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:13](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L13)
+[packages/cozy-client/src/models/permission.js:14](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L14)

--- a/docs/api/cozy-client/interfaces/models.permission.Permission.md
+++ b/docs/api/cozy-client/interfaces/models.permission.Permission.md
@@ -14,7 +14,7 @@ Permission document
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:161](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L161)
+[packages/cozy-client/src/models/permission.js:162](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L162)
 
 ***
 
@@ -26,4 +26,4 @@ Member information from the sharing
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:162](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L162)
+[packages/cozy-client/src/models/permission.js:163](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L163)

--- a/docs/api/cozy-client/interfaces/models.permission.PermissionItem.md
+++ b/docs/api/cozy-client/interfaces/models.permission.PermissionItem.md
@@ -14,7 +14,7 @@ defaults to `id`
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:23](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L23)
+[packages/cozy-client/src/models/permission.js:24](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L24)
 
 ***
 
@@ -26,7 +26,7 @@ a couch db database like 'io.cozy.files'
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:25](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L25)
+[packages/cozy-client/src/models/permission.js:26](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L26)
 
 ***
 
@@ -36,7 +36,7 @@ a couch db database like 'io.cozy.files'
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:24](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L24)
+[packages/cozy-client/src/models/permission.js:25](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L25)
 
 ***
 
@@ -48,4 +48,4 @@ ALL, GET, PUT, PATCH, DELETE, POST…
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:22](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L22)
+[packages/cozy-client/src/models/permission.js:23](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L23)

--- a/docs/api/cozy-client/modules/models.contact.md
+++ b/docs/api/cozy-client/modules/models.contact.md
@@ -26,7 +26,7 @@ Returns 'byFamilyNameGivenNameEmailCozyUrl' index of a contact
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:197](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L197)
+[packages/cozy-client/src/models/contact.js:198](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L198)
 
 ***
 
@@ -50,7 +50,7 @@ Returns a display name for the contact
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:159](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L159)
+[packages/cozy-client/src/models/contact.js:160](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L160)
 
 ***
 
@@ -74,7 +74,7 @@ Returns the contact's fullname
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:121](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L121)
+[packages/cozy-client/src/models/contact.js:122](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L122)
 
 ***
 
@@ -100,7 +100,7 @@ Returns 'byFamilyNameGivenNameEmailCozyUrl' index of a contact
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:218](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L218)
+[packages/cozy-client/src/models/contact.js:219](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L219)
 
 ***
 
@@ -124,7 +124,7 @@ Returns the initials of the contact.
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:15](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L15)
+[packages/cozy-client/src/models/contact.js:16](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L16)
 
 ***
 
@@ -148,7 +148,7 @@ Returns the contact's main address
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:88](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L88)
+[packages/cozy-client/src/models/contact.js:89](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L89)
 
 ***
 
@@ -172,7 +172,7 @@ Returns the contact's main cozy
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:53](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L53)
+[packages/cozy-client/src/models/contact.js:54](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L54)
 
 ***
 
@@ -196,7 +196,7 @@ Returns the contact's main cozy url without protocol
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:64](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L64)
+[packages/cozy-client/src/models/contact.js:65](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L65)
 
 ***
 
@@ -220,7 +220,7 @@ Returns the contact's main email
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:42](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L42)
+[packages/cozy-client/src/models/contact.js:43](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L43)
 
 ***
 
@@ -252,7 +252,7 @@ Returns the contact's main email
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:4](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L4)
+[packages/cozy-client/src/models/contact.js:5](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L5)
 
 ***
 
@@ -276,7 +276,7 @@ Returns the contact's main phone number
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:79](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L79)
+[packages/cozy-client/src/models/contact.js:80](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L80)
 
 ***
 
@@ -300,7 +300,7 @@ Makes 'byFamilyNameGivenNameEmailCozyUrl' index of a contact
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:173](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L173)
+[packages/cozy-client/src/models/contact.js:174](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L174)
 
 ***
 
@@ -324,7 +324,7 @@ Makes displayName from contact data
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:135](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L135)
+[packages/cozy-client/src/models/contact.js:136](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L136)
 
 ***
 
@@ -348,4 +348,4 @@ Makes fullname from contact name
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:97](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L97)
+[packages/cozy-client/src/models/contact.js:98](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L98)

--- a/docs/api/cozy-client/modules/models.file.md
+++ b/docs/api/cozy-client/modules/models.file.md
@@ -16,7 +16,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:14](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L14)
+[packages/cozy-client/src/models/file.js:15](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L15)
 
 ## Functions
 
@@ -40,7 +40,7 @@ Upload a file on a mobile
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:569](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L569)
+[packages/cozy-client/src/models/file.js:570](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L570)
 
 ***
 
@@ -65,7 +65,7 @@ file object with path attribute
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:136](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L136)
+[packages/cozy-client/src/models/file.js:137](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L137)
 
 ***
 
@@ -86,7 +86,7 @@ file object with path attribute
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:615](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L615)
+[packages/cozy-client/src/models/file.js:616](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L616)
 
 ***
 
@@ -111,7 +111,7 @@ The files found by the rules
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:256](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L256)
+[packages/cozy-client/src/models/file.js:257](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L257)
 
 ***
 
@@ -135,7 +135,7 @@ Generate a file name for a revision
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:451](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L451)
+[packages/cozy-client/src/models/file.js:452](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L452)
 
 ***
 
@@ -159,7 +159,7 @@ A filename with the right suffix
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:426](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L426)
+[packages/cozy-client/src/models/file.js:427](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L427)
 
 ***
 
@@ -185,7 +185,7 @@ The full path of the file in the cozy
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:314](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L314)
+[packages/cozy-client/src/models/file.js:315](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L315)
 
 ***
 
@@ -209,7 +209,7 @@ id of the parent folder, if any
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:150](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L150)
+[packages/cozy-client/src/models/file.js:151](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L151)
 
 ***
 
@@ -233,7 +233,7 @@ A description of the status
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:162](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L162)
+[packages/cozy-client/src/models/file.js:163](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L163)
 
 ***
 
@@ -257,7 +257,7 @@ A doctype
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:182](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L182)
+[packages/cozy-client/src/models/file.js:183](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L183)
 
 ***
 
@@ -281,7 +281,7 @@ The mime-type of the target file, or an empty string is the target is not a file
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:172](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L172)
+[packages/cozy-client/src/models/file.js:173](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L173)
 
 ***
 
@@ -301,7 +301,7 @@ The mime-type of the target file, or an empty string is the target is not a file
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:595](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L595)
+[packages/cozy-client/src/models/file.js:596](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L596)
 
 ***
 
@@ -325,7 +325,7 @@ Whether the file's metadata attribute exists
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:303](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L303)
+[packages/cozy-client/src/models/file.js:304](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L304)
 
 ***
 
@@ -345,7 +345,7 @@ Whether the file's metadata attribute exists
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:587](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L587)
+[packages/cozy-client/src/models/file.js:588](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L588)
 
 ***
 
@@ -365,7 +365,7 @@ Whether the file's metadata attribute exists
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:46](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L46)
+[packages/cozy-client/src/models/file.js:47](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L47)
 
 ***
 
@@ -387,7 +387,7 @@ Whether the file is client-side encrypted
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:74](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L74)
+[packages/cozy-client/src/models/file.js:75](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L75)
 
 ***
 
@@ -407,7 +407,7 @@ Whether the file is client-side encrypted
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:40](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L40)
+[packages/cozy-client/src/models/file.js:41](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L41)
 
 ***
 
@@ -427,7 +427,7 @@ Whether the file is client-side encrypted
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:606](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L606)
+[packages/cozy-client/src/models/file.js:607](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L607)
 
 ***
 
@@ -447,7 +447,7 @@ Whether the file is client-side encrypted
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:52](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L52)
+[packages/cozy-client/src/models/file.js:53](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L53)
 
 ***
 
@@ -469,7 +469,7 @@ Whether the file is supported by Only Office
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:84](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L84)
+[packages/cozy-client/src/models/file.js:85](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L85)
 
 ***
 
@@ -490,7 +490,7 @@ Whether the file is supported by Only Office
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:579](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L579)
+[packages/cozy-client/src/models/file.js:580](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L580)
 
 ***
 
@@ -512,7 +512,7 @@ Whether the file is referenced by an album
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:278](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L278)
+[packages/cozy-client/src/models/file.js:279](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L279)
 
 ***
 
@@ -536,7 +536,7 @@ Returns whether the file is a shortcut to a sharing
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:202](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L202)
+[packages/cozy-client/src/models/file.js:203](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L203)
 
 ***
 
@@ -560,7 +560,7 @@ Returns whether the sharing shortcut is new
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:227](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L227)
+[packages/cozy-client/src/models/file.js:228](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L228)
 
 ***
 
@@ -582,7 +582,7 @@ Returns whether the file is a shortcut to a sharing
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:192](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L192)
+[packages/cozy-client/src/models/file.js:193](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L193)
 
 ***
 
@@ -604,7 +604,7 @@ Returns whether the sharing shortcut is new
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:216](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L216)
+[packages/cozy-client/src/models/file.js:217](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L217)
 
 ***
 
@@ -626,7 +626,7 @@ true if the file is a shortcut
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:109](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L109)
+[packages/cozy-client/src/models/file.js:110](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L110)
 
 ***
 
@@ -655,7 +655,7 @@ Move file to destination.
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:338](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L338)
+[packages/cozy-client/src/models/file.js:339](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L339)
 
 ***
 
@@ -681,7 +681,7 @@ full normalized object
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:122](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L122)
+[packages/cozy-client/src/models/file.js:123](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L123)
 
 ***
 
@@ -708,7 +708,7 @@ The overrided file
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:393](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L393)
+[packages/cozy-client/src/models/file.js:394](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L394)
 
 ***
 
@@ -730,7 +730,7 @@ Read a file on a mobile
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:522](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L522)
+[packages/cozy-client/src/models/file.js:523](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L523)
 
 ***
 
@@ -756,7 +756,7 @@ The saved file
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:242](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L242)
+[packages/cozy-client/src/models/file.js:243](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L243)
 
 ***
 
@@ -780,7 +780,7 @@ But we want to exclude .txt and .md because the CozyUI Viewer can already show t
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:99](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L99)
+[packages/cozy-client/src/models/file.js:100](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L100)
 
 ***
 
@@ -804,7 +804,7 @@ Returns base filename and extension
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:24](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L24)
+[packages/cozy-client/src/models/file.js:25](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L25)
 
 ***
 
@@ -837,4 +837,4 @@ If there is a conflict, then we apply the conflict strategy : `erase` or `rename
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:483](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L483)
+[packages/cozy-client/src/models/file.js:484](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L484)

--- a/docs/api/cozy-client/modules/models.note.md
+++ b/docs/api/cozy-client/modules/models.note.md
@@ -27,7 +27,7 @@ url
 
 *Defined in*
 
-[packages/cozy-client/src/models/note.js:29](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L29)
+[packages/cozy-client/src/models/note.js:31](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L31)
 
 ***
 
@@ -49,7 +49,7 @@ url
 
 *Defined in*
 
-[packages/cozy-client/src/models/note.js:7](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L7)
+[packages/cozy-client/src/models/note.js:9](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L9)
 
 ***
 
@@ -70,4 +70,4 @@ url
 
 *Defined in*
 
-[packages/cozy-client/src/models/note.js:16](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L16)
+[packages/cozy-client/src/models/note.js:18](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L18)

--- a/docs/api/cozy-client/modules/models.permission.md
+++ b/docs/api/cozy-client/modules/models.permission.md
@@ -18,7 +18,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:17](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L17)
+[packages/cozy-client/src/models/permission.js:18](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L18)
 
 ## Functions
 
@@ -42,7 +42,7 @@ list of permissions
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:52](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L52)
+[packages/cozy-client/src/models/permission.js:53](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L53)
 
 ***
 
@@ -62,7 +62,7 @@ list of permissions
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:128](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L128)
+[packages/cozy-client/src/models/permission.js:129](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L129)
 
 ***
 
@@ -85,7 +85,7 @@ Checks if the permission item is about a specific doctype
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:66](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L66)
+[packages/cozy-client/src/models/permission.js:67](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L67)
 
 ***
 
@@ -120,4 +120,4 @@ both situation.
 
 *Defined in*
 
-[packages/cozy-client/src/models/permission.js:166](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L166)
+[packages/cozy-client/src/models/permission.js:167](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/permission.js#L167)

--- a/docs/api/cozy-client/modules/models.trigger.md
+++ b/docs/api/cozy-client/modules/models.trigger.md
@@ -24,7 +24,7 @@ Trigger states come from /jobs/triggers
 
 *Defined in*
 
-[packages/cozy-client/src/models/trigger.js:17](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/trigger.js#L17)
+[packages/cozy-client/src/models/trigger.js:18](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/trigger.js#L18)
 
 ***
 
@@ -44,4 +44,4 @@ Trigger states come from /jobs/triggers
 
 *Defined in*
 
-[packages/cozy-client/src/models/trigger.js:38](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/trigger.js#L38)
+[packages/cozy-client/src/models/trigger.js:39](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/trigger.js#L39)

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -477,7 +477,7 @@ the query run again.
 
 ### documentCollection.find(selector, options) ⇒ <code>Promise.&lt;{data, skip, bookmark, next, execution\_stats}&gt;</code>
 Returns a filtered list of documents using a Mango selector.
-
+   
 The returned documents are paginated by the stack.
 
 **Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -74,7 +74,7 @@ const ensureArray = arr => (Array.isArray(arr) ? arr : [arr])
 
 const deprecatedHandler = msg => ({
   get(target, prop) {
-    console.warn(msg)
+    logger.warn(msg)
     return target[prop]
   }
 })
@@ -173,7 +173,7 @@ class CozyClient {
       ...options
     } = rawOptions
     if (link) {
-      console.warn('`link` is deprecated, use `links`')
+      logger.warn('`link` is deprecated, use `links`')
     }
 
     this.appMetadata = appMetadata
@@ -436,7 +436,7 @@ class CozyClient {
         try {
           link.registerClient(this)
         } catch (e) {
-          console.warn(e)
+          logger.warn(e)
         }
       }
     }
@@ -464,7 +464,7 @@ class CozyClient {
     // This allows us to autoLogin in constructor without breaking any compatibility
     // with codes that uses an explicit login.
     if (this.isLogged && !this.isRevoked) {
-      console.warn(`CozyClient is already logged.`)
+      logger.warn(`CozyClient is already logged.`)
       return this.loginPromise
     }
     return (this.loginPromise = this._login(options))
@@ -541,7 +541,7 @@ class CozyClient {
         try {
           await link.reset()
         } catch (e) {
-          console.warn(e)
+          logger.warn(e)
         }
       }
     }
@@ -577,14 +577,14 @@ client.query(Q('io.cozy.bills'))`)
   }
 
   find(doctype, selector = undefined) {
-    console.warn(
+    logger.warn(
       'client.find(doctype, selector) is deprecated, please use Q(doctype).where(selector) to build the same query.'
     )
     return new QueryDefinition({ doctype, selector })
   }
 
   get(doctype, id) {
-    console.warn(
+    logger.warn(
       `client.get(${doctype}, id) is deprecated, please use Q(${doctype}).getById(id) to build the same query.`
     )
     return new QueryDefinition({ doctype, id })
@@ -667,7 +667,7 @@ client.query(Q('io.cozy.bills'))`)
     )
     const errors = validations.filter(validation => validation !== true)
     if (errors.length > 0) {
-      console.warn(
+      logger.warn(
         'There has been some validation errors while bulk saving',
         errors
       )
@@ -1006,7 +1006,7 @@ client.query(Q('io.cozy.bills'))`)
   }
 
   watchQuery(...args) {
-    console.warn(
+    logger.warn(
       'client.watchQuery is deprecated, please use client.makeObservableQuery.'
     )
     return this.makeObservableQuery(...args)
@@ -1347,7 +1347,7 @@ client.query(Q('io.cozy.bills'))`)
         data: isSingleDocQuery && singleDocData ? data[0] : data
       }
     } catch (e) {
-      console.warn(
+      logger.warn(
         `Could not get query from state. queryId: ${id}, error: ${e.message}`
       )
       return null
@@ -1563,7 +1563,7 @@ instantiation of the client.`
    */
   createClient() {
     if (this.options.client) {
-      console.warn(
+      logger.warn(
         'CozyClient: Using options.client is deprecated, please use options.stackClient.'
       )
     }
@@ -1590,7 +1590,7 @@ instantiation of the client.`
           stackClient.options[handlerName] = handlers[handlerName]
         } else {
           if (warningForCustomHandlers) {
-            console.warn(
+            logger.warn(
               `You passed a stackClient with its own ${handlerName}. It is not supported, unexpected things might happen.`
             )
           }
@@ -1615,7 +1615,7 @@ instantiation of the client.`
   }
 
   getClient() {
-    console.warn(
+    logger.warn(
       'CozyClient: getClient() is deprecated, please use getStackClient().'
     )
     return this.getStackClient()

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -34,7 +34,7 @@ import {
 import { HasManyFiles, Association, HasMany } from './associations'
 import mapValues from 'lodash/mapValues'
 import FileCollection from 'cozy-stack-client/dist/FileCollection'
-
+import logger from './logger'
 const normalizeData = data =>
   mapValues(data, (docs, doctype) => {
     return docs.map(doc => ({
@@ -86,10 +86,10 @@ describe('CozyClient initialization', () => {
 
   describe('explicit login', () => {
     beforeEach(() => {
-      jest.spyOn(console, 'warn').mockImplementation(() => {})
+      jest.spyOn(logger, 'warn').mockImplementation(() => {})
     })
     afterEach(() => {
-      console.warn.mockRestore()
+      logger.warn.mockRestore()
     })
 
     it('should not break explicit login when provided token and uri', () => {
@@ -380,22 +380,22 @@ describe('CozyClient initialization', () => {
   })
 
   it('should create a store when calling makeObservableQuery', () => {
-    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    jest.spyOn(logger, 'warn').mockImplementation(() => {})
     client.makeObservableQuery(
       new QueryDefinition({ doctype: 'io.cozy.todos' })
     )
-    console.warn.mockRestore()
+    logger.warn.mockRestore()
     expect(client.store).not.toBe(undefined)
   })
 })
 
 describe('Stack client initialization', () => {
   beforeEach(() => {
-    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    jest.spyOn(logger, 'warn').mockImplementation(() => {})
   })
 
   afterEach(() => {
-    console.warn.mockRestore()
+    logger.warn.mockRestore()
   })
 
   it('should add default callbacks', async () => {
@@ -444,13 +444,13 @@ describe('CozyClient handlers', () => {
   })
 
   it('should warn when overriding default handlers', () => {
-    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    jest.spyOn(logger, 'warn').mockImplementation(() => {})
     new CozyClient({
       stackClient: new CozyStackClient({
         onRevocationChange: () => {}
       })
     })
-    expect(console.warn).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledWith(
       'You passed a stackClient with its own onRevocationChange. It is not supported, unexpected things might happen.'
     )
   })
@@ -501,23 +501,21 @@ describe('CozyClient logout', () => {
     expect(links[2].reset).toHaveBeenCalledTimes(1)
 
     // test if we launch twice logout, it doesn't launch twice reset.
-    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    jest.spyOn(logger, 'warn').mockImplementation(() => {})
     await client.logout()
-    console.warn.mockRestore()
+    logger.warn.mockRestore()
 
     expect(links[0].reset).toHaveBeenCalledTimes(1)
     expect(links[2].reset).toHaveBeenCalledTimes(1)
   })
 
   it('should call all reset even if a reset throws an error', async () => {
-    const spy = jest.spyOn(global.console, 'warn').mockReturnValue(jest.fn())
     links[0].reset = jest.fn().mockRejectedValue(new Error('Async error'))
     links[2].reset = jest.fn()
     await client.login()
     await client.logout()
     expect(links[0].reset).toHaveBeenCalledTimes(1)
     expect(links[2].reset).toHaveBeenCalledTimes(1)
-    spy.mockRestore()
   })
 
   it('should emit events', async () => {

--- a/packages/cozy-client/src/StackLink.js
+++ b/packages/cozy-client/src/StackLink.js
@@ -1,9 +1,12 @@
+import zipWith from 'lodash/zipWith'
+
 import { MutationTypes, QueryDefinition } from './queries/dsl'
 import CozyLink from './CozyLink'
 import { CozyClientDocument, CouchDBBulkResult, ClientResponse } from './types'
 import { DOCTYPE_FILES } from './const'
 import { BulkEditError } from './errors'
-import zipWith from 'lodash/zipWith'
+import logger from './logger'
+
 /**
  *
  * To know if cozy-client should use Document.find()
@@ -19,6 +22,7 @@ const hasFindOptions = queryDefinition => {
   if (selector || partialFilter || sort || fields) return true
   return false
 }
+
 /**
  * Returns full documents after a bulk update
  *
@@ -59,7 +63,7 @@ export default class StackLink extends CozyLink {
   constructor({ client, stackClient } = {}) {
     super()
     if (client) {
-      console.warn(
+      logger.warn(
         'Using options.client is deprecated, prefer options.stackClient'
       )
     }
@@ -88,7 +92,7 @@ export default class StackLink extends CozyLink {
   executeQuery(query) {
     const { doctype, selector, id, ids, referenced, ...options } = query
     if (!doctype) {
-      console.warn('Bad query', query)
+      logger.warn('Bad query', query)
       throw new Error('No doctype found in a query definition')
     }
     const collection = this.stackClient.collection(doctype)

--- a/packages/cozy-client/src/associations/HasMany.js
+++ b/packages/cozy-client/src/associations/HasMany.js
@@ -4,6 +4,7 @@ import { QueryDefinition } from '../queries/dsl'
 import { getDocumentFromState, receiveQueryResult } from '../store'
 import { CozyClientDocument } from '../types'
 import Association from './Association'
+import logger from '../logger'
 
 /**
  * @typedef {object} Relationship
@@ -209,7 +210,7 @@ class HasMany extends Association {
     const relationship = get(this.target, `relationships.${this.name}`)
     if (!relationship) {
       if (rawData && rawData.length) {
-        console.warn(
+        logger.warn(
           "You're trying to access data on a relationship that appear to not be loaded yet. You may want to use 'include()' on your query"
         )
       }

--- a/packages/cozy-client/src/associations/HasOne.js
+++ b/packages/cozy-client/src/associations/HasOne.js
@@ -3,6 +3,7 @@ import set from 'lodash/set'
 import { Q, QueryDefinition } from '../queries/dsl'
 import { CozyClientDocument } from '../types'
 import Association from './Association'
+import logger from '../logger'
 
 export default class HasOne extends Association {
   get raw() {
@@ -73,14 +74,14 @@ export default class HasOne extends Association {
   }
 
   set(doc) {
-    console.warn(
+    logger.warn(
       'set is deprecated for has-one relationships. Use `add` instead.'
     )
     this.setRelationship(doc)
   }
 
   unset() {
-    console.warn(
+    logger.warn(
       'unset is deprecated for has-one relationships. Use `remove` instead.'
     )
     this.setRelationship(undefined)

--- a/packages/cozy-client/src/cli/index.js
+++ b/packages/cozy-client/src/cli/index.js
@@ -152,7 +152,7 @@ const readJSON = (fs, filename) => {
     const res = JSON.parse(fs.readFileSync(filename).toString())
     return res
   } catch (e) {
-    console.warn(`Could not load ${filename} (${e.message})`)
+    logger.warn(`Could not load ${filename} (${e.message})`)
     return null
   }
 }

--- a/packages/cozy-client/src/hoc.jsx
+++ b/packages/cozy-client/src/hoc.jsx
@@ -4,6 +4,7 @@ import compose from 'lodash/flowRight'
 import Query from './Query'
 import useClient from './hooks/useClient'
 import { useQueries } from './hooks/useQuery'
+import logger from './logger'
 
 /**
  * @function
@@ -44,7 +45,7 @@ const withQuery = (dest, queryOpts, Original) => {
         typeof queryOpts === 'function' ? queryOpts(props) : queryOpts
 
       if (queryOpts.doc) {
-        console.warn('queryOpts.doc is deprecated')
+        logger.warn('queryOpts.doc is deprecated')
         return <Component {...{ [dest]: queryOptsRes.doc, ...props }} />
       }
 

--- a/packages/cozy-client/src/hoc.spec.jsx
+++ b/packages/cozy-client/src/hoc.spec.jsx
@@ -5,17 +5,17 @@ import { mount } from 'enzyme'
 import { withClient, queryConnect, queryConnectFlat } from './hoc'
 import { Q } from './queries/dsl'
 import Provider from './Provider'
-
+import logger from './logger'
 // At some point __tests__/mocks and testing/utils shall be reconciled
 import * as mocks from './__tests__/mocks'
 import { setupClient } from './testing/utils'
 
 beforeEach(() => {
-  jest.spyOn(console, 'warn').mockImplementation(() => {})
+  jest.spyOn(logger, 'warn').mockImplementation(() => {})
 })
 
 afterEach(() => {
-  console.warn.mockRestore()
+  logger.warn.mockRestore()
 })
 
 class Component extends React.Component {

--- a/packages/cozy-client/src/models/accounts.js
+++ b/packages/cozy-client/src/models/accounts.js
@@ -1,6 +1,7 @@
 import { getMutedErrors, muteError } from './account'
 export { getMutedErrors, muteError }
+import logger from '../logger'
 
-console.warn(
+logger.warn(
   'models/accounts is deprecated in cozy-client, please use models/account instead'
 )

--- a/packages/cozy-client/src/models/contact.js
+++ b/packages/cozy-client/src/models/contact.js
@@ -1,5 +1,6 @@
 import get from 'lodash/get'
 import isEmpty from 'lodash/isEmpty'
+import logger from '../logger'
 
 export const getPrimaryOrFirst = property => obj =>
   !obj[property] || obj[property].length === 0
@@ -216,7 +217,7 @@ export const getDefaultSortIndexValue = contact => {
  * @returns {string} - the contact's 'byFamilyNameGivenNameEmailCozyUrl' index
  */
 export const getIndexByFamilyNameGivenNameEmailCozyUrl = contact => {
-  console.warn(
+  logger.warn(
     'Deprecation: `getIndexByFamilyNameGivenNameEmailCozyUrl` is deprecated, please use `getDefaultSortIndexValue` instead'
   )
 

--- a/packages/cozy-client/src/models/document/qualification.js
+++ b/packages/cozy-client/src/models/document/qualification.js
@@ -1,6 +1,6 @@
 import { get, set, difference } from 'lodash'
 import * as qualificationModel from '../../assets/qualifications.json'
-
+import logger from '../../logger'
 /**
  * @typedef {object} QualificationAttributes
  * @property {string} [label] - The qualification label.
@@ -67,7 +67,7 @@ export class Qualification {
           attributes.purpose
         )
         if (!isKnownValue) {
-          console.info(
+          logger.info(
             `This purpose is not listed among the known values: ${attributes.purpose}. ` +
               `Please open an issue on https://github.com/cozy/cozy-client/issues`
           )
@@ -85,7 +85,7 @@ export class Qualification {
           attributes.sourceCategory
         )
         if (!isKnownValue) {
-          console.info(
+          logger.info(
             `This sourceCategory is not listed among the known values: ${attributes.sourceCategory}. ` +
               `Please open an issue on https://github.com/cozy/cozy-client/issues`
           )
@@ -103,7 +103,7 @@ export class Qualification {
           attributes.sourceSubCategory
         )
         if (!isKnownValue) {
-          console.info(
+          logger.info(
             `This sourceSubCategory is not listed among the known values: ${attributes.sourceSubCategory}. ` +
               `Please open an issue on https://github.com/cozy/cozy-client/issues`
           )
@@ -130,7 +130,7 @@ export class Qualification {
         qualificationModel.subjectsKnownValues
       )
       if (unknownSubjects.length > 0)
-        console.info(
+        logger.info(
           `These subjects are not listed among the known values: ${unknownSubjects}. ` +
             `Please open an issue on https://github.com/cozy/cozy-client/issues`
         )

--- a/packages/cozy-client/src/models/document/qualification.spec.js
+++ b/packages/cozy-client/src/models/document/qualification.spec.js
@@ -4,16 +4,17 @@ import {
   getQualification
 } from './qualification'
 import * as qualificationModel from '../../assets/qualifications.json'
+import logger from '../../logger'
 
 describe('document qualification', () => {
   beforeEach(() => {
-    jest.spyOn(console, 'warn').mockImplementation(() => jest.fn())
-    jest.spyOn(console, 'info').mockImplementation(() => jest.fn())
+    jest.spyOn(logger, 'warn').mockImplementation(() => jest.fn())
+    jest.spyOn(logger, 'info').mockImplementation(() => jest.fn())
   })
 
   afterEach(() => {
-    console.warn.mockRestore()
-    console.info.mockRestore()
+    logger.warn.mockRestore()
+    logger.info.mockRestore()
   })
 
   it('should get the correct qualification by the label', () => {
@@ -112,7 +113,7 @@ describe('document qualification', () => {
       subjects: ['very_hard_drugs']
     }
     setQualification({}, qualification)
-    expect(console.info).toHaveBeenCalledTimes(1)
+    expect(logger.info).toHaveBeenCalledTimes(1)
   })
 })
 describe('qualifications items', () => {

--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -8,6 +8,7 @@ import { Q } from '../queries/dsl'
 import { IOCozyFile, QueryResult } from '../types'
 import { DOCTYPE_FILES } from '../const'
 import CozyClient from '../CozyClient'
+import logger from '../logger'
 
 const FILE_TYPE = 'file'
 const DIR_TYPE = 'directory'
@@ -200,7 +201,7 @@ export const isSharingShortcut = file => Boolean(getSharingShortcutStatus(file))
  * @returns {boolean}
  */
 export const isSharingShorcut = file => {
-  console.warn(
+  logger.warn(
     'Deprecation: `isSharingShorcut` is deprecated, please use `isSharingShortcut` instead'
   )
   return isSharingShortcut(file)
@@ -225,7 +226,7 @@ export const isSharingShortcutNew = file =>
  * @returns {boolean}
  */
 export const isSharingShorcutNew = file => {
-  console.warn(
+  logger.warn(
     'Deprecation: `isSharingShorcutNew` is deprecated, please use `isSharingShortcutNew` instead'
   )
   return isSharingShortcutNew(file)

--- a/packages/cozy-client/src/models/note.js
+++ b/packages/cozy-client/src/models/note.js
@@ -1,4 +1,6 @@
 import { generateWebLink } from '../helpers'
+import logger from '../logger'
+
 /**
  *
  * @param {string} notesAppUrl URL to the Notes App (https://notes.foo.mycozy.cloud)
@@ -14,7 +16,7 @@ export const generatePrivateUrl = (notesAppUrl, file, options = {}) => {
   return url.toString()
 }
 export const generateUrlForNote = (notesAppUrl, file) => {
-  console.warn(
+  logger.warn(
     'generateUrlForNote is deprecated. Please use models.note.generatePrivateUrl instead'
   )
   return generatePrivateUrl(notesAppUrl, file)

--- a/packages/cozy-client/src/models/permission.js
+++ b/packages/cozy-client/src/models/permission.js
@@ -4,6 +4,7 @@ import CozyClient from '../CozyClient'
 import { Q } from '../queries/dsl'
 import { getParentFolderId } from './file'
 import { DOCTYPE_FILES } from '../const'
+import logger from '../logger'
 
 /**
  * @typedef {object} Document - Couchdb document like an io.cozy.files
@@ -140,7 +141,7 @@ export async function isDocumentReadOnly(args) {
   if (perm) {
     return isReadOnly(perm, { writability })
   } else {
-    console.warn(`can't find the document in current attached permissions`)
+    logger.warn(`can't find the document in current attached permissions`)
     return undefined
   }
 }

--- a/packages/cozy-client/src/models/trigger.js
+++ b/packages/cozy-client/src/models/trigger.js
@@ -1,5 +1,6 @@
 import get from 'lodash/get'
 import { getMutedErrors } from './account'
+import logger from '../logger'
 
 const actionableErrors = [
   'CHALLENGE_ASKED',
@@ -19,7 +20,7 @@ const triggerStates = {
   getLastExecution: triggerState =>
     get(triggerState, 'current_state.last_execution'),
   getLastsuccess: triggerState => {
-    console.warn(
+    logger.warn(
       'Deprecated, please use getLastSuccess instead of getLastsuccess'
     )
     return get(triggerState, 'current_state.last_success')

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -1,6 +1,7 @@
 import isArray from 'lodash/isArray'
 import findKey from 'lodash/findKey'
 import { CouchDBViewCursor, DocId, Doctype } from '../types'
+import logger from '../logger'
 
 /**
  * @typedef PartialQueryDefinition
@@ -87,7 +88,7 @@ class QueryDefinition {
       return
     }
     if (_sort.length > fieldsToIndex.length) {
-      console.warn(
+      logger.warn(
         `You should not sort on non-indexed fields.\n
         Sort: ${JSON.stringify(_sort)}\n
         Indexed fields: ${fieldsToIndex}`
@@ -96,7 +97,7 @@ class QueryDefinition {
     }
     for (let i = 0; i < _sort.length; i++) {
       if (Object.keys(_sort[i])[0] !== fieldsToIndex[i]) {
-        console.warn(
+        logger.warn(
           `The sort order should be the same than the indexed fields.\n
           Sort: ${JSON.stringify(_sort)}\n
           Indexed fields: ${fieldsToIndex}\n`
@@ -117,14 +118,14 @@ class QueryDefinition {
   checkSelector(selector) {
     const hasExistsFalse = findKey(selector, ['$exists', false])
     if (hasExistsFalse) {
-      console.warn(
+      logger.warn(
         `The "$exists: false" predicate should be defined as a partial index for better performance.\n
         Selector: ${selector}`
       )
     }
     const hasNe = findKey(selector, '$ne')
     if (hasNe) {
-      console.info(
+      logger.info(
         `The use of the $ne operator is more efficient with a partial index.\n
         Selector: ${selector}`
       )

--- a/packages/cozy-client/src/queries/dsl.spec.js
+++ b/packages/cozy-client/src/queries/dsl.spec.js
@@ -1,14 +1,15 @@
 import { QueryDefinition, Q } from '../queries/dsl'
+import logger from '../logger'
 
 describe('QueryDefinition', () => {
   beforeEach(() => {
-    jest.spyOn(console, 'warn').mockImplementation(() => jest.fn())
-    jest.spyOn(console, 'info').mockImplementation(() => jest.fn())
+    jest.spyOn(logger, 'warn').mockImplementation(() => jest.fn())
+    jest.spyOn(logger, 'info').mockImplementation(() => jest.fn())
   })
 
   afterEach(() => {
-    console.warn.mockRestore()
-    console.info.mockRestore()
+    logger.warn.mockRestore()
+    logger.info.mockRestore()
   })
 
   it('should build query defs on selected fields', () => {
@@ -72,40 +73,40 @@ describe('QueryDefinition', () => {
       .sortBy([{ type: 'asc' }, { dirID: 'asc' }])
       .where({ type: 'file', dirID: '123' })
       .indexFields(['type', 'dirID'])
-    expect(console.warn).toHaveBeenCalledTimes(0)
+    expect(logger.warn).toHaveBeenCalledTimes(0)
   })
   it('should warn on sorting non-indexed fields', () => {
     Q('io.cozy.files')
       .where({ type: 'file', dirID: '123' })
       .indexFields(['type', 'dirID'])
       .sortBy([{ type: 'asc' }, { dirID: 'asc' }, { date: 'asc' }])
-    expect(console.warn).toHaveBeenCalledTimes(1)
+    expect(logger.warn).toHaveBeenCalledTimes(1)
   })
   it('should warn on sort order', () => {
     Q('io.cozy.files')
       .where({ type: 'file', dirID: '123' })
       .indexFields(['type', 'dirID'])
       .sortBy([{ dirID: 'asc' }, { type: 'asc' }])
-    expect(console.warn).toHaveBeenCalledTimes(1)
+    expect(logger.warn).toHaveBeenCalledTimes(1)
   })
   it('should warn on sort order through the selector', () => {
     Q('io.cozy.files')
       .where({ type: 'file', dirID: '123' })
       .sortBy([{ dirID: 'asc' }, { type: 'asc' }])
-    expect(console.warn).toHaveBeenCalledTimes(1)
+    expect(logger.warn).toHaveBeenCalledTimes(1)
   })
   it('should not warn for queries with no selector', () => {
     Q('io.cozy.files').sortBy([{ dirID: 'asc' }, { type: 'asc' }])
-    expect(console.warn).toHaveBeenCalledTimes(0)
+    expect(logger.warn).toHaveBeenCalledTimes(0)
   })
 
   it('should warn when using a selector with $exists: false', () => {
     Q('io.cozy.files').where({ trashed: { $exists: false } })
-    expect(console.warn).toHaveBeenCalledTimes(1)
+    expect(logger.warn).toHaveBeenCalledTimes(1)
   })
   it('should inform when using a selector with $neq', () => {
     Q('io.cozy.files').where({ _id: { $ne: 'io.cozy.root-id' } })
-    expect(console.info).toHaveBeenCalledTimes(1)
+    expect(logger.info).toHaveBeenCalledTimes(1)
   })
 
   it('should throw an error when there is a select without all the fields in selector', () => {

--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -24,6 +24,7 @@ import {
   CozyClientDocument,
   QueryOptions
 } from '../types'
+import logger from '../logger'
 
 const INIT_QUERY = 'INIT_QUERY'
 const LOAD_QUERY = 'LOAD_QUERY'
@@ -332,7 +333,7 @@ export const makeSorterFromDefinition = definition => {
   if (!sort) {
     return docs => docs
   } else if (!isArray(definition.sort)) {
-    console.warn(
+    logger.warn(
       'Correct update of queries with a sort that is not an array is not supported. Use an array as argument of QueryDefinition::sort'
     )
     return docs => docs

--- a/packages/cozy-client/src/utils.js
+++ b/packages/cozy-client/src/utils.js
@@ -1,3 +1,5 @@
+import logger from './logger'
+
 /**
  * @typedef {Promise} CancelablePromise
  * @property {Function} cancel - Cancel the promise
@@ -36,7 +38,7 @@ export { cancelable }
  */
 export const isQueryLoading = col => {
   if (!col) {
-    console.warn('isQueryLoading called on falsy value.') // eslint-disable-line no-console
+    logger.warn('isQueryLoading called on falsy value.')
     return false
   }
   return col.fetchStatus === 'loading' || col.fetchStatus === 'pending'

--- a/packages/cozy-client/src/withMutations.jsx
+++ b/packages/cozy-client/src/withMutations.jsx
@@ -1,6 +1,7 @@
 import merge from 'lodash/merge'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import logger from './logger'
 
 const makeMutationsObject = (mutations, client, props) => {
   return merge(
@@ -32,7 +33,7 @@ const withMutations = (...mutations) => WrappedComponent => {
     constructor(props, context) {
       super(props, context)
       const client = props.client || context.client
-      console.warn(
+      logger.warn(
         `Deprecation: withMutations will be removed in the near future, prefer to use withClient to access the client. See https://github.com/cozy/cozy-client/pull/638 for more information.`
       )
       if (!client) {

--- a/packages/cozy-stack-client/src/AppCollection.js
+++ b/packages/cozy-stack-client/src/AppCollection.js
@@ -7,6 +7,7 @@ import {
 import Collection from './Collection'
 import DocumentCollection, { normalizeDoc } from './DocumentCollection'
 import { FetchError } from './errors'
+import logger from './logger'
 
 export const APPS_DOCTYPE = 'io.cozy.apps'
 
@@ -33,7 +34,7 @@ class AppCollection extends DocumentCollection {
     if (idArg.indexOf('/') > -1) {
       id = idArg.split('/')[1]
     } else {
-      console.warn(
+      logger.warn(
         `Deprecated: in next versions of cozy-client, it will not be possible to query apps/konnectors only with id, please use the form ${this.doctype}/${idArg}
 
 - Q('io.cozy.apps').getById('banks')

--- a/packages/cozy-stack-client/src/AppCollection.spec.js
+++ b/packages/cozy-stack-client/src/AppCollection.spec.js
@@ -3,7 +3,7 @@ jest.mock('./CozyStackClient')
 import CozyStackClient from './CozyStackClient'
 import AppCollection from './AppCollection'
 import { ALL_APPS_RESPONSE, GET_APPS_RESPONSE } from './__tests__/fixtures/apps'
-
+import logger from './logger'
 const FIXTURES = {
   ALL_APPS_RESPONSE,
   GET_APPS_RESPONSE
@@ -70,11 +70,11 @@ describe(`AppCollection`, () => {
 
     describe('deprecated get call without <doctype>/', () => {
       beforeEach(() => {
-        jest.spyOn(console, 'warn').mockImplementation(() => {})
+        jest.spyOn(logger, 'warn').mockImplementation(() => {})
       })
 
       afterEach(() => {
-        console.warn.mockRestore()
+        logger.warn.mockRestore()
       })
       it('should call the right route (deprecated call with <doctype>/)', async () => {
         await collection.get('fakeid')

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -22,6 +22,7 @@ import errors from './errors'
 import { fetchWithXMLHttpRequest, shouldXMLHTTPRequestBeUsed } from './xhrFetch'
 import MicroEE from 'microee'
 import { FetchError } from './errors'
+import logger from './logger'
 
 const normalizeUri = uriArg => {
   let uri = uriArg
@@ -320,7 +321,7 @@ class CozyStackClient {
         // jwt string
         this.token = new AppToken(token)
       } else {
-        console.warn('Cozy-Client: Unknown token format', token)
+        logger.warn('Cozy-Client: Unknown token format', token)
         throw new Error('Cozy-Client: Unknown token format')
       }
       this.onRevocationChange(false)

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -27,6 +27,8 @@ import {
 import * as querystring from './querystring'
 import { FetchError } from './errors'
 
+import logger from './logger'
+
 const DATABASE_DOES_NOT_EXIST = 'Database does not exist.'
 
 /**
@@ -289,7 +291,7 @@ class DocumentCollection {
 
   /**
    * Returns a filtered list of documents using a Mango selector.
-
+   
 The returned documents are paginated by the stack.
    *
    * @param {MangoSelector} selector The Mango selector.
@@ -493,7 +495,7 @@ The returned documents are paginated by the stack.
     sort = transformSort(sort)
 
     if (!indexedFields && selector) {
-      console.warn(
+      logger.warn(
         'Selector fields should be manually indexed to prevent unexpected behaviour'
       )
     }
@@ -781,7 +783,7 @@ The returned documents are paginated by the stack.
     }
     if (typeof couchOptions !== 'object') {
       opts.since = couchOptions
-      console.warn(
+      logger.warn(
         `fetchChanges use couchOptions as Object not a string, since is deprecated, please use fetchChanges({since: "${couchOptions}"}).`
       )
     } else if (Object.keys(couchOptions).length > 0) {

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -4,6 +4,7 @@ import flag from 'cozy-flags'
 import CozyStackClient from './CozyStackClient'
 import DocumentCollection from './DocumentCollection'
 import { isMatchingIndex } from './mangoIndex'
+import logger from './logger'
 
 jest.mock('./mangoIndex', () => ({
   ...jest.requireActual('./mangoIndex'),
@@ -116,7 +117,7 @@ describe('DocumentCollection', () => {
 
     beforeAll(() => {
       client.fetchJSON.mockResolvedValue(NORMAL_RESPONSE_FIXTURE)
-      jest.spyOn(console, 'warn').mockImplementation(() => {})
+      jest.spyOn(logger, 'warn').mockImplementation(() => {})
     })
 
     it('should call the right route', async () => {
@@ -1082,9 +1083,9 @@ describe('DocumentCollection', () => {
     })
 
     it('should call the right route with deprecated parameter', async () => {
-      jest.spyOn(console, 'warn').mockImplementation(() => {})
+      jest.spyOn(logger, 'warn').mockImplementation(() => {})
       await collection.fetchChanges('my-seq')
-      console.warn.mockRestore()
+      logger.warn.mockRestore()
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'GET',
         '/data/io.cozy.todos/_changes?since=my-seq&include_docs=true',
@@ -1373,7 +1374,7 @@ describe('DocumentCollection', () => {
 
     beforeEach(() => {
       jest.resetAllMocks()
-      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {})
     })
 
     it('should correctly build the indexName', () => {

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -11,6 +11,7 @@ import { FetchError } from './errors'
 import { dontThrowNotFoundError } from './Collection'
 import { getIllegalCharacters } from './getIllegalCharacter'
 import * as querystring from './querystring'
+import logger from './logger'
 /**
  * @typedef {object} IOCozyFolder Folder
  */
@@ -149,6 +150,7 @@ export const isFile = ({ _type, type }) =>
 
 /**
  * Returns true when parameters has type directory
+ *
  * @param {object} args File
  * @param {string} args.type - The type of the file
  * @returns {boolean} true when parameters has type directory or false
@@ -651,7 +653,7 @@ class FileCollection extends DocumentCollection {
   }
 
   async fetchFileContent(id) {
-    console.warn(
+    logger.warn(
       'FileCollection.fetchFileContent() is deprecated. Use FileCollection.fetchFileContentById() instead'
     )
     return this.fetchFileContentById(id)
@@ -900,7 +902,7 @@ class FileCollection extends DocumentCollection {
   }
 
   async updateFileMetadata(id, attributes) {
-    console.warn(
+    logger.warn(
       'CozyClient FileCollection updateFileMetadata method is deprecated. Use updateAttributes instead'
     )
     return this.updateAttributes(id, attributes)
@@ -1165,7 +1167,7 @@ class FileCollection extends DocumentCollection {
     let opts = {}
     if (typeof couchOptions !== 'object') {
       opts.since = couchOptions
-      console.warn(
+      logger.warn(
         `fetchChanges use couchOptions as Object not a string, since is deprecated, please use fetchChanges({since: "${couchOptions}"}).`
       )
     } else if (Object.keys(couchOptions).length > 0) {

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -2,6 +2,7 @@ jest.mock('./CozyStackClient')
 
 import CozyStackClient from './CozyStackClient'
 import FileCollection from './FileCollection'
+import logger from './logger'
 
 const STAT_BY_ID_RESPONSE = {
   data: {
@@ -1517,9 +1518,9 @@ describe('FileCollection', () => {
     })
 
     it('should call the right route with deprecated parameter', async () => {
-      jest.spyOn(console, 'warn').mockImplementation(() => {})
+      jest.spyOn(logger, 'warn').mockImplementation(() => {})
       await collection.fetchChanges('my-seq')
-      console.warn.mockRestore()
+      logger.warn.mockRestore()
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'GET',
         '/files/_changes?since=my-seq'

--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -1,6 +1,7 @@
 import DocumentCollection, { normalizeDoc } from './DocumentCollection'
 import { isFile } from './FileCollection'
 import { uri } from './utils'
+import logger from './logger'
 
 const normalizePermission = perm => normalizeDoc(perm, 'io.cozy.permissions')
 
@@ -202,7 +203,7 @@ class PermissionCollection extends DocumentCollection {
    * @returns {Permission} permission
    */
   async getOwnPermissions() {
-    console.warn(
+    logger.warn(
       'getOwnPermissions is deprecated, please use fetchOwnPermissions instead'
     )
     return this.fetchOwnPermissions()

--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -1,6 +1,8 @@
 import DocumentCollection, { normalizeDoc } from './DocumentCollection'
 import { isFile, isDirectory } from './FileCollection'
 import { uri } from './utils'
+import logger from './logger'
+
 export const SHARING_DOCTYPE = 'io.cozy.sharings'
 export const BITWARDEN_ORGANIZATIONS_DOCTYPE = 'com.bitwarden.organizations'
 export const BITWARDEN_CIPHERS_DOCTYPE = 'com.bitwarden.ciphers'
@@ -139,7 +141,7 @@ class SharingCollection extends DocumentCollection {
     description,
     previewPath = null
   ) {
-    console.warn(
+    logger.warn(
       'SharingCollection.share is deprecated, use SharingCollection.create instead'
     )
     const recipientsToUse =
@@ -262,7 +264,7 @@ const getSharingRulesWithoutWarning = (document, sharingType) => {
  */
 export const getSharingRules = (document, sharingType) => {
   if (sharingType) {
-    console.warn(
+    logger.warn(
       `sharingType is deprecated and will be removed. We now set this default rules: ${getSharingRulesWithoutWarning(
         document
       )}} \n      

--- a/packages/cozy-stack-client/src/getIconURL.spec.js
+++ b/packages/cozy-stack-client/src/getIconURL.spec.js
@@ -1,5 +1,6 @@
 import { getIconURL } from './getIconURL'
 import { ErrorReturned } from './memoize'
+import logger from './logger'
 
 const FakeBlob = (data, options) => {
   return { data, ...options }
@@ -114,9 +115,9 @@ describe('get icon', () => {
       responses['/registry/caissedepargne1'] = {
         data: { name: 'caissedepargne1', icon: 'icon.mp4' }
       }
-      jest.spyOn(console, 'warn').mockImplementation(() => {})
+      jest.spyOn(logger, 'warn').mockImplementation(() => {})
       const url = await getIconURL(stackClient, defaultOpts)
-      console.warn.mockRestore()
+      logger.warn.mockRestore()
       expect(url).toEqual('')
     })
 

--- a/packages/cozy-stack-client/src/logDeprecate.js
+++ b/packages/cozy-stack-client/src/logDeprecate.js
@@ -1,8 +1,10 @@
+import logger from './logger'
+
 const logDeprecate = (...args) => {
   if (process.env.NODE_ENV === 'test') {
     throw new Error('Deprecation error: ' + args[0])
   }
-  console.warn(...args)
+  logger.warn(...args)
 }
 
 export default logDeprecate

--- a/packages/cozy-stack-client/src/logger.js
+++ b/packages/cozy-stack-client/src/logger.js
@@ -1,0 +1,6 @@
+import minilog from '@cozy/minilog'
+
+const logger = minilog('cozy-stack-client')
+minilog.suggest.deny('cozy-stack-client', 'info')
+
+export default logger

--- a/packages/cozy-stack-client/src/mangoIndex.js
+++ b/packages/cozy-stack-client/src/mangoIndex.js
@@ -2,6 +2,7 @@ import { transform } from './utils'
 import head from 'lodash/head'
 import get from 'lodash/get'
 import isEqual from 'lodash/isEqual'
+import logger from './logger'
 
 /**
  * @typedef {object} MangoPartialFilter
@@ -74,7 +75,7 @@ export const transformSort = sort => {
   if (!sort || Array.isArray(sort)) {
     return sort
   }
-  console.warn(
+  logger.warn(
     'Passing an object to the "sort" is deprecated, please use an array instead.'
   )
   return transform(


### PR DESCRIPTION
Cozy-Client can be used in a web app but also in konnectors or services. 

When run in the browser, there is no issue using console.* directly. But when it comes to run it on the server (services or server side konnectors), logs need to have a special format that cozy-client doesn't respect for now. See this issue https://github.com/cozy/cozy-client/issues/866 

The idea is to not use console.* anymore in CC, but use the logger. This is the first step. After that, we'll be able to format correctly the log. 