### PR TITLE
fix: Don't throw error when removing inconsistent indexes

### DIFF
--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -715,15 +715,29 @@ The returned documents are paginated by the stack.
     const existingIndex = indexes.find(index => {
       return isMatchingIndex(index, fieldsToIndex, partialFilter)
     })
-    for (const index of indexes) {
-      // This is a safeguard for potential inconsistent indexes
-      if (isInconsistentIndex(index)) {
-        await this.destroyIndex(index)
-      }
-    }
+    // Since we have fetched all the existing indexes
+    // let's clean them up.
+    // This is a safeguard for potential inconsistent indexes
+    this.removeInconsistentIndex(indexes)
     return existingIndex
   }
 
+  async removeInconsistentIndex(indexes) {
+    for (const index of indexes) {
+      // Since we use this as a safeguard and only for
+      // this case, then we don't want to throw if an
+      // error is raised.
+      if (isInconsistentIndex(index)) {
+        try {
+          await this.destroyIndex(index)
+        } catch (error) {
+          logger.warn(
+            `Destroy index has errored for ${index} with the following error: ${error?.toString()}`
+          )
+        }
+      }
+    }
+  }
   /**
    * Calls _changes route from CouchDB
    * No further treatment is done contrary to fetchchanges

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -1312,6 +1312,27 @@ describe('DocumentCollection', () => {
     })
   })
 
+  describe('removeInconsistentIndex', () => {
+    const collection = new DocumentCollection('io.cozy.triggers', client)
+    const inconsistentIndex = {
+      _id: '_design/by_aaaaa',
+      views: {
+        '123': {
+          map: {
+            fields: {
+              'cozyMetadata.createdAt': 'desc'
+            }
+          }
+        }
+      }
+    }
+    it('should not throw an error if the deletion failed', async () => {
+      client.fetchJSON.mockRejectedValue()
+      await expect(
+        collection.removeInconsistentIndex([inconsistentIndex])
+      ).resolves.not.toThrowError()
+    })
+  })
   describe('findExistingIndex', () => {
     const collection = new DocumentCollection('io.cozy.triggers', client)
     const selector = {


### PR DESCRIPTION
When we have a mango request that tells us that the index is not used because not valid or not existing, we have a mechanism that fetch all the exising indexes and check if an index can be used for this request. If yes, then we do a few manipulation on it (like renaiming it), if no then we create it.

But in the meantime, since we've fetched all the indexes we check them for inconsistence. By inconsistence we mean that the name is not the right one based on the fields & partialFilterFields.

We use this mechanism to remove & migrate old indexes.

But we had a flaw in this mechanism: Sometimes, an application can launch several requests at the same time with the same index. This use case is valid.

Since the request are treated at the same time, we fetch several times the all existing indexes, and we try to remove several times the inconsistent indexes.

Since one request will be treated before, others will receive a 404 (not existing) when trying to delete the index. Since errors are thrown, then the execution stops here and the request is not replayed anymore.

This fix is about not throwing an error when doing something "collateral". Like that, if an error happens in that case, the execution still continue.

The real fix should certainly be a kind of singleton to store the "index" we're dealing with in order to not do the same work several times. But it requires more reflexion & work on the subject.