### PR TITLE
fix(ContactsCollection): Check selector to prevent undefined

### DIFF
--- a/packages/cozy-stack-client/src/ContactsCollection.js
+++ b/packages/cozy-stack-client/src/ContactsCollection.js
@@ -10,7 +10,11 @@ const normalizeMyselfResp = resp => {
 
 class ContactsCollection extends DocumentCollection {
   async find(selector, options) {
-    if (Object.values(selector).length === 1 && selector['me'] == true) {
+    if (
+      selector !== undefined &&
+      Object.values(selector).length === 1 &&
+      selector['me'] == true
+    ) {
       return this.findMyself()
     } else {
       return super.find(selector, options)

--- a/packages/cozy-stack-client/src/ContactsCollection.spec.js
+++ b/packages/cozy-stack-client/src/ContactsCollection.spec.js
@@ -36,6 +36,16 @@ describe('ContactsCollection', () => {
     jest.spyOn(console, 'warn').mockImplementation(() => {})
   })
 
+  it('call find route if there is no selector', async () => {
+    const { col, stackClient } = setup()
+    await col.find()
+    expect(stackClient.fetchJSON).toHaveBeenCalledWith(
+      'POST',
+      '/data/io.cozy.contacts/_find',
+      expect.any(Object)
+    )
+  })
+
   it('should use a special route for the myself contact', async () => {
     const { col, stackClient } = setup()
     const resp = await col.find({


### PR DESCRIPTION
This problem appears when you only have partialIndex so the selector which is where return undefined. This problem was found into : https://github.com/cozy/cozy-contacts/pull/898 