### PR TITLE
feat: Replace isExpiringResidencePermit function to another more generic

### DIFF
--- a/docs/api/cozy-client/modules/models.paper.md
+++ b/docs/api/cozy-client/modules/models.paper.md
@@ -36,7 +36,7 @@ Expiration date
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:85](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L85)
+[packages/cozy-client/src/models/paper.js:84](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L84)
 
 ***
 
@@ -60,7 +60,7 @@ Expiration notice date
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:121](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L121)
+[packages/cozy-client/src/models/paper.js:120](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L120)
 
 ***
 
@@ -84,7 +84,7 @@ Expiration notice link
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:140](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L140)
+[packages/cozy-client/src/models/paper.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L139)
 
 ***
 
@@ -128,7 +128,7 @@ Expiration notice link
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:67](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L67)
+[packages/cozy-client/src/models/paper.js:66](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L66)
 
 ***
 

--- a/packages/cozy-client/src/models/paper.js
+++ b/packages/cozy-client/src/models/paper.js
@@ -32,13 +32,12 @@ const isExpiringFrenchNationalIdCard = file => {
 /**
  * @param {IOCozyFile} file - io.cozy.files document
  * @returns {boolean}
- * @description Tells if a given file is a residence permit, has an expiration date set and a notice period set
+ * @description Tells if a given file has an expiration date set and a notice period set
  */
-const isExpiringResidencePermit = file => {
-  const label = file.metadata?.qualification?.label
+const isExpiringGeneric = file => {
   const expirationDate = file.metadata?.expirationDate
   const noticePeriod = file.metadata?.noticePeriod
-  if (label === 'residence_permit' && expirationDate && noticePeriod) {
+  if (expirationDate && noticePeriod) {
     return true
   }
   return false
@@ -68,7 +67,7 @@ export const isExpiring = file => {
   if (isExpiringFrenchNationalIdCard(file)) {
     return true
   }
-  if (isExpiringResidencePermit(file)) {
+  if (isExpiringGeneric(file)) {
     return true
   }
   if (isExpiringPersonalSportingLicense(file)) {
@@ -83,7 +82,7 @@ export const isExpiring = file => {
  * @description Computes et returns the expiration date of the given file, or null if it is not expiring
  */
 export const computeExpirationDate = file => {
-  if (isExpiringFrenchNationalIdCard(file) || isExpiringResidencePermit(file)) {
+  if (isExpiringFrenchNationalIdCard(file) || isExpiringGeneric(file)) {
     const expirationDate = file.metadata?.expirationDate
     return new Date(expirationDate)
   }
@@ -103,7 +102,7 @@ export const computeExpirationDate = file => {
  * @description Computes et returns the expiration notice period of the given file, or null if it is not expiring
  */
 const computeExpirationNoticePeriodInDays = file => {
-  if (isExpiringFrenchNationalIdCard(file) || isExpiringResidencePermit(file)) {
+  if (isExpiringFrenchNationalIdCard(file) || isExpiringGeneric(file)) {
     const noticePeriodInDays = file.metadata?.noticePeriod
     return parseInt(noticePeriodInDays, 10)
   }
@@ -138,10 +137,11 @@ export const computeExpirationNoticeDate = file => {
  * @description Computes et returns the expiration notice link of the given file, or null if it has none or it is not expiring
  */
 export const computeExpirationNoticeLink = file => {
+  const qualificationLabel = file.metadata?.qualification?.label
   if (isExpiringFrenchNationalIdCard(file)) {
     return 'https://www.service-public.fr/particuliers/vosdroits/N358'
   }
-  if (isExpiringResidencePermit(file)) {
+  if (isExpiringGeneric(file) && qualificationLabel === 'residence_permit') {
     return 'https://www.service-public.fr/particuliers/vosdroits/N110'
   }
   return null

--- a/packages/cozy-client/src/models/paper.spec.js
+++ b/packages/cozy-client/src/models/paper.spec.js
@@ -2,6 +2,32 @@ import MockDate from 'mockdate'
 
 import * as paperModel from './paper'
 
+/**
+ *
+ * @param {object} param - options
+ * @param {string} param.qualificationLabel - qualification label
+ * @param {string} [param.expirationDate] - expiration date of file
+ * @param {string} [param.referencedDate] - reference date of file
+ * @param {string} [param.noticePeriod] - period before send notification
+ */
+const buildMockFile = ({
+  qualificationLabel,
+  expirationDate,
+  referencedDate,
+  noticePeriod
+}) => {
+  return /** @type {import('../types').IOCozyFile} */ ({
+    name: qualificationLabel,
+    created_at: '2022-09-01T00:00:00.000Z',
+    metadata: {
+      qualification: { label: qualificationLabel },
+      ...(expirationDate && { expirationDate }),
+      ...(referencedDate && { referencedDate }),
+      ...(noticePeriod && { noticePeriod })
+    }
+  })
+}
+
 describe('Expiration', () => {
   beforeEach(() => {
     MockDate.set('2022-11-01T11:35:58.118Z')
@@ -10,44 +36,41 @@ describe('Expiration', () => {
     MockDate.reset()
   })
 
-  const fakeFile01 = {
-    _id: '01',
-    name: 'national id card',
-    created_at: '2022-09-01T00:00:00.000Z',
-    metadata: {
-      qualification: { label: 'national_id_card' },
-      expirationDate: '2022-09-23T11:35:58.118Z',
-      noticePeriod: '90'
-    }
-  }
-  const fakeFile02 = {
-    _id: '02',
-    name: 'personal sporting licence',
-    created_at: '2022-09-01T00:00:00.000Z',
-    metadata: {
-      qualification: { label: 'personal_sporting_licence' },
-      referencedDate: '2022-09-23T11:35:58.118Z'
-    }
-  }
-  const fakeFile03 = {
-    _id: '03',
+  const fakeFileWithoutMetadata = /** @type {import('../types').IOCozyFile} */ ({
+    _id: '00',
     name: 'unknown'
-  }
+  })
+  const fakeNationalIdCardFile = buildMockFile({
+    qualificationLabel: 'national_id_card',
+    expirationDate: '2022-09-23T11:35:58.118Z',
+    noticePeriod: '90'
+  })
+  const fakePersonalSportingLicenceFile = buildMockFile({
+    qualificationLabel: 'personal_sporting_licence',
+    referencedDate: '2022-09-23T11:35:58.118Z'
+  })
+  const fakeResidencePermitFile = buildMockFile({
+    qualificationLabel: 'residence_permit',
+    expirationDate: '2022-09-23T11:35:58.118Z',
+    noticePeriod: '90'
+  })
 
   describe('computeExpirationDate', () => {
     it('should return expirationDate', () => {
-      const res = paperModel.computeExpirationDate(fakeFile01)
+      const res = paperModel.computeExpirationDate(fakeNationalIdCardFile)
 
       expect(res.toISOString()).toBe('2022-09-23T11:35:58.118Z')
     })
     it('should return referencedDate plus 365 days', () => {
-      const res = paperModel.computeExpirationDate(fakeFile02)
+      const res = paperModel.computeExpirationDate(
+        fakePersonalSportingLicenceFile
+      )
 
       expect(res.toISOString()).toBe('2023-09-23T11:35:58.118Z')
     })
 
     it('should return "null" if metadata is not found', () => {
-      const res = paperModel.computeExpirationDate(fakeFile03)
+      const res = paperModel.computeExpirationDate(fakeFileWithoutMetadata)
 
       expect(res).toBeNull()
     })
@@ -55,19 +78,93 @@ describe('Expiration', () => {
 
   describe('computeExpirationNoticeDate', () => {
     it('should return notice date for file with expirationDate metadata', () => {
-      const res = paperModel.computeExpirationNoticeDate(fakeFile01)
+      const res = paperModel.computeExpirationNoticeDate(fakeNationalIdCardFile)
 
       expect(res.toISOString()).toBe('2022-06-25T11:35:58.118Z')
     })
     it('should return notice date for file with referencedDate metadata', () => {
-      const res = paperModel.computeExpirationNoticeDate(fakeFile02)
+      const res = paperModel.computeExpirationNoticeDate(
+        fakePersonalSportingLicenceFile
+      )
 
       expect(res.toISOString()).toBe('2023-09-08T11:35:58.118Z')
     })
     it('should return null for file without corresponding metadata', () => {
-      const res = paperModel.computeExpirationNoticeDate(fakeFile03)
+      const res = paperModel.computeExpirationNoticeDate(
+        fakeFileWithoutMetadata
+      )
 
       expect(res).toBeNull()
     })
+  })
+
+  describe('computeExpirationNoticeLink', () => {
+    it.each`
+      file                       | link
+      ${fakeNationalIdCardFile}  | ${'https://www.service-public.fr/particuliers/vosdroits/N358'}
+      ${fakeResidencePermitFile} | ${'https://www.service-public.fr/particuliers/vosdroits/N110'}
+    `(
+      `should return "$link" link for an file with "$file.metadata.qualification.label" qualification label`,
+      ({ file, link }) => {
+        expect(paperModel.computeExpirationNoticeLink(file)).toEqual(link)
+      }
+    )
+  })
+
+  describe('isExpiring', () => {
+    const fakeNationalIdCardFileWithoutNoticeDate = buildMockFile({
+      qualificationLabel: 'national_id_card',
+      expirationDate: '2022-09-23T11:35:58.118Z',
+      noticePeriod: ''
+    })
+    const fakeResidencePermitFileWithoutNoticeDate = buildMockFile({
+      qualificationLabel: 'residence_permit',
+      expirationDate: '2022-09-23T11:35:58.118Z',
+      noticePeriod: ''
+    })
+    const fakeNationalIdCardFileWithoutExpirationDate = buildMockFile({
+      qualificationLabel: 'national_id_card',
+      expirationDate: '',
+      noticePeriod: '90'
+    })
+    const fakeResidencePermitFileWithoutExpirationDate = buildMockFile({
+      qualificationLabel: 'residence_permit',
+      expirationDate: '',
+      noticePeriod: '90'
+    })
+
+    it.each`
+      file                               | result
+      ${fakeNationalIdCardFile}          | ${true}
+      ${fakePersonalSportingLicenceFile} | ${true}
+      ${fakeResidencePermitFile}         | ${true}
+    `(
+      `should return "$result" for each file with "noticePeriod" & "expirationDate" metadata`,
+      ({ file, result }) => {
+        expect(paperModel.isExpiring(file)).toEqual(result)
+      }
+    )
+
+    it.each`
+      file                                        | result
+      ${fakeNationalIdCardFileWithoutNoticeDate}  | ${false}
+      ${fakeResidencePermitFileWithoutNoticeDate} | ${false}
+    `(
+      `should return "$result" for each file without "noticePeriod" metadata`,
+      ({ file, result }) => {
+        expect(paperModel.isExpiring(file)).toEqual(result)
+      }
+    )
+
+    it.each`
+      file                                            | result
+      ${fakeNationalIdCardFileWithoutExpirationDate}  | ${false}
+      ${fakeResidencePermitFileWithoutExpirationDate} | ${false}
+    `(
+      `should return "$result" for each file without "expirationDate" metadata`,
+      ({ file, result }) => {
+        expect(paperModel.isExpiring(file)).toEqual(result)
+      }
+    )
   })
 })


### PR DESCRIPTION
With a few exceptions (already covered), all papers qualifications should have the same treatment as the `residence_permit`.