### PR TITLE
feat: JobCollection extends DocumentCollection

### DIFF
--- a/packages/cozy-stack-client/src/JobCollection.js
+++ b/packages/cozy-stack-client/src/JobCollection.js
@@ -1,5 +1,5 @@
 import Collection from './Collection'
-import { normalizeDoc } from './DocumentCollection'
+import DocumentCollection, { normalizeDoc } from './DocumentCollection'
 import { uri } from './utils'
 
 export const JOBS_DOCTYPE = 'io.cozy.jobs'
@@ -27,10 +27,11 @@ export const hasJobFinished = job => {
  * @property {string} attributes.error - Error message of the job if any
  */
 
-class JobCollection {
+class JobCollection extends DocumentCollection {
   constructor(stackClient) {
-    this.stackClient = stackClient
+    super(JOBS_DOCTYPE, stackClient)
   }
+
   queued(workerType) {
     return this.stackClient.fetchJSON('GET', `/jobs/queue/${workerType}`)
   }


### PR DESCRIPTION
Every colleciton should extend `DocumentCollection` to benefit from
the fallback methods when not defined specifically.
`JobCollection` was not extending it and has no `find` method so we
could not make use `CozyClient#query()` for example.