### PR TITLE
fix(useQuery): Enabled option must throw an error

### DIFF
--- a/packages/cozy-client/src/hooks/useQuery.js
+++ b/packages/cozy-client/src/hooks/useQuery.js
@@ -39,6 +39,12 @@ const useQuery = (queryDefinition, options) => {
   }
 
   const { as, enabled = true } = options
+
+  if (typeof enabled !== 'boolean') {
+    throw new Error(
+      `useQuery options.enabled must be a boolean, please check the value given to it.`
+    )
+  }
   // If the query is not enabled, no need to call the queryDefinition
   // because sometimes, we can have a getById(null) since we want to
   // enabled the query only when the specific id is defined. And since

--- a/packages/cozy-client/src/hooks/useQuery.spec.jsx
+++ b/packages/cozy-client/src/hooks/useQuery.spec.jsx
@@ -69,6 +69,36 @@ describe('use query', () => {
     })
     expect(client.query).not.toHaveBeenCalled()
   })
+  it.each`
+    queryOptions                         | error
+    ${{ as: 'simpsons', enabled: '' }}   | ${'useQuery options.enabled must be a boolean, please check the value given to it.'}
+    ${{ as: 'simpsons', enabled: [] }}   | ${'useQuery options.enabled must be a boolean, please check the value given to it.'}
+    ${{ as: 'simpsons', enabled: 0 }}    | ${'useQuery options.enabled must be a boolean, please check the value given to it.'}
+    ${{ as: 'simpsons', enabled: null }} | ${'useQuery options.enabled must be a boolean, please check the value given to it.'}
+  `(
+    `should throw "$error" if no respect the type of the enable property`,
+    ({ queryOptions, error }) => {
+      try {
+        const { hookResult } = setupQuery({
+          queryOptions,
+          queryDefinition: () => Q('io.cozy.simpsons')
+        })
+        expect(hookResult.result.current).toBe(undefined)
+      } catch (err) {
+        expect(err).toEqual(Error(error))
+      }
+    }
+  )
+  it('should not throw error if pass "undefined" of the enable property', () => {
+    const { hookResult } = setupQuery({
+      queryOptions: { as: 'simpsons', enabled: undefined },
+      queryDefinition: () => Q('io.cozy.simpsons')
+    })
+    expect(hookResult.result.current.data).toEqual([
+      { _id: 'homer', _type: 'io.cozy.simpsons', id: 'homer', name: 'Homer' },
+      { _id: 'marge', _type: 'io.cozy.simpsons', id: 'marge', name: 'Marge' }
+    ])
+  })
   it('should respect not throw error if the qDef contains a getById with null', () => {
     const {
       client,


### PR DESCRIPTION
If a non boolean value passed to it

One approach, among others but which seems to me the most appropriate