### PR TITLE
fix: Normalize doc for fetchChanges

### DIFF
--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -827,7 +827,10 @@ The returned documents are paginated by the stack.
     if (!options.includeDeleted) {
       docs = docs.filter(doc => !doc._deleted)
     }
-    return { newLastSeq, documents: docs }
+    return {
+      newLastSeq,
+      documents: docs.map(doc => normalizeDoc(doc, this.doctype))
+    }
   }
 }
 

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -1251,7 +1251,15 @@ describe('DocumentCollection', () => {
       )
       expect(changes).toEqual({
         newLastSeq: 'new-seq',
-        documents: [{ _id: '1', done: false, label: 'Fetch changes' }]
+        documents: [
+          {
+            _id: '1',
+            id: '1',
+            _type: 'io.cozy.todos',
+            done: false,
+            label: 'Fetch changes'
+          }
+        ]
       })
     })
 
@@ -1262,8 +1270,20 @@ describe('DocumentCollection', () => {
       expect(changes).toEqual({
         newLastSeq: 'new-seq',
         documents: [
-          { _id: '1', done: false, label: 'Fetch changes' },
-          { _id: '2', _deleted: true, label: 'Refactor code' }
+          {
+            _id: '1',
+            id: '1',
+            _type: 'io.cozy.todos',
+            done: false,
+            label: 'Fetch changes'
+          },
+          {
+            _id: '2',
+            id: '2',
+            _type: 'io.cozy.todos',
+            _deleted: true,
+            label: 'Refactor code'
+          }
         ]
       })
     })
@@ -1275,8 +1295,14 @@ describe('DocumentCollection', () => {
       expect(changes).toEqual({
         newLastSeq: 'new-seq',
         documents: [
-          { _id: '1', done: false, label: 'Fetch changes' },
-          { _id: '_design/view' }
+          {
+            _id: '1',
+            id: '1',
+            _type: 'io.cozy.todos',
+            done: false,
+            label: 'Fetch changes'
+          },
+          { _id: '_design/view', id: '_design/view', _type: 'io.cozy.todos' }
         ]
       })
     })


### PR DESCRIPTION
Recently, we changed in Banks from
BankTransaction.updateAll() to client.saveAll().

But we had errors in our log saying that we were
calling collection without a doctype
(CozyStackClient.collection() called without a doctype)

In fact, this is because saveAll need to read the
_type for the documents to update them cf:
https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L122

Sometime it worked for Banks sometime not. It was due to the fact that we have a condition here:
https://github.com/cozy/cozy-banks/blob/master/src/targets/services/helpers/helpers.js#L19-L45

The fix, is to normalize the document returned by fetchChanges() like that we add _type & id automatically.

We have a fetchChangesRaw() to get the real changes without any edition.