### PR TITLE
feat: Expose setAppMetadata

### DIFF
--- a/docs/api/cozy-client/classes/CozyClient.md
+++ b/docs/api/cozy-client/classes/CozyClient.md
@@ -1588,6 +1588,26 @@ Saves multiple documents in one batch
 
 ***
 
+### setAppMetadata
+
+▸ **setAppMetadata**(`newAppMetadata`): `void`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `newAppMetadata` | `any` | AppMetadata to update |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:1746](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1746)
+
+***
+
 ### setData
 
 ▸ **setData**(`data`): `void`

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -1739,6 +1739,16 @@ instantiation of the client.`
   toJSON() {
     return new SnapshotClient({ uri: this.options.uri })
   }
+  /**
+   *
+   * @param {AppMetadata} newAppMetadata AppMetadata to update
+   */
+  setAppMetadata(newAppMetadata) {
+    this.appMetadata = {
+      ...this.appMetadata,
+      ...newAppMetadata
+    }
+  }
 }
 
 CozyClient.hooks = CozyClient.hooks || {}

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -698,7 +698,13 @@ describe('CozyClient', () => {
   afterEach(() => {
     requestHandler.mockReset()
   })
-
+  describe('setAppMetadata', () => {
+    it('should update the appMetadata', () => {
+      client.setAppMetadata({ slug: 'test' })
+      expect(client.appMetadata.slug).toEqual('test')
+      expect(client.appMetadata.sourceAccount).toEqual(SOURCE_ACCOUNT_ID)
+    })
+  })
   describe('all', () => {
     it('should return a QueryDefinition', () => {
       expect(Q('io.cozy.todos')).toEqual({ doctype: 'io.cozy.todos' })

--- a/packages/cozy-client/types/CozyClient.d.ts
+++ b/packages/cozy-client/types/CozyClient.d.ts
@@ -708,6 +708,11 @@ declare class CozyClient {
      */
     setOnError(onError?: Function): void;
     toJSON(): SnapshotClient;
+    /**
+     *
+     * @param {AppMetadata} newAppMetadata AppMetadata to update
+     */
+    setAppMetadata(newAppMetadata: AppMetadata): void;
 }
 declare namespace CozyClient {
     export const hooks: {};


### PR DESCRIPTION
In the context of the flagship app, we create a new CozyClient for the clisk. We set the appMetadata we have when we do the instanciation aka slug & version. But in some scenario, we don't have yet the accountIdentifier. So we can't pass it at this moment.

In order to still write this metadata, we now expose a setAppMetadata() to be able to use it later after the creation of the client.

Related PR https://github.com/cozy/cozy-flagship-app/pull/706 