### PR TITLE
feat: Add contract type locales

### DIFF
--- a/packages/cozy-client/src/models/document/locales/en.json
+++ b/packages/cozy-client/src/models/document/locales/en.json
@@ -18,7 +18,6 @@
     "successful": {
       "qualified_ok": "You just have successfully described your file! "
     },
-
     "items": {
       "accommodation_proof": "Proof of accommodation",
       "appliance_invoice": "Appliance invoice",
@@ -113,6 +112,15 @@
       "work_invoice": "Work invoice",
       "work_quote": "Work quote",
       "work_study": "Work & Study"
+    },
+    "attributes":{
+      "contractType": {
+        "cdi": "CDI",
+        "cdd": "CDD",
+        "alternate": "Alternate",
+        "internship": "Internship",
+        "other": "Other"
+      }
     },
     "themes": {
       "activity": "Activities",

--- a/packages/cozy-client/src/models/document/locales/fr.json
+++ b/packages/cozy-client/src/models/document/locales/fr.json
@@ -18,7 +18,6 @@
     "successful": {
       "qualified_ok": "Vous venez de qualifier votre fichier avec succès !"
     },
-
     "items": {
       "accommodation_proof": "Attestation d'hébergement",
       "appliance_invoice": "Facture d'électroménager",
@@ -113,6 +112,15 @@
       "work_invoice": "Facture de travaux",
       "work_quote": "Devis de travaux",
       "work_study": "Travail & Études"
+    },
+    "attributes":{
+      "contractType": {
+        "cdi": "CDI",
+        "cdd": "CDD",
+        "alternate": "Alternance",
+        "internship": "Stage",
+        "other": "Autre"
+      }
     },
     "themes": {
       "activity": "Activités & loisirs",


### PR DESCRIPTION
Une metadata `contractType` peut-être utilisé sur les files dans le cas d'une création d'un fichier qualifié `contrat de travail` (l'app MesPapiers par exemple ou plus tard un connecteur).

Dans ce cas, on stocke en valeur le type de contrat sous cette forme `cdi|cdd|alternate|internship`

On veut donc pouvoir traduire cette valeur dans la bonne langue, aussi bien dans les apps (MesPapiers), que les libs (cozy-ui). Nous stockons donc cette information dans cozy-client, récupérable depuis la méthode déjà existante `getBoundT`