### PR TITLE
fix: Remove isReferencedByAlbum

### DIFF
--- a/docs/api/cozy-client/interfaces/models.file.FileUploadOptions.md
+++ b/docs/api/cozy-client/interfaces/models.file.FileUploadOptions.md
@@ -14,7 +14,7 @@ Erase / rename
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:466](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L466)
+[packages/cozy-client/src/models/file.js:443](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L443)
 
 ***
 
@@ -26,7 +26,7 @@ The file Content-Type
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:465](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L465)
+[packages/cozy-client/src/models/file.js:442](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L442)
 
 ***
 
@@ -38,7 +38,7 @@ The dirId to upload the file to
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:463](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L463)
+[packages/cozy-client/src/models/file.js:440](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L440)
 
 ***
 
@@ -50,7 +50,7 @@ An object containing the metadata to attach
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:464](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L464)
+[packages/cozy-client/src/models/file.js:441](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L441)
 
 ***
 
@@ -62,4 +62,4 @@ The file name to upload
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:462](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L462)
+[packages/cozy-client/src/models/file.js:439](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L439)

--- a/docs/api/cozy-client/modules/models.file.md
+++ b/docs/api/cozy-client/modules/models.file.md
@@ -40,7 +40,7 @@ Upload a file on a mobile
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:570](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L570)
+[packages/cozy-client/src/models/file.js:547](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L547)
 
 ***
 
@@ -86,7 +86,7 @@ file object with path attribute
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:616](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L616)
+[packages/cozy-client/src/models/file.js:593](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L593)
 
 ***
 
@@ -135,7 +135,7 @@ Generate a file name for a revision
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:452](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L452)
+[packages/cozy-client/src/models/file.js:429](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L429)
 
 ***
 
@@ -159,7 +159,7 @@ A filename with the right suffix
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:427](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L427)
+[packages/cozy-client/src/models/file.js:404](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L404)
 
 ***
 
@@ -185,7 +185,7 @@ The full path of the file in the cozy
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:315](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L315)
+[packages/cozy-client/src/models/file.js:292](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L292)
 
 ***
 
@@ -301,7 +301,7 @@ The mime-type of the target file, or an empty string is the target is not a file
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:596](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L596)
+[packages/cozy-client/src/models/file.js:573](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L573)
 
 ***
 
@@ -325,7 +325,7 @@ Whether the file's metadata attribute exists
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:304](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L304)
+[packages/cozy-client/src/models/file.js:281](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L281)
 
 ***
 
@@ -345,7 +345,7 @@ Whether the file's metadata attribute exists
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:588](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L588)
+[packages/cozy-client/src/models/file.js:565](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L565)
 
 ***
 
@@ -427,7 +427,7 @@ Whether the file is client-side encrypted
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:607](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L607)
+[packages/cozy-client/src/models/file.js:584](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L584)
 
 ***
 
@@ -492,29 +492,7 @@ Whether the file is supported by Only Office
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:580](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L580)
-
-***
-
-### isReferencedByAlbum
-
-▸ **isReferencedByAlbum**(`file`): `boolean`
-
-Whether the file is referenced by an album
-
-*Parameters*
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `file` | `IOCozyFile` | An io.cozy.files document |
-
-*Returns*
-
-`boolean`
-
-*Defined in*
-
-[packages/cozy-client/src/models/file.js:279](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L279)
+[packages/cozy-client/src/models/file.js:557](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L557)
 
 ***
 
@@ -657,7 +635,7 @@ Move file to destination.
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:339](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L339)
+[packages/cozy-client/src/models/file.js:316](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L316)
 
 ***
 
@@ -710,7 +688,7 @@ The overrided file
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:394](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L394)
+[packages/cozy-client/src/models/file.js:371](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L371)
 
 ***
 
@@ -732,7 +710,7 @@ Read a file on a mobile
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:523](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L523)
+[packages/cozy-client/src/models/file.js:500](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L500)
 
 ***
 
@@ -839,4 +817,4 @@ If there is a conflict, then we apply the conflict strategy : `erase` or `rename
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:484](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L484)
+[packages/cozy-client/src/models/file.js:461](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L461)

--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -271,29 +271,6 @@ export const fetchFilesByQualificationRules = async (client, docRules) => {
 }
 
 /**
- * Whether the file is referenced by an album
- *
- * @param {IOCozyFile} file - An io.cozy.files document
- * @returns {boolean}
- */
-export const isReferencedByAlbum = file => {
-  if (
-    file.relationships &&
-    file.relationships.referenced_by &&
-    file.relationships.referenced_by.data &&
-    file.relationships.referenced_by.data.length > 0
-  ) {
-    const references = file.relationships.referenced_by.data
-    for (const reference of references) {
-      if (reference.type === ALBUMS_DOCTYPE) {
-        return true
-      }
-    }
-  }
-  return false
-}
-
-/**
  * Whether the file's metadata attribute exists
  *
  * @param {object} params - Param

--- a/packages/cozy-client/types/models/file.d.ts
+++ b/packages/cozy-client/types/models/file.d.ts
@@ -42,7 +42,6 @@ export function isSharingShortcutNew(file: IOCozyFile): boolean;
 export function isSharingShorcutNew(file: object): boolean;
 export function saveFileQualification(client: CozyClient, file: IOCozyFile, qualification: object): Promise<IOCozyFile>;
 export function fetchFilesByQualificationRules(client: object, docRules: object): Promise<QueryResult>;
-export function isReferencedByAlbum(file: IOCozyFile): boolean;
 export function hasMetadataAttribute({ file, attribute }: {
     file: IOCozyFile;
     attribute: string;


### PR DESCRIPTION
BREAKING CHANGE: Since the introduction of the photos' clustering, each photo is at least referenced by an automatic album. Therefore, this method which was used to know if a file was referenced by an album, will always return true, does not make sense anymore because it is not what we want to test.

Instead, we now want to see if a file is not referenced by an album that has not been created automatically. This implementation has been done in Drive directly in eb76c831b3deabd0857b9472451830831df5fb3a

Linked to https://github.com/cozy/cozy-drive/pull/2739