### PR TITLE
Add helper link for passport

### DIFF
--- a/docs/api/cozy-client/modules/models.paper.md
+++ b/docs/api/cozy-client/modules/models.paper.md
@@ -36,7 +36,7 @@ Expiration date
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:84](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L84)
+[packages/cozy-client/src/models/paper.js:89](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L89)
 
 ***
 
@@ -60,7 +60,7 @@ Expiration notice date
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:120](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L120)
+[packages/cozy-client/src/models/paper.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L125)
 
 ***
 
@@ -68,7 +68,7 @@ Expiration notice date
 
 ▸ **computeExpirationNoticeLink**(`file`): `string`
 
-**`description`** Computes et returns the expiration notice link of the given file, or null if it has none or it is not expiring
+**`description`** Computes and returns the expiration notice link of the given file, or null if it has none
 
 *Parameters*
 
@@ -84,7 +84,7 @@ Expiration notice link
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L139)
+[packages/cozy-client/src/models/paper.js:144](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L144)
 
 ***
 
@@ -106,7 +106,7 @@ Expiration notice link
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:155](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L155)
+[packages/cozy-client/src/models/paper.js:156](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L156)
 
 ***
 
@@ -128,7 +128,7 @@ Expiration notice link
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:66](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L66)
+[packages/cozy-client/src/models/paper.js:71](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L71)
 
 ***
 
@@ -150,4 +150,4 @@ Expiration notice link
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:167](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L167)
+[packages/cozy-client/src/models/paper.js:168](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L168)

--- a/packages/cozy-client/src/models/paper.js
+++ b/packages/cozy-client/src/models/paper.js
@@ -7,6 +7,10 @@ import sub from 'date-fns/sub'
 
 const PERSONAL_SPORTING_LICENCE_PERIOD_DAYS = 365
 const PERSONAL_SPORTING_LICENCE_NOTICE_PERIOD_DAYS = 15
+const EXPIRATION_LINK_BY_LABEL = {
+  national_id_card: 'https://www.service-public.fr/particuliers/vosdroits/N358',
+  residence_permit: 'https://www.service-public.fr/particuliers/vosdroits/N110'
+}
 
 /**
  * @param {IOCozyFile} file - io.cozy.files document
@@ -134,17 +138,13 @@ export const computeExpirationNoticeDate = file => {
 /**
  * @param {IOCozyFile} file - io.cozy.files document
  * @returns {string | null} Expiration notice link
- * @description Computes et returns the expiration notice link of the given file, or null if it has none or it is not expiring
+ * @description Computes and returns the expiration notice link of the given file, or null if it has none
  */
 export const computeExpirationNoticeLink = file => {
   const qualificationLabel = file.metadata?.qualification?.label
-  if (isExpiringFrenchNationalIdCard(file)) {
-    return 'https://www.service-public.fr/particuliers/vosdroits/N358'
-  }
-  if (isExpiringGeneric(file) && qualificationLabel === 'residence_permit') {
-    return 'https://www.service-public.fr/particuliers/vosdroits/N110'
-  }
-  return null
+  if (!qualificationLabel) return null
+
+  return EXPIRATION_LINK_BY_LABEL[qualificationLabel] || null
 }
 
 /**

--- a/packages/cozy-client/src/models/paper.js
+++ b/packages/cozy-client/src/models/paper.js
@@ -9,7 +9,8 @@ const PERSONAL_SPORTING_LICENCE_PERIOD_DAYS = 365
 const PERSONAL_SPORTING_LICENCE_NOTICE_PERIOD_DAYS = 15
 const EXPIRATION_LINK_BY_LABEL = {
   national_id_card: 'https://www.service-public.fr/particuliers/vosdroits/N358',
-  residence_permit: 'https://www.service-public.fr/particuliers/vosdroits/N110'
+  residence_permit: 'https://www.service-public.fr/particuliers/vosdroits/N110',
+  passport: 'https://www.service-public.fr/particuliers/vosdroits/N360'
 }
 
 /**

--- a/packages/cozy-client/src/models/paper.spec.js
+++ b/packages/cozy-client/src/models/paper.spec.js
@@ -45,6 +45,11 @@ describe('Expiration', () => {
     expirationDate: '2022-09-23T11:35:58.118Z',
     noticePeriod: '90'
   })
+  const fakePassportFile = buildMockFile({
+    qualificationLabel: 'passport',
+    expirationDate: '2022-09-23T11:35:58.118Z',
+    noticePeriod: '90'
+  })
   const fakePersonalSportingLicenceFile = buildMockFile({
     qualificationLabel: 'personal_sporting_licence',
     referencedDate: '2022-09-23T11:35:58.118Z'
@@ -103,6 +108,7 @@ describe('Expiration', () => {
       file                       | link
       ${fakeNationalIdCardFile}  | ${'https://www.service-public.fr/particuliers/vosdroits/N358'}
       ${fakeResidencePermitFile} | ${'https://www.service-public.fr/particuliers/vosdroits/N110'}
+      ${fakePassportFile}        | ${'https://www.service-public.fr/particuliers/vosdroits/N360'}
     `(
       `should return "$link" link for an file with "$file.metadata.qualification.label" qualification label`,
       ({ file, link }) => {


### PR DESCRIPTION
Ajout d'un lien pour aider l'utilisateur lorsque son passeport est sur le point d'expiré.

Ainsi que la simplification de la fonction `computeExpirationNoticeLink`, ajoutée il y a quelques jours.
Son but étant de fournir un lien en fonction d'un label de qualification, elle n'a pas à être plus complexe que ça.