### PR TITLE
feat(index.node.js): Export fetchPolicies

### DIFF
--- a/packages/cozy-client/src/index.node.js
+++ b/packages/cozy-client/src/index.node.js
@@ -39,3 +39,5 @@ export * from './cli'
 
 import * as models from './models'
 export { models }
+
+export { default as fetchPolicies } from './policies'

--- a/packages/cozy-client/types/index.node.d.ts
+++ b/packages/cozy-client/types/index.node.d.ts
@@ -8,6 +8,7 @@ export { default as Registry } from "./registry";
 export * from "./mock";
 export * from "./cli";
 export { BulkEditError } from "./errors";
+export { default as fetchPolicies } from "./policies";
 import * as manifest from "./manifest";
 import * as models from "./models";
 export { manifest, models };


### PR DESCRIPTION
We centralise all queries into a queries.js file in application. fetchPolicies is often use in query from front-end. As we extract also query from service. Node tries to find fetchPolicies, it's create crashs (ex: [cozy-contact](https://github.com/cozy/cozy-contacts/pull/901)). As fetchPolicies is agnostic from react.js, we can expose to node and prevent future problem.

**Related PRs :**
- https://github.com/cozy/cozy-contacts/pull/901