### PR TITLE
fix: Update registry types to return Promise

### DIFF
--- a/docs/api/cozy-client/classes/Registry.md
+++ b/docs/api/cozy-client/classes/Registry.md
@@ -16,7 +16,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:39](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L39)
+[packages/cozy-client/src/registry.js:40](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L40)
 
 ## Properties
 
@@ -26,13 +26,13 @@
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:43](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L43)
+[packages/cozy-client/src/registry.js:44](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L44)
 
 ## Methods
 
 ### fetchApp
 
-▸ **fetchApp**(`slug`): `RegistryApp`
+▸ **fetchApp**(`slug`): `Promise`<`RegistryApp`>
 
 Fetch the status of a single app on the registry
 
@@ -44,17 +44,17 @@ Fetch the status of a single app on the registry
 
 *Returns*
 
-`RegistryApp`
+`Promise`<`RegistryApp`>
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:128](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L128)
+[packages/cozy-client/src/registry.js:132](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L132)
 
 ***
 
 ### fetchAppVersion
 
-▸ **fetchAppVersion**(`params`): `RegistryApp`
+▸ **fetchAppVersion**(`params`): `Promise`<`RegistryApp`>
 
 Fetch the latest version of an app for the given channel and slug
 
@@ -69,11 +69,11 @@ Fetch the latest version of an app for the given channel and slug
 
 *Returns*
 
-`RegistryApp`
+`Promise`<`RegistryApp`>
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:142](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L142)
+[packages/cozy-client/src/registry.js:146](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L146)
 
 ***
 
@@ -98,23 +98,23 @@ Fetch at most 200 apps from the channel
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:92](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L92)
+[packages/cozy-client/src/registry.js:96](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L96)
 
 ***
 
 ### fetchAppsInMaintenance
 
-▸ **fetchAppsInMaintenance**(): `RegistryApp`\[]
+▸ **fetchAppsInMaintenance**(): `Promise`<`RegistryApp`\[]>
 
 Fetch the list of apps that are in maintenance mode
 
 *Returns*
 
-`RegistryApp`\[]
+`Promise`<`RegistryApp`\[]>
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L117)
+[packages/cozy-client/src/registry.js:121](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L121)
 
 ***
 
@@ -139,7 +139,7 @@ Accepts the terms if the app has them.
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:55](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L55)
+[packages/cozy-client/src/registry.js:56](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L56)
 
 ***
 
@@ -151,9 +151,9 @@ Uninstalls an app.
 
 *Parameters*
 
-| Name | Type |
-| :------ | :------ |
-| `app` | `any` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `app` | `RegistryApp` | App to be installed |
 
 *Returns*
 
@@ -161,4 +161,4 @@ Uninstalls an app.
 
 *Defined in*
 
-[packages/cozy-client/src/registry.js:76](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L76)
+[packages/cozy-client/src/registry.js:80](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/registry.js#L80)

--- a/packages/cozy-client/src/registry.js
+++ b/packages/cozy-client/src/registry.js
@@ -29,6 +29,7 @@ const getBaseRoute = app => {
  * @property {string} slug
  * @property {object} terms
  * @property {boolean} installed
+ * @property {string} type
  */
 
 /**
@@ -72,6 +73,9 @@ class Registry {
 
   /**
    * Uninstalls an app.
+   *
+   * @param  {RegistryApp} app - App to be installed
+   * @returns {Promise}
    */
   async uninstallApp(app) {
     const { slug } = app
@@ -112,7 +116,7 @@ class Registry {
   /**
    * Fetch the list of apps that are in maintenance mode
    *
-   * @returns {Array<RegistryApp>}
+   * @returns {Promise<Array<RegistryApp>>}
    */
   fetchAppsInMaintenance() {
     return this.client.stackClient.fetchJSON('GET', '/registry/maintenance')
@@ -123,7 +127,7 @@ class Registry {
    *
    * @param  {string} slug - The slug of the app to fetch
    *
-   * @returns {RegistryApp}
+   * @returns {Promise<RegistryApp>}
    */
   fetchApp(slug) {
     return this.client.stackClient.fetchJSON('GET', `/registry/${slug}`)
@@ -137,7 +141,7 @@ class Registry {
    * @param  {RegistryAppChannel} params.channel - The channel of the app to fetch
    * @param  {string} params.version - The version of the app to fetch. Can also be "latest"
    *
-   * @returns {RegistryApp}
+   * @returns {Promise<RegistryApp>}
    */
   fetchAppVersion(params) {
     if (!params.slug) {

--- a/packages/cozy-client/types/registry.d.ts
+++ b/packages/cozy-client/types/registry.d.ts
@@ -5,6 +5,7 @@ export type RegistryApp = {
     slug: string;
     terms: object;
     installed: boolean;
+    type: string;
 };
 export type RegistryAppChannel = "stable" | "dev" | "beta";
 /**
@@ -12,6 +13,7 @@ export type RegistryAppChannel = "stable" | "dev" | "beta";
  * @property {string} slug
  * @property {object} terms
  * @property {boolean} installed
+ * @property {string} type
  */
 /**
  * @typedef {"dev"|"beta"|"stable"} RegistryAppChannel
@@ -31,8 +33,11 @@ declare class Registry {
     installApp(app: RegistryApp, source: string): Promise<any>;
     /**
      * Uninstalls an app.
+     *
+     * @param  {RegistryApp} app - App to be installed
+     * @returns {Promise}
      */
-    uninstallApp(app: any): Promise<any>;
+    uninstallApp(app: RegistryApp): Promise<any>;
     /**
      * Fetch at most 200 apps from the channel
      *
@@ -51,17 +56,17 @@ declare class Registry {
     /**
      * Fetch the list of apps that are in maintenance mode
      *
-     * @returns {Array<RegistryApp>}
+     * @returns {Promise<Array<RegistryApp>>}
      */
-    fetchAppsInMaintenance(): Array<RegistryApp>;
+    fetchAppsInMaintenance(): Promise<Array<RegistryApp>>;
     /**
      * Fetch the status of a single app on the registry
      *
      * @param  {string} slug - The slug of the app to fetch
      *
-     * @returns {RegistryApp}
+     * @returns {Promise<RegistryApp>}
      */
-    fetchApp(slug: string): RegistryApp;
+    fetchApp(slug: string): Promise<RegistryApp>;
     /**
      * Fetch the latest version of an app for the given channel and slug
      *
@@ -70,11 +75,11 @@ declare class Registry {
      * @param  {RegistryAppChannel} params.channel - The channel of the app to fetch
      * @param  {string} params.version - The version of the app to fetch. Can also be "latest"
      *
-     * @returns {RegistryApp}
+     * @returns {Promise<RegistryApp>}
      */
     fetchAppVersion(params: {
         slug: string;
         channel: RegistryAppChannel;
         version: string;
-    }): RegistryApp;
+    }): Promise<RegistryApp>;
 }


### PR DESCRIPTION
Some methods of Registry, use stackClient method `fetchJSON` which return a promise. I adapt the return type to match this specification