### PR TITLE
fix: Do not overwrite mandatory fields in updateInformation

### DIFF
--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -227,8 +227,8 @@ class OAuthClient extends CozyStackClient {
       softwareID: this.oauthOptions.softwareID
     }
     const data = this.snakeCaseOAuthData({
-      ...mandatoryFields,
-      ...information
+      ...information,
+      ...mandatoryFields
     })
 
     if (resetSecret) data['client_secret'] = this.oauthOptions.clientSecret


### PR DESCRIPTION
According to the function specification, mandatory fields can not be updated.

So we invert information and mandatoryFields.