### PR TITLE
fix: Limit DocsIds according to limit instead of queryState.count

### DIFF
--- a/packages/cozy-client/src/store.spec.js
+++ b/packages/cozy-client/src/store.spec.js
@@ -216,7 +216,7 @@ describe('Store', () => {
       expect(queryResult.data.map(x => x._id)).toEqual(['todo_1', 'todo_2'])
       queryResult = getQueryFromStore(store, 'Q2')
       expect(queryResult.data.length).toBe(2)
-      expect(queryResult.data.map(x => x._id)).toEqual(['todo_3', 'todo_4'])
+      expect(queryResult.data.map(x => x._id)).toEqual(['todo_1', 'todo_2'])
     })
 
     it('should respect the query limit with sort', () => {

--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -94,7 +94,7 @@ export const sortAndLimitDocsIds = (
       // When there are less results than the limit, this is either the first
       // or last paginated query.
       sliceCount =
-        fetchedPagesCount > 1 ? limit * (fetchedPagesCount - 1) + count : count
+        fetchedPagesCount > 1 ? limit * (fetchedPagesCount - 1) + count : limit
     } else {
       sliceCount = limit * fetchedPagesCount
     }

--- a/packages/cozy-client/src/store/queries.spec.js
+++ b/packages/cozy-client/src/store/queries.spec.js
@@ -527,7 +527,7 @@ describe('sortAndLimitDocsIds', () => {
         fetchedPagesCount: 1
       }
     )
-    expect(ids1.length).toEqual(1)
+    expect(ids1.length).toEqual(2)
 
     const query2 = Q('io.cozy.files')
       .sortBy([{ name: 'asc' }])
@@ -543,5 +543,37 @@ describe('sortAndLimitDocsIds', () => {
       }
     )
     expect(ids2.length).toEqual(3)
+  })
+
+  it('should correctly handle count null, using the limit then', () => {
+    const query1 = Q('io.cozy.files')
+      .sortBy([{ name: 'asc' }])
+      .limitBy(2)
+
+    const ids1 = sortAndLimitDocsIds(
+      { definition: query1.toDefinition() },
+      docs,
+      ['doc1', 'doc2'],
+      {
+        count: 0,
+        fetchedPagesCount: 1
+      }
+    )
+    expect(ids1.length).toEqual(2)
+
+    const query2 = Q('io.cozy.files')
+      .sortBy([{ name: 'asc' }])
+      .limitBy(2)
+
+    const ids2 = sortAndLimitDocsIds(
+      { definition: query2.toDefinition() },
+      docs,
+      ['doc1', 'doc2', 'doc3'],
+      {
+        count: 0,
+        fetchedPagesCount: 2
+      }
+    )
+    expect(ids2.length).toEqual(2)
   })
 })


### PR DESCRIPTION
Bugs happen when creating a shortcut, inside a new folder in Drive
queryState returns a data as an empty array, so count was 0
And sliceCount removes the new shortcut ids create, because it is 0
The fix using a limit - to 100 in our case, handles that case.
And should not break other scenarii.