### PR TITLE
fix: Translation key `work_disability_recognition`

### DIFF
--- a/packages/cozy-client/src/models/document/locales/en.json
+++ b/packages/cozy-client/src/models/document/locales/en.json
@@ -59,7 +59,7 @@
       "other_work_document": "Other work document",
       "health_book": "Health book",
       "health_certificate": "Health/Vaccination certificate",
-      "disability_recognition": "Recognition of disability",
+      "work_disability_recognition": "Recognition of disability",
       "pregnancy_medical_certificate": "Certificate of pregnancy",
       "national_health_insurance_card": "National health insurance card",
       "national_health_insurance_right_certificate": "National health insurance right certificate",


### PR DESCRIPTION
Translation key `work_disability_recognition` was misnamed in EN translations when added here cozy/cozy-client@25e4953