### PR TITLE
Fix/fetch query and get f rom state

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -1380,7 +1380,7 @@ client.query(Q('io.cozy.bills'))`)
   fetchQueryAndGetFromState = async ({ definition, options }) => {
     try {
       await this.query(definition, options)
-      return this.getQueryFromState(options.as)
+      return this.getQueryFromState(options.as, options)
     } catch (error) {
       throw error
     }

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -919,7 +919,7 @@ client.query(Q('io.cozy.bills'))`)
     this.ensureStore()
     const queryId =
       options.as || this.queryIdGenerator.generateId(queryDefinition)
-    const existingQuery = this.getQueryFromState(queryId)
+    const existingQuery = this.getQueryFromState(queryId, options)
 
     if (options.fetchPolicy) {
       if (!options.as) {

--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -84,8 +84,8 @@ import { QueryDefinition } from './queries/dsl'
  * @property {Function} [onError] - Callback when the query is errored
  * @property {boolean} [enabled=true] - If set to false, the query won't be executed
  * @property {boolean} [backgroundFetching] - If set to true, when the fetchStatus has already been loaded, it won't be updated during future fetches. Instead, a `isFetching` attribute will be used to indicate when background fetching is started.
- * @property {object} [hydrated=true] - Whether documents should be returned already hydrated
- * @property {object} [singleDocData] - If true, the "data" returned will be
+ * @property {boolean} [hydrated=true] - Whether documents should be returned already hydrated
+ * @property {boolean} [singleDocData] - If true, the "data" returned will be
  * a single doc instead of an array for single doc queries. Defaults to false for backward
  * compatibility but will be set to true in the future.
  */

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -81,13 +81,13 @@ export type QueryOptions = {
     /**
      * - Whether documents should be returned already hydrated
      */
-    hydrated?: object;
+    hydrated?: boolean;
     /**
      * - If true, the "data" returned will be
      * a single doc instead of an array for single doc queries. Defaults to false for backward
      * compatibility but will be set to true in the future.
      */
-    singleDocData?: object;
+    singleDocData?: boolean;
 };
 export type FetchMoreAble = {
     fetchMore: Function;


### PR DESCRIPTION
I changed something like: 
```
 const { data: context } = (await client.query(
          Q('io.cozy.settings').getById('context')
        )) as ExpectedContext
```
to : 
```
await client.fetchQueryAndGetFromState({
            definition: Q('io.cozy.settings').getById('context'),
            options: {
              fetchPolicy: CozyClient.fetchPolicies.olderThan(3000 * 1000)
            }
          }
```

But I got a few errors because by default, query() will set the options.singleDocData to true if there is an `id` inside the definition. But this option was not passed all the way down with the fetchQueryAndGetFromState method. 