### PR TITLE
fix: Use id instead of path in SettingsCollection.get()

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -1654,6 +1654,11 @@ Destroy a sharing link and the related permissions
 Implements `DocumentCollection` API to interact with the /settings endpoint of the stack
 
 **Kind**: global class  
+
+* [SettingsCollection](#SettingsCollection)
+    * [.get(id)](#SettingsCollection+get) ⇒ <code>object</code>
+    * [.update(document)](#SettingsCollection+update)
+
 <a name="SettingsCollection+get"></a>
 
 ### settingsCollection.get(id) ⇒ <code>object</code>
@@ -1665,6 +1670,17 @@ async get - Calls a route on the /settings API
 | Param | Type | Description |
 | --- | --- | --- |
 | id | <code>string</code> | The setting id to call, eg `io.cozy.settings.instance` for `instance` route or `io.cozy.settings.context` for `context`route |
+
+<a name="SettingsCollection+update"></a>
+
+### settingsCollection.update(document)
+Updates a settings document
+
+**Kind**: instance method of [<code>SettingsCollection</code>](#SettingsCollection)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | <code>object</code> | Document to update. Do not forget the _id attribute |
 
 <a name="SharingCollection"></a>
 

--- a/packages/cozy-stack-client/src/SettingsCollection.js
+++ b/packages/cozy-stack-client/src/SettingsCollection.js
@@ -1,5 +1,6 @@
-import DocumentCollection from './DocumentCollection'
+import DocumentCollection, { normalizeDoc } from './DocumentCollection'
 import logger from './logger'
+import { uri } from './utils'
 
 export const SETTINGS_DOCTYPE = 'io.cozy.settings'
 
@@ -38,6 +39,33 @@ class SettingsCollection extends DocumentCollection {
         { id: `/settings/${path}`, ...resp.data },
         resp
       )
+    }
+  }
+
+  /**
+   * Updates a settings document
+   *
+   * @param {object} document - Document to update. Do not forget the _id attribute
+   */
+  async update(document) {
+    let resp
+
+    if (document._id === 'io.cozy.settings.instance') {
+      resp = await this.stackClient.fetchJSON(
+        'PUT',
+        '/settings/instance',
+        document
+      )
+    } else {
+      resp = await this.stackClient.fetchJSON(
+        'PUT',
+        uri`/data/${this.doctype}/${document._id}`,
+        document
+      )
+    }
+
+    return {
+      data: normalizeDoc(resp.data, this.doctype)
     }
   }
 }


### PR DESCRIPTION
Previously, get was receiveing a path like "instance". This path was used to call a correct route like "/settings/instance" but was also used internally as an id for store stuff. But the id of the document behind "/settings/instance" is
"io.cozy.settings.instance" and not "instance" leading to store issue.