### PR TITLE
fix: Handle undefined `pathname` in `generateWebLink()` method

### DIFF
--- a/packages/cozy-client/src/helpers/urlHelper.js
+++ b/packages/cozy-client/src/helpers/urlHelper.js
@@ -44,7 +44,7 @@ export const generateWebLink = ({
           .split('.')
           .map((x, i) => (i === 0 ? x + '-' + slug : x))
           .join('.')
-  url.pathname = pathname
+  url.pathname = ensureFirstSlash(pathname)
   url.hash = ensureFirstSlash(hash)
 
   for (const [param, value] of searchParams) {

--- a/packages/cozy-client/src/helpers/urlHelper.spec.js
+++ b/packages/cozy-client/src/helpers/urlHelper.spec.js
@@ -40,6 +40,18 @@ describe('generateWebLink', () => {
       })
     ).toEqual(`https://drive.alice.cozy.tools/public/#/files/432432`)
   })
+
+  it('should handle undefined pathname', () => {
+    expect(
+      generateWebLink({
+        cozyUrl: 'https://alice.cozy.tools',
+        pathname: undefined,
+        hash: 'files/432432',
+        slug: 'drive',
+        subDomainType: 'nested'
+      })
+    ).toEqual(`https://drive.alice.cozy.tools/#/files/432432`)
+  })
 })
 
 describe('deconstructWebLink', () => {


### PR DESCRIPTION
The URL javascript object does not support undefined `pathname`. This member should be an empty string (transformed to `/`) or have a value

```js
const url = new URL('https://cozy.io')
console.log(url.pathname) // prints '/'
console.log(url.toString()) // prints 'https://cozy.io/'

url.pathname = undefined
console.log(url.pathname) // prints '/undefined'
console.log(url.toString()) // prints 'https://cozy.io/undefined'

url.pathname = ''
console.log(url.pathname) // prints '/'
console.log(url.toString()) // prints 'https://cozy.io/'

url.pathname = ensureFirstSlash(undefined)
console.log(url.pathname) // prints '/'
console.log(url.toString()) // prints 'https://cozy.io/'
```

By using 'ensureFirstSlash' method we ensure that the caller can pass undefined `pathname` without negative side effect