### PR TITLE
fix: Query definition replay with only a partialFilter

### DIFF
--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -261,7 +261,7 @@ export const convert$gtNullSelectors = selector => {
  * @returns {object} A query definition selector
  */
 export const mergeSelectorAndPartialIndex = queryDefinition => ({
-  ...queryDefinition.selector,
+  ...get(queryDefinition, 'selector'),
   ...get(queryDefinition, 'partialFilter')
 })
 
@@ -270,7 +270,7 @@ export const mergeSelectorAndPartialIndex = queryDefinition => ({
  * @returns {function(CozyClientDocument): boolean}
  */
 const getSelectorFilterFn = queryDefinition => {
-  if (queryDefinition.selector) {
+  if (queryDefinition.selector || queryDefinition.partialFilter) {
     const selectors = mergeSelectorAndPartialIndex(queryDefinition)
     // sift does not work like couchdb when using { $gt: null } as a selector, so we use a custom operator
     sift.use({

--- a/packages/cozy-client/src/store/queries.spec.js
+++ b/packages/cozy-client/src/store/queries.spec.js
@@ -418,6 +418,22 @@ describe('mergeSelectorAndPartialIndex', () => {
 
     expect(mergeSelectorAndPartialIndex(query)).toMatchObject(result)
   })
+
+  it('should return a selector even if only partial index', () => {
+    const query = Q('io.cozy.files').partialIndex({
+      specificAttributes: {
+        $exists: false
+      }
+    })
+
+    const result = {
+      specificAttributes: {
+        $exists: false
+      }
+    }
+
+    expect(mergeSelectorAndPartialIndex(query)).toMatchObject(result)
+  })
 })
 
 describe('sortAndLimitDocsIds', () => {


### PR DESCRIPTION
When we had a query with no selector but a partial index,
we were missing the sift evaluation.