### PR TITLE
fix: Do not rely on potentially missing datetime

### DIFF
--- a/packages/cozy-client/src/associations/HasManyFiles.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.js
@@ -23,6 +23,17 @@ const newCursor = ([doctype, id, lastDatetime], startDocId) => {
 }
 
 /**
+ * Get the file datetime
+ *
+ * @param  {import('../types').IOCozyFile} file - io.cozy.files document
+ * @returns {string} The file datetime
+ */
+export const getFileDatetime = file => {
+  // Some files do not have any metadata, e.g. bitmap files.
+  return file.metadata?.datetime || file.created_at
+}
+
+/**
  *  This class is only used for photos albums relationships.
  *  Behind the hood, the queries uses a view returning the files sorted
  *  by datetime, with a cursor-based pagination.
@@ -48,8 +59,7 @@ export default class HasManyFiles extends HasMany {
         lastRelationship._type,
         lastRelationship._id
       )
-      // Photos always have a datetime field in metadata
-      const lastDatetime = lastRelDoc.attributes.metadata.datetime
+      const lastDatetime = getFileDatetime(lastRelDoc.attributes)
       // cursor-based pagination
       const cursor = newCursor(
         [this.target._type, this.target._id, lastDatetime],

--- a/packages/cozy-client/src/associations/HasManyFiles.spec.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.spec.js
@@ -1,5 +1,5 @@
 import { DOCTYPE_FILES } from '../const'
-import HasManyFiles from './HasManyFiles'
+import HasManyFiles, { getFileDatetime } from './HasManyFiles'
 
 describe('HasManyFiles', () => {
   let originalFile, hydratedFile, originalTodo, hydratedTodo, save, mutate
@@ -153,5 +153,23 @@ describe('HasManyFiles', () => {
 
     expect(queryDef.doctype).toEqual('io.cozy.todos')
     expect(queryDef.ids).toEqual(['1234'])
+  })
+})
+
+describe('getFileDatetime', () => {
+  it('should get the metadata datetime when it exists', () => {
+    const file = {
+      created_at: '2023-01-01',
+      metadata: {
+        datetime: '2023-02-01'
+      }
+    }
+    expect(getFileDatetime(file)).toEqual('2023-02-01')
+  })
+  it('should get the created_at when there is no datetime metadata', () => {
+    const file = {
+      created_at: '2023-01-01'
+    }
+    expect(getFileDatetime(file)).toEqual('2023-01-01')
   })
 })

--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -239,6 +239,7 @@ import { QueryDefinition } from './queries/dsl'
  * @property {string} [expirationDate] - Expiration date of the paper
  * @property {string} [referencedDate] - Reference date of the paper
  * @property {string} [noticePeriod] - Notice period of the paper, in days
+ * @property {string} [datetime] - Image EXIF date, if relevant
  */
 
 /**

--- a/packages/cozy-client/types/associations/HasManyFiles.d.ts
+++ b/packages/cozy-client/types/associations/HasManyFiles.d.ts
@@ -1,3 +1,4 @@
+export function getFileDatetime(file: import('../types').IOCozyFile): string;
 /**
  *  This class is only used for photos albums relationships.
  *  Behind the hood, the queries uses a view returning the files sorted

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -361,6 +361,10 @@ export type FileMetadata = {
      * - Notice period of the paper, in days
      */
     noticePeriod?: string;
+    /**
+     * - Image EXIF date, if relevant
+     */
+    datetime?: string;
 };
 /**
  * - An io.cozy.files document


### PR DESCRIPTION
Some images such as bitmaps do not have any `metadata` object.
However, we were relying on the existence of a `metadata.datetime` date
in order to build the cursor for fetching HasManyFiles relationship,
which was causing errors in the photos clustering service.

Kudos to the inspector @Crash-- for finding out this bug :clap: 