### PR TITLE
fix: Export `deconstructCozyWebLinkWithSlug` from `index.node.js`

### DIFF
--- a/packages/cozy-client/src/index.node.js
+++ b/packages/cozy-client/src/index.node.js
@@ -18,6 +18,7 @@ export {
   HasManyTriggers
 } from './associations'
 export {
+  deconstructCozyWebLinkWithSlug,
   dehydrate,
   generateWebLink,
   rootCozyUrl,

--- a/packages/cozy-client/types/index.node.d.ts
+++ b/packages/cozy-client/types/index.node.d.ts
@@ -13,4 +13,4 @@ import * as models from "./models";
 export { manifest, models };
 export { QueryDefinition, Mutations, MutationTypes, getDoctypeFromOperation, Q } from "./queries/dsl";
 export { Association, HasMany, HasOne, HasOneInPlace, HasManyInPlace, HasManyTriggers } from "./associations";
-export { dehydrate, generateWebLink, rootCozyUrl, InvalidCozyUrlError, InvalidProtocolError } from "./helpers";
+export { deconstructCozyWebLinkWithSlug, dehydrate, generateWebLink, rootCozyUrl, InvalidCozyUrlError, InvalidProtocolError } from "./helpers";


### PR DESCRIPTION
In #1217 we forgot to expose this method from `index.node.js`