### PR TITLE
fix: Correctly type nullable return for `useClient()`

### DIFF
--- a/packages/cozy-client/src/context.js
+++ b/packages/cozy-client/src/context.js
@@ -2,7 +2,7 @@ import { createContext } from 'react'
 import CozyClient from './CozyClient'
 
 export const clientContext = createContext({
-  /** @type {CozyClient}  */
+  /** @type {CozyClient|null}  */
   client: null,
   store: null
 })

--- a/packages/cozy-client/src/hooks/useClient.js
+++ b/packages/cozy-client/src/hooks/useClient.js
@@ -4,7 +4,7 @@ import CozyClient from '../CozyClient'
 /**
  * Returns the cozy client from the context
  *
- * @returns {CozyClient} - Current cozy client
+ * @returns {CozyClient|null} - Current cozy client
  */
 const useClient = () => {
   const { client } = useContext(clientContext)

--- a/packages/cozy-client/types/context.d.ts
+++ b/packages/cozy-client/types/context.d.ts
@@ -1,6 +1,6 @@
 export const clientContext: import("react").Context<{
-    /** @type {CozyClient}  */
-    client: CozyClient;
+    /** @type {CozyClient|null}  */
+    client: CozyClient | null;
     store: any;
 }>;
 export default clientContext;

--- a/packages/cozy-client/types/hooks/useClient.d.ts
+++ b/packages/cozy-client/types/hooks/useClient.d.ts
@@ -2,7 +2,7 @@ export default useClient;
 /**
  * Returns the cozy client from the context
  *
- * @returns {CozyClient} - Current cozy client
+ * @returns {CozyClient|null} - Current cozy client
  */
-declare function useClient(): CozyClient;
+declare function useClient(): CozyClient | null;
 import CozyClient from "../CozyClient";


### PR DESCRIPTION
If no `CozyProvider` is set on the components tree, then `useClient()` would return no `client`