### PR TITLE
fix: Use io.cozy.settings.capabilities full id in getById

### DIFF
--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -1699,7 +1699,7 @@ instantiation of the client.`
    */
   async loadInstanceOptionsFromStack() {
     const { data } = await this.query(
-      Q('io.cozy.settings').getById('capabilities')
+      Q('io.cozy.settings').getById('io.cozy.settings.capabilities')
     )
 
     this.instanceOptions = {

--- a/packages/cozy-client/src/hooks/useCapabilities.jsx
+++ b/packages/cozy-client/src/hooks/useCapabilities.jsx
@@ -10,7 +10,7 @@ const useCapabilities = client => {
       setFetchStatus('loading')
       try {
         const capabilitiesResult = await client.query(
-          Q('io.cozy.settings').getById('capabilities')
+          Q('io.cozy.settings').getById('io.cozy.settings.capabilities')
         )
 
         setCapabilities(get(capabilitiesResult, 'data.attributes', {}))


### PR DESCRIPTION
The new recommended way. Also to avoid to flood log in flagship-app.