### PR TITLE
fix: Do not call the queryDefinition if enabled is false

### DIFF
--- a/packages/cozy-client/src/hooks/useQuery.js
+++ b/packages/cozy-client/src/hooks/useQuery.js
@@ -38,8 +38,13 @@ const useQuery = (queryDefinition, options) => {
     throw new Error('Bad query')
   }
 
-  const definition = resolveToValue(queryDefinition)
   const { as, enabled = true } = options
+  // If the query is not enabled, no need to call the queryDefinition
+  // because sometimes, we can have a getById(null) since we want to
+  // enabled the query only when the specific id is defined. And since
+  // Q() can throw error when some checks are KO we don't call Q() if
+  // enabled is not true
+  const definition = enabled ? resolveToValue(queryDefinition) : null
 
   if (!as) {
     throw new Error('You must specify options.as when using useQuery')

--- a/packages/cozy-client/src/hooks/useQuery.spec.jsx
+++ b/packages/cozy-client/src/hooks/useQuery.spec.jsx
@@ -8,6 +8,14 @@ import { Q } from '../queries/dsl'
 import { setupClient, makeWrapper } from '../testing/utils'
 import simpsonsFixture from '../testing/simpsons.json'
 
+/**
+ * @param {object} Options options
+ * @param {object=} Options.customClient custom Client
+ * @param {object=} Options.queryDefinition custom Querydef
+ * @param {object=} Options.queryOptions custom QueryOpts
+ * @param {object=} Options.storeQueries custome StoreQueries
+ * @returns
+ */
 const setupQuery = ({
   customClient,
   queryDefinition,
@@ -51,7 +59,32 @@ describe('use query', () => {
       })
     })
   })
-
+  it('should respect the enable property', () => {
+    const { client } = setupQuery({
+      queryOptions: {
+        as: 'simpsons',
+        enabled: false
+      },
+      queryDefinition: () => Q('io.cozy.simpsons')
+    })
+    expect(client.query).not.toHaveBeenCalled()
+  })
+  it('should respect not throw error if the qDef contains a getById with null', () => {
+    const {
+      client,
+      hookResult: {
+        result: { current }
+      }
+    } = setupQuery({
+      queryOptions: {
+        as: 'simpsonsTest',
+        enabled: false
+      },
+      queryDefinition: () => Q('io.cozy.simpsons').getById(null)
+    })
+    expect(client.query).not.toThrowError()
+    expect(current.fetchStatus).toEqual('pending')
+  })
   it('should share the same API than ObservableQuery', () => {
     const {
       hookResult: {


### PR DESCRIPTION
It's a legit use case to have something like this:
```
const id = useParam('id');
const file = useQuery(Q('io.cozy.files').getById(id),
{
enabled: !!id
}
if(!id) return null
if(file.fetchStatus === 'loaded'){
   return <File file={file.data} />
}
...
```

This case was failing beforce because getById() checks if the `id` is there or not. And since even if `enabled` was set to false we called the getById(), it throws an error.

This fix a part of https://github.com/cozy/cozy-client/issues/961

I don't know yet what to think about the `fetchStatus` equal to `pending` or `loaded` so I just added a test to be sure to create a BC if we change the behavior. But to me, the called should not rely on the result of the useQuery hook when enabled is set to false.

This fix also enable the fact to be able to call useQuery without a queryDefinition if `enabled` is set to false. I don't like it but it's a collateral damage.
The difference between this PR and this one
 https://github.com/cozy/cozy-client/pull/970

is that this is not the responsability to cozy-client to handle the result of the enabled props. Since `enabled` is passed by the caller, the caller has the responsability to not use the data coming from the useQuery hook. Like I did in the begining of this commit.