### PR TITLE
feat: Allow to provide `credential` value in `fetchJSON()` options

### DIFF
--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -120,7 +120,8 @@ class CozyStackClient {
 
     // the option credentials:include tells fetch to include the cookies in the
     // request even for cross-origin requests
-    options.credentials = 'include'
+    // it is still prossible to enforce `credentials` value by providing one in the `opts` prop
+    options.credentials = options.credentials || 'include'
 
     const fullPath = this.fullpath(path)
 


### PR DESCRIPTION
`fetchJSON()` enforce `credential:include` value in fetch options

In our Flagship mobile app, we want to be able to provide a custom value for this option

___

Related PRs:

- https://github.com/cozy/cozy-react-native/pull/425