### PR TITLE
fix: MatchingIndex with partialFilter

### DIFF
--- a/packages/cozy-stack-client/src/mangoIndex.js
+++ b/packages/cozy-stack-client/src/mangoIndex.js
@@ -143,13 +143,13 @@ export const isMatchingIndex = (index, fields, partialFilter) => {
   const viewId = Object.keys(get(index, `views`))[0]
   const fieldsInIndex = Object.keys(get(index, `views.${viewId}.map.fields`))
   if (isEqual(fieldsInIndex, fields)) {
-    if (!partialFilter) {
-      return true
-    }
     const partialFilterInIndex = get(
       index,
       `views.${viewId}.map.partial_filter_selector`
     )
+    if (!partialFilter && !partialFilterInIndex) {
+      return true
+    }
     if (isEqual(partialFilter, partialFilterInIndex)) {
       return true
     }

--- a/packages/cozy-stack-client/src/mangoIndex.spec.js
+++ b/packages/cozy-stack-client/src/mangoIndex.spec.js
@@ -84,6 +84,23 @@ describe('matching index', () => {
       })
     ).toEqual(false)
   })
+
+  it('should not match index with same fields and index with existing partialFilter but asked for index without partialFilter', () => {
+    const partialFilter = {
+      baz: {
+        $ne: 'xyz',
+        $exists: true
+      }
+    }
+    const matchingIndex = buildDesignDoc(
+      {
+        foo: 'asc',
+        bar: 'asc'
+      },
+      { partialFilter }
+    )
+    expect(isMatchingIndex(matchingIndex, ['foo', 'bar'])).toEqual(false)
+  })
 })
 
 describe('inconsistent index', () => {


### PR DESCRIPTION
If we had an existing index with partial filter
but if we made a request with the same fields but
without partial filter, then isMatchingIndex
returned true and then we used it and then we
renamed it and we destroyed the existing index...

We fixed isMatchingIndex to check if
partialFilters are the same.