### PR TITLE
fix: Use the right id

### DIFF
--- a/packages/cozy-client/src/hooks/useCapabilities.jsx
+++ b/packages/cozy-client/src/hooks/useCapabilities.jsx
@@ -10,7 +10,7 @@ const useCapabilities = client => {
       setFetchStatus('loading')
       try {
         const capabilitiesResult = await client.query(
-          Q('io.cozy.settings').getById('capabilities')
+          Q('io.cozy.settings').getById('io.cozy.settings.capabilities')
         )
 
         setCapabilities(get(capabilitiesResult, 'data.attributes', {}))


### PR DESCRIPTION
In order to remove warning: 

```
Deprecated: in next versions of cozy-client, it will not be possible to query settings with an incomplete id

- Q('io.cozy.settings').getById('capabilities')
+ Q('io.cozy.settings').getById('io.cozy.settings.capabilities')
```