### PR TITLE
Fix/deconstruct redirect link api

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -21,6 +21,7 @@ cozy-client
 *   [HasOneInPlace](classes/HasOneInPlace.md)
 *   [InvalidCozyUrlError](classes/InvalidCozyUrlError.md)
 *   [InvalidProtocolError](classes/InvalidProtocolError.md)
+*   [InvalidRedirectLinkError](classes/InvalidRedirectLinkError.md)
 *   [Query](classes/Query.md)
 *   [QueryDefinition](classes/QueryDefinition.md)
 *   [Registry](classes/Registry.md)
@@ -221,7 +222,9 @@ Deconstructed link
 
 ▸ **deconstructRedirectLink**(`redirectLink`): `RedirectLinkData`
 
-Deconstruct the given redirect link in order to retrieve slug and hash
+Deconstruct the given redirect link in order to retrieve slug, pathname and hash
+
+**`throws`** {InvalidRedirectLinkError} Thrown when redirect link is invalid
 
 *Parameters*
 
@@ -237,7 +240,7 @@ Deconstructed link
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:105](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L105)
+[packages/cozy-client/src/helpers/urlHelper.js:108](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L108)
 
 ***
 
@@ -612,7 +615,7 @@ The root Cozy URL
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:236](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L236)
+[packages/cozy-client/src/helpers/urlHelper.js:251](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L251)
 
 ***
 

--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -227,7 +227,7 @@ Deconstruct the given redirect link in order to retrieve slug and hash
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `redirectLink` | `string` | redirect link to deconstruct (i.e. 'slug/#/path') |
+| `redirectLink` | `string` | redirect link to deconstruct (i.e. 'drive/public/#/folder/SOME_ID') |
 
 *Returns*
 

--- a/docs/api/cozy-client/classes/InvalidCozyUrlError.md
+++ b/docs/api/cozy-client/classes/InvalidCozyUrlError.md
@@ -26,7 +26,7 @@ Error.constructor
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L125)
+[packages/cozy-client/src/helpers/urlHelper.js:140](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L140)
 
 ## Properties
 
@@ -36,4 +36,4 @@ Error.constructor
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:128](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L128)
+[packages/cozy-client/src/helpers/urlHelper.js:143](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L143)

--- a/docs/api/cozy-client/classes/InvalidProtocolError.md
+++ b/docs/api/cozy-client/classes/InvalidProtocolError.md
@@ -26,7 +26,7 @@ Error.constructor
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L117)
+[packages/cozy-client/src/helpers/urlHelper.js:132](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L132)
 
 ## Properties
 
@@ -36,4 +36,4 @@ Error.constructor
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:120](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L120)
+[packages/cozy-client/src/helpers/urlHelper.js:135](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L135)

--- a/docs/api/cozy-client/classes/InvalidRedirectLinkError.md
+++ b/docs/api/cozy-client/classes/InvalidRedirectLinkError.md
@@ -1,0 +1,39 @@
+[cozy-client](../README.md) / InvalidRedirectLinkError
+
+# Class: InvalidRedirectLinkError
+
+## Hierarchy
+
+*   `Error`
+
+    ↳ **`InvalidRedirectLinkError`**
+
+## Constructors
+
+### constructor
+
+• **new InvalidRedirectLinkError**(`redirectLink`)
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `redirectLink` | `any` |
+
+*Overrides*
+
+Error.constructor
+
+*Defined in*
+
+[packages/cozy-client/src/helpers/urlHelper.js:124](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L124)
+
+## Properties
+
+### redirectLink
+
+• **redirectLink**: `any`
+
+*Defined in*
+
+[packages/cozy-client/src/helpers/urlHelper.js:127](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L127)

--- a/packages/cozy-client/src/helpers/index.js
+++ b/packages/cozy-client/src/helpers/index.js
@@ -4,6 +4,7 @@ export {
   generateWebLink,
   ensureFirstSlash,
   rootCozyUrl,
+  InvalidRedirectLinkError,
   InvalidCozyUrlError,
   InvalidProtocolError
 } from './urlHelper'

--- a/packages/cozy-client/src/helpers/urlHelper.js
+++ b/packages/cozy-client/src/helpers/urlHelper.js
@@ -95,21 +95,36 @@ export const deconstructCozyWebLinkWithSlug = (
   }
 }
 
+const isValidSlug = slug => slug.match(/^[a-z0-9]+$/)
+
 /**
- * Deconstruct the given redirect link in order to retrieve slug and hash
+ * Deconstruct the given redirect link in order to retrieve slug, pathname and hash
  *
  * @param {string} redirectLink - redirect link to deconstruct (i.e. 'drive/public/#/folder/SOME_ID')
  * @returns {RedirectLinkData} Deconstructed link
+ * @throws {InvalidRedirectLinkError} Thrown when redirect link is invalid
  */
 
 export const deconstructRedirectLink = redirectLink => {
   const [splits, hash] = redirectLink.split('#')
   const [slug, pathname] = splits.split(/\/(.*)/)
 
+  if (!isValidSlug(slug)) {
+    throw new InvalidRedirectLinkError(redirectLink)
+  }
+
   return {
     slug,
     pathname,
     hash
+  }
+}
+
+export class InvalidRedirectLinkError extends Error {
+  constructor(redirectLink) {
+    super(`Invalid redirect link ${redirectLink}`)
+
+    this.redirectLink = redirectLink
   }
 }
 

--- a/packages/cozy-client/src/helpers/urlHelper.js
+++ b/packages/cozy-client/src/helpers/urlHelper.js
@@ -98,17 +98,17 @@ export const deconstructCozyWebLinkWithSlug = (
 /**
  * Deconstruct the given redirect link in order to retrieve slug and hash
  *
- * @param {string} redirectLink - redirect link to deconstruct (i.e. 'slug/#/path')
+ * @param {string} redirectLink - redirect link to deconstruct (i.e. 'drive/public/#/folder/SOME_ID')
  * @returns {RedirectLinkData} Deconstructed link
  */
 
 export const deconstructRedirectLink = redirectLink => {
   const [splits, hash] = redirectLink.split('#')
-  const [slug, path] = splits.split(/\/(.*)/)
+  const [slug, pathname] = splits.split(/\/(.*)/)
 
   return {
     slug,
-    path,
+    pathname,
     hash
   }
 }

--- a/packages/cozy-client/src/helpers/urlHelper.spec.js
+++ b/packages/cozy-client/src/helpers/urlHelper.spec.js
@@ -5,6 +5,7 @@ import {
   deconstructRedirectLink,
   generateWebLink,
   rootCozyUrl,
+  InvalidRedirectLinkError,
   InvalidCozyUrlError,
   InvalidProtocolError
 } from './urlHelper'
@@ -162,6 +163,15 @@ describe('deconstructRedirectLink', () => {
     ]
   ])('should deconstruct %p redirect link', (link, result) => {
     expect(deconstructRedirectLink(link)).toEqual(result)
+  })
+
+  it.each([
+    ['camillenimbus-photos.mycozy.cloud'],
+    ['http://camillenimbus-photos.mycozy.cloud']
+  ])('should throw when redirect link is invalid', link => {
+    expect(() => deconstructRedirectLink(link)).toThrow(
+      InvalidRedirectLinkError
+    )
   })
 })
 

--- a/packages/cozy-client/src/helpers/urlHelper.spec.js
+++ b/packages/cozy-client/src/helpers/urlHelper.spec.js
@@ -124,7 +124,7 @@ describe('deconstructRedirectLink', () => {
       'contacts/#/',
       {
         slug: 'contacts',
-        path: '',
+        pathname: '',
         hash: '/'
       }
     ],
@@ -132,7 +132,7 @@ describe('deconstructRedirectLink', () => {
       'contacts/#/hash',
       {
         slug: 'contacts',
-        path: '',
+        pathname: '',
         hash: '/hash'
       }
     ],
@@ -140,23 +140,23 @@ describe('deconstructRedirectLink', () => {
       'contacts/#/long/hash',
       {
         slug: 'contacts',
-        path: '',
+        pathname: '',
         hash: '/long/hash'
       }
     ],
     [
-      'contacts/path/#/long/hash',
+      'contacts/pathname/#/long/hash',
       {
         slug: 'contacts',
-        path: 'path/',
+        pathname: 'pathname/',
         hash: '/long/hash'
       }
     ],
     [
-      'contacts/long/path/#/long/hash',
+      'contacts/long/pathname/#/long/hash',
       {
         slug: 'contacts',
-        path: 'long/path/',
+        pathname: 'long/pathname/',
         hash: '/long/hash'
       }
     ]

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -30,6 +30,7 @@ export {
   generateWebLink,
   ensureFirstSlash,
   rootCozyUrl,
+  InvalidRedirectLinkError,
   InvalidCozyUrlError,
   InvalidProtocolError
 } from './helpers'

--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -494,7 +494,7 @@ import { QueryDefinition } from './queries/dsl'
  *
  * @typedef {object} RedirectLinkData
  * @property {string} slug - The redirect link's slug (i.e. 'drive')
- * @property {string} path - The redirect link's path (i.e. 'public')
+ * @property {string} pathname - The redirect link's path (i.e. 'public')
  * @property {string} hash - The redirect link's path (i.e. '/folder/SOME_FOLDER_ID')
  */
 

--- a/packages/cozy-client/types/helpers/index.d.ts
+++ b/packages/cozy-client/types/helpers/index.d.ts
@@ -1,2 +1,2 @@
 export { dehydrate } from "./dehydrateHelper";
-export { deconstructCozyWebLinkWithSlug, deconstructRedirectLink, generateWebLink, ensureFirstSlash, rootCozyUrl, InvalidCozyUrlError, InvalidProtocolError } from "./urlHelper";
+export { deconstructCozyWebLinkWithSlug, deconstructRedirectLink, generateWebLink, ensureFirstSlash, rootCozyUrl, InvalidRedirectLinkError, InvalidCozyUrlError, InvalidProtocolError } from "./urlHelper";

--- a/packages/cozy-client/types/helpers/urlHelper.d.ts
+++ b/packages/cozy-client/types/helpers/urlHelper.d.ts
@@ -9,6 +9,10 @@ export function generateWebLink({ cozyUrl, searchParams: searchParamsOption, pat
 }): string;
 export function deconstructCozyWebLinkWithSlug(webLink: string, subDomainType?: SubdomainType): CozyLinkData;
 export function deconstructRedirectLink(redirectLink: string): RedirectLinkData;
+export class InvalidRedirectLinkError extends Error {
+    constructor(redirectLink: any);
+    redirectLink: any;
+}
 export class InvalidProtocolError extends Error {
     constructor(url: any);
     url: any;

--- a/packages/cozy-client/types/index.d.ts
+++ b/packages/cozy-client/types/index.d.ts
@@ -19,6 +19,6 @@ export { manifest, models };
 export { QueryDefinition, Q, Mutations, MutationTypes, getDoctypeFromOperation } from "./queries/dsl";
 export { Association, HasMany, HasOne, HasOneInPlace, HasManyInPlace, HasManyTriggers } from "./associations";
 export { isReferencedBy, isReferencedById, getReferencedBy, getReferencedById } from "./associations/helpers";
-export { deconstructCozyWebLinkWithSlug, deconstructRedirectLink, dehydrate, generateWebLink, ensureFirstSlash, rootCozyUrl, InvalidCozyUrlError, InvalidProtocolError } from "./helpers";
+export { deconstructCozyWebLinkWithSlug, deconstructRedirectLink, dehydrate, generateWebLink, ensureFirstSlash, rootCozyUrl, InvalidRedirectLinkError, InvalidCozyUrlError, InvalidProtocolError } from "./helpers";
 export { cancelable, isQueryLoading, hasQueryBeenLoaded } from "./utils";
 export { queryConnect, queryConnectFlat, withClient } from "./hoc";

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -746,7 +746,7 @@ export type RedirectLinkData = {
     /**
      * - The redirect link's path (i.e. 'public')
      */
-    path: string;
+    pathname: string;
     /**
      * - The redirect link's path (i.e. '/folder/SOME_FOLDER_ID')
      */


### PR DESCRIPTION
## Harmonize deconstructRedirectLink return path to pathname

deconstructRedirectLink is useful with generateWebLink.
But for the same value, deconstructRedirectLink uses the name "path"
and generateWebLink uses the name "pathname".

BREAKING CHANGE: deconstructRedirectLink return an object
with an attribute called "pathname" instead of "path".

## Throw when redirect link not correct in deconstructRedirectLink

deconstructRedirectLink was returning  nonsense when we gave
it an incorrect redirect link. Now, it throws when the slug returned
is not valid.