### PR TITLE
fix: Encode filename

### DIFF
--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -614,7 +614,10 @@ class FileCollection extends DocumentCollection {
 
   getDownloadLinkById(id, filename) {
     return this.stackClient
-      .fetchJSON('POST', uri`/files/downloads?Id=${id}&Filename=${filename}`)
+      .fetchJSON(
+        'POST',
+        uri`/files/downloads?Id=${id}&Filename=${encodeURIComponent(filename)}`
+      )
       .then(this.extractResponseLinkRelated)
   }
 
@@ -622,7 +625,9 @@ class FileCollection extends DocumentCollection {
     return this.stackClient
       .fetchJSON(
         'POST',
-        uri`/files/downloads?VersionId=${versionId}&Filename=${filename}`
+        uri`/files/downloads?VersionId=${versionId}&Filename=${encodeURIComponent(
+          filename
+        )}`
       )
       .then(this.extractResponseLinkRelated)
   }

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -83,6 +83,54 @@ describe('FileCollection', () => {
     })
   })
 
+  describe('getDownloadLinkByRevision', () => {
+    beforeEach(() => {
+      client.fetchJSON.mockResolvedValue({
+        ...STAT_BY_ID_RESPONSE,
+
+        links: {
+          related: 'http://foo'
+        }
+      })
+    })
+
+    afterEach(() => {
+      client.fetchJSON.mockReset()
+    })
+
+    it('should encode filename', async () => {
+      await collection.getDownloadLinkByRevision('1', '#name')
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        '/files/downloads?VersionId=1&Filename=%2523name'
+      )
+    })
+  })
+
+  describe('getDownloadLinkById', () => {
+    beforeEach(() => {
+      client.fetchJSON.mockResolvedValue({
+        ...STAT_BY_ID_RESPONSE,
+
+        links: {
+          related: 'http://foo'
+        }
+      })
+    })
+
+    afterEach(() => {
+      client.fetchJSON.mockReset()
+    })
+
+    it('should encode filename', async () => {
+      await collection.getDownloadLinkById('1', '#name')
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        '/files/downloads?Id=1&Filename=%2523name'
+      )
+    })
+  })
+
   describe('find', () => {
     client.uri = 'http://cozy.tools'
     const FIND_RESPONSE = {


### PR DESCRIPTION
When filename is used inside the URL we have
to encode it in order to avoid error.

Fix a downloading bug when a file
has "#test.png" as name.