### PR TITLE
fix: Do not modify selector with lodash merge

### DIFF
--- a/packages/cozy-client/examples/simple-test-query.js
+++ b/packages/cozy-client/examples/simple-test-query.js
@@ -1,0 +1,36 @@
+const { createClientInteractive, Q } = require('../dist/index.node')
+const { ArgumentParser } = require('argparse')
+
+global.fetch = require('node-fetch')
+
+// Change those 2 variables accordingly to your needs
+const DOCTYPE = 'io.cozy.files'
+const QUERY = Q(DOCTYPE)
+  .where({
+    'cozyMetadata.createdByApp': 'drive'
+  })
+  .indexFields(['cozyMetadata.createdByApp'])
+  .partialIndex({
+    restore_path: { $exists: false },
+    type: 'directory'
+  })
+  .limit(100)
+
+const main = async () => {
+  const parser = new ArgumentParser()
+  parser.addArgument('--url', { defaultValue: 'http://cozy.localhost:8080' })
+  const args = parser.parseArgs()
+
+  const client = await createClientInteractive({
+    scope: [DOCTYPE],
+    uri: args.url,
+    oauth: {
+      softwareID: 'io.cozy.client.cli'
+    }
+  })
+
+  const resp = await client.query(QUERY)
+  console.log(resp)
+}
+
+main().catch(e => console.error(e))

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -533,7 +533,7 @@ The returned documents are paginated by the stack.
     // We need to pass the partialFilter in the selector, otherwise CouchDB might
     // fallback on another index if it does not exist yet
     const mergedSelector = partialFilter
-      ? merge(selector, partialFilter)
+      ? merge({ ...selector }, partialFilter)
       : selector
 
     return {

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -1490,6 +1490,18 @@ describe('DocumentCollection', () => {
       })
     })
 
+    it('should not modify the selector after merge', () => {
+      // This test is made to ensure there is no side-effect on the selector
+      const selector = {
+        name: {
+          $gt: null
+        }
+      }
+      const selectorCopy = { ...selector }
+      collection.toMangoOptions(selector, { partialFilter: { trashed: false } })
+      expect(selector).toEqual(selectorCopy)
+    })
+
     it('should correctly build the sort', () => {
       const selector = {
         name: {


### PR DESCRIPTION
Lodash merge modify the source object to apply the merge
on it.
That was causing errors on queries without `.indexfields` but with
selector and a partial filter.
In such situation, the final selector is a merge between the actual
selector and the partial index.
After the first query, the selector became the merge one.
Then, the query is replayed when the index is missing, this time with
a merged selector.
As the indexed fields were not specified, and we are using the
selector fields to guess them, the resulting index was wrong, as
partially based on the partial filter.