### PR TITLE
fix: Fix store issue with creation mutation

### DIFF
--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -355,7 +355,7 @@ export const makeSorterFromDefinition = definition => {
  * @param  {DocumentsStateSlice} documents - A reference to the documents slice
  * @returns {QueryState} - Updated query state
  */
-const updateData = (query, newData, documents) => {
+export const updateData = (query, newData, documents) => {
   const belongsToQuery = getQueryDocumentsChecker(query)
   const res = mapValues(groupBy(newData, belongsToQuery), docs =>
     docs.map(properId)
@@ -378,16 +378,15 @@ const updateData = (query, newData, documents) => {
   // toAdd does not contain any id present in originalIds, by construction.
   // It is also faster than union.
   let updatedData = difference(concat(originalIds, toAdd), toRemove)
-  const { count, fetchedPagesCount } = query
+  const { fetchedPagesCount } = query
   const docsIds = sortAndLimitDocsIds(query, documents, updatedData, {
-    count,
+    count: updatedData.length,
     fetchedPagesCount
   })
-
   return {
     ...query,
     data: docsIds,
-    count: updatedData.length,
+    count: docsIds.length,
     fetchedPagesCount,
     lastUpdate: changed ? Date.now() : query.lastUpdate
   }

--- a/packages/cozy-client/src/store/queries.spec.js
+++ b/packages/cozy-client/src/store/queries.spec.js
@@ -6,7 +6,8 @@ import queries, {
   mergeSelectorAndPartialIndex,
   sortAndLimitDocsIds,
   loadQuery,
-  receiveQueryError
+  receiveQueryError,
+  updateData
 } from './queries'
 import { Q } from '../queries/dsl'
 import { TODO_1, TODO_2, TODO_3 } from '../__tests__/fixtures'
@@ -543,5 +544,71 @@ describe('sortAndLimitDocsIds', () => {
       }
     )
     expect(ids2.length).toEqual(3)
+  })
+})
+
+describe('updateData', () => {
+  it('should update correctly the data after a create mutation', () => {
+    const queryState = {
+      definition: {
+        doctype: 'io.cozy.files',
+        selector: {
+          dir_id: 'd6fa040d335c5f49e8c4b674a001849a',
+          type: 'file',
+          name: {
+            $gt: null
+          },
+          _id: {
+            $ne: 'io.cozy.files.trash-dir'
+          }
+        },
+        sort: [
+          {
+            dir_id: 'asc'
+          }
+        ],
+        limit: 100
+      }
+    }
+
+    const createdDocument = {
+      id: 'd6fa040d335c5f49e8c4b674a00216d2',
+      _type: 'io.cozy.files',
+      type: 'file',
+      _id: 'd6fa040d335c5f49e8c4b674a00216d2',
+      _rev: '1-b8663df3d2a468171ceaccc7049421ba',
+      name: 'cozy.url',
+      dir_id: 'd6fa040d335c5f49e8c4b674a001849a',
+      created_at: '2022-09-01T10:39:01.759905+02:00',
+      updated_at: '2022-09-01T10:39:01.759905+02:00'
+    }
+    const newData = [createdDocument]
+
+    const documents = {
+      'io.cozy.files': {
+        d6fa040d335c5f49e8c4b674a001849a: {
+          id: 'd6fa040d335c5f49e8c4b674a001849a',
+          _id: 'd6fa040d335c5f49e8c4b674a001849a',
+          _type: 'io.cozy.files',
+          type: 'directory',
+          attributes: {
+            type: 'directory',
+            name: 'test',
+            dir_id: 'io.cozy.files.root-dir',
+            created_at: '2022-08-31T13:07:19.976349+02:00',
+            updated_at: '2022-08-31T13:07:19.976349+02:00',
+            path: '/test'
+          },
+          name: 'test',
+          dir_id: 'io.cozy.files.root-dir'
+        },
+        [createdDocument.id]: {
+          ...createdDocument
+        }
+      }
+    }
+    const updatedDataToCheck = updateData(queryState, newData, documents)
+    expect(updatedDataToCheck.data.length).toEqual(1)
+    expect(updatedDataToCheck.count).toEqual(1)
   })
 })

--- a/packages/cozy-client/types/store/queries.d.ts
+++ b/packages/cozy-client/types/store/queries.d.ts
@@ -7,6 +7,7 @@ export function sortAndLimitDocsIds(queryState: QueryState, documents: Documents
 export function convert$gtNullSelectors(selector: any): object;
 export function mergeSelectorAndPartialIndex(queryDefinition: object): object;
 export function makeSorterFromDefinition(definition: QueryDefinition): (arg0: Array<CozyClientDocument>) => Array<CozyClientDocument>;
+export function updateData(query: QueryState, newData: Array<CozyClientDocument>, documents: DocumentsStateSlice): QueryState;
 export default queries;
 export function initQuery(queryId: string, queryDefinition: QueryDefinition, options?: QueryOptions): object;
 export function loadQuery(queryId: string, options?: QueryOptions): object;


### PR DESCRIPTION
We had an issue when using the creation mutation.
Document's slice was correctly updated but the
queries' one was not correctly updated. Some of
this date was right, not the other.

This is because since
0f2e8a3f2f13157723fa6395929476d66b860dec
&
d986f59781557a97ff2545b228153325d18307b9

We try to respect the Query Definition even with
a limitBy attribute. But we were using the wrong
data.

Since we're in a mutation context, we need to
use the mutated data, not the one we got during the
request. So instead of relying on old `count` from
the previous query, we rely on `updatedData`.length
to get the right information.