### PR TITLE
fix: Get apps method was returning wrong type for not-registry source

### DIFF
--- a/packages/cozy-stack-client/src/AppCollection.js
+++ b/packages/cozy-stack-client/src/AppCollection.js
@@ -60,7 +60,7 @@ class AppCollection extends DocumentCollection {
           this.stackClient,
           `${this.endpoint}${encodeURIComponent(id)}`,
           {
-            normalize: (data, doctype) => normalizeApp(data, doctype)
+            normalize: data => normalizeApp(data, this.doctype)
           }
         ),
       registry: () => this.stackClient.fetchJSON('GET', registryEndpoint + id)
@@ -69,13 +69,11 @@ class AppCollection extends DocumentCollection {
     for (const source of sources) {
       try {
         const res = await dataFetchers[source]()
-
         if (source !== 'registry') {
           return res
         }
 
         const data = transformRegistryFormatToStackFormat(res)
-
         return { data: normalizeApp(data, this.doctype) }
       } catch (err) {
         if (source === sources[sources.length - 1]) {

--- a/packages/cozy-stack-client/src/AppCollection.spec.js
+++ b/packages/cozy-stack-client/src/AppCollection.spec.js
@@ -2,6 +2,7 @@ jest.mock('./CozyStackClient')
 
 import CozyStackClient from './CozyStackClient'
 import AppCollection from './AppCollection'
+import { APPS_DOCTYPE } from './AppCollection'
 import { ALL_APPS_RESPONSE, GET_APPS_RESPONSE } from './__tests__/fixtures/apps'
 import logger from './logger'
 const FIXTURES = {
@@ -66,7 +67,7 @@ describe(`AppCollection`, () => {
     it('should return normalized document', async () => {
       const resp = await collection.get('io.cozy.apps/fakeid')
       expect(resp.data).toHaveDocumentIdentity()
-      expect(resp.data.name).toEqual('Drive')
+      expect(resp.data._type).toEqual(APPS_DOCTYPE)
     })
 
     describe('deprecated get call without <doctype>/', () => {


### PR DESCRIPTION
Any call to `collection('io.cozy.apps').getById('...')` with not-registry
source was failing to properly return data.
