### PR TITLE
refactor: Remove JS import for the JSDoc one

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -214,7 +214,7 @@ Deconstructed link
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:66](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L66)
+[packages/cozy-client/src/helpers/urlHelper.js:64](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L64)
 
 ***
 
@@ -240,7 +240,7 @@ Deconstructed link
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:108](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L108)
+[packages/cozy-client/src/helpers/urlHelper.js:106](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L106)
 
 ***
 
@@ -280,7 +280,7 @@ Deconstructed link
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:3](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L3)
+[packages/cozy-client/src/helpers/urlHelper.js:1](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L1)
 
 ***
 
@@ -315,7 +315,7 @@ Generated URL
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:29](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L29)
+[packages/cozy-client/src/helpers/urlHelper.js:27](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L27)
 
 ***
 
@@ -381,7 +381,7 @@ Array of references found
 
 *Defined in*
 
-[packages/cozy-client/src/associations/helpers.js:134](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/helpers.js#L134)
+[packages/cozy-client/src/associations/helpers.js:133](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/helpers.js#L133)
 
 ***
 
@@ -407,7 +407,7 @@ Array of the reference found
 
 *Defined in*
 
-[packages/cozy-client/src/associations/helpers.js:148](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/helpers.js#L148)
+[packages/cozy-client/src/associations/helpers.js:147](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/helpers.js#L147)
 
 ***
 
@@ -477,7 +477,7 @@ If a reference is found
 
 *Defined in*
 
-[packages/cozy-client/src/associations/helpers.js:102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/helpers.js#L102)
+[packages/cozy-client/src/associations/helpers.js:101](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/helpers.js#L101)
 
 ***
 
@@ -503,7 +503,7 @@ If a reference is found
 
 *Defined in*
 
-[packages/cozy-client/src/associations/helpers.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/helpers.js#L117)
+[packages/cozy-client/src/associations/helpers.js:116](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/helpers.js#L116)
 
 ***
 
@@ -615,7 +615,7 @@ The root Cozy URL
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:251](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L251)
+[packages/cozy-client/src/helpers/urlHelper.js:249](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L249)
 
 ***
 
@@ -667,7 +667,7 @@ An array with all apps in maintenance
 
 *Defined in*
 
-[packages/cozy-client/src/hooks/useAppsInMaintenance.jsx:13](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hooks/useAppsInMaintenance.jsx#L13)
+[packages/cozy-client/src/hooks/useAppsInMaintenance.jsx:12](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hooks/useAppsInMaintenance.jsx#L12)
 
 ***
 
@@ -760,7 +760,7 @@ Fetches a queryDefinition and returns the queryState
 
 *Defined in*
 
-[packages/cozy-client/src/hooks/useQuery.js:29](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hooks/useQuery.js#L29)
+[packages/cozy-client/src/hooks/useQuery.js:28](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hooks/useQuery.js#L28)
 
 ***
 
@@ -783,7 +783,7 @@ Fetches a queryDefinition and run fetchMore on the query until the query is full
 
 *Defined in*
 
-[packages/cozy-client/src/hooks/useQueryAll.jsx:15](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hooks/useQueryAll.jsx#L15)
+[packages/cozy-client/src/hooks/useQueryAll.jsx:14](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hooks/useQueryAll.jsx#L14)
 
 ***
 

--- a/docs/api/cozy-client/classes/Association.md
+++ b/docs/api/cozy-client/classes/Association.md
@@ -106,7 +106,7 @@ Each different type of Association may change:
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:88](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L88)
+[packages/cozy-client/src/associations/Association.js:87](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L87)
 
 ## Properties
 
@@ -118,7 +118,7 @@ Dispatch an action on the store.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:145](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L145)
+[packages/cozy-client/src/associations/Association.js:144](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L144)
 
 ***
 
@@ -132,7 +132,7 @@ Doctype of the relationship
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:110](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L110)
+[packages/cozy-client/src/associations/Association.js:109](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L109)
 
 ***
 
@@ -144,7 +144,7 @@ Returns the document from the store
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L117)
+[packages/cozy-client/src/associations/Association.js:116](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L116)
 
 ***
 
@@ -158,7 +158,7 @@ Performs a mutation on the relationship.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:132](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L132)
+[packages/cozy-client/src/associations/Association.js:131](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L131)
 
 ***
 
@@ -172,7 +172,7 @@ The name of the relationship.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L102)
+[packages/cozy-client/src/associations/Association.js:101](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L101)
 
 ***
 
@@ -188,7 +188,7 @@ Performs a query to retrieve relationship documents.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L125)
+[packages/cozy-client/src/associations/Association.js:124](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L124)
 
 ***
 
@@ -200,7 +200,7 @@ Saves the relationship in store.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L139)
+[packages/cozy-client/src/associations/Association.js:138](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L138)
 
 ***
 
@@ -212,7 +212,7 @@ The original document declaring the relationship
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:95](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L95)
+[packages/cozy-client/src/associations/Association.js:94](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L94)
 
 ## Accessors
 
@@ -257,7 +257,7 @@ Derived `Association`s need to implement this method.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:219](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L219)
+[packages/cozy-client/src/associations/Association.js:218](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L218)
 
 ***
 
@@ -300,7 +300,7 @@ Derived `Association`s need to implement this method.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:181](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L181)
+[packages/cozy-client/src/associations/Association.js:180](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L180)
 
 ## Methods
 
@@ -324,4 +324,4 @@ Derived `Association`s need to implement this method.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:232](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L232)
+[packages/cozy-client/src/associations/Association.js:231](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L231)

--- a/docs/api/cozy-client/classes/BulkEditError.md
+++ b/docs/api/cozy-client/classes/BulkEditError.md
@@ -29,7 +29,7 @@ Error.constructor
 
 *Defined in*
 
-[packages/cozy-client/src/errors.js:11](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/errors.js#L11)
+[packages/cozy-client/src/errors.js:10](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/errors.js#L10)
 
 ## Properties
 
@@ -43,7 +43,7 @@ Error.name
 
 *Defined in*
 
-[packages/cozy-client/src/errors.js:13](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/errors.js#L13)
+[packages/cozy-client/src/errors.js:12](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/errors.js#L12)
 
 ***
 
@@ -53,7 +53,7 @@ Error.name
 
 *Defined in*
 
-[packages/cozy-client/src/errors.js:14](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/errors.js#L14)
+[packages/cozy-client/src/errors.js:13](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/errors.js#L13)
 
 ## Methods
 
@@ -71,7 +71,7 @@ Get bulk errors results
 
 *Defined in*
 
-[packages/cozy-client/src/errors.js:33](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/errors.js#L33)
+[packages/cozy-client/src/errors.js:32](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/errors.js#L32)
 
 ***
 
@@ -87,4 +87,4 @@ Get documents that have been correctly updated
 
 *Defined in*
 
-[packages/cozy-client/src/errors.js:24](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/errors.js#L24)
+[packages/cozy-client/src/errors.js:23](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/errors.js#L23)

--- a/docs/api/cozy-client/classes/CozyClient.md
+++ b/docs/api/cozy-client/classes/CozyClient.md
@@ -43,7 +43,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:166](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L166)
+[packages/cozy-client/src/CozyClient.js:145](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L145)
 
 ## Properties
 
@@ -53,7 +53,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:179](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L179)
+[packages/cozy-client/src/CozyClient.js:158](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L158)
 
 ***
 
@@ -63,7 +63,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:207](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L207)
+[packages/cozy-client/src/CozyClient.js:186](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L186)
 
 ***
 
@@ -73,7 +73,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:200](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L200)
+[packages/cozy-client/src/CozyClient.js:179](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L179)
 
 ***
 
@@ -83,7 +83,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1633](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1633)
+[packages/cozy-client/src/CozyClient.js:1612](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1612)
 
 ***
 
@@ -93,7 +93,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:187](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L187)
+[packages/cozy-client/src/CozyClient.js:166](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L166)
 
 ***
 
@@ -103,7 +103,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:186](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L186)
+[packages/cozy-client/src/CozyClient.js:165](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L165)
 
 ***
 
@@ -113,7 +113,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:501](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L501)
+[packages/cozy-client/src/CozyClient.js:480](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L480)
 
 ***
 
@@ -123,7 +123,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:197](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L197)
+[packages/cozy-client/src/CozyClient.js:176](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L176)
 
 ***
 
@@ -133,7 +133,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:180](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L180)
+[packages/cozy-client/src/CozyClient.js:159](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L159)
 
 ***
 
@@ -159,7 +159,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:183](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L183)
+[packages/cozy-client/src/CozyClient.js:162](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L162)
 
 ***
 
@@ -169,7 +169,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:210](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L210)
+[packages/cozy-client/src/CozyClient.js:189](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L189)
 
 ***
 
@@ -179,7 +179,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:185](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L185)
+[packages/cozy-client/src/CozyClient.js:164](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L164)
 
 ***
 
@@ -189,7 +189,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:202](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L202)
+[packages/cozy-client/src/CozyClient.js:181](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L181)
 
 ***
 
@@ -199,7 +199,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1608](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1608)
+[packages/cozy-client/src/CozyClient.js:1587](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1587)
 
 ***
 
@@ -209,7 +209,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1542](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1542)
+[packages/cozy-client/src/CozyClient.js:1521](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1521)
 
 ***
 
@@ -219,7 +219,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:235](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L235)
+[packages/cozy-client/src/CozyClient.js:214](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L214)
 
 ***
 
@@ -239,7 +239,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1295](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1295)
+[packages/cozy-client/src/CozyClient.js:1274](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1274)
 
 ***
 
@@ -284,7 +284,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:480](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L480)
+[packages/cozy-client/src/CozyClient.js:459](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L459)
 
 ***
 
@@ -304,7 +304,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:436](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L436)
+[packages/cozy-client/src/CozyClient.js:415](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L415)
 
 ***
 
@@ -324,7 +324,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:581](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L581)
+[packages/cozy-client/src/CozyClient.js:560](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L560)
 
 ***
 
@@ -353,7 +353,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1458](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1458)
+[packages/cozy-client/src/CozyClient.js:1437](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1437)
 
 ***
 
@@ -371,7 +371,7 @@ This mechanism is described in https://github.com/cozy/cozy-client/blob/master/p
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1439](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1439)
+[packages/cozy-client/src/CozyClient.js:1418](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1418)
 
 ***
 
@@ -387,7 +387,7 @@ Returns whether the client has been revoked on the server
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1554](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1554)
+[packages/cozy-client/src/CozyClient.js:1533](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1533)
 
 ***
 
@@ -412,7 +412,7 @@ Collection corresponding to the doctype
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:573](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L573)
+[packages/cozy-client/src/CozyClient.js:552](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L552)
 
 ***
 
@@ -450,7 +450,7 @@ await client.create('io.cozy.todos', {
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:628](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L628)
+[packages/cozy-client/src/CozyClient.js:607](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L607)
 
 ***
 
@@ -471,7 +471,7 @@ If `oauth` options are passed, stackClient is an OAuthStackClient.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1588](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1588)
+[packages/cozy-client/src/CozyClient.js:1567](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1567)
 
 ***
 
@@ -496,7 +496,7 @@ The document that has been deleted
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:878](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L878)
+[packages/cozy-client/src/CozyClient.js:857](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L857)
 
 ***
 
@@ -516,7 +516,7 @@ The document that has been deleted
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1659](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1659)
+[packages/cozy-client/src/CozyClient.js:1638](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1638)
 
 ***
 
@@ -542,7 +542,7 @@ a method from cozy-client
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:249](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L249)
+[packages/cozy-client/src/CozyClient.js:228](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L228)
 
 ***
 
@@ -564,7 +564,7 @@ a method from cozy-client
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:698](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L698)
+[packages/cozy-client/src/CozyClient.js:677](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L677)
 
 ***
 
@@ -588,7 +588,7 @@ Makes sure that the query exists in the store
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:899](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L899)
+[packages/cozy-client/src/CozyClient.js:878](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L878)
 
 ***
 
@@ -602,7 +602,7 @@ Makes sure that the query exists in the store
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1545](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1545)
+[packages/cozy-client/src/CozyClient.js:1524](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1524)
 
 ***
 
@@ -625,7 +625,7 @@ Makes sure that the query exists in the store
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:577](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L577)
+[packages/cozy-client/src/CozyClient.js:556](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L556)
 
 ***
 
@@ -654,7 +654,7 @@ Query state
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1392](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1392)
+[packages/cozy-client/src/CozyClient.js:1371](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1371)
 
 ***
 
@@ -675,7 +675,7 @@ Query state
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:590](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L590)
+[packages/cozy-client/src/CozyClient.js:569](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L569)
 
 ***
 
@@ -689,7 +689,7 @@ Query state
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1270](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1270)
+[packages/cozy-client/src/CozyClient.js:1249](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1249)
 
 ***
 
@@ -710,7 +710,7 @@ Query state
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:597](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L597)
+[packages/cozy-client/src/CozyClient.js:576](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L576)
 
 ***
 
@@ -733,7 +733,7 @@ Creates an association that is linked to the store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1277](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1277)
+[packages/cozy-client/src/CozyClient.js:1256](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1256)
 
 ***
 
@@ -747,7 +747,7 @@ Creates an association that is linked to the store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1641](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1641)
+[packages/cozy-client/src/CozyClient.js:1620](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1620)
 
 ***
 
@@ -771,7 +771,7 @@ Array of documents or null if the collection does not exist.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1313](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1313)
+[packages/cozy-client/src/CozyClient.js:1292](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1292)
 
 ***
 
@@ -796,7 +796,7 @@ Document or null if the object does not exist.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1330](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1330)
+[packages/cozy-client/src/CozyClient.js:1309](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1309)
 
 ***
 
@@ -831,7 +831,7 @@ One or more mutation to execute
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:791](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L791)
+[packages/cozy-client/src/CozyClient.js:770](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L770)
 
 ***
 
@@ -851,7 +851,7 @@ One or more mutation to execute
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1197](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1197)
+[packages/cozy-client/src/CozyClient.js:1176](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1176)
 
 ***
 
@@ -867,7 +867,7 @@ getInstanceOptions - Returns current instance options, such as domain or app slu
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1668](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1668)
+[packages/cozy-client/src/CozyClient.js:1647](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1647)
 
 ***
 
@@ -894,7 +894,7 @@ Get a query from the internal store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1351](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1351)
+[packages/cozy-client/src/CozyClient.js:1330](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1330)
 
 ***
 
@@ -923,7 +923,7 @@ the store up, which in turn will update the `<Query>`s and re-render the data.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1293](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1293)
+[packages/cozy-client/src/CozyClient.js:1272](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1272)
 
 ***
 
@@ -937,7 +937,7 @@ the store up, which in turn will update the `<Query>`s and re-render the data.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1648](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1648)
+[packages/cozy-client/src/CozyClient.js:1627](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1627)
 
 ***
 
@@ -959,7 +959,7 @@ Sets public attribute and emits event related to revocation
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1559](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1559)
+[packages/cozy-client/src/CozyClient.js:1538](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1538)
 
 ***
 
@@ -981,7 +981,7 @@ Emits event when token is refreshed
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1570](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1570)
+[packages/cozy-client/src/CozyClient.js:1549](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1549)
 
 ***
 
@@ -1007,7 +1007,7 @@ the relationship
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1240](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1240)
+[packages/cozy-client/src/CozyClient.js:1219](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1219)
 
 ***
 
@@ -1032,7 +1032,7 @@ Instead, the relationships will have null documents.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1217](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1217)
+[packages/cozy-client/src/CozyClient.js:1196](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1196)
 
 ***
 
@@ -1053,7 +1053,7 @@ Instead, the relationships will have null documents.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1251](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1251)
+[packages/cozy-client/src/CozyClient.js:1230](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1230)
 
 ***
 
@@ -1067,7 +1067,7 @@ Instead, the relationships will have null documents.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1415](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1415)
+[packages/cozy-client/src/CozyClient.js:1394](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1394)
 
 ***
 
@@ -1089,7 +1089,7 @@ loadInstanceOptionsFromDOM - Loads the dataset injected by the Stack in web page
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1679](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1679)
+[packages/cozy-client/src/CozyClient.js:1658](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1658)
 
 ***
 
@@ -1107,7 +1107,7 @@ For now only retrieving capabilities is supported
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1700](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1700)
+[packages/cozy-client/src/CozyClient.js:1679](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1679)
 
 ***
 
@@ -1141,7 +1141,7 @@ Emits
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:469](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L469)
+[packages/cozy-client/src/CozyClient.js:448](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L448)
 
 ***
 
@@ -1164,7 +1164,7 @@ Emits
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:520](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L520)
+[packages/cozy-client/src/CozyClient.js:499](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L499)
 
 ***
 
@@ -1188,7 +1188,7 @@ and working.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1263](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1263)
+[packages/cozy-client/src/CozyClient.js:1242](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1242)
 
 ***
 
@@ -1209,7 +1209,7 @@ and working.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1039](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1039)
+[packages/cozy-client/src/CozyClient.js:1018](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1018)
 
 ***
 
@@ -1235,7 +1235,7 @@ Mutate a document
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1057](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1057)
+[packages/cozy-client/src/CozyClient.js:1036](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1036)
 
 ***
 
@@ -1255,7 +1255,7 @@ Mutate a document
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:250](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L250)
+[packages/cozy-client/src/CozyClient.js:229](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L229)
 
 ***
 
@@ -1277,7 +1277,7 @@ Dehydrates and adds metadata before saving a document
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:762](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L762)
+[packages/cozy-client/src/CozyClient.js:741](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L741)
 
 ***
 
@@ -1304,7 +1304,7 @@ executes its query when mounted if no fetch policy has been indicated.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:922](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L922)
+[packages/cozy-client/src/CozyClient.js:901](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L901)
 
 ***
 
@@ -1331,7 +1331,7 @@ All documents matching the query
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:999](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L999)
+[packages/cozy-client/src/CozyClient.js:978](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L978)
 
 ***
 
@@ -1365,7 +1365,7 @@ All documents matching the query
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1655](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1655)
+[packages/cozy-client/src/CozyClient.js:1634](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1634)
 
 ***
 
@@ -1391,7 +1391,7 @@ Contains the fetched token and the client information.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1409](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1409)
+[packages/cozy-client/src/CozyClient.js:1388](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1388)
 
 ***
 
@@ -1405,7 +1405,7 @@ Contains the fetched token and the client information.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:440](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L440)
+[packages/cozy-client/src/CozyClient.js:419](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L419)
 
 ***
 
@@ -1473,7 +1473,7 @@ client.plugins.alerts
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:300](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L300)
+[packages/cozy-client/src/CozyClient.js:279](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L279)
 
 ***
 
@@ -1493,7 +1493,7 @@ client.plugins.alerts
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:251](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L251)
+[packages/cozy-client/src/CozyClient.js:230](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L230)
 
 ***
 
@@ -1512,7 +1512,7 @@ Contains the fetched token and the client information.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1504](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1504)
+[packages/cozy-client/src/CozyClient.js:1483](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1483)
 
 ***
 
@@ -1532,7 +1532,7 @@ Contains the fetched token and the client information.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1181](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1181)
+[packages/cozy-client/src/CozyClient.js:1160](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1160)
 
 ***
 
@@ -1555,7 +1555,7 @@ Create or update a document on the server
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:650](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L650)
+[packages/cozy-client/src/CozyClient.js:629](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L629)
 
 ***
 
@@ -1584,7 +1584,7 @@ Saves multiple documents in one batch
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:671](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L671)
+[packages/cozy-client/src/CozyClient.js:650](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L650)
 
 ***
 
@@ -1604,7 +1604,7 @@ Saves multiple documents in one batch
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1746](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1746)
+[packages/cozy-client/src/CozyClient.js:1725](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1725)
 
 ***
 
@@ -1628,7 +1628,7 @@ set some data in the store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1719](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1719)
+[packages/cozy-client/src/CozyClient.js:1698](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1698)
 
 ***
 
@@ -1652,7 +1652,7 @@ At any time put an error function
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1732](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1732)
+[packages/cozy-client/src/CozyClient.js:1711](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1711)
 
 ***
 
@@ -1690,7 +1690,7 @@ use options.force = true.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1530](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1530)
+[packages/cozy-client/src/CozyClient.js:1509](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1509)
 
 ***
 
@@ -1714,7 +1714,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1425](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1425)
+[packages/cozy-client/src/CozyClient.js:1404](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1404)
 
 ***
 
@@ -1728,7 +1728,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1739](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1739)
+[packages/cozy-client/src/CozyClient.js:1718](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1718)
 
 ***
 
@@ -1749,7 +1749,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:863](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L863)
+[packages/cozy-client/src/CozyClient.js:842](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L842)
 
 ***
 
@@ -1771,7 +1771,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:888](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L888)
+[packages/cozy-client/src/CozyClient.js:867](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L867)
 
 ***
 
@@ -1791,7 +1791,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:639](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L639)
+[packages/cozy-client/src/CozyClient.js:618](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L618)
 
 ***
 
@@ -1811,7 +1811,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1032](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1032)
+[packages/cozy-client/src/CozyClient.js:1011](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1011)
 
 ***
 
@@ -1837,7 +1837,7 @@ the DOM.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:403](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L403)
+[packages/cozy-client/src/CozyClient.js:382](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L382)
 
 ***
 
@@ -1861,7 +1861,7 @@ environment variables
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:374](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L374)
+[packages/cozy-client/src/CozyClient.js:353](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L353)
 
 ***
 
@@ -1885,7 +1885,7 @@ a client with a cookie-based instance of cozy-client-js.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:324](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L324)
+[packages/cozy-client/src/CozyClient.js:303](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L303)
 
 ***
 
@@ -1913,7 +1913,7 @@ An instance of a client, configured from the old client
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:342](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L342)
+[packages/cozy-client/src/CozyClient.js:321](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L321)
 
 ***
 
@@ -1947,4 +1947,4 @@ There are at the moment only 2 hooks available.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:857](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L857)
+[packages/cozy-client/src/CozyClient.js:836](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L836)

--- a/docs/api/cozy-client/classes/HasMany.md
+++ b/docs/api/cozy-client/classes/HasMany.md
@@ -70,7 +70,7 @@ Responsible for
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:88](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L88)
+[packages/cozy-client/src/associations/Association.js:87](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L87)
 
 ## Properties
 
@@ -86,7 +86,7 @@ Dispatch an action on the store.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:145](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L145)
+[packages/cozy-client/src/associations/Association.js:144](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L144)
 
 ***
 
@@ -104,7 +104,7 @@ Doctype of the relationship
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:110](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L110)
+[packages/cozy-client/src/associations/Association.js:109](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L109)
 
 ***
 
@@ -120,7 +120,7 @@ Returns the document from the store
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L117)
+[packages/cozy-client/src/associations/Association.js:116](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L116)
 
 ***
 
@@ -138,7 +138,7 @@ Performs a mutation on the relationship.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:132](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L132)
+[packages/cozy-client/src/associations/Association.js:131](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L131)
 
 ***
 
@@ -156,7 +156,7 @@ The name of the relationship.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L102)
+[packages/cozy-client/src/associations/Association.js:101](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L101)
 
 ***
 
@@ -176,7 +176,7 @@ Performs a query to retrieve relationship documents.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L125)
+[packages/cozy-client/src/associations/Association.js:124](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L124)
 
 ***
 
@@ -192,7 +192,7 @@ Saves the relationship in store.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L139)
+[packages/cozy-client/src/associations/Association.js:138](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L138)
 
 ***
 
@@ -208,7 +208,7 @@ The original document declaring the relationship
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:95](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L95)
+[packages/cozy-client/src/associations/Association.js:94](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L94)
 
 ## Accessors
 
@@ -228,7 +228,7 @@ to do that, you can use .data.length.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:94](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L94)
+[packages/cozy-client/src/associations/HasMany.js:93](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L93)
 
 ***
 
@@ -248,7 +248,7 @@ Association.data
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:77](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L77)
+[packages/cozy-client/src/associations/HasMany.js:76](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L76)
 
 ***
 
@@ -262,7 +262,7 @@ Association.data
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:83](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L83)
+[packages/cozy-client/src/associations/HasMany.js:82](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L82)
 
 ***
 
@@ -280,7 +280,7 @@ Association.raw
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:70](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L70)
+[packages/cozy-client/src/associations/HasMany.js:69](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L69)
 
 ## Methods
 
@@ -304,7 +304,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L125)
+[packages/cozy-client/src/associations/HasMany.js:124](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L124)
 
 ***
 
@@ -331,7 +331,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:175](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L175)
+[packages/cozy-client/src/associations/HasMany.js:174](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L174)
 
 ***
 
@@ -353,7 +353,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:148](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L148)
+[packages/cozy-client/src/associations/HasMany.js:147](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L147)
 
 ***
 
@@ -373,7 +373,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:109](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L109)
+[packages/cozy-client/src/associations/HasMany.js:108](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L108)
 
 ***
 
@@ -393,7 +393,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:257](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L257)
+[packages/cozy-client/src/associations/HasMany.js:256](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L256)
 
 ***
 
@@ -413,7 +413,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:105](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L105)
+[packages/cozy-client/src/associations/HasMany.js:104](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L104)
 
 ***
 
@@ -433,7 +433,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:115](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L115)
+[packages/cozy-client/src/associations/HasMany.js:114](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L114)
 
 ***
 
@@ -447,7 +447,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:101](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L101)
+[packages/cozy-client/src/associations/HasMany.js:100](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L100)
 
 ***
 
@@ -461,7 +461,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:208](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L208)
+[packages/cozy-client/src/associations/HasMany.js:207](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L207)
 
 ***
 
@@ -485,7 +485,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:137](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L137)
+[packages/cozy-client/src/associations/HasMany.js:136](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L136)
 
 ***
 
@@ -505,7 +505,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:194](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L194)
+[packages/cozy-client/src/associations/HasMany.js:193](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L193)
 
 ***
 
@@ -527,7 +527,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:185](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L185)
+[packages/cozy-client/src/associations/HasMany.js:184](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L184)
 
 ***
 
@@ -541,7 +541,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:199](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L199)
+[packages/cozy-client/src/associations/HasMany.js:198](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L198)
 
 ***
 
@@ -562,7 +562,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:229](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L229)
+[packages/cozy-client/src/associations/HasMany.js:228](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L228)
 
 ***
 
@@ -595,7 +595,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:233](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L233)
+[packages/cozy-client/src/associations/HasMany.js:232](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L232)
 
 ***
 
@@ -616,7 +616,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:222](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L222)
+[packages/cozy-client/src/associations/HasMany.js:221](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L221)
 
 ***
 
@@ -638,7 +638,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:290](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L290)
+[packages/cozy-client/src/associations/HasMany.js:289](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L289)
 
 ***
 
@@ -659,7 +659,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:299](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L299)
+[packages/cozy-client/src/associations/HasMany.js:298](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L298)
 
 ***
 
@@ -685,7 +685,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:276](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L276)
+[packages/cozy-client/src/associations/HasMany.js:275](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L275)
 
 ***
 
@@ -707,7 +707,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:337](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L337)
+[packages/cozy-client/src/associations/HasMany.js:336](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L336)
 
 ***
 
@@ -730,7 +730,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:311](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L311)
+[packages/cozy-client/src/associations/HasMany.js:310](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L310)
 
 ***
 
@@ -753,7 +753,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:361](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L361)
+[packages/cozy-client/src/associations/HasMany.js:360](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L360)
 
 ***
 
@@ -775,4 +775,4 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:372](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L372)
+[packages/cozy-client/src/associations/HasMany.js:371](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L371)

--- a/docs/api/cozy-client/classes/HasManyInPlace.md
+++ b/docs/api/cozy-client/classes/HasManyInPlace.md
@@ -74,7 +74,7 @@ const todo = {
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:88](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L88)
+[packages/cozy-client/src/associations/Association.js:87](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L87)
 
 ## Properties
 
@@ -90,7 +90,7 @@ Dispatch an action on the store.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:145](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L145)
+[packages/cozy-client/src/associations/Association.js:144](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L144)
 
 ***
 
@@ -108,7 +108,7 @@ Doctype of the relationship
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:110](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L110)
+[packages/cozy-client/src/associations/Association.js:109](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L109)
 
 ***
 
@@ -124,7 +124,7 @@ Returns the document from the store
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L117)
+[packages/cozy-client/src/associations/Association.js:116](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L116)
 
 ***
 
@@ -142,7 +142,7 @@ Performs a mutation on the relationship.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:132](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L132)
+[packages/cozy-client/src/associations/Association.js:131](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L131)
 
 ***
 
@@ -160,7 +160,7 @@ The name of the relationship.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L102)
+[packages/cozy-client/src/associations/Association.js:101](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L101)
 
 ***
 
@@ -180,7 +180,7 @@ Performs a query to retrieve relationship documents.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L125)
+[packages/cozy-client/src/associations/Association.js:124](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L124)
 
 ***
 
@@ -196,7 +196,7 @@ Saves the relationship in store.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L139)
+[packages/cozy-client/src/associations/Association.js:138](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L138)
 
 ***
 
@@ -212,7 +212,7 @@ The original document declaring the relationship
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:95](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L95)
+[packages/cozy-client/src/associations/Association.js:94](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L94)
 
 ## Accessors
 
@@ -230,7 +230,7 @@ Association.data
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasManyInPlace.js:88](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L88)
+[packages/cozy-client/src/associations/HasManyInPlace.js:87](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L87)
 
 ***
 
@@ -250,7 +250,7 @@ Association.raw
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasManyInPlace.js:54](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L54)
+[packages/cozy-client/src/associations/HasManyInPlace.js:53](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L53)
 
 ## Methods
 
@@ -270,7 +270,7 @@ Association.raw
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasManyInPlace.js:58](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L58)
+[packages/cozy-client/src/associations/HasManyInPlace.js:57](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L57)
 
 ***
 
@@ -290,7 +290,7 @@ Association.raw
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasManyInPlace.js:81](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L81)
+[packages/cozy-client/src/associations/HasManyInPlace.js:80](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L80)
 
 ***
 
@@ -310,7 +310,7 @@ Association.raw
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasManyInPlace.js:71](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L71)
+[packages/cozy-client/src/associations/HasManyInPlace.js:70](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L70)
 
 ***
 
@@ -324,7 +324,7 @@ Association.raw
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasManyInPlace.js:76](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L76)
+[packages/cozy-client/src/associations/HasManyInPlace.js:75](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L75)
 
 ***
 
@@ -344,7 +344,7 @@ Association.raw
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasManyInPlace.js:63](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L63)
+[packages/cozy-client/src/associations/HasManyInPlace.js:62](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L62)
 
 ***
 
@@ -370,4 +370,4 @@ Association.raw
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasManyInPlace.js:100](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L100)
+[packages/cozy-client/src/associations/HasManyInPlace.js:99](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasManyInPlace.js#L99)

--- a/docs/api/cozy-client/classes/HasManyTriggers.md
+++ b/docs/api/cozy-client/classes/HasManyTriggers.md
@@ -36,7 +36,7 @@ Association used for konnectors to retrieve all their related triggers.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:88](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L88)
+[packages/cozy-client/src/associations/Association.js:87](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L87)
 
 ## Properties
 
@@ -52,7 +52,7 @@ Dispatch an action on the store.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:145](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L145)
+[packages/cozy-client/src/associations/Association.js:144](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L144)
 
 ***
 
@@ -70,7 +70,7 @@ Doctype of the relationship
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:110](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L110)
+[packages/cozy-client/src/associations/Association.js:109](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L109)
 
 ***
 
@@ -86,7 +86,7 @@ Returns the document from the store
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L117)
+[packages/cozy-client/src/associations/Association.js:116](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L116)
 
 ***
 
@@ -104,7 +104,7 @@ Performs a mutation on the relationship.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:132](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L132)
+[packages/cozy-client/src/associations/Association.js:131](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L131)
 
 ***
 
@@ -122,7 +122,7 @@ The name of the relationship.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L102)
+[packages/cozy-client/src/associations/Association.js:101](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L101)
 
 ***
 
@@ -142,7 +142,7 @@ Performs a query to retrieve relationship documents.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L125)
+[packages/cozy-client/src/associations/Association.js:124](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L124)
 
 ***
 
@@ -158,7 +158,7 @@ Saves the relationship in store.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L139)
+[packages/cozy-client/src/associations/Association.js:138](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L138)
 
 ***
 
@@ -174,7 +174,7 @@ The original document declaring the relationship
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:95](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L95)
+[packages/cozy-client/src/associations/Association.js:94](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L94)
 
 ## Accessors
 
@@ -198,7 +198,7 @@ HasMany.count
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:94](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L94)
+[packages/cozy-client/src/associations/HasMany.js:93](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L93)
 
 ***
 
@@ -234,7 +234,7 @@ HasMany.hasMore
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:83](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L83)
+[packages/cozy-client/src/associations/HasMany.js:82](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L82)
 
 ***
 
@@ -252,7 +252,7 @@ HasMany.raw
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:70](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L70)
+[packages/cozy-client/src/associations/HasMany.js:69](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L69)
 
 ## Methods
 
@@ -280,7 +280,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L125)
+[packages/cozy-client/src/associations/HasMany.js:124](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L124)
 
 ***
 
@@ -311,7 +311,7 @@ We certainly should use something like `updateRelationship`
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:175](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L175)
+[packages/cozy-client/src/associations/HasMany.js:174](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L174)
 
 ***
 
@@ -337,7 +337,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:148](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L148)
+[packages/cozy-client/src/associations/HasMany.js:147](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L147)
 
 ***
 
@@ -361,7 +361,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:109](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L109)
+[packages/cozy-client/src/associations/HasMany.js:108](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L108)
 
 ***
 
@@ -385,7 +385,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:257](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L257)
+[packages/cozy-client/src/associations/HasMany.js:256](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L256)
 
 ***
 
@@ -409,7 +409,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:105](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L105)
+[packages/cozy-client/src/associations/HasMany.js:104](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L104)
 
 ***
 
@@ -433,7 +433,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:115](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L115)
+[packages/cozy-client/src/associations/HasMany.js:114](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L114)
 
 ***
 
@@ -451,7 +451,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:101](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L101)
+[packages/cozy-client/src/associations/HasMany.js:100](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L100)
 
 ***
 
@@ -469,7 +469,7 @@ Update target document with relationships
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:208](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L208)
+[packages/cozy-client/src/associations/HasMany.js:207](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L207)
 
 ***
 
@@ -497,7 +497,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:137](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L137)
+[packages/cozy-client/src/associations/HasMany.js:136](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L136)
 
 ***
 
@@ -521,7 +521,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:194](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L194)
+[packages/cozy-client/src/associations/HasMany.js:193](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L193)
 
 ***
 
@@ -547,7 +547,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:185](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L185)
+[packages/cozy-client/src/associations/HasMany.js:184](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L184)
 
 ***
 
@@ -565,7 +565,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:199](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L199)
+[packages/cozy-client/src/associations/HasMany.js:198](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L198)
 
 ***
 
@@ -590,7 +590,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:229](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L229)
+[packages/cozy-client/src/associations/HasMany.js:228](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L228)
 
 ***
 
@@ -627,7 +627,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:233](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L233)
+[packages/cozy-client/src/associations/HasMany.js:232](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L232)
 
 ***
 
@@ -652,7 +652,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:222](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L222)
+[packages/cozy-client/src/associations/HasMany.js:221](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L221)
 
 ***
 
@@ -678,7 +678,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:290](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L290)
+[packages/cozy-client/src/associations/HasMany.js:289](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L289)
 
 ***
 
@@ -703,7 +703,7 @@ Remove relationships from target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:299](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L299)
+[packages/cozy-client/src/associations/HasMany.js:298](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L298)
 
 ***
 
@@ -758,7 +758,7 @@ having for the 'konnector' worker, and then filter them based on their
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:337](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L337)
+[packages/cozy-client/src/associations/HasMany.js:336](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L336)
 
 ***
 
@@ -785,7 +785,7 @@ having for the 'konnector' worker, and then filter them based on their
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:311](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L311)
+[packages/cozy-client/src/associations/HasMany.js:310](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L310)
 
 ***
 
@@ -812,7 +812,7 @@ having for the 'konnector' worker, and then filter them based on their
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:361](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L361)
+[packages/cozy-client/src/associations/HasMany.js:360](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L360)
 
 ***
 
@@ -838,4 +838,4 @@ having for the 'konnector' worker, and then filter them based on their
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasMany.js:372](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L372)
+[packages/cozy-client/src/associations/HasMany.js:371](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasMany.js#L371)

--- a/docs/api/cozy-client/classes/HasOne.md
+++ b/docs/api/cozy-client/classes/HasOne.md
@@ -34,7 +34,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:88](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L88)
+[packages/cozy-client/src/associations/Association.js:87](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L87)
 
 ## Properties
 
@@ -50,7 +50,7 @@ Dispatch an action on the store.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:145](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L145)
+[packages/cozy-client/src/associations/Association.js:144](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L144)
 
 ***
 
@@ -68,7 +68,7 @@ Doctype of the relationship
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:110](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L110)
+[packages/cozy-client/src/associations/Association.js:109](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L109)
 
 ***
 
@@ -84,7 +84,7 @@ Returns the document from the store
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L117)
+[packages/cozy-client/src/associations/Association.js:116](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L116)
 
 ***
 
@@ -102,7 +102,7 @@ Performs a mutation on the relationship.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:132](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L132)
+[packages/cozy-client/src/associations/Association.js:131](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L131)
 
 ***
 
@@ -120,7 +120,7 @@ The name of the relationship.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L102)
+[packages/cozy-client/src/associations/Association.js:101](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L101)
 
 ***
 
@@ -140,7 +140,7 @@ Performs a query to retrieve relationship documents.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L125)
+[packages/cozy-client/src/associations/Association.js:124](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L124)
 
 ***
 
@@ -156,7 +156,7 @@ Saves the relationship in store.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L139)
+[packages/cozy-client/src/associations/Association.js:138](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L138)
 
 ***
 
@@ -172,7 +172,7 @@ The original document declaring the relationship
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:95](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L95)
+[packages/cozy-client/src/associations/Association.js:94](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L94)
 
 ## Accessors
 
@@ -190,7 +190,7 @@ Association.data
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:13](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L13)
+[packages/cozy-client/src/associations/HasOne.js:12](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L12)
 
 ***
 
@@ -208,7 +208,7 @@ Association.raw
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:9](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L9)
+[packages/cozy-client/src/associations/HasOne.js:8](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L8)
 
 ## Methods
 
@@ -232,7 +232,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:42](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L42)
+[packages/cozy-client/src/associations/HasOne.js:41](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L41)
 
 ***
 
@@ -252,7 +252,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:90](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L90)
+[packages/cozy-client/src/associations/HasOne.js:89](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L89)
 
 ***
 
@@ -270,7 +270,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:52](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L52)
+[packages/cozy-client/src/associations/HasOne.js:51](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L51)
 
 ***
 
@@ -290,7 +290,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:76](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L76)
+[packages/cozy-client/src/associations/HasOne.js:75](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L75)
 
 ***
 
@@ -310,7 +310,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:57](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L57)
+[packages/cozy-client/src/associations/HasOne.js:56](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L56)
 
 ***
 
@@ -324,7 +324,7 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:83](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L83)
+[packages/cozy-client/src/associations/HasOne.js:82](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L82)
 
 ***
 
@@ -350,4 +350,4 @@ The saved target document
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOne.js:28](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L28)
+[packages/cozy-client/src/associations/HasOne.js:27](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOne.js#L27)

--- a/docs/api/cozy-client/classes/HasOneInPlace.md
+++ b/docs/api/cozy-client/classes/HasOneInPlace.md
@@ -37,7 +37,7 @@ of the document, not in the relationships attribute
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:88](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L88)
+[packages/cozy-client/src/associations/Association.js:87](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L87)
 
 ## Properties
 
@@ -53,7 +53,7 @@ Dispatch an action on the store.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:145](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L145)
+[packages/cozy-client/src/associations/Association.js:144](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L144)
 
 ***
 
@@ -71,7 +71,7 @@ Doctype of the relationship
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:110](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L110)
+[packages/cozy-client/src/associations/Association.js:109](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L109)
 
 ***
 
@@ -87,7 +87,7 @@ Returns the document from the store
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L117)
+[packages/cozy-client/src/associations/Association.js:116](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L116)
 
 ***
 
@@ -105,7 +105,7 @@ Performs a mutation on the relationship.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:132](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L132)
+[packages/cozy-client/src/associations/Association.js:131](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L131)
 
 ***
 
@@ -123,7 +123,7 @@ The name of the relationship.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L102)
+[packages/cozy-client/src/associations/Association.js:101](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L101)
 
 ***
 
@@ -143,7 +143,7 @@ Performs a query to retrieve relationship documents.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L125)
+[packages/cozy-client/src/associations/Association.js:124](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L124)
 
 ***
 
@@ -159,7 +159,7 @@ Saves the relationship in store.
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L139)
+[packages/cozy-client/src/associations/Association.js:138](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L138)
 
 ***
 
@@ -175,7 +175,7 @@ The original document declaring the relationship
 
 *Defined in*
 
-[packages/cozy-client/src/associations/Association.js:95](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L95)
+[packages/cozy-client/src/associations/Association.js:94](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/Association.js#L94)
 
 ## Accessors
 
@@ -193,7 +193,7 @@ Association.data
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOneInPlace.js:14](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOneInPlace.js#L14)
+[packages/cozy-client/src/associations/HasOneInPlace.js:13](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOneInPlace.js#L13)
 
 ***
 
@@ -211,7 +211,7 @@ Association.raw
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOneInPlace.js:10](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOneInPlace.js#L10)
+[packages/cozy-client/src/associations/HasOneInPlace.js:9](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOneInPlace.js#L9)
 
 ## Methods
 
@@ -231,7 +231,7 @@ Association.raw
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOneInPlace.js:33](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOneInPlace.js#L33)
+[packages/cozy-client/src/associations/HasOneInPlace.js:32](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOneInPlace.js#L32)
 
 ***
 
@@ -257,4 +257,4 @@ Association.raw
 
 *Defined in*
 
-[packages/cozy-client/src/associations/HasOneInPlace.js:25](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOneInPlace.js#L25)
+[packages/cozy-client/src/associations/HasOneInPlace.js:24](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/associations/HasOneInPlace.js#L24)

--- a/docs/api/cozy-client/classes/InvalidCozyUrlError.md
+++ b/docs/api/cozy-client/classes/InvalidCozyUrlError.md
@@ -26,7 +26,7 @@ Error.constructor
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:140](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L140)
+[packages/cozy-client/src/helpers/urlHelper.js:138](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L138)
 
 ## Properties
 
@@ -36,4 +36,4 @@ Error.constructor
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:143](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L143)
+[packages/cozy-client/src/helpers/urlHelper.js:141](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L141)

--- a/docs/api/cozy-client/classes/InvalidProtocolError.md
+++ b/docs/api/cozy-client/classes/InvalidProtocolError.md
@@ -26,7 +26,7 @@ Error.constructor
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:132](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L132)
+[packages/cozy-client/src/helpers/urlHelper.js:130](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L130)
 
 ## Properties
 
@@ -36,4 +36,4 @@ Error.constructor
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:135](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L135)
+[packages/cozy-client/src/helpers/urlHelper.js:133](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L133)

--- a/docs/api/cozy-client/classes/InvalidRedirectLinkError.md
+++ b/docs/api/cozy-client/classes/InvalidRedirectLinkError.md
@@ -26,7 +26,7 @@ Error.constructor
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:124](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L124)
+[packages/cozy-client/src/helpers/urlHelper.js:122](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L122)
 
 ## Properties
 
@@ -36,4 +36,4 @@ Error.constructor
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:127](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L127)
+[packages/cozy-client/src/helpers/urlHelper.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L125)

--- a/docs/api/cozy-client/classes/StackLink.md
+++ b/docs/api/cozy-client/classes/StackLink.md
@@ -30,7 +30,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:63](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L63)
+[packages/cozy-client/src/StackLink.js:62](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L62)
 
 ## Properties
 
@@ -40,7 +40,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:70](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L70)
+[packages/cozy-client/src/StackLink.js:69](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L69)
 
 ## Methods
 
@@ -62,7 +62,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:115](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L115)
+[packages/cozy-client/src/StackLink.js:114](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L114)
 
 ***
 
@@ -82,7 +82,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:92](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L92)
+[packages/cozy-client/src/StackLink.js:91](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L91)
 
 ***
 
@@ -102,7 +102,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:73](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L73)
+[packages/cozy-client/src/StackLink.js:72](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L72)
 
 ***
 
@@ -128,7 +128,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:81](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L81)
+[packages/cozy-client/src/StackLink.js:80](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L80)
 
 ***
 
@@ -142,4 +142,4 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:77](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L77)
+[packages/cozy-client/src/StackLink.js:76](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L76)

--- a/docs/api/cozy-client/interfaces/models.dacc.Params.md
+++ b/docs/api/cozy-client/interfaces/models.dacc.Params.md
@@ -16,7 +16,7 @@ The measure end date
 
 *Defined in*
 
-[packages/cozy-client/src/models/dacc.js:102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L102)
+[packages/cozy-client/src/models/dacc.js:97](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L97)
 
 ***
 
@@ -28,7 +28,7 @@ The measure name
 
 *Defined in*
 
-[packages/cozy-client/src/models/dacc.js:100](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L100)
+[packages/cozy-client/src/models/dacc.js:95](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L95)
 
 ***
 
@@ -40,4 +40,4 @@ The measure start date
 
 *Defined in*
 
-[packages/cozy-client/src/models/dacc.js:101](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L101)
+[packages/cozy-client/src/models/dacc.js:96](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L96)

--- a/docs/api/cozy-client/interfaces/models.file.FileUploadOptions.md
+++ b/docs/api/cozy-client/interfaces/models.file.FileUploadOptions.md
@@ -14,7 +14,7 @@ Erase / rename
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:443](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L443)
+[packages/cozy-client/src/models/file.js:442](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L442)
 
 ***
 
@@ -26,7 +26,7 @@ The file Content-Type
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:442](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L442)
+[packages/cozy-client/src/models/file.js:441](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L441)
 
 ***
 
@@ -38,7 +38,7 @@ The dirId to upload the file to
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:440](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L440)
+[packages/cozy-client/src/models/file.js:439](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L439)
 
 ***
 
@@ -50,7 +50,7 @@ An object containing the metadata to attach
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:441](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L441)
+[packages/cozy-client/src/models/file.js:440](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L440)
 
 ***
 
@@ -62,4 +62,4 @@ The file name to upload
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:439](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L439)
+[packages/cozy-client/src/models/file.js:438](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L438)

--- a/docs/api/cozy-client/interfaces/models.timeseries.TimeSeries.md
+++ b/docs/api/cozy-client/interfaces/models.timeseries.TimeSeries.md
@@ -14,7 +14,7 @@ The type of time series, e.g. 'electricity'
 
 *Defined in*
 
-[packages/cozy-client/src/models/timeseries.js:23](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L23)
+[packages/cozy-client/src/models/timeseries.js:22](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L22)
 
 ***
 
@@ -26,7 +26,7 @@ The end date of the series
 
 *Defined in*
 
-[packages/cozy-client/src/models/timeseries.js:25](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L25)
+[packages/cozy-client/src/models/timeseries.js:24](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L24)
 
 ***
 
@@ -38,7 +38,7 @@ The starting date of the series
 
 *Defined in*
 
-[packages/cozy-client/src/models/timeseries.js:26](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L26)
+[packages/cozy-client/src/models/timeseries.js:25](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L25)
 
 ***
 
@@ -50,7 +50,7 @@ An array of objects representing the time series
 
 *Defined in*
 
-[packages/cozy-client/src/models/timeseries.js:29](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L29)
+[packages/cozy-client/src/models/timeseries.js:28](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L28)
 
 ***
 
@@ -62,7 +62,7 @@ The data source, e.g. 'enedis.fr'
 
 *Defined in*
 
-[packages/cozy-client/src/models/timeseries.js:27](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L27)
+[packages/cozy-client/src/models/timeseries.js:26](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L26)
 
 ***
 
@@ -74,7 +74,7 @@ The starting date of the series
 
 *Defined in*
 
-[packages/cozy-client/src/models/timeseries.js:24](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L24)
+[packages/cozy-client/src/models/timeseries.js:23](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L23)
 
 ***
 
@@ -86,4 +86,4 @@ The theme used to group time series, e.g. 'energy'
 
 *Defined in*
 
-[packages/cozy-client/src/models/timeseries.js:28](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L28)
+[packages/cozy-client/src/models/timeseries.js:27](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L27)

--- a/docs/api/cozy-client/interfaces/models.timeseries.TimeSeriesJSONAPI.md
+++ b/docs/api/cozy-client/interfaces/models.timeseries.TimeSeriesJSONAPI.md
@@ -14,4 +14,4 @@ The JSON-API data response
 
 *Defined in*
 
-[packages/cozy-client/src/models/timeseries.js:75](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L75)
+[packages/cozy-client/src/models/timeseries.js:74](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L74)

--- a/docs/api/cozy-client/modules/models.dacc.md
+++ b/docs/api/cozy-client/modules/models.dacc.md
@@ -34,7 +34,7 @@ Build parameters to request DACC aggregate
 
 *Defined in*
 
-[packages/cozy-client/src/models/dacc.js:107](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L107)
+[packages/cozy-client/src/models/dacc.js:102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L102)
 
 ***
 
@@ -56,7 +56,7 @@ Throw an errror if a DACC parameter is incorrect.
 
 *Defined in*
 
-[packages/cozy-client/src/models/dacc.js:29](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L29)
+[packages/cozy-client/src/models/dacc.js:24](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L24)
 
 ***
 
@@ -80,7 +80,7 @@ Send measures to a DACC through a remote doctype
 
 *Defined in*
 
-[packages/cozy-client/src/models/dacc.js:132](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L132)
+[packages/cozy-client/src/models/dacc.js:127](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L127)
 
 ***
 
@@ -102,7 +102,7 @@ Check whether or not the given date is in YYYY-MM-DD format
 
 *Defined in*
 
-[packages/cozy-client/src/models/dacc.js:15](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L15)
+[packages/cozy-client/src/models/dacc.js:10](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L10)
 
 ***
 
@@ -126,4 +126,4 @@ Send measures to a DACC through a remote doctype
 
 *Defined in*
 
-[packages/cozy-client/src/models/dacc.js:76](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L76)
+[packages/cozy-client/src/models/dacc.js:71](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/dacc.js#L71)

--- a/docs/api/cozy-client/modules/models.document.helpers.md
+++ b/docs/api/cozy-client/modules/models.document.helpers.md
@@ -22,4 +22,4 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/document/documentTypeDataHelpers.js:19](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document/documentTypeDataHelpers.js#L19)
+[packages/cozy-client/src/models/document/documentTypeDataHelpers.js:17](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document/documentTypeDataHelpers.js#L17)

--- a/docs/api/cozy-client/modules/models.document.themes.md
+++ b/docs/api/cozy-client/modules/models.document.themes.md
@@ -12,4 +12,4 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/document/documentTypeData.js:190](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document/documentTypeData.js#L190)
+[packages/cozy-client/src/models/document/documentTypeData.js:176](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document/documentTypeData.js#L176)

--- a/docs/api/cozy-client/modules/models.file.md
+++ b/docs/api/cozy-client/modules/models.file.md
@@ -16,7 +16,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:15](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L15)
+[packages/cozy-client/src/models/file.js:14](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L14)
 
 ## Functions
 
@@ -40,7 +40,7 @@ Upload a file on a mobile
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:547](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L547)
+[packages/cozy-client/src/models/file.js:546](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L546)
 
 ***
 
@@ -65,7 +65,7 @@ file object with path attribute
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:137](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L137)
+[packages/cozy-client/src/models/file.js:136](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L136)
 
 ***
 
@@ -86,7 +86,7 @@ file object with path attribute
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:593](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L593)
+[packages/cozy-client/src/models/file.js:592](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L592)
 
 ***
 
@@ -111,7 +111,7 @@ The files found by the rules
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:257](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L257)
+[packages/cozy-client/src/models/file.js:256](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L256)
 
 ***
 
@@ -135,7 +135,7 @@ Generate a file name for a revision
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:429](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L429)
+[packages/cozy-client/src/models/file.js:428](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L428)
 
 ***
 
@@ -159,7 +159,7 @@ A filename with the right suffix
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:404](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L404)
+[packages/cozy-client/src/models/file.js:403](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L403)
 
 ***
 
@@ -185,7 +185,7 @@ The full path of the file in the cozy
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:292](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L292)
+[packages/cozy-client/src/models/file.js:291](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L291)
 
 ***
 
@@ -209,7 +209,7 @@ id of the parent folder, if any
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:151](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L151)
+[packages/cozy-client/src/models/file.js:150](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L150)
 
 ***
 
@@ -233,7 +233,7 @@ A description of the status
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:163](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L163)
+[packages/cozy-client/src/models/file.js:162](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L162)
 
 ***
 
@@ -257,7 +257,7 @@ A doctype
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:183](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L183)
+[packages/cozy-client/src/models/file.js:182](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L182)
 
 ***
 
@@ -281,7 +281,7 @@ The mime-type of the target file, or an empty string is the target is not a file
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:173](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L173)
+[packages/cozy-client/src/models/file.js:172](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L172)
 
 ***
 
@@ -301,7 +301,7 @@ The mime-type of the target file, or an empty string is the target is not a file
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:573](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L573)
+[packages/cozy-client/src/models/file.js:572](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L572)
 
 ***
 
@@ -325,7 +325,7 @@ Whether the file's metadata attribute exists
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:281](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L281)
+[packages/cozy-client/src/models/file.js:280](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L280)
 
 ***
 
@@ -345,7 +345,7 @@ Whether the file's metadata attribute exists
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:565](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L565)
+[packages/cozy-client/src/models/file.js:564](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L564)
 
 ***
 
@@ -365,7 +365,7 @@ Whether the file's metadata attribute exists
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:47](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L47)
+[packages/cozy-client/src/models/file.js:46](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L46)
 
 ***
 
@@ -387,7 +387,7 @@ Whether the file is client-side encrypted
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:75](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L75)
+[packages/cozy-client/src/models/file.js:74](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L74)
 
 ***
 
@@ -407,7 +407,7 @@ Whether the file is client-side encrypted
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:41](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L41)
+[packages/cozy-client/src/models/file.js:40](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L40)
 
 ***
 
@@ -427,7 +427,7 @@ Whether the file is client-side encrypted
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:584](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L584)
+[packages/cozy-client/src/models/file.js:583](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L583)
 
 ***
 
@@ -449,7 +449,7 @@ Is file param a correct note
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:55](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L55)
+[packages/cozy-client/src/models/file.js:54](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L54)
 
 ***
 
@@ -471,7 +471,7 @@ Whether the file is supported by Only Office
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:85](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L85)
+[packages/cozy-client/src/models/file.js:84](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L84)
 
 ***
 
@@ -492,7 +492,7 @@ Whether the file is supported by Only Office
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:557](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L557)
+[packages/cozy-client/src/models/file.js:556](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L556)
 
 ***
 
@@ -516,7 +516,7 @@ Returns whether the file is a shortcut to a sharing
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:203](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L203)
+[packages/cozy-client/src/models/file.js:202](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L202)
 
 ***
 
@@ -540,7 +540,7 @@ Returns whether the sharing shortcut is new
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:228](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L228)
+[packages/cozy-client/src/models/file.js:227](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L227)
 
 ***
 
@@ -562,7 +562,7 @@ Returns whether the file is a shortcut to a sharing
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:193](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L193)
+[packages/cozy-client/src/models/file.js:192](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L192)
 
 ***
 
@@ -584,7 +584,7 @@ Returns whether the sharing shortcut is new
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:217](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L217)
+[packages/cozy-client/src/models/file.js:216](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L216)
 
 ***
 
@@ -606,7 +606,7 @@ true if the file is a shortcut
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:110](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L110)
+[packages/cozy-client/src/models/file.js:109](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L109)
 
 ***
 
@@ -635,7 +635,7 @@ Move file to destination.
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:316](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L316)
+[packages/cozy-client/src/models/file.js:315](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L315)
 
 ***
 
@@ -661,7 +661,7 @@ full normalized object
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:123](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L123)
+[packages/cozy-client/src/models/file.js:122](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L122)
 
 ***
 
@@ -688,7 +688,7 @@ The overrided file
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:371](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L371)
+[packages/cozy-client/src/models/file.js:370](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L370)
 
 ***
 
@@ -710,7 +710,7 @@ Read a file on a mobile
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:500](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L500)
+[packages/cozy-client/src/models/file.js:499](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L499)
 
 ***
 
@@ -736,7 +736,7 @@ The saved file
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:243](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L243)
+[packages/cozy-client/src/models/file.js:242](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L242)
 
 ***
 
@@ -760,7 +760,7 @@ But we want to exclude .txt and .md because the CozyUI Viewer can already show t
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:100](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L100)
+[packages/cozy-client/src/models/file.js:99](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L99)
 
 ***
 
@@ -784,7 +784,7 @@ Returns base filename and extension
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:25](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L25)
+[packages/cozy-client/src/models/file.js:24](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L24)
 
 ***
 
@@ -817,4 +817,4 @@ If there is a conflict, then we apply the conflict strategy : `erase` or `rename
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:461](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L461)
+[packages/cozy-client/src/models/file.js:460](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L460)

--- a/docs/api/cozy-client/modules/models.folder.md
+++ b/docs/api/cozy-client/modules/models.folder.md
@@ -25,7 +25,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/folder.js:10](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L10)
+[packages/cozy-client/src/models/folder.js:9](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L9)
 
 ## Functions
 
@@ -51,7 +51,7 @@ Folder document
 
 *Defined in*
 
-[packages/cozy-client/src/models/folder.js:70](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L70)
+[packages/cozy-client/src/models/folder.js:69](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L69)
 
 ***
 
@@ -77,7 +77,7 @@ Folder document
 
 *Defined in*
 
-[packages/cozy-client/src/models/folder.js:30](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L30)
+[packages/cozy-client/src/models/folder.js:29](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L29)
 
 ***
 
@@ -102,4 +102,4 @@ Folder referenced by the given document
 
 *Defined in*
 
-[packages/cozy-client/src/models/folder.js:91](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L91)
+[packages/cozy-client/src/models/folder.js:90](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/folder.js#L90)

--- a/docs/api/cozy-client/modules/models.timeseries.md
+++ b/docs/api/cozy-client/modules/models.timeseries.md
@@ -39,7 +39,7 @@ The TimeSeries found by the query in JSON-API format
 
 *Defined in*
 
-[packages/cozy-client/src/models/timeseries.js:78](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L78)
+[packages/cozy-client/src/models/timeseries.js:77](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L77)
 
 ***
 
@@ -62,4 +62,4 @@ Helper to save a time series document.
 
 *Defined in*
 
-[packages/cozy-client/src/models/timeseries.js:40](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L40)
+[packages/cozy-client/src/models/timeseries.js:39](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/timeseries.js#L39)

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -43,27 +43,6 @@ import { chain } from './CozyLink'
 import ObservableQuery from './ObservableQuery'
 import { CozyClient as SnapshotClient } from './testing/snapshots'
 import logger from './logger'
-import {
-  AppMetadata,
-  ClientCapabilities,
-  ClientResponse,
-  CozyClientDocument,
-  DocumentCollection,
-  HydratedDocument,
-  Link,
-  Mutation,
-  NodeEnvironment,
-  OldCozyClient,
-  OpenURLCallback,
-  PKCECodes,
-  QueryOptions,
-  QueryResult,
-  QueryState,
-  ReduxStore,
-  ReferenceMap,
-  SessionCode,
-  Token
-} from './types'
 import { QueryIDGenerator } from './store/queries'
 import stringify from 'json-stable-stringify'
 import PromiseCache from './promise-cache'
@@ -115,7 +94,7 @@ const DOC_UPDATE = 'update'
  * @property {object} [client]
  * @property {object} [link]
  * @property {object} [links]
- * @property {Token} [token]
+ * @property {import("./types").Token} [token]
  * @property {string} [uri]
  * @property {object} [stackClient]
  * @property {boolean} [warningForCustomHandlers]
@@ -124,11 +103,11 @@ const DOC_UPDATE = 'update'
  * @property {object} [oauth]
  * @property {Function} [onTokenRefresh]
  * @property {Function} [onError] - Default callback if a query is errored
- * @property  {Link}         [link]   - Backward compatibility
- * @property  {Array<Link>}  [links]  - List of links
+ * @property  {import("./types").Link}         [link]   - Backward compatibility
+ * @property  {Array<import("./types").Link>}  [links]  - List of links
  * @property  {object}       [schema] - Schema description for each doctypes
- * @property  {AppMetadata}  [appMetadata] - Metadata about the application that will be used in ensureCozyMetadata
- * @property  {ClientCapabilities} [capabilities] - Capabilities sent by the stack
+ * @property  {import("./types").AppMetadata}  [appMetadata] - Metadata about the application that will be used in ensureCozyMetadata
+ * @property  {import("./types").ClientCapabilities} [capabilities] - Capabilities sent by the stack
  * @property  {boolean} [store] - If set to false, the client will not instantiate a Redux store automatically. Use this if you want to merge cozy-client's store with your own redux store. See [here](https://docs.cozy.io/en/cozy-client/react-integration/#1b-use-your-own-redux-store) for more information.
  */
 
@@ -202,7 +181,7 @@ class CozyClient {
     this.schema = new Schema(schema, stackClient)
 
     /**
-     * @type {ClientCapabilities}
+     * @type {import("./types").ClientCapabilities}
      */
     this.capabilities = capabilities || null
 
@@ -317,7 +296,7 @@ class CozyClient {
    * To help with the transition from cozy-client-js to cozy-client, it is possible to instantiate
    * a client with a cookie-based instance of cozy-client-js.
    *
-   * @param {OldCozyClient} oldClient - An instance of the deprecated cozy-client
+   * @param {import("./types").OldCozyClient} oldClient - An instance of the deprecated cozy-client
    * @param {object} options - CozyStackClient options
    * @returns {CozyClient}
    */
@@ -335,7 +314,7 @@ class CozyClient {
    *
    * Warning: unlike other instantiators, this one needs to be awaited.
    *
-   * @param {OldCozyClient} oldClient - An OAuth instance of the deprecated cozy-client
+   * @param {import("./types").OldCozyClient} oldClient - An OAuth instance of the deprecated cozy-client
    * @param {object} options - CozyStackClient options
    * @returns {Promise<CozyClient>} An instance of a client, configured from the old client
    */
@@ -367,7 +346,7 @@ class CozyClient {
    * In konnector/service context, CozyClient can be instantiated from
    * environment variables
    *
-   * @param  {NodeEnvironment} [envArg]  - The environment
+   * @param  {import("./types").NodeEnvironment} [envArg]  - The environment
    * @param  {object} options - Options
    * @returns {CozyClient}
    */
@@ -568,7 +547,7 @@ class CozyClient {
    * a [DocumentCollection]{@link https://docs.cozy.io/en/cozy-client/api/cozy-stack-client/#DocumentCollection} instance.
    *
    * @param  {string} doctype The collection doctype.
-   * @returns {DocumentCollection} Collection corresponding to the doctype
+   * @returns {import("./types").DocumentCollection} Collection corresponding to the doctype
    */
   collection(doctype) {
     return this.getStackClient().collection(doctype)
@@ -606,7 +585,7 @@ client.query(Q('io.cozy.bills'))`)
    *
    * @param  {string} type - Doctype of the document
    * @param  {object} doc - Document to save
-   * @param  {ReferenceMap} [references] - References are a special kind of relationship
+   * @param  {import("./types").ReferenceMap} [references] - References are a special kind of relationship
    * that is not stored inside the referencer document, they are used for example between a photo
    * and its album. You should not need to use it normally.
    * @param  {object} options - Mutation options
@@ -661,7 +640,7 @@ client.query(Q('io.cozy.bills'))`)
    * - Can only be called with documents from the same doctype
    * - Does not support automatic creation of references
    *
-   * @param  {CozyClientDocument[]} docs - Documents from the same doctype
+   * @param  {import("./types").CozyClientDocument[]} docs - Documents from the same doctype
    * @param  {Object} mutationOptions - Mutation Options
    * @param  {string}    [mutationOptions.as] - Mutation id
    * @param  {Function}    [mutationOptions.update] - Function to update the document
@@ -690,10 +669,10 @@ client.query(Q('io.cozy.bills'))`)
     return this.mutate(mutation, mutationOptions)
   }
   /**
-   * @param  {CozyClientDocument} document - Document that will be saved
+   * @param  {import("./types").CozyClientDocument} document - Document that will be saved
    * @param {object} [options={event: DOC_CREATION}] - Event
    * @param {string} [options.event] - Mutation type
-   * @returns {CozyClientDocument}
+   * @returns {import("./types").CozyClientDocument}
    */
   ensureCozyMetadata(
     document,
@@ -756,8 +735,8 @@ client.query(Q('io.cozy.bills'))`)
   /**
    * Dehydrates and adds metadata before saving a document
    *
-   * @param  {CozyClientDocument} doc - Document that will be saved
-   * @returns {CozyClientDocument}
+   * @param  {import("./types").CozyClientDocument} doc - Document that will be saved
+   * @returns {import("./types").CozyClientDocument}
    */
   prepareDocumentForSave(doc) {
     const isNewDoc = !doc._rev
@@ -781,12 +760,12 @@ client.query(Q('io.cozy.bills'))`)
    * ```
    *
    *
-   * @param  {CozyClientDocument} document - Document to create
-   * @param  {ReferenceMap} [referencesByName] - References to the created document. The
+   * @param  {import("./types").CozyClientDocument} document - Document to create
+   * @param  {import("./types").ReferenceMap} [referencesByName] - References to the created document. The
    * relationship class associated to each reference list should support references, otherwise this
    * method will throw.
    *
-   * @returns {Mutation[]|Mutation}  One or more mutation to execute
+   * @returns {import("./types").Mutation[]|import("./types").Mutation}  One or more mutation to execute
    */
   getDocumentSavePlan(document, referencesByName) {
     const isNewDoc = !document._rev
@@ -872,8 +851,8 @@ client.query(Q('io.cozy.bills'))`)
   /**
    * Destroys a document. {before,after}:destroy hooks will be fired.
    *
-   * @param  {CozyClientDocument} document - Document to be deleted
-   * @returns {Promise<CozyClientDocument>} The document that has been deleted
+   * @param  {import("./types").CozyClientDocument} document - Document to be deleted
+   * @returns {Promise<import("./types").CozyClientDocument>} The document that has been deleted
    */
   async destroy(document, mutationOptions = {}) {
     await this.triggerHook('before:destroy', document)
@@ -894,7 +873,7 @@ client.query(Q('io.cozy.bills'))`)
    *
    * @param  {string} queryId - Id of the query
    * @param  {QueryDefinition} queryDefinition - Definition of the query
-   * @param  {QueryOptions} [options] - Additional options
+   * @param  {import("./types").QueryOptions} [options] - Additional options
    */
   ensureQueryExists(queryId, queryDefinition, options) {
     this.ensureStore()
@@ -916,8 +895,8 @@ client.query(Q('io.cozy.bills'))`)
    * executes its query when mounted if no fetch policy has been indicated.
    *
    * @param  {QueryDefinition} queryDefinition - Definition that will be executed
-   * @param  {QueryOptions} [options] - Options
-   * @returns {Promise<QueryResult>}
+   * @param  {import("./types").QueryOptions} [options] - Options
+   * @returns {Promise<import("./types").QueryResult>}
    */
   async query(queryDefinition, { update, ...options } = {}) {
     this.ensureStore()
@@ -993,8 +972,8 @@ client.query(Q('io.cozy.bills'))`)
    * result in a lot of network requests.
    *
    * @param  {QueryDefinition} queryDefinition - Definition to be executed
-   * @param {QueryOptions} [options] - Options
-   * @returns {Promise<QueryResult>} All documents matching the query
+   * @param {import("./types").QueryOptions} [options] - Options
+   * @returns {Promise<import("./types").QueryResult>} All documents matching the query
    */
   async queryAll(queryDefinition, options = {}) {
     const queryId =
@@ -1084,7 +1063,7 @@ client.query(Q('io.cozy.bills'))`)
    *
    * @private
    * @param  {QueryDefinition} definition QueryDefinition to be executed
-   * @returns {Promise<ClientResponse>}
+   * @returns {Promise<import("./types").ClientResponse>}
    */
   async requestQuery(definition) {
     const mainResponse = await this.chain.request(definition)
@@ -1211,8 +1190,8 @@ client.query(Q('io.cozy.bills'))`)
    * Instead, the relationships will have null documents.
    *
    * @param  {string} doctype - Doctype of the documents being hydrated
-   * @param  {Array<CozyClientDocument>} documents - Documents to be hydrated
-   * @returns {Array<HydratedDocument>}
+   * @param  {Array<import("./types").CozyClientDocument>} documents - Documents to be hydrated
+   * @returns {Array<import("./types").HydratedDocument>}
    */
   hydrateDocuments(doctype, documents) {
     if (this.options.autoHydrate === false) {
@@ -1233,9 +1212,9 @@ client.query(Q('io.cozy.bills'))`)
    * The original document is kept in the target attribute of
    * the relationship
    *
-   * @param  {CozyClientDocument} document - for which relationships must be resolved
+   * @param  {import("./types").CozyClientDocument} document - for which relationships must be resolved
    * @param  {Schema} [schemaArg] - Optional
-   * @returns {HydratedDocument}
+   * @returns {import("./types").HydratedDocument}
    */
   hydrateDocument(document, schemaArg) {
     if (!document) {
@@ -1308,7 +1287,7 @@ client.query(Q('io.cozy.bills'))`)
    *
    * @param {string} type - Doctype of the collection
    *
-   * @returns {CozyClientDocument[]} Array of documents or null if the collection does not exist.
+   * @returns {import("./types").CozyClientDocument[]} Array of documents or null if the collection does not exist.
    */
   getCollectionFromState(type) {
     try {
@@ -1325,7 +1304,7 @@ client.query(Q('io.cozy.bills'))`)
    * @param {string} type - Doctype of the document
    * @param {string} id   - Id of the document
    *
-   * @returns {CozyClientDocument} Document or null if the object does not exist.
+   * @returns {import("./types").CozyClientDocument} Document or null if the object does not exist.
    */
   getDocumentFromState(type, id) {
     try {
@@ -1346,7 +1325,7 @@ client.query(Q('io.cozy.bills'))`)
    * a single doc instead of an array for single doc queries. Defaults to false for backward
    * compatibility but will be set to true in the future.
    *
-   * @returns {QueryState} - Query state or null if it does not exist.
+   * @returns {import("./types").QueryState} - Query state or null if it does not exist.
    */
   getQueryFromState(id, options = {}) {
     const hydrated = options.hydrated || false
@@ -1386,8 +1365,8 @@ client.query(Q('io.cozy.bills'))`)
    *
    * @param {object} query - Query with definition and options
    * @param {QueryDefinition} query.definition - Query Definition
-   * @param {QueryOptions} query.options - Query Options
-   * @returns {Promise<QueryState>} Query state
+   * @param {import("./types").QueryOptions} query.options - Query Options
+   * @returns {Promise<import("./types").QueryState>} Query state
    */
   fetchQueryAndGetFromState = async ({ definition, options }) => {
     try {
@@ -1419,7 +1398,7 @@ client.query(Q('io.cozy.bills'))`)
   /**
    * Performs a complete OAuth flow, including updating the internal token at the end.
    *
-   * @param   {OpenURLCallback} openURLCallback Receives the URL to present to the user as a parameter, and should return a promise that resolves with the URL the user was redirected to after accepting the permissions.
+   * @param   {import("./types").OpenURLCallback} openURLCallback Receives the URL to present to the user as a parameter, and should return a promise that resolves with the URL the user was redirected to after accepting the permissions.
    * @returns {Promise<object>} Contains the fetched token and the client information. These should be stored and used to restore the client.
    */
   async startOAuthFlow(openURLCallback) {
@@ -1450,9 +1429,9 @@ client.query(Q('io.cozy.bills'))`)
    * It is possible to skip the session creation process (when using an in-app browser) by passing a sessionCode (see https://docs.cozy.io/en/cozy-stack/auth/#post-authsession_code)
    *
    * @param {object} [options] - Authorization options
-   * @param {OpenURLCallback} [options.openURLCallback] - Receives the URL to present to the user as a parameter, and should return a promise that resolves with the URL the user was redirected to after accepting the permissions.
-   * @param {SessionCode} [options.sessionCode] - session code than can be added to the authorization URL to automatically create the session.
-   * @param {PKCECodes} [options.pkceCodes] - code verifier and a code challenge that should be used in the PKCE verification process.
+   * @param {import("./types").OpenURLCallback} [options.openURLCallback] - Receives the URL to present to the user as a parameter, and should return a promise that resolves with the URL the user was redirected to after accepting the permissions.
+   * @param {import("./types").SessionCode} [options.sessionCode] - session code than can be added to the authorization URL to automatically create the session.
+   * @param {import("./types").PKCECodes} [options.pkceCodes] - code verifier and a code challenge that should be used in the PKCE verification process.
    * @returns {Promise<object>} Contains the fetched token and the client information. These should be stored and used to restore the client.
    */
   async authorize({
@@ -1523,7 +1502,7 @@ client.query(Q('io.cozy.bills'))`)
    * client.setStore(store)
    * ```
    *
-   * @param {ReduxStore} store - A redux store
+   * @param {import("./types").ReduxStore} store - A redux store
    * @param {object} [options] - Options
    * @param {boolean} [options.force] - Will deactivate throwing when client's store already exists
    */
@@ -1741,7 +1720,7 @@ instantiation of the client.`
   }
   /**
    *
-   * @param {AppMetadata} newAppMetadata AppMetadata to update
+   * @param {import("./types").AppMetadata} newAppMetadata AppMetadata to update
    */
   setAppMetadata(newAppMetadata) {
     this.appMetadata = {

--- a/packages/cozy-client/src/RealTimeQueries.jsx
+++ b/packages/cozy-client/src/RealTimeQueries.jsx
@@ -3,7 +3,6 @@ import useClient from './hooks/useClient'
 import { Mutations } from './queries/dsl'
 import { receiveMutationResult } from './store'
 import CozyClient from './CozyClient'
-import { CouchDBDocument, CozyClientDocument, Doctype, Mutation } from './types'
 
 /**
  * Normalizes an object representing a CouchDB document
@@ -11,8 +10,8 @@ import { CouchDBDocument, CozyClientDocument, Doctype, Mutation } from './types'
  * Ensures existence of `_type`
  *
  * @public
- * @param {CouchDBDocument} couchDBDoc - object representing the document
- * @returns {CozyClientDocument} full normalized document
+ * @param {import("./types").CouchDBDocument} couchDBDoc - object representing the document
+ * @returns {import("./types").CozyClientDocument} full normalized document
  */
 const normalizeDoc = (couchDBDoc, doctype) => {
   return {
@@ -26,9 +25,9 @@ const normalizeDoc = (couchDBDoc, doctype) => {
  * DispatchChange
  *
  * @param {CozyClient} client CozyClient instane
- * @param {Doctype} doctype Doctype of the document to update
- * @param {CouchDBDocument} couchDBDoc Document to update
- * @param {Mutation} mutationDefinitionCreator Mutation to apply
+ * @param {import("./types").Doctype} doctype Doctype of the document to update
+ * @param {import("./types").CouchDBDocument} couchDBDoc Document to update
+ * @param {import("./types").Mutation} mutationDefinitionCreator Mutation to apply
  */
 const dispatchChange = (
   client,
@@ -57,7 +56,7 @@ const dispatchChange = (
  * internal store updated.
  *
  * @param  {object} options - Options
- * @param  {Doctype} options.doctype - The doctype to watch
+ * @param  {import("./types").Doctype} options.doctype - The doctype to watch
  * @returns {null} The component does not display anything.
  */
 const RealTimeQueries = ({ doctype }) => {

--- a/packages/cozy-client/src/StackLink.js
+++ b/packages/cozy-client/src/StackLink.js
@@ -2,7 +2,6 @@ import zipWith from 'lodash/zipWith'
 
 import { MutationTypes, QueryDefinition } from './queries/dsl'
 import CozyLink from './CozyLink'
-import { CozyClientDocument, CouchDBBulkResult, ClientResponse } from './types'
 import { DOCTYPE_FILES } from './const'
 import { BulkEditError } from './errors'
 import logger from './logger'
@@ -28,9 +27,9 @@ const hasFindOptions = queryDefinition => {
  *
  * @private
  *
- * @param  {CouchDBBulkResult[]} bulkResponse - Response from bulk docs
- * @param  {CozyClientDocument[]} originalDocuments - Documents that were updated
- * @returns {{ data: CozyClientDocument[] }} - Full documents with updated _id and _rev
+ * @param  {import("./types").CouchDBBulkResult[]} bulkResponse - Response from bulk docs
+ * @param  {import("./types").CozyClientDocument[]} originalDocuments - Documents that were updated
+ * @returns {{ data: import("./types").CozyClientDocument[] }} - Full documents with updated _id and _rev
  */
 export const transformBulkDocsResponse = (bulkResponse, originalDocuments) => {
   const updatedDocs = zipWith(bulkResponse, originalDocuments, (result, od) =>
@@ -87,7 +86,7 @@ export default class StackLink extends CozyLink {
   /**
    *
    * @param {QueryDefinition} query - Query to execute
-   * @returns {Promise<ClientResponse>}
+   * @returns {Promise<import("./types").ClientResponse>}
    */
   executeQuery(query) {
     const { doctype, selector, id, ids, referenced, ...options } = query

--- a/packages/cozy-client/src/associations/Association.js
+++ b/packages/cozy-client/src/associations/Association.js
@@ -1,4 +1,3 @@
-import { CozyClientDocument } from '../types'
 import { QueryDefinition } from '../queries/dsl'
 
 /**
@@ -223,11 +222,11 @@ class Association {
   /**
    * Derived `Association`s need to implement this method.
    *
-   * @param {CozyClientDocument} document - Document to query
+   * @param {import("../types").CozyClientDocument} document - Document to query
    * @param {object} client - The CozyClient instance
    * @param {Association} assoc - Association containing info on how to build the query to fetch related documents
    *
-   * @returns {CozyClientDocument | QueryDefinition }
+   * @returns {import("../types").CozyClientDocument | QueryDefinition }
    */
   static query(document, client, assoc) {
     throw new Error('A custom relationship must define its query() function')

--- a/packages/cozy-client/src/associations/HasMany.js
+++ b/packages/cozy-client/src/associations/HasMany.js
@@ -2,7 +2,6 @@ import get from 'lodash/get'
 import merge from 'lodash/merge'
 import { QueryDefinition } from '../queries/dsl'
 import { getDocumentFromState, receiveQueryResult } from '../store'
-import { CozyClientDocument } from '../types'
 import Association from './Association'
 import logger from '../logger'
 
@@ -119,8 +118,8 @@ class HasMany extends Association {
   /**
    * Add the relationships to the target document
    *
-   * @param {CozyClientDocument[]} docsArg - Documents to add as relationships
-   * @returns {CozyClientDocument} The saved target document
+   * @param {import("../types").CozyClientDocument[]} docsArg - Documents to add as relationships
+   * @returns {import("../types").CozyClientDocument} The saved target document
    */
   add(docsArg) {
     const docs = Array.isArray(docsArg) ? docsArg : [docsArg]
@@ -131,8 +130,8 @@ class HasMany extends Association {
   /**
    * Remove the relationships from the target document
    *
-   * @param {CozyClientDocument[]} docsArg - Documents to remove as relationships
-   * @returns {CozyClientDocument} The saved target document
+   * @param {import("../types").CozyClientDocument[]} docsArg - Documents to remove as relationships
+   * @returns {import("../types").CozyClientDocument} The saved target document
    */
   remove(docsArg) {
     const docs = Array.isArray(docsArg) ? docsArg : [docsArg]
@@ -267,11 +266,11 @@ class HasMany extends Association {
   }
 
   /**
-   * @param {CozyClientDocument} document - Document to query
+   * @param {import("../types").CozyClientDocument} document - Document to query
    * @param {object} client - The CozyClient instance
    * @param {Association} assoc - The query params
    *
-   * @returns {CozyClientDocument | QueryDefinition}
+   * @returns {import("../types").CozyClientDocument | QueryDefinition}
    */
   static query(document, client, assoc) {
     const relationships = get(document, `relationships.${assoc.name}.data`, [])

--- a/packages/cozy-client/src/associations/HasManyFiles.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.js
@@ -3,19 +3,17 @@ import omit from 'lodash/omit'
 import uniq from 'lodash/uniq'
 import { Mutations, Q, QueryDefinition } from '../queries/dsl'
 import { getDocumentFromState } from '../store'
-import { CozyClientDocument } from '../types'
 import { DOCTYPE_FILES } from '../const'
 import Association from './Association'
 import HasMany from './HasMany'
-import { CouchDBViewCursor, DocId, ViewKey } from '../types'
 
 /**
  * newCursor - Returns a CouchDB view Cursor for cursor-based pagination
  *
- * @param {ViewKey} key - The CouchDB key of the view which will be requested
- * @param {DocId} startDocId - The first doc _id to return from the view
+ * @param {import("../types").ViewKey} key - The CouchDB key of the view which will be requested
+ * @param {import("../types").DocId} startDocId - The first doc _id to return from the view
  *
- * @returns {CouchDBViewCursor}
+ * @returns {import("../types").CouchDBViewCursor}
  */
 const newCursor = ([doctype, id, lastDatetime], startDocId) => {
   const cursorKey = lastDatetime ? [doctype, id, lastDatetime] : [doctype, id]
@@ -132,11 +130,11 @@ export default class HasManyFiles extends HasMany {
   }
 
   /**
-   * @param {CozyClientDocument} document - Document to query
+   * @param {import("../types").CozyClientDocument} document - Document to query
    * @param {object} client - The CozyClient instance
    * @param {Association} assoc - The query params
    *
-   * @returns {CozyClientDocument | QueryDefinition}
+   * @returns {import("../types").CozyClientDocument | QueryDefinition}
    */
   static query(document, client, assoc) {
     if (document._type === DOCTYPE_FILES) {

--- a/packages/cozy-client/src/associations/HasManyInPlace.js
+++ b/packages/cozy-client/src/associations/HasManyInPlace.js
@@ -1,5 +1,4 @@
 import { Q, QueryDefinition } from '../queries/dsl'
-import { CozyClientDocument } from '../types'
 import Association from './Association'
 
 /**
@@ -91,11 +90,11 @@ class HasManyInPlace extends Association {
   }
 
   /**
-   * @param {CozyClientDocument} document - Document to query
+   * @param {import("../types").CozyClientDocument} document - Document to query
    * @param {object} client - The CozyClient instance
    * @param {Association} assoc - The query params
    *
-   * @returns {CozyClientDocument | QueryDefinition}
+   * @returns {import("../types").CozyClientDocument | QueryDefinition}
    */
   static query(document, client, assoc) {
     const ids = document[assoc.name]

--- a/packages/cozy-client/src/associations/HasOne.js
+++ b/packages/cozy-client/src/associations/HasOne.js
@@ -1,7 +1,6 @@
 import get from 'lodash/get'
 import set from 'lodash/set'
 import { Q, QueryDefinition } from '../queries/dsl'
-import { CozyClientDocument } from '../types'
 import Association from './Association'
 import logger from '../logger'
 
@@ -19,11 +18,11 @@ export default class HasOne extends Association {
   }
 
   /**
-   * @param {CozyClientDocument} document - Document to query
+   * @param {import("../types").CozyClientDocument} document - Document to query
    * @param {object} client - The CozyClient instance
    * @param {Association} assoc - The query params
    *
-   * @returns {CozyClientDocument | QueryDefinition}
+   * @returns {import("../types").CozyClientDocument | QueryDefinition}
    */
   static query(document, client, assoc) {
     const relationship = get(document, `relationships.${assoc.name}.data`, {})
@@ -36,8 +35,8 @@ export default class HasOne extends Association {
   /**
    * Add the relationship to the target document
    *
-   * @param {CozyClientDocument} doc - Document to add as a relationship
-   * @returns {CozyClientDocument} The saved target document
+   * @param {import("../types").CozyClientDocument} doc - Document to add as a relationship
+   * @returns {import("../types").CozyClientDocument} The saved target document
    */
   add(doc) {
     this.setRelationship(doc)
@@ -47,7 +46,7 @@ export default class HasOne extends Association {
   /**
    * Remove the relationship from the target document
    *
-   * @returns {CozyClientDocument} The saved target document
+   * @returns {import("../types").CozyClientDocument} The saved target document
    */
   remove() {
     this.setRelationship(undefined)

--- a/packages/cozy-client/src/associations/HasOneInPlace.js
+++ b/packages/cozy-client/src/associations/HasOneInPlace.js
@@ -1,6 +1,5 @@
 import Association from './Association'
 import { Q, QueryDefinition } from '../queries/dsl'
-import { CozyClientDocument } from '../types'
 
 /**
  * Here the id of the document is directly set in the attribute
@@ -16,11 +15,11 @@ export default class HasOneInPlace extends Association {
   }
 
   /**
-   * @param {CozyClientDocument} document - Document to query
+   * @param {import("../types").CozyClientDocument} document - Document to query
    * @param {object} client - The CozyClient instance
    * @param {Association} assoc - The query params
    *
-   * @returns {CozyClientDocument | QueryDefinition}
+   * @returns {import("../types").CozyClientDocument | QueryDefinition}
    */
   static query(document, client, assoc) {
     const id = document[assoc.name]

--- a/packages/cozy-client/src/associations/helpers.js
+++ b/packages/cozy-client/src/associations/helpers.js
@@ -6,7 +6,6 @@ import HasOneInPlace from './HasOneInPlace'
 import HasMany from './HasMany'
 import HasManyInPlace from './HasManyInPlace'
 import HasManyFiles from './HasManyFiles'
-import { IOCozyFile, Doctype, Reference } from '../types'
 
 export const pickTypeAndId = x => pick(x, '_type', '_id')
 
@@ -95,8 +94,8 @@ export const create = (target, { name, type, doctype }, accessors) => {
 /**
  * Checks if the file is referenced by a specific doctype
  *
- * @param {IOCozyFile} file - io.cozy.files document
- * @param {Doctype} referencedBy - Doctype where document is referenced
+ * @param {import("../types").IOCozyFile} file - io.cozy.files document
+ * @param {import("../types").Doctype} referencedBy - Doctype where document is referenced
  * @returns {boolean} If a reference is found
  */
 export const isReferencedBy = (file, referencedBy) => {
@@ -109,8 +108,8 @@ export const isReferencedBy = (file, referencedBy) => {
 /**
  * Checks if the file is referenced by a specific doctype and a specific Id of that reference
  *
- * @param {IOCozyFile} file - io.cozy.files document
- * @param {Doctype} referencedBy - Doctype where document is referenced
+ * @param {import("../types").IOCozyFile} file - io.cozy.files document
+ * @param {import("../types").Doctype} referencedBy - Doctype where document is referenced
  * @param {string} referencedId - Id of the referenced document
  * @returns {boolean} If a reference is found
  */
@@ -127,9 +126,9 @@ export const isReferencedById = (file, referencedBy, referencedId) => {
 /**
  * Get array of reference by an specific doctype
  *
- * @param {IOCozyFile} file - io.cozy.files document
- * @param {Doctype} referencedBy - Doctype where document is referenced
- * @returns {Reference[]} Array of references found
+ * @param {import("../types").IOCozyFile} file - io.cozy.files document
+ * @param {import("../types").Doctype} referencedBy - Doctype where document is referenced
+ * @returns {import("../types").Reference[]} Array of references found
  */
 export const getReferencedBy = (file, referencedBy) => {
   const references =
@@ -140,10 +139,10 @@ export const getReferencedBy = (file, referencedBy) => {
 /**
  * Get array of reference by an specific doctype and a specific Id of that reference
  *
- * @param {IOCozyFile} file - io.cozy.files document
- * @param {Doctype} referencedBy - Doctype where document is referenced
+ * @param {import("../types").IOCozyFile} file - io.cozy.files document
+ * @param {import("../types").Doctype} referencedBy - Doctype where document is referenced
  * @param {string} referencedId - Id of the referenced document
- * @returns {Reference[]} Array of the reference found
+ * @returns {import("../types").Reference[]} Array of the reference found
  */
 export const getReferencedById = (file, referencedBy, referencedId) => {
   const references =

--- a/packages/cozy-client/src/authentication/mobile.js
+++ b/packages/cozy-client/src/authentication/mobile.js
@@ -5,10 +5,9 @@ import {
   hasSafariPlugin,
   isIOSApp
 } from 'cozy-device-helper'
-import { CordovaWindow } from '../types'
 
 /**
- * @type {CordovaWindow}
+ * @type {import("../types").CordovaWindow}
  */
 // @ts-ignore
 const win = typeof window !== 'undefined' ? window : null

--- a/packages/cozy-client/src/devtools/Queries.jsx
+++ b/packages/cozy-client/src/devtools/Queries.jsx
@@ -23,7 +23,6 @@ import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import CozyContext from '../context'
 import useClient from '../hooks/useClient'
 
-import { QueryState, CozyClientDocument } from '../types'
 import { NavSecondaryAction, ListGridItem } from './common'
 import PanelContent from './PanelContent'
 
@@ -55,7 +54,7 @@ const getClassNameForExecutedTimesQuery = time => {
 }
 
 /**
- * @param  {{ queryState: QueryState }} props - Query state containing fetchStatus, lastError
+ * @param  {{ queryState: import("../types").QueryState }} props - Query state containing fetchStatus, lastError
  */
 const FetchStatus = props => {
   const { queryState } = props
@@ -79,7 +78,7 @@ const FetchStatus = props => {
 }
 
 /**
- * @param  {{ queryState: QueryState }} props - Query state containing definition
+ * @param  {{ queryState: import("../types").QueryState }} props - Query state containing definition
  */
 const IndexedFields = props => {
   const { queryState } = props
@@ -93,7 +92,7 @@ const IndexedFields = props => {
 
 /**
  * @param  {string} search - Search string
- * @returns {function(CozyClientDocument): Boolean}
+ * @returns {function(import("../types").CozyClientDocument): Boolean}
  */
 const makeMatcher = search => {
   const specs = search.split(';')
@@ -192,7 +191,7 @@ const ObjectInspectorAndStringificator = ({ object }) => {
 }
 const QueryStateView = ({ name }) => {
   /**
-   * @type {QueryState}
+   * @type {import("../types").QueryState}
    */
   const queryState = useCozySelector(state => state.cozy.queries[name])
   const { data, options } = queryState

--- a/packages/cozy-client/src/errors.js
+++ b/packages/cozy-client/src/errors.js
@@ -1,12 +1,11 @@
 import zipWith from 'lodash/zipWith'
-import { CozyClientDocument, CouchDBBulkResult } from './types'
 
 export class BulkEditError extends Error {
   /**
    * Indicates that a bulk edit has (potentially partially) failed
    *
-   * @param  {CouchDBBulkResult[]} bulkResponse - CouchDB Bulk response
-   * @param  {CozyClientDocument[]} updatedDocs - Docs with updated _id and _rev
+   * @param  {import("./types").CouchDBBulkResult[]} bulkResponse - CouchDB Bulk response
+   * @param  {import("./types").CozyClientDocument[]} updatedDocs - Docs with updated _id and _rev
    */
   constructor(bulkResponse, updatedDocs) {
     super('Error while bulk saving')
@@ -19,7 +18,7 @@ export class BulkEditError extends Error {
   /**
    * Get documents that have been correctly updated
    *
-   * @returns {CozyClientDocument[]}
+   * @returns {import("./types").CozyClientDocument[]}
    */
   getUpdatedDocuments() {
     return this.results.filter(r => r.ok).map(r => r.doc)
@@ -28,7 +27,7 @@ export class BulkEditError extends Error {
   /**
    * Get bulk errors results
    *
-   * @returns {Array<CouchDBBulkResult & { doc: CozyClientDocument }>}
+   * @returns {Array<import("./types").CouchDBBulkResult & { doc: import("./types").CozyClientDocument }>}
    */
   getErrors() {
     return this.results.filter(r => !r.ok)

--- a/packages/cozy-client/src/flagship-certification/flagship-certification.js
+++ b/packages/cozy-client/src/flagship-certification/flagship-certification.js
@@ -2,7 +2,6 @@ import CozyClient from '../CozyClient'
 import logger from '../logger'
 
 import { getAppAttestationFromStore } from './store-attestation'
-import { AttestationResult, CertificationConfig } from './typedefs'
 /**
  * Request a challenge from the Stack that can be used to request the app attestation from the app store
  *
@@ -36,7 +35,7 @@ const getStackChallenge = async client => {
 /**
  * Give the app attestation to the Stack
  *
- * @param {AttestationResult} appAttestation - the app attestation that was returned by the app store
+ * @param {import("./typedefs").AttestationResult} appAttestation - the app attestation that was returned by the app store
  * @param {string} nonce - the Nonce string retrieved from the stack
  * @param {CozyClient} client - the CozyClient instance
  */
@@ -73,7 +72,7 @@ const giveAppAttestationToStack = async (appAttestation, nonce, client) => {
  * Verify app's identity and integrity so the Stack can trust it
  * Verification is done on Stack side by using information from the app's store (Google Play or Apple AppStore)
  *
- * @param {CertificationConfig} certificationConfig - the required configuration to access the stores API
+ * @param {import("./typedefs").CertificationConfig} certificationConfig - the required configuration to access the stores API
  * @param {CozyClient} client - the CozyClient instance
  */
 export const certifyFlagship = async (certificationConfig, client) => {

--- a/packages/cozy-client/src/flagship-certification/store-attestation.android.js
+++ b/packages/cozy-client/src/flagship-certification/store-attestation.android.js
@@ -1,14 +1,12 @@
 //@ts-ignore next-line
 import RNGoogleSafetyNet from 'react-native-google-safetynet'
 
-import { AttestationResult, CertificationConfig } from './typedefs'
-
 /**
  * Retrieve the app's attestation from the Google Play store
  *
  * @param {string} nonce - the Nonce string retrieved from the stack
- * @param {CertificationConfig} certificationConfig - Configuration to access the stores certification API
- * @returns {Promise<AttestationResult>} the app's attestation
+ * @param {import("./typedefs").CertificationConfig} certificationConfig - Configuration to access the stores certification API
+ * @returns {Promise<import("./typedefs").AttestationResult>} the app's attestation
  */
 export const getAppAttestationFromStore = async (
   nonce,

--- a/packages/cozy-client/src/flagship-certification/store-attestation.ios.js
+++ b/packages/cozy-client/src/flagship-certification/store-attestation.ios.js
@@ -1,14 +1,12 @@
 //@ts-ignore next-line
 import RNIOS11DeviceCheck from 'react-native-ios11-devicecheck'
 
-import { AttestationResult, CertificationConfig } from './typedefs'
-
 /**
  * Retrieve the app's attestation from the Apple AppStore
  *
  * @param {string} nonce - the Nonce string retrieved from the stack
- * @param {CertificationConfig} certificationConfig - Configuration to access the stores certification API
- * @returns {Promise<AttestationResult>} the app's attestation
+ * @param {import("./typedefs").CertificationConfig} certificationConfig - Configuration to access the stores certification API
+ * @returns {Promise<import("./typedefs").AttestationResult>} the app's attestation
  */
 export const getAppAttestationFromStore = async (
   nonce,

--- a/packages/cozy-client/src/flagship-certification/store-attestation.js
+++ b/packages/cozy-client/src/flagship-certification/store-attestation.js
@@ -1,12 +1,10 @@
-import { AttestationResult, CertificationConfig } from './typedefs'
-
 /**
  * Retrieve the app's attestation from the app's store
  * /!\ This is a mock implementation that should never be called
  *
  * @param {string} nonce - the Nonce string retrieved from the stack
- * @param {CertificationConfig} certificationConfig - Configuration to access the stores certification API
- * @returns {Promise<AttestationResult>} the app's attestation
+ * @param {import("./typedefs").CertificationConfig} certificationConfig - Configuration to access the stores certification API
+ * @returns {Promise<import("./typedefs").AttestationResult>} the app's attestation
  */
 const validateAppMock = async (nonce, certificationConfig) => {
   throw new Error(

--- a/packages/cozy-client/src/helpers/urlHelper.js
+++ b/packages/cozy-client/src/helpers/urlHelper.js
@@ -1,5 +1,3 @@
-import { CozyLinkData, RedirectLinkData, SubdomainType } from '../types'
-
 export const ensureFirstSlash = path => {
   if (!path) {
     return '/'
@@ -60,8 +58,8 @@ export const generateWebLink = ({
  * The given link MUST contain a slug
  *
  * @param {string} webLink - link to deconstruct. It should be a link from a Cozy and containing a slug
- * @param {SubdomainType} [subDomainType=flat] - whether the cozy is using flat or nested subdomains.
- * @returns {CozyLinkData} Deconstructed link
+ * @param {import("../types").SubdomainType} [subDomainType=flat] - whether the cozy is using flat or nested subdomains.
+ * @returns {import("../types").CozyLinkData} Deconstructed link
  */
 export const deconstructCozyWebLinkWithSlug = (
   webLink,
@@ -101,7 +99,7 @@ const isValidSlug = slug => slug.match(/^[a-z0-9]+$/)
  * Deconstruct the given redirect link in order to retrieve slug, pathname and hash
  *
  * @param {string} redirectLink - redirect link to deconstruct (i.e. 'drive/public/#/folder/SOME_ID')
- * @returns {RedirectLinkData} Deconstructed link
+ * @returns {import("../types").RedirectLinkData} Deconstructed link
  * @throws {InvalidRedirectLinkError} Thrown when redirect link is invalid
  */
 

--- a/packages/cozy-client/src/hooks/useAppsInMaintenance.jsx
+++ b/packages/cozy-client/src/hooks/useAppsInMaintenance.jsx
@@ -1,14 +1,13 @@
 import { useState, useEffect } from 'react'
 import Registry from '../registry'
 import CozyClient from '../CozyClient'
-import { AppsDoctype } from '../types'
 
 /**
  * Returns all apps in maintenance
  *
  * @param {CozyClient} client CozyClient instance
  *
- * @returns {AppsDoctype[]} An array with all apps in maintenance
+ * @returns {import("../types").AppsDoctype[]} An array with all apps in maintenance
  */
 const useAppsInMaintenance = client => {
   const [appsInMaintenance, setAppsInMaintenance] = useState([])

--- a/packages/cozy-client/src/hooks/useClientErrors.jsx
+++ b/packages/cozy-client/src/hooks/useClientErrors.jsx
@@ -3,7 +3,6 @@ import QuotaAlert from 'cozy-ui/transpiled/react/QuotaAlert'
 import filter from 'lodash/filter'
 import { FetchError } from 'cozy-stack-client'
 import { useClient } from './'
-import { ClientError } from '../types'
 
 /**
  * Rendering functions for client fetch errors by status code
@@ -31,7 +30,7 @@ function QuotaError({ dismiss }) {
 /**
  * Returns the handler for an error
  *
- * @param {ClientError} error - The error
+ * @param {import("../types").ClientError} error - The error
  * @returns {Function|null} React Component
  */
 function getErrorComponent(error) {
@@ -47,7 +46,7 @@ function getErrorComponent(error) {
  *
  * @private
  * @see ClientErrors
- * @param {ClientError[]} errorStack - array of errors/exceptions
+ * @param {import("../types").ClientError[]} errorStack - array of errors/exceptions
  * @param {Function} setErrorStack - mutates the array of errors
  * @returns {Array<React.ReactElement>} React rendering
  */
@@ -96,7 +95,7 @@ export default function useClientErrors({ handleExceptions = true } = {}) {
   /**
    * Handle client errors, add them to the error stack
    *
-   * @param {ClientError} error -
+   * @param {import("../types").ClientError} error -
    * @returns {boolean} true if the error was manager, false otherwise
    */
   const handleError = useCallback(

--- a/packages/cozy-client/src/hooks/useQuery.js
+++ b/packages/cozy-client/src/hooks/useQuery.js
@@ -3,7 +3,6 @@ import { createSelectorHook } from 'react-redux'
 import get from 'lodash/get'
 import useClient from './useClient'
 import logger from '../logger'
-import { UseQueryReturnValue, QueryOptions } from '../types'
 import { clientContext } from '../context'
 import { QueryDefinition } from '../queries/dsl'
 
@@ -23,8 +22,8 @@ const generateFetchMoreQueryDefinition = queryResult => {
  * Fetches a queryDefinition and returns the queryState
  *
  * @param {QueryDefinition} queryDefinition - Definition created with Q()
- * @param {QueryOptions} options - Options created with Q()
- * @returns {UseQueryReturnValue}
+ * @param {import("../types").QueryOptions} options - Options created with Q()
+ * @returns {import("../types").UseQueryReturnValue}
  */
 const useQuery = (queryDefinition, options) => {
   if (!useSelector) {

--- a/packages/cozy-client/src/hooks/useQueryAll.jsx
+++ b/packages/cozy-client/src/hooks/useQueryAll.jsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react'
 
-import { UseQueryReturnValue, QueryOptions } from '../types'
 import { QueryDefinition } from '../queries/dsl'
 import useQuery from './useQuery'
 import useSafeState from './helpers/useSafeState'
@@ -9,8 +8,8 @@ import useSafeState from './helpers/useSafeState'
  * Fetches a queryDefinition and run fetchMore on the query until the query is fully loaded
  *
  * @param {QueryDefinition} queryDefinition - Definition created with Q()
- * @param {QueryOptions} options - Options created with Q()
- * @returns {UseQueryReturnValue}
+ * @param {import("../types").QueryOptions} options - Options created with Q()
+ * @returns {import("../types").UseQueryReturnValue}
  */
 const useQueryAll = (queryDefinition, options) => {
   const [fetching, setFetching] = useSafeState(false)

--- a/packages/cozy-client/src/models/dacc.js
+++ b/packages/cozy-client/src/models/dacc.js
@@ -1,9 +1,4 @@
 import log from 'cozy-logger'
-import {
-  DACCMeasure,
-  DACCAggregatesParams,
-  DACCAggregatesResponse
-} from '../types'
 import CozyClient from '../CozyClient'
 
 /**
@@ -24,7 +19,7 @@ export const isCorrectDateFormat = date => {
 /**
  * Throw an errror if a DACC parameter is incorrect.
  *
- * @param { DACCMeasure} measure - The DACC measure
+ * @param { import("../types").DACCMeasure} measure - The DACC measure
  */
 export const checkMeasureParams = measure => {
   const {
@@ -71,7 +66,7 @@ export const checkMeasureParams = measure => {
  *
  * @param {CozyClient} client - The CozyClient instance
  * @param {string} remoteDoctype - The remote doctype to use
- * @param {DACCMeasure} measure - The DACC measure
+ * @param {import("../types").DACCMeasure} measure - The DACC measure
  */
 export const sendMeasureToDACC = async (client, remoteDoctype, measure) => {
   try {
@@ -102,7 +97,7 @@ export const sendMeasureToDACC = async (client, remoteDoctype, measure) => {
  * @property {string} [endDate]     - The measure end date
  *
  * @param {Params} params - The unformatted DACC aggregate params
- * @returns {DACCAggregatesParams}
+ * @returns {import("../types").DACCAggregatesParams}
  */
 export const buildAggregateParams = params => {
   const { measureName } = params
@@ -126,8 +121,8 @@ export const buildAggregateParams = params => {
  *
  * @param {CozyClient} client - The CozyClient instance
  * @param {string} remoteDoctype - The remote doctype to use
- * @param {DACCAggregatesParams} params - The request params
- * @returns { Promise<DACCAggregatesResponse> }
+ * @param {import("../types").DACCAggregatesParams} params - The request params
+ * @returns { Promise<import("../types").DACCAggregatesResponse> }
  */
 export const fetchAggregatesFromDACC = async (
   client,

--- a/packages/cozy-client/src/models/document/documentTypeData.js
+++ b/packages/cozy-client/src/models/document/documentTypeData.js
@@ -1,23 +1,9 @@
 import { Qualification } from './qualification'
-import {
-  ThemesList,
-  QualificationAttributes,
-  IdentityLabel,
-  FamilyLabel,
-  WorkStudyLabels,
-  HealthLabels,
-  HomeLabels,
-  TransportLabels,
-  FinanceLabels,
-  InvoiceLabels,
-  ItemsLabels,
-  ActivityLabels
-} from '../../types'
 
 /**
  *
- * @param {Array<ItemsLabels>} labels - Array of items labels
- * @returns {Array<QualificationAttributes>}
+ * @param {Array<import("../../types").ItemsLabels>} labels - Array of items labels
+ * @returns {Array<import("../../types").QualificationAttributes>}
  */
 const buildItemsByLabel = labels => {
   return labels
@@ -33,7 +19,7 @@ const buildItemsByLabel = labels => {
 }
 
 /**
- * @type {Array<IdentityLabel>}
+ * @type {Array<import("../../types").IdentityLabel>}
  */
 const identityLabels = [
   'identity_photo',
@@ -49,7 +35,7 @@ const identityLabels = [
 ]
 
 /**
- * @type {Array<FamilyLabel>}
+ * @type {Array<import("../../types").FamilyLabel>}
  */
 const familyLabels = [
   'family_record_book',
@@ -65,7 +51,7 @@ const familyLabels = [
 ]
 
 /**
- * @type {Array<WorkStudyLabels>}
+ * @type {Array<import("../../types").WorkStudyLabels>}
  */
 const workStudyLabels = [
   'diploma',
@@ -85,7 +71,7 @@ const workStudyLabels = [
 ]
 
 /**
- * @type {Array<HealthLabels>}
+ * @type {Array<import("../../types").HealthLabels>}
  */
 const healthLabels = [
   'health_certificate',
@@ -101,7 +87,7 @@ const healthLabels = [
 ]
 
 /**
- * @type {Array<HomeLabels>}
+ * @type {Array<import("../../types").HomeLabels>}
  */
 const homeLabels = [
   'phone_invoice',
@@ -124,7 +110,7 @@ const homeLabels = [
 ]
 
 /**
- * @type {Array<TransportLabels>}
+ * @type {Array<import("../../types").TransportLabels>}
  */
 const transportLabels = [
   'driver_license',
@@ -137,7 +123,7 @@ const transportLabels = [
 ]
 
 /**
- * @type {Array<ActivityLabels>}
+ * @type {Array<import("../../types").ActivityLabels>}
  */
 const activityLabels = [
   'personal_sporting_licence',
@@ -147,7 +133,7 @@ const activityLabels = [
 ]
 
 /**
- * @type {Array<FinanceLabels>}
+ * @type {Array<import("../../types").FinanceLabels>}
  */
 const financeLabels = [
   'tax_return',
@@ -167,7 +153,7 @@ const financeLabels = [
 ]
 
 /**
- * @type {Array<InvoiceLabels>}
+ * @type {Array<import("../../types").InvoiceLabels>}
  */
 const invoiceLabels = [
   'phone_invoice',
@@ -185,7 +171,7 @@ const invoiceLabels = [
 ]
 
 /**
- * @type {ThemesList}
+ * @type {import("../../types").ThemesList}
  */
 export const themesList = [
   {

--- a/packages/cozy-client/src/models/document/documentTypeDataHelpers.js
+++ b/packages/cozy-client/src/models/document/documentTypeDataHelpers.js
@@ -1,10 +1,8 @@
-import { Theme, QualificationAttributes } from '../../types'
-
 import { themesList } from './documentTypeData'
 
 /**
- * @param {QualificationAttributes} item - Qualification item
- * @returns {Theme|undefined}
+ * @param {import("../../types").QualificationAttributes} item - Qualification item
+ * @returns {import("../../types").Theme|undefined}
  */
 const findDefaultItemTheme = item => {
   return themesList.find(
@@ -13,8 +11,8 @@ const findDefaultItemTheme = item => {
 }
 
 /**
- * @param {QualificationAttributes} item - Qualification item
- * @returns {Theme|undefined}
+ * @param {import("../../types").QualificationAttributes} item - Qualification item
+ * @returns {import("../../types").Theme|undefined}
  */
 export const getThemeByItem = item => {
   const defaultTheme = findDefaultItemTheme(item)

--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -5,7 +5,6 @@ import trimEnd from 'lodash/trimEnd'
 
 import { setQualification } from './document/qualification'
 import { Q } from '../queries/dsl'
-import { IOCozyFile, QueryResult } from '../types'
 import { DOCTYPE_FILES } from '../const'
 import CozyClient from '../CozyClient'
 import logger from '../logger'
@@ -19,7 +18,7 @@ const FILENAME_WITH_EXTENSION_REGEX = /(.+)(\..*)$/
 /**
  * Returns base filename and extension
  *
- * @param {IOCozyFile} file An io.cozy.files
+ * @param {import("../types").IOCozyFile} file An io.cozy.files
  * @returns {object}  {filename, extension}
  */
 export const splitFilename = file => {
@@ -36,20 +35,20 @@ export const splitFilename = file => {
 
 /**
  *
- * @param {IOCozyFile} file io.cozy.files
+ * @param {import("../types").IOCozyFile} file io.cozy.files
  */
 export const isFile = file => file && file.type === FILE_TYPE
 
 /**
  *
- * @param {IOCozyFile} file io.cozy.files
+ * @param {import("../types").IOCozyFile} file io.cozy.files
  */
 export const isDirectory = file => file && file.type === DIR_TYPE
 
 /**
  * Is file param a correct note
  *
- * @param {IOCozyFile} file io.cozy.files
+ * @param {import("../types").IOCozyFile} file io.cozy.files
  * @returns {boolean}
  */
 export const isNote = file => {
@@ -69,7 +68,7 @@ export const isNote = file => {
 /**
  * Whether the file is client-side encrypted
  *
- * @param {IOCozyFile} file - io.cozy.files document
+ * @param {import("../types").IOCozyFile} file - io.cozy.files document
  * @returns {boolean}
  */
 export const isEncrypted = file => {
@@ -79,7 +78,7 @@ export const isEncrypted = file => {
 /**
  * Whether the file is supported by Only Office
  *
- * @param {IOCozyFile} file - io.cozy.file document
+ * @param {import("../types").IOCozyFile} file - io.cozy.file document
  * @returns {boolean}
  */
 export const isOnlyOfficeFile = file =>
@@ -94,7 +93,7 @@ export const isOnlyOfficeFile = file =>
  * We want to be consistent with the stack so we check the class attributes
  * But we want to exclude .txt and .md because the CozyUI Viewer can already show them
  *
- * @param {IOCozyFile} file - io.cozy.file document
+ * @param {import("../types").IOCozyFile} file - io.cozy.file document
  * @returns {boolean}
  */
 export const shouldBeOpenedByOnlyOffice = file =>
@@ -104,7 +103,7 @@ export const shouldBeOpenedByOnlyOffice = file =>
 
 /**
  *
- * @param {IOCozyFile} file - io.cozy.files document
+ * @param {import("../types").IOCozyFile} file - io.cozy.files document
  * @returns {boolean} true if the file is a shortcut
  */
 export const isShortcut = file => {
@@ -156,7 +155,7 @@ export function getParentFolderId(file) {
 /**
  * Returns the status of a sharing shortcut.
  *
- * @param {IOCozyFile} file - io.cozy.files document
+ * @param {import("../types").IOCozyFile} file - io.cozy.files document
  *
  * @returns {string} A description of the status
  */
@@ -166,7 +165,7 @@ export const getSharingShortcutStatus = file =>
 /**
  * Returns the mime type of the target of the sharing shortcut, if it is a file.
  *
- * @param {IOCozyFile} file  - io.cozy.files document
+ * @param {import("../types").IOCozyFile} file  - io.cozy.files document
  *
  * @returns {string} The mime-type of the target file, or an empty string is the target is not a file.
  */
@@ -176,7 +175,7 @@ export const getSharingShortcutTargetMime = file =>
 /**
  * Returns the doctype of the target of the sharing shortcut.
  *
- * @param {IOCozyFile} file - io.cozy.files document
+ * @param {import("../types").IOCozyFile} file - io.cozy.files document
  *
  * @returns {string} A doctype
  */
@@ -186,7 +185,7 @@ export const getSharingShortcutTargetDoctype = file =>
 /**
  * Returns whether the file is a shortcut to a sharing
  *
- * @param {IOCozyFile} file - io.cozy.files document
+ * @param {import("../types").IOCozyFile} file - io.cozy.files document
  *
  * @returns {boolean}
  */
@@ -196,7 +195,7 @@ export const isSharingShortcut = file => Boolean(getSharingShortcutStatus(file))
  * Returns whether the file is a shortcut to a sharing
  *
  * @deprecated Prefer to use isSharingShortcut.
- * @param {IOCozyFile} file - io.cozy.files document
+ * @param {import("../types").IOCozyFile} file - io.cozy.files document
  *
  * @returns {boolean}
  */
@@ -210,7 +209,7 @@ export const isSharingShorcut = file => {
 /**
  * Returns whether the sharing shortcut is new
  *
- * @param {IOCozyFile} file - io.cozy.files document
+ * @param {import("../types").IOCozyFile} file - io.cozy.files document
  *
  * @returns {boolean}
  */
@@ -236,9 +235,9 @@ export const isSharingShorcutNew = file => {
  * Save the file with the given qualification
  *
  * @param {CozyClient} client - The CozyClient instance
- * @param {IOCozyFile} file - The file to qualify
+ * @param {import("../types").IOCozyFile} file - The file to qualify
  * @param {object} qualification - The file qualification
- * @returns {Promise<IOCozyFile>} The saved file
+ * @returns {Promise<import("../types").IOCozyFile>} The saved file
  */
 export const saveFileQualification = async (client, file, qualification) => {
   const qualifiedFile = setQualification(file, qualification)
@@ -252,7 +251,7 @@ export const saveFileQualification = async (client, file, qualification) => {
  *
  * @param {object} client - The CozyClient instance
  * @param {object} docRules - the rules containing the searched qualification and the count
- * @returns {Promise<QueryResult>} The files found by the rules
+ * @returns {Promise<import("../types").QueryResult>} The files found by the rules
  */
 export const fetchFilesByQualificationRules = async (client, docRules) => {
   const { rules, count } = docRules
@@ -274,7 +273,7 @@ export const fetchFilesByQualificationRules = async (client, docRules) => {
  * Whether the file's metadata attribute exists
  *
  * @param {object} params - Param
- * @param {IOCozyFile} params.file - An io.cozy.files document
+ * @param {import("../types").IOCozyFile} params.file - An io.cozy.files document
  * @param {string} params.attribute - Metadata attribute to check
  * @returns {boolean}
  */
@@ -366,7 +365,7 @@ export const move = async (client, fileId, destination, force = false) => {
  * @param {string} dirPath      - Fullpath of directory to upload to ex: path/to/
  * @param {object} file         - HTML Object file
  * @param {object} metadata     - An object containing the wanted metadata to attach
- * @returns {Promise<IOCozyFile>} The overrided file
+ * @returns {Promise<import("../types").IOCozyFile>} The overrided file
  */
 export const overrideFileForPath = async (client, dirPath, file, metadata) => {
   let path = dirPath
@@ -422,7 +421,7 @@ export const generateNewFileNameOnConflict = filenameWithoutExtension => {
 /**
  * Generate a file name for a revision
  *
- * @param {IOCozyFile} file - io.cozy.files document
+ * @param {import("../types").IOCozyFile} file - io.cozy.files document
  * @param {object} revision - The revision containing the updated_at
  * @param {function} f      - A function taking a a date and a format as arguments to generate the name.
  */
@@ -559,7 +558,7 @@ export const isPlainText = (mimeType = '', fileName = '') => {
 }
 
 /**
- * @param {IOCozyFile} file - io.cozy.files document
+ * @param {import("../types").IOCozyFile} file - io.cozy.files document
  * @returns {boolean}
  */
 export const hasQualifications = file => {
@@ -567,7 +566,7 @@ export const hasQualifications = file => {
 }
 
 /**
- * @param {IOCozyFile} file - io.cozy.files document
+ * @param {import("../types").IOCozyFile} file - io.cozy.files document
  * @returns {boolean}
  */
 export const hasCertifications = file => {
@@ -578,7 +577,7 @@ export const hasCertifications = file => {
 }
 
 /**
- * @param {IOCozyFile} file - io.cozy.files document
+ * @param {import("../types").IOCozyFile} file - io.cozy.files document
  * @returns {boolean}
  */
 export const isFromKonnector = file => {

--- a/packages/cozy-client/src/models/folder.js
+++ b/packages/cozy-client/src/models/folder.js
@@ -1,6 +1,5 @@
 import sortBy from 'lodash/sortBy'
 import CozyClient from '../CozyClient'
-import { IOCozyFolder, CozyClientDocument } from '../types'
 import { DOCTYPE_FILES } from '../const'
 
 const APP_DOCTYPE = 'io.cozy.apps'
@@ -25,7 +24,7 @@ export const MAGIC_FOLDERS = {
  * @param  {string} id Magic Folder id. `CozyFolder.magicFolders` contains the
  * ids of folders that can be magic folders.
  * @param {string} path Default path to use if magic folder does not exist
- * @returns {Promise<IOCozyFolder>} Folder document
+ * @returns {Promise<import("../types").IOCozyFolder>} Folder document
  */
 export const ensureMagicFolder = async (client, id, path) => {
   const magicFolderDocument = {
@@ -64,8 +63,8 @@ export const ensureMagicFolder = async (client, id, path) => {
  *
  * @param  {CozyClient}  client - cozy-client instance
  * @param  {string}  path - Folder path
- * @param  {CozyClientDocument}  document - Document to make reference to. Any doctype.
- * @returns {Promise<IOCozyFolder>}  Folder document
+ * @param  {import("../types").CozyClientDocument}  document - Document to make reference to. Any doctype.
+ * @returns {Promise<import("../types").IOCozyFolder>}  Folder document
  */
 export const createFolderWithReference = async (client, path, document) => {
   const collection = client.collection(DOCTYPE_FILES)
@@ -85,8 +84,8 @@ export const createFolderWithReference = async (client, path, document) => {
  * Returns the most recent folder referenced by the given document
  *
  * @param  {CozyClient}  client    cozy-client instance
- * @param  {CozyClientDocument}  document  Document to get references from
- * @returns {Promise<IOCozyFolder>} Folder referenced by the given document
+ * @param  {import("../types").CozyClientDocument}  document  Document to get references from
+ * @returns {Promise<import("../types").IOCozyFolder>} Folder referenced by the given document
  */
 export const getReferencedFolder = async (client, document) => {
   const { included } = await client

--- a/packages/cozy-client/src/models/timeseries.js
+++ b/packages/cozy-client/src/models/timeseries.js
@@ -1,5 +1,4 @@
 import { Q } from '../queries/dsl'
-import { Doctype } from '../types'
 
 const validateTimeSeriesFormat = timeseries => {
   if (!timeseries.startDate || !timeseries.endDate) {
@@ -80,7 +79,7 @@ export const fetchTimeSeriesByIntervalAndSource = async (
   { startDate, endDate, dataType, source, limit }
 ) => {
   /**
-   * @type {Doctype}
+   * @type {import("../types").Doctype}
    */
   const doctype = `io.cozy.timeseries.${dataType}`
   const query = Q(doctype)

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -1,6 +1,6 @@
 import isArray from 'lodash/isArray'
 import findKey from 'lodash/findKey'
-import { CouchDBViewCursor, DocId, Doctype } from '../types'
+
 import logger from '../logger'
 
 /**
@@ -33,9 +33,9 @@ class QueryDefinition {
    * @class
    *
    * @param {object} options Initial options for the query definition
-   * @param {Doctype} [options.doctype] - The doctype of the doc.
-   * @param {DocId|null} [options.id] - The id of the doc.
-   * @param {Array<DocId>} [options.ids] - The ids of the docs.
+   * @param  {import('../types').Doctype} [options.doctype] - The doctype of the doc.
+   * @param {import('../types').DocId|null} [options.id] - The id of the doc.
+   * @param {Array<import('../types').DocId>} [options.ids] - The ids of the docs.
    * @param {MangoSelector} [options.selector] - The selector to query the docs.
    * @param {Array<string>} [options.fields] - The fields to return.
    * @param {Array<string>} [options.indexedFields] - The fields to index.
@@ -45,7 +45,7 @@ class QueryDefinition {
    * @param {string|null} [options.referenced] - The referenced document.
    * @param {number|null} [options.limit] - The document's limit to return.
    * @param {number|null} [options.skip] - The number of docs to skip.
-   * @param {CouchDBViewCursor} [options.cursor] - The cursor to paginate views.
+   * @param {import('../types').CouchDBViewCursor} [options.cursor] - The cursor to paginate views.
    * @param {string} [options.bookmark] - The bookmark to paginate mango queries.
    */
   constructor(options = {}) {
@@ -304,7 +304,7 @@ class QueryDefinition {
    * the starting document of the query, e.g. "file-id".
    * Use the last docid of each query as startkey_docid to paginate or leave blank for the first query.
    *
-   * @param {CouchDBViewCursor} cursor The cursor for pagination.
+   * @param {import('../types').CouchDBViewCursor} cursor The cursor for pagination.
    * @returns {QueryDefinition}  The QueryDefinition object.
    */
   offsetCursor(cursor) {
@@ -368,7 +368,7 @@ class QueryDefinition {
  * Helper to create a QueryDefinition. Recommended way to create
  * query definitions.
  *
- * @param {Doctype} doctype - Doctype of the query definition
+ * @param {import('../types').Doctype} doctype - Doctype of the query definition
  *
  * @example
  * ```

--- a/packages/cozy-client/src/store/documents.js
+++ b/packages/cozy-client/src/store/documents.js
@@ -9,7 +9,6 @@ import logger from '../logger'
 import { isReceivingData } from './queries'
 import { MutationTypes } from '../queries/dsl'
 import { isReceivingMutationResult } from './mutations'
-import { CozyClientDocument } from '../types'
 
 import { properId } from './helpers'
 
@@ -51,7 +50,7 @@ export const mergeDocumentsWithRelationships = (
   nextDocument = {}
 ) => {
   /**
-   * @type {CozyClientDocument}
+   * @type {import("../types").CozyClientDocument}
    */
   const merged = {
     ...prevDocument,

--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -17,13 +17,6 @@ import { getDocumentFromSlice } from './documents'
 import { isReceivingMutationResult } from './mutations'
 import { properId } from './helpers'
 import { isAGetByIdQuery, QueryDefinition } from '../queries/dsl'
-import {
-  QueryState,
-  QueriesStateSlice,
-  DocumentsStateSlice,
-  CozyClientDocument,
-  QueryOptions
-} from '../types'
 import logger from '../logger'
 
 const INIT_QUERY = 'INIT_QUERY'
@@ -44,7 +37,7 @@ export const isQueryAction = action =>
 
 export const isReceivingData = action => action.type === RECEIVE_QUERY_RESULT
 
-/** @type {QueryState} */
+/** @type {import("../types").QueryState} */
 const queryInitialState = {
   id: null,
   definition: null,
@@ -64,8 +57,8 @@ const queryInitialState = {
 /**
  * Return the docs ids accordingly to the given sort and fetched docs
  *
- * @param {QueryState} queryState - Current state
- * @param {DocumentsStateSlice} documents - Reference to the documents slice
+ * @param {import("../types").QueryState} queryState - Current state
+ * @param {import("../types").DocumentsStateSlice} documents - Reference to the documents slice
  * @param {Array<string>} ids - The updated ids after query
  * @param {object} params - The additional params
  * @param {number} params.count - The count of retrieved docs
@@ -106,9 +99,9 @@ export const sortAndLimitDocsIds = (
 /**
  * Return the query docs ids, taken from the action response and the documents' slice
  *
- * @param {QueryState} queryState - Current state
+ * @param {import("../types").QueryState} queryState - Current state
  * @param {object} response - The action response
- * @param {DocumentsStateSlice} documents - Reference to the documents slice
+ * @param {import("../types").DocumentsStateSlice} documents - Reference to the documents slice
  * @param {object} params - The additional params
  * @param {number} params.count - The count of retrieved docs
  * @param {number} params.fetchedPagesCount - The number of pages already fetched
@@ -130,10 +123,10 @@ const updateQueryDataFromResponse = (
 /**
  * Reducer for a query slice
  *
- * @param  {QueryState} state - Current state
+ * @param  {import("../types").QueryState} state - Current state
  * @param  {any} action - Redux action
- * @param  {DocumentsStateSlice} documents - Reference to the next documents slice
- * @returns {QueryState} - Next state
+ * @param  {import("../types").DocumentsStateSlice} documents - Reference to the next documents slice
+ * @returns {import("../types").QueryState} - Next state
  */
 const query = (state = queryInitialState, action, documents) => {
   switch (action.type) {
@@ -182,7 +175,7 @@ const query = (state = queryInitialState, action, documents) => {
         }
       }
 
-      /** @type {Partial<QueryState>} */
+      /** @type {Partial<import("../types").QueryState>} */
       const common = {
         fetchStatus: 'loaded',
         isFetching: action.backgroundFetching ? false : null,
@@ -267,7 +260,7 @@ export const mergeSelectorAndPartialIndex = queryDefinition => ({
 
 /**
  * @param  {QueryDefinition} queryDefinition - A query definition
- * @returns {function(CozyClientDocument): boolean}
+ * @returns {function(import("../types").CozyClientDocument): boolean}
  */
 const getSelectorFilterFn = queryDefinition => {
   if (queryDefinition.selector || queryDefinition.partialFilter) {
@@ -297,8 +290,8 @@ const getSelectorFilterFn = queryDefinition => {
  * Returns a predicate function that checks if a document should be
  * included in the result of the query.
  *
- * @param  {QueryState} query - Definition of the query
- * @returns {function(CozyClientDocument): boolean} Predicate function
+ * @param  {import("../types").QueryState} query - Definition of the query
+ * @returns {function(import("../types").CozyClientDocument): boolean} Predicate function
  */
 const getQueryDocumentsChecker = query => {
   const qdoctype = query.definition.doctype
@@ -324,7 +317,7 @@ const makeCaseInsensitiveStringSorter = attrName => item => {
  * receiving updates.
  *
  * @param {QueryDefinition} definition - A query definition
- * @returns {function(Array<CozyClientDocument>): Array<CozyClientDocument>}
+ * @returns {function(Array<import("../types").CozyClientDocument>): Array<import("../types").CozyClientDocument>}
  *
  * @private
  */
@@ -350,10 +343,10 @@ export const makeSorterFromDefinition = definition => {
 /**
  * Updates query state when new data comes in
  *
- * @param  {QueryState} query - Current query state
- * @param  {Array<CozyClientDocument>} newData - New documents (in most case from the server)
- * @param  {DocumentsStateSlice} documents - A reference to the documents slice
- * @returns {QueryState} - Updated query state
+ * @param  {import("../types").QueryState} query - Current query state
+ * @param  {Array<import("../types").CozyClientDocument>} newData - New documents (in most case from the server)
+ * @param  {import("../types").DocumentsStateSlice} documents - A reference to the documents slice
+ * @returns {import("../types").QueryState} - Updated query state
  */
 export const updateData = (query, newData, documents) => {
   const belongsToQuery = getQueryDocumentsChecker(query)
@@ -397,8 +390,8 @@ export const updateData = (query, newData, documents) => {
  * from an action
  *
  * @param  {object} action - A redux action
- * @param  {DocumentsStateSlice} documents - Reference to documents slice
- * @returns {function(QueryState): QueryState} - Updater query state
+ * @param  {import("../types").DocumentsStateSlice} documents - Reference to documents slice
+ * @returns {function(import("../types").QueryState): import("../types").QueryState} - Updater query state
  */
 const autoQueryUpdater = (action, documents) => query => {
   let data = get(action, 'response.data') || get(action, 'definition.document')
@@ -424,8 +417,8 @@ const autoQueryUpdater = (action, documents) => query => {
  * from an action
  *
  * @param  {object} action - A redux action
- * @param  {DocumentsStateSlice} documents - Reference to documents slice
- * @returns {function(QueryState): QueryState} - Updater query state
+ * @param  {import("../types").DocumentsStateSlice} documents - Reference to documents slice
+ * @returns {function(import("../types").QueryState): import("../types").QueryState} - Updater query state
  */
 const manualQueryUpdater = (action, documents) => query => {
   const updateQueries = action.updateQueries
@@ -449,11 +442,11 @@ const manualQueryUpdater = (action, documents) => query => {
 }
 
 /**
- * @param  {QueriesStateSlice}  state - Redux slice containing all the query states indexed by name
+ * @param  {import("../types").QueriesStateSlice}  state - Redux slice containing all the query states indexed by name
  * @param  {object}  action - Income redux action
- * @param  {DocumentsStateSlice}  documents - Reference to documents slice
+ * @param  {import("../types").DocumentsStateSlice}  documents - Reference to documents slice
  * @param  {boolean} haveDocumentsChanged - Has the document slice changed with current action
- * @returns {QueriesStateSlice}
+ * @returns {import("../types").QueriesStateSlice}
  */
 const queries = (
   state = {},
@@ -500,7 +493,7 @@ export default queries
  *
  * @param  {string} queryId  Name/id of the query
  * @param  {QueryDefinition} queryDefinition - Definition of the created query
- * @param  {QueryOptions} [options] - Options for the created query
+ * @param  {import("../types").QueryOptions} [options] - Options for the created query
  * @returns {object} Redux action to dispatch
  */
 export const initQuery = (queryId, queryDefinition, options = null) => {
@@ -519,7 +512,7 @@ export const initQuery = (queryId, queryDefinition, options = null) => {
  * Update the fetchStatus when the query is loading
  *
  * @param  {string} queryId - id of the query
- * @param  {QueryOptions} [options] - Options for the created query
+ * @param  {import("../types").QueryOptions} [options] - Options for the created query
  * @returns {object} Redux action to dispatch
  */
 export const loadQuery = (queryId, options) => {
@@ -535,7 +528,7 @@ export const loadQuery = (queryId, options) => {
  *
  * @param  {string} queryId - id of the query
  * @param {object} response - The action response
- * @param  {QueryOptions} [options] - Options for the created query
+ * @param  {import("../types").QueryOptions} [options] - Options for the created query
  * @returns {object} Redux action to dispatch
  */
 export const receiveQueryResult = (queryId, response, options = {}) => ({
@@ -550,7 +543,7 @@ export const receiveQueryResult = (queryId, response, options = {}) => ({
  *
  * @param  {string} queryId - id of the query
  * @param {object} error - The action error
- * @param  {QueryOptions} [options] - Options for the created query
+ * @param  {import("../types").QueryOptions} [options] - Options for the created query
  * @returns {object} Redux action to dispatch
  */
 export const receiveQueryError = (queryId, error, options = {}) => ({

--- a/packages/cozy-client/types/CozyClient.d.ts
+++ b/packages/cozy-client/types/CozyClient.d.ts
@@ -3,7 +3,7 @@ export type ClientOptions = {
     client?: object;
     link?: object;
     links?: object;
-    token?: Token;
+    token?: import("./types").Token;
     uri?: string;
     stackClient?: object;
     warningForCustomHandlers?: boolean;
@@ -25,11 +25,11 @@ export type ClientOptions = {
     /**
      * - Metadata about the application that will be used in ensureCozyMetadata
      */
-    appMetadata?: AppMetadata;
+    appMetadata?: import("./types").AppMetadata;
     /**
      * - Capabilities sent by the stack
      */
-    capabilities?: ClientCapabilities;
+    capabilities?: import("./types").ClientCapabilities;
     /**
      * - If set to false, the client will not instantiate a Redux store automatically. Use this if you want to merge cozy-client's store with your own redux store. See [here](https://docs.cozy.io/en/cozy-client/react-integration/#1b-use-your-own-redux-store) for more information.
      */
@@ -40,7 +40,7 @@ export type ClientOptions = {
  * @property {object} [client]
  * @property {object} [link]
  * @property {object} [links]
- * @property {Token} [token]
+ * @property {import("./types").Token} [token]
  * @property {string} [uri]
  * @property {object} [stackClient]
  * @property {boolean} [warningForCustomHandlers]
@@ -49,11 +49,11 @@ export type ClientOptions = {
  * @property {object} [oauth]
  * @property {Function} [onTokenRefresh]
  * @property {Function} [onError] - Default callback if a query is errored
- * @property  {Link}         [link]   - Backward compatibility
- * @property  {Array<Link>}  [links]  - List of links
+ * @property  {import("./types").Link}         [link]   - Backward compatibility
+ * @property  {Array<import("./types").Link>}  [links]  - List of links
  * @property  {object}       [schema] - Schema description for each doctypes
- * @property  {AppMetadata}  [appMetadata] - Metadata about the application that will be used in ensureCozyMetadata
- * @property  {ClientCapabilities} [capabilities] - Capabilities sent by the stack
+ * @property  {import("./types").AppMetadata}  [appMetadata] - Metadata about the application that will be used in ensureCozyMetadata
+ * @property  {import("./types").ClientCapabilities} [capabilities] - Capabilities sent by the stack
  * @property  {boolean} [store] - If set to false, the client will not instantiate a Redux store automatically. Use this if you want to merge cozy-client's store with your own redux store. See [here](https://docs.cozy.io/en/cozy-client/react-integration/#1b-use-your-own-redux-store) for more information.
  */
 /**
@@ -69,31 +69,31 @@ declare class CozyClient {
      * To help with the transition from cozy-client-js to cozy-client, it is possible to instantiate
      * a client with a cookie-based instance of cozy-client-js.
      *
-     * @param {OldCozyClient} oldClient - An instance of the deprecated cozy-client
+     * @param {import("./types").OldCozyClient} oldClient - An instance of the deprecated cozy-client
      * @param {object} options - CozyStackClient options
      * @returns {CozyClient}
      */
-    static fromOldClient(oldClient: OldCozyClient, options: object): CozyClient;
+    static fromOldClient(oldClient: import("./types").OldCozyClient, options: object): CozyClient;
     /**
      * To help with the transition from cozy-client-js to cozy-client, it is possible to instantiate
      * a client with an OAuth-based instance of cozy-client-js.
      *
      * Warning: unlike other instantiators, this one needs to be awaited.
      *
-     * @param {OldCozyClient} oldClient - An OAuth instance of the deprecated cozy-client
+     * @param {import("./types").OldCozyClient} oldClient - An OAuth instance of the deprecated cozy-client
      * @param {object} options - CozyStackClient options
      * @returns {Promise<CozyClient>} An instance of a client, configured from the old client
      */
-    static fromOldOAuthClient(oldClient: OldCozyClient, options: object): Promise<CozyClient>;
+    static fromOldOAuthClient(oldClient: import("./types").OldCozyClient, options: object): Promise<CozyClient>;
     /**
      * In konnector/service context, CozyClient can be instantiated from
      * environment variables
      *
-     * @param  {NodeEnvironment} [envArg]  - The environment
+     * @param  {import("./types").NodeEnvironment} [envArg]  - The environment
      * @param  {object} options - Options
      * @returns {CozyClient}
      */
-    static fromEnv(envArg?: NodeEnvironment, options?: object): CozyClient;
+    static fromEnv(envArg?: import("./types").NodeEnvironment, options?: object): CozyClient;
     /**
      * When used from an app, CozyClient can be instantiated from the data injected by the stack in
      * the DOM.
@@ -149,7 +149,7 @@ declare class CozyClient {
     loginPromise: Promise<void>;
     options: {
         client?: object;
-        token?: Token;
+        token?: import("./types").Token;
         uri?: string;
         stackClient?: object;
         warningForCustomHandlers?: boolean;
@@ -180,9 +180,9 @@ declare class CozyClient {
     chain: any;
     schema: Schema;
     /**
-     * @type {ClientCapabilities}
+     * @type {import("./types").ClientCapabilities}
      */
-    capabilities: ClientCapabilities;
+    capabilities: import("./types").ClientCapabilities;
     plugins: {};
     /**
      * Holds in-flight promises for deduplication purpose
@@ -294,9 +294,9 @@ declare class CozyClient {
      * a [DocumentCollection]{@link https://docs.cozy.io/en/cozy-client/api/cozy-stack-client/#DocumentCollection} instance.
      *
      * @param  {string} doctype The collection doctype.
-     * @returns {DocumentCollection} Collection corresponding to the doctype
+     * @returns {import("./types").DocumentCollection} Collection corresponding to the doctype
      */
-    collection(doctype: string): DocumentCollection;
+    collection(doctype: string): import("./types").DocumentCollection;
     fetch(method: any, path: any, body: any, options?: {}): any;
     all(doctype: any): QueryDefinition;
     find(doctype: any, selector?: any): QueryDefinition;
@@ -306,7 +306,7 @@ declare class CozyClient {
      *
      * @param  {string} type - Doctype of the document
      * @param  {object} doc - Document to save
-     * @param  {ReferenceMap} [references] - References are a special kind of relationship
+     * @param  {import("./types").ReferenceMap} [references] - References are a special kind of relationship
      * that is not stored inside the referencer document, they are used for example between a photo
      * and its album. You should not need to use it normally.
      * @param  {object} options - Mutation options
@@ -325,7 +325,7 @@ declare class CozyClient {
      *
      * @returns {Promise}
      */
-    create(type: string, doc: object, references?: ReferenceMap, options?: object): Promise<any>;
+    create(type: string, doc: object, references?: import("./types").ReferenceMap, options?: object): Promise<any>;
     validate(document: any): Promise<{}>;
     /**
      * Create or update a document on the server
@@ -340,34 +340,34 @@ declare class CozyClient {
      * - Can only be called with documents from the same doctype
      * - Does not support automatic creation of references
      *
-     * @param  {CozyClientDocument[]} docs - Documents from the same doctype
+     * @param  {import("./types").CozyClientDocument[]} docs - Documents from the same doctype
      * @param  {Object} mutationOptions - Mutation Options
      * @param  {string}    [mutationOptions.as] - Mutation id
      * @param  {Function}    [mutationOptions.update] - Function to update the document
      * @param  {Function}    [mutationOptions.updateQueries] - Function to update queries
      * @returns {Promise<void>}
      */
-    saveAll(docs: CozyClientDocument[], mutationOptions?: {
+    saveAll(docs: import("./types").CozyClientDocument[], mutationOptions?: {
         as?: string;
         update?: Function;
         updateQueries?: Function;
     }): Promise<void>;
     /**
-     * @param  {CozyClientDocument} document - Document that will be saved
+     * @param  {import("./types").CozyClientDocument} document - Document that will be saved
      * @param {object} [options={event: DOC_CREATION}] - Event
      * @param {string} [options.event] - Mutation type
-     * @returns {CozyClientDocument}
+     * @returns {import("./types").CozyClientDocument}
      */
-    ensureCozyMetadata(document: CozyClientDocument, options?: {
+    ensureCozyMetadata(document: import("./types").CozyClientDocument, options?: {
         event?: string;
-    }): CozyClientDocument;
+    }): import("./types").CozyClientDocument;
     /**
      * Dehydrates and adds metadata before saving a document
      *
-     * @param  {CozyClientDocument} doc - Document that will be saved
-     * @returns {CozyClientDocument}
+     * @param  {import("./types").CozyClientDocument} doc - Document that will be saved
+     * @returns {import("./types").CozyClientDocument}
      */
-    prepareDocumentForSave(doc: CozyClientDocument): CozyClientDocument;
+    prepareDocumentForSave(doc: import("./types").CozyClientDocument): import("./types").CozyClientDocument;
     /**
      * Creates a list of mutations to execute to create a document and its relationships.
      *
@@ -382,31 +382,31 @@ declare class CozyClient {
      * ```
      *
      *
-     * @param  {CozyClientDocument} document - Document to create
-     * @param  {ReferenceMap} [referencesByName] - References to the created document. The
+     * @param  {import("./types").CozyClientDocument} document - Document to create
+     * @param  {import("./types").ReferenceMap} [referencesByName] - References to the created document. The
      * relationship class associated to each reference list should support references, otherwise this
      * method will throw.
      *
-     * @returns {Mutation[]|Mutation}  One or more mutation to execute
+     * @returns {import("./types").Mutation[]|import("./types").Mutation}  One or more mutation to execute
      */
-    getDocumentSavePlan(document: CozyClientDocument, referencesByName?: ReferenceMap): Mutation[] | Mutation;
+    getDocumentSavePlan(document: import("./types").CozyClientDocument, referencesByName?: import("./types").ReferenceMap): import("./types").Mutation[] | import("./types").Mutation;
     triggerHook(name: any, document: any): void;
     /**
      * Destroys a document. {before,after}:destroy hooks will be fired.
      *
-     * @param  {CozyClientDocument} document - Document to be deleted
-     * @returns {Promise<CozyClientDocument>} The document that has been deleted
+     * @param  {import("./types").CozyClientDocument} document - Document to be deleted
+     * @returns {Promise<import("./types").CozyClientDocument>} The document that has been deleted
      */
-    destroy(document: CozyClientDocument, mutationOptions?: {}): Promise<CozyClientDocument>;
+    destroy(document: import("./types").CozyClientDocument, mutationOptions?: {}): Promise<import("./types").CozyClientDocument>;
     upload(file: any, dirPath: any, mutationOptions?: {}): Promise<any>;
     /**
      * Makes sure that the query exists in the store
      *
      * @param  {string} queryId - Id of the query
      * @param  {QueryDefinition} queryDefinition - Definition of the query
-     * @param  {QueryOptions} [options] - Additional options
+     * @param  {import("./types").QueryOptions} [options] - Additional options
      */
-    ensureQueryExists(queryId: string, queryDefinition: QueryDefinition, options?: QueryOptions): void;
+    ensureQueryExists(queryId: string, queryDefinition: QueryDefinition, options?: import("./types").QueryOptions): void;
     /**
      * Executes a query and returns its results.
      *
@@ -415,20 +415,20 @@ declare class CozyClient {
      * executes its query when mounted if no fetch policy has been indicated.
      *
      * @param  {QueryDefinition} queryDefinition - Definition that will be executed
-     * @param  {QueryOptions} [options] - Options
-     * @returns {Promise<QueryResult>}
+     * @param  {import("./types").QueryOptions} [options] - Options
+     * @returns {Promise<import("./types").QueryResult>}
      */
-    query(queryDefinition: QueryDefinition, { update, ...options }?: QueryOptions): Promise<QueryResult>;
+    query(queryDefinition: QueryDefinition, { update, ...options }?: import("./types").QueryOptions): Promise<import("./types").QueryResult>;
     /**
      * Will fetch all documents for a `queryDefinition`, automatically fetching more
      * documents if the total of documents is superior to the pagination limit. Can
      * result in a lot of network requests.
      *
      * @param  {QueryDefinition} queryDefinition - Definition to be executed
-     * @param {QueryOptions} [options] - Options
-     * @returns {Promise<QueryResult>} All documents matching the query
+     * @param {import("./types").QueryOptions} [options] - Options
+     * @returns {Promise<import("./types").QueryResult>} All documents matching the query
      */
-    queryAll(queryDefinition: QueryDefinition, options?: QueryOptions): Promise<QueryResult>;
+    queryAll(queryDefinition: QueryDefinition, options?: import("./types").QueryOptions): Promise<import("./types").QueryResult>;
     watchQuery(...args: any[]): ObservableQuery;
     makeObservableQuery(queryDefinition: any, options?: {}): ObservableQuery;
     /**
@@ -451,7 +451,7 @@ declare class CozyClient {
      *
      * @private
      * @param  {QueryDefinition} definition QueryDefinition to be executed
-     * @returns {Promise<ClientResponse>}
+     * @returns {Promise<import("./types").ClientResponse>}
      */
     private requestQuery;
     /**
@@ -473,21 +473,21 @@ declare class CozyClient {
      * Instead, the relationships will have null documents.
      *
      * @param  {string} doctype - Doctype of the documents being hydrated
-     * @param  {Array<CozyClientDocument>} documents - Documents to be hydrated
-     * @returns {Array<HydratedDocument>}
+     * @param  {Array<import("./types").CozyClientDocument>} documents - Documents to be hydrated
+     * @returns {Array<import("./types").HydratedDocument>}
      */
-    hydrateDocuments(doctype: string, documents: Array<CozyClientDocument>): Array<HydratedDocument>;
+    hydrateDocuments(doctype: string, documents: Array<import("./types").CozyClientDocument>): Array<import("./types").HydratedDocument>;
     /**
      * Resolves relationships on a document.
      *
      * The original document is kept in the target attribute of
      * the relationship
      *
-     * @param  {CozyClientDocument} document - for which relationships must be resolved
+     * @param  {import("./types").CozyClientDocument} document - for which relationships must be resolved
      * @param  {Schema} [schemaArg] - Optional
-     * @returns {HydratedDocument}
+     * @returns {import("./types").HydratedDocument}
      */
-    hydrateDocument(document: CozyClientDocument, schemaArg?: Schema): HydratedDocument;
+    hydrateDocument(document: import("./types").CozyClientDocument, schemaArg?: Schema): import("./types").HydratedDocument;
     hydrateRelationships(document: any, schemaRelationships: any): {
         [x: string]: any;
     };
@@ -529,18 +529,18 @@ declare class CozyClient {
      *
      * @param {string} type - Doctype of the collection
      *
-     * @returns {CozyClientDocument[]} Array of documents or null if the collection does not exist.
+     * @returns {import("./types").CozyClientDocument[]} Array of documents or null if the collection does not exist.
      */
-    getCollectionFromState(type: string): CozyClientDocument[];
+    getCollectionFromState(type: string): import("./types").CozyClientDocument[];
     /**
      * Get a document from the internal store.
      *
      * @param {string} type - Doctype of the document
      * @param {string} id   - Id of the document
      *
-     * @returns {CozyClientDocument} Document or null if the object does not exist.
+     * @returns {import("./types").CozyClientDocument} Document or null if the object does not exist.
      */
-    getDocumentFromState(type: string, id: string): CozyClientDocument;
+    getDocumentFromState(type: string, id: string): import("./types").CozyClientDocument;
     /**
      * Get a query from the internal store.
      *
@@ -551,12 +551,12 @@ declare class CozyClient {
      * a single doc instead of an array for single doc queries. Defaults to false for backward
      * compatibility but will be set to true in the future.
      *
-     * @returns {QueryState} - Query state or null if it does not exist.
+     * @returns {import("./types").QueryState} - Query state or null if it does not exist.
      */
     getQueryFromState(id: string, options?: {
         hydrated?: boolean;
         singleDocData?: object;
-    }): QueryState;
+    }): import("./types").QueryState;
     /**
      * Executes a query and returns the results from internal store.
      *
@@ -565,13 +565,13 @@ declare class CozyClient {
      *
      * @param {object} query - Query with definition and options
      * @param {QueryDefinition} query.definition - Query Definition
-     * @param {QueryOptions} query.options - Query Options
-     * @returns {Promise<QueryState>} Query state
+     * @param {import("./types").QueryOptions} query.options - Query Options
+     * @returns {Promise<import("./types").QueryState>} Query state
      */
     fetchQueryAndGetFromState: ({ definition, options }: {
         definition: QueryDefinition;
-        options: QueryOptions;
-    }) => Promise<QueryState>;
+        options: import("./types").QueryOptions;
+    }) => Promise<import("./types").QueryState>;
     /**
      * Performs a complete OAuth flow using a Cordova webview
      * or React Native WebView for auth.
@@ -585,10 +585,10 @@ declare class CozyClient {
     /**
      * Performs a complete OAuth flow, including updating the internal token at the end.
      *
-     * @param   {OpenURLCallback} openURLCallback Receives the URL to present to the user as a parameter, and should return a promise that resolves with the URL the user was redirected to after accepting the permissions.
+     * @param   {import("./types").OpenURLCallback} openURLCallback Receives the URL to present to the user as a parameter, and should return a promise that resolves with the URL the user was redirected to after accepting the permissions.
      * @returns {Promise<object>} Contains the fetched token and the client information. These should be stored and used to restore the client.
      */
-    startOAuthFlow(openURLCallback: OpenURLCallback): Promise<object>;
+    startOAuthFlow(openURLCallback: import("./types").OpenURLCallback): Promise<object>;
     /**
      * Perform the Flagship certification process for verifying that the current running app is a genuine Cozy application
      *
@@ -601,15 +601,15 @@ declare class CozyClient {
      * It is possible to skip the session creation process (when using an in-app browser) by passing a sessionCode (see https://docs.cozy.io/en/cozy-stack/auth/#post-authsession_code)
      *
      * @param {object} [options] - Authorization options
-     * @param {OpenURLCallback} [options.openURLCallback] - Receives the URL to present to the user as a parameter, and should return a promise that resolves with the URL the user was redirected to after accepting the permissions.
-     * @param {SessionCode} [options.sessionCode] - session code than can be added to the authorization URL to automatically create the session.
-     * @param {PKCECodes} [options.pkceCodes] - code verifier and a code challenge that should be used in the PKCE verification process.
+     * @param {import("./types").OpenURLCallback} [options.openURLCallback] - Receives the URL to present to the user as a parameter, and should return a promise that resolves with the URL the user was redirected to after accepting the permissions.
+     * @param {import("./types").SessionCode} [options.sessionCode] - session code than can be added to the authorization URL to automatically create the session.
+     * @param {import("./types").PKCECodes} [options.pkceCodes] - code verifier and a code challenge that should be used in the PKCE verification process.
      * @returns {Promise<object>} Contains the fetched token and the client information. These should be stored and used to restore the client.
      */
     authorize({ openURLCallback, sessionCode, pkceCodes }?: {
-        openURLCallback?: OpenURLCallback;
-        sessionCode?: SessionCode;
-        pkceCodes?: PKCECodes;
+        openURLCallback?: import("./types").OpenURLCallback;
+        sessionCode?: import("./types").SessionCode;
+        pkceCodes?: import("./types").PKCECodes;
     }): Promise<object>;
     /**
      * Renews the token if, for instance, new permissions are required or token
@@ -636,11 +636,11 @@ declare class CozyClient {
      * client.setStore(store)
      * ```
      *
-     * @param {ReduxStore} store - A redux store
+     * @param {import("./types").ReduxStore} store - A redux store
      * @param {object} [options] - Options
      * @param {boolean} [options.force] - Will deactivate throwing when client's store already exists
      */
-    setStore(store: ReduxStore, { force }?: {
+    setStore(store: import("./types").ReduxStore, { force }?: {
         force?: boolean;
     }): void;
     store: any;
@@ -667,7 +667,7 @@ declare class CozyClient {
         queries: {};
     }, action: any) => {
         documents: any;
-        queries: Record<string, QueryState>;
+        queries: Record<string, import("./types").QueryState>;
     };
     dispatch(action: any): any;
     /**
@@ -710,35 +710,18 @@ declare class CozyClient {
     toJSON(): SnapshotClient;
     /**
      *
-     * @param {AppMetadata} newAppMetadata AppMetadata to update
+     * @param {import("./types").AppMetadata} newAppMetadata AppMetadata to update
      */
-    setAppMetadata(newAppMetadata: AppMetadata): void;
+    setAppMetadata(newAppMetadata: import("./types").AppMetadata): void;
 }
 declare namespace CozyClient {
     export const hooks: {};
     export { fetchPolicies };
     export const version: string;
 }
-import { Token } from "./types";
-import { AppMetadata } from "./types";
-import { ClientCapabilities } from "./types";
 import { QueryIDGenerator } from "./store/queries";
 import Schema from "./Schema";
-import { DocumentCollection } from "./types";
 import { QueryDefinition } from "./queries/dsl";
-import { ReferenceMap } from "./types";
-import { CozyClientDocument } from "./types";
-import { Mutation } from "./types";
-import { QueryOptions } from "./types";
-import { QueryResult } from "./types";
 import ObservableQuery from "./ObservableQuery";
-import { HydratedDocument } from "./types";
-import { QueryState } from "./types";
-import { OpenURLCallback } from "./types";
-import { SessionCode } from "./types";
-import { PKCECodes } from "./types";
-import { ReduxStore } from "./types";
 import { CozyClient as SnapshotClient } from "./testing/snapshots";
-import { OldCozyClient } from "./types";
-import { NodeEnvironment } from "./types";
 import fetchPolicies from "./policies";

--- a/packages/cozy-client/types/RealTimeQueries.d.ts
+++ b/packages/cozy-client/types/RealTimeQueries.d.ts
@@ -1,5 +1,4 @@
 declare var _default: import("react").MemoExoticComponent<({ doctype }: {
-    doctype: Doctype;
+    doctype: import("./types").Doctype;
 }) => null>;
 export default _default;
-import { Doctype } from "./types";

--- a/packages/cozy-client/types/StackLink.d.ts
+++ b/packages/cozy-client/types/StackLink.d.ts
@@ -1,5 +1,5 @@
-export function transformBulkDocsResponse(bulkResponse: CouchDBBulkResult[], originalDocuments: CozyClientDocument[]): {
-    data: CozyClientDocument[];
+export function transformBulkDocsResponse(bulkResponse: import("./types").CouchDBBulkResult[], originalDocuments: import("./types").CozyClientDocument[]): {
+    data: import("./types").CozyClientDocument[];
 };
 /**
  * Transfers queries and mutations to a remote stack
@@ -20,13 +20,10 @@ export default class StackLink extends CozyLink {
     /**
      *
      * @param {QueryDefinition} query - Query to execute
-     * @returns {Promise<ClientResponse>}
+     * @returns {Promise<import("./types").ClientResponse>}
      */
-    executeQuery(query: QueryDefinition): Promise<ClientResponse>;
+    executeQuery(query: QueryDefinition): Promise<import("./types").ClientResponse>;
     executeMutation(mutation: any, result: any, forward: any): Promise<any>;
 }
-import { CouchDBBulkResult } from "./types";
-import { CozyClientDocument } from "./types";
 import CozyLink from "./CozyLink";
 import { QueryDefinition } from "./queries/dsl";
-import { ClientResponse } from "./types";

--- a/packages/cozy-client/types/associations/Association.d.ts
+++ b/packages/cozy-client/types/associations/Association.d.ts
@@ -75,13 +75,13 @@ declare class Association {
     /**
      * Derived `Association`s need to implement this method.
      *
-     * @param {CozyClientDocument} document - Document to query
+     * @param {import("../types").CozyClientDocument} document - Document to query
      * @param {object} client - The CozyClient instance
      * @param {Association} assoc - Association containing info on how to build the query to fetch related documents
      *
-     * @returns {CozyClientDocument | QueryDefinition }
+     * @returns {import("../types").CozyClientDocument | QueryDefinition }
      */
-    static query(document: CozyClientDocument, client: object, assoc: Association): CozyClientDocument | QueryDefinition;
+    static query(document: import("../types").CozyClientDocument, client: object, assoc: Association): import("../types").CozyClientDocument | QueryDefinition;
     /**
      * @param  {object} target - Original object containing raw data
      * @param  {string} name - Attribute under which the association is stored
@@ -221,5 +221,4 @@ declare class Association {
      */
     get data(): any;
 }
-import { CozyClientDocument } from "../types";
 import { QueryDefinition } from "../queries/dsl";

--- a/packages/cozy-client/types/associations/HasMany.d.ts
+++ b/packages/cozy-client/types/associations/HasMany.d.ts
@@ -90,17 +90,17 @@ declare class HasMany extends Association {
     /**
      * Add the relationships to the target document
      *
-     * @param {CozyClientDocument[]} docsArg - Documents to add as relationships
-     * @returns {CozyClientDocument} The saved target document
+     * @param {import("../types").CozyClientDocument[]} docsArg - Documents to add as relationships
+     * @returns {import("../types").CozyClientDocument} The saved target document
      */
-    add(docsArg: CozyClientDocument[]): CozyClientDocument;
+    add(docsArg: import("../types").CozyClientDocument[]): import("../types").CozyClientDocument;
     /**
      * Remove the relationships from the target document
      *
-     * @param {CozyClientDocument[]} docsArg - Documents to remove as relationships
-     * @returns {CozyClientDocument} The saved target document
+     * @param {import("../types").CozyClientDocument[]} docsArg - Documents to remove as relationships
+     * @returns {import("../types").CozyClientDocument} The saved target document
      */
-    remove(docsArg: CozyClientDocument[]): CozyClientDocument;
+    remove(docsArg: import("../types").CozyClientDocument[]): import("../types").CozyClientDocument;
     /**
      * Update target document with relationships
      *
@@ -132,4 +132,3 @@ declare class HasMany extends Association {
     dehydrate(doc: any): any;
 }
 import Association from "./Association";
-import { CozyClientDocument } from "../types";

--- a/packages/cozy-client/types/associations/HasOne.d.ts
+++ b/packages/cozy-client/types/associations/HasOne.d.ts
@@ -9,20 +9,19 @@ export default class HasOne extends Association {
     /**
      * Add the relationship to the target document
      *
-     * @param {CozyClientDocument} doc - Document to add as a relationship
-     * @returns {CozyClientDocument} The saved target document
+     * @param {import("../types").CozyClientDocument} doc - Document to add as a relationship
+     * @returns {import("../types").CozyClientDocument} The saved target document
      */
-    add(doc: CozyClientDocument): CozyClientDocument;
+    add(doc: import("../types").CozyClientDocument): import("../types").CozyClientDocument;
     /**
      * Remove the relationship from the target document
      *
-     * @returns {CozyClientDocument} The saved target document
+     * @returns {import("../types").CozyClientDocument} The saved target document
      */
-    remove(): CozyClientDocument;
+    remove(): import("../types").CozyClientDocument;
     setRelationship(doc: any): void;
     set(doc: any): void;
     unset(): void;
     dehydrate(doc: any): any;
 }
 import Association from "./Association";
-import { CozyClientDocument } from "../types";

--- a/packages/cozy-client/types/associations/helpers.d.ts
+++ b/packages/cozy-client/types/associations/helpers.d.ts
@@ -7,10 +7,7 @@ export function create(target: any, { name, type, doctype }: {
     type: any;
     doctype: any;
 }, accessors: any): any;
-export function isReferencedBy(file: IOCozyFile, referencedBy: Doctype): boolean;
-export function isReferencedById(file: IOCozyFile, referencedBy: Doctype, referencedId: string): boolean;
-export function getReferencedBy(file: IOCozyFile, referencedBy: Doctype): Reference[];
-export function getReferencedById(file: IOCozyFile, referencedBy: Doctype, referencedId: string): Reference[];
-import { IOCozyFile } from "../types";
-import { Doctype } from "../types";
-import { Reference } from "../types";
+export function isReferencedBy(file: import("../types").IOCozyFile, referencedBy: import("../types").Doctype): boolean;
+export function isReferencedById(file: import("../types").IOCozyFile, referencedBy: import("../types").Doctype, referencedId: string): boolean;
+export function getReferencedBy(file: import("../types").IOCozyFile, referencedBy: import("../types").Doctype): import("../types").Reference[];
+export function getReferencedById(file: import("../types").IOCozyFile, referencedBy: import("../types").Doctype, referencedId: string): import("../types").Reference[];

--- a/packages/cozy-client/types/errors.d.ts
+++ b/packages/cozy-client/types/errors.d.ts
@@ -2,12 +2,12 @@ export class BulkEditError extends Error {
     /**
      * Indicates that a bulk edit has (potentially partially) failed
      *
-     * @param  {CouchDBBulkResult[]} bulkResponse - CouchDB Bulk response
-     * @param  {CozyClientDocument[]} updatedDocs - Docs with updated _id and _rev
+     * @param  {import("./types").CouchDBBulkResult[]} bulkResponse - CouchDB Bulk response
+     * @param  {import("./types").CozyClientDocument[]} updatedDocs - Docs with updated _id and _rev
      */
-    constructor(bulkResponse: CouchDBBulkResult[], updatedDocs: CozyClientDocument[]);
+    constructor(bulkResponse: import("./types").CouchDBBulkResult[], updatedDocs: import("./types").CozyClientDocument[]);
     results: {
-        doc: CozyClientDocument;
+        doc: import("./types").CozyClientDocument;
         ok: boolean;
         id: string;
         rev: string;
@@ -23,17 +23,15 @@ export class BulkEditError extends Error {
     /**
      * Get documents that have been correctly updated
      *
-     * @returns {CozyClientDocument[]}
+     * @returns {import("./types").CozyClientDocument[]}
      */
-    getUpdatedDocuments(): CozyClientDocument[];
+    getUpdatedDocuments(): import("./types").CozyClientDocument[];
     /**
      * Get bulk errors results
      *
-     * @returns {Array<CouchDBBulkResult & { doc: CozyClientDocument }>}
+     * @returns {Array<import("./types").CouchDBBulkResult & { doc: import("./types").CozyClientDocument }>}
      */
-    getErrors(): Array<CouchDBBulkResult & {
-        doc: CozyClientDocument;
+    getErrors(): Array<import("./types").CouchDBBulkResult & {
+        doc: import("./types").CozyClientDocument;
     }>;
 }
-import { CozyClientDocument } from "./types";
-import { CouchDBBulkResult } from "./types";

--- a/packages/cozy-client/types/flagship-certification/flagship-certification.d.ts
+++ b/packages/cozy-client/types/flagship-certification/flagship-certification.d.ts
@@ -1,3 +1,2 @@
-export function certifyFlagship(certificationConfig: CertificationConfig, client: CozyClient): Promise<void>;
-import { CertificationConfig } from "./typedefs";
+export function certifyFlagship(certificationConfig: import("./typedefs").CertificationConfig, client: CozyClient): Promise<void>;
 import CozyClient from "../CozyClient";

--- a/packages/cozy-client/types/flagship-certification/store-attestation.android.d.ts
+++ b/packages/cozy-client/types/flagship-certification/store-attestation.android.d.ts
@@ -1,3 +1,1 @@
-export function getAppAttestationFromStore(nonce: string, certificationConfig: CertificationConfig): Promise<AttestationResult>;
-import { CertificationConfig } from "./typedefs";
-import { AttestationResult } from "./typedefs";
+export function getAppAttestationFromStore(nonce: string, certificationConfig: import("./typedefs").CertificationConfig): Promise<import("./typedefs").AttestationResult>;

--- a/packages/cozy-client/types/flagship-certification/store-attestation.d.ts
+++ b/packages/cozy-client/types/flagship-certification/store-attestation.d.ts
@@ -3,9 +3,7 @@
  * /!\ This is a mock implementation that should never be called
  *
  * @param {string} nonce - the Nonce string retrieved from the stack
- * @param {CertificationConfig} certificationConfig - Configuration to access the stores certification API
- * @returns {Promise<AttestationResult>} the app's attestation
+ * @param {import("./typedefs").CertificationConfig} certificationConfig - Configuration to access the stores certification API
+ * @returns {Promise<import("./typedefs").AttestationResult>} the app's attestation
  */
-export function getAppAttestationFromStore(nonce: string, certificationConfig: CertificationConfig): Promise<AttestationResult>;
-import { CertificationConfig } from "./typedefs";
-import { AttestationResult } from "./typedefs";
+export function getAppAttestationFromStore(nonce: string, certificationConfig: import("./typedefs").CertificationConfig): Promise<import("./typedefs").AttestationResult>;

--- a/packages/cozy-client/types/flagship-certification/store-attestation.ios.d.ts
+++ b/packages/cozy-client/types/flagship-certification/store-attestation.ios.d.ts
@@ -1,3 +1,1 @@
-export function getAppAttestationFromStore(nonce: string, certificationConfig: CertificationConfig): Promise<AttestationResult>;
-import { CertificationConfig } from "./typedefs";
-import { AttestationResult } from "./typedefs";
+export function getAppAttestationFromStore(nonce: string, certificationConfig: import("./typedefs").CertificationConfig): Promise<import("./typedefs").AttestationResult>;

--- a/packages/cozy-client/types/helpers/urlHelper.d.ts
+++ b/packages/cozy-client/types/helpers/urlHelper.d.ts
@@ -7,8 +7,8 @@ export function generateWebLink({ cozyUrl, searchParams: searchParamsOption, pat
     slug: string;
     subDomainType: string;
 }): string;
-export function deconstructCozyWebLinkWithSlug(webLink: string, subDomainType?: SubdomainType): CozyLinkData;
-export function deconstructRedirectLink(redirectLink: string): RedirectLinkData;
+export function deconstructCozyWebLinkWithSlug(webLink: string, subDomainType?: import("../types").SubdomainType): import("../types").CozyLinkData;
+export function deconstructRedirectLink(redirectLink: string): import("../types").RedirectLinkData;
 export class InvalidRedirectLinkError extends Error {
     constructor(redirectLink: any);
     redirectLink: any;
@@ -22,6 +22,3 @@ export class InvalidCozyUrlError extends Error {
     url: any;
 }
 export function rootCozyUrl(url: URL): Promise<URL>;
-import { SubdomainType } from "../types";
-import { CozyLinkData } from "../types";
-import { RedirectLinkData } from "../types";

--- a/packages/cozy-client/types/hooks/useAppsInMaintenance.d.ts
+++ b/packages/cozy-client/types/hooks/useAppsInMaintenance.d.ts
@@ -4,8 +4,7 @@ export default useAppsInMaintenance;
  *
  * @param {CozyClient} client CozyClient instance
  *
- * @returns {AppsDoctype[]} An array with all apps in maintenance
+ * @returns {import("../types").AppsDoctype[]} An array with all apps in maintenance
  */
-declare function useAppsInMaintenance(client: CozyClient): AppsDoctype[];
+declare function useAppsInMaintenance(client: CozyClient): import("../types").AppsDoctype[];
 import CozyClient from "../CozyClient";
-import { AppsDoctype } from "../types";

--- a/packages/cozy-client/types/hooks/useQuery.d.ts
+++ b/packages/cozy-client/types/hooks/useQuery.d.ts
@@ -4,10 +4,8 @@ export default useQuery;
  * Fetches a queryDefinition and returns the queryState
  *
  * @param {QueryDefinition} queryDefinition - Definition created with Q()
- * @param {QueryOptions} options - Options created with Q()
- * @returns {UseQueryReturnValue}
+ * @param {import("../types").QueryOptions} options - Options created with Q()
+ * @returns {import("../types").UseQueryReturnValue}
  */
-declare function useQuery(queryDefinition: QueryDefinition, options: QueryOptions): UseQueryReturnValue;
+declare function useQuery(queryDefinition: QueryDefinition, options: import("../types").QueryOptions): import("../types").UseQueryReturnValue;
 import { QueryDefinition } from "../queries/dsl";
-import { QueryOptions } from "../types";
-import { UseQueryReturnValue } from "../types";

--- a/packages/cozy-client/types/hooks/useQueryAll.d.ts
+++ b/packages/cozy-client/types/hooks/useQueryAll.d.ts
@@ -3,10 +3,8 @@ export default useQueryAll;
  * Fetches a queryDefinition and run fetchMore on the query until the query is fully loaded
  *
  * @param {QueryDefinition} queryDefinition - Definition created with Q()
- * @param {QueryOptions} options - Options created with Q()
- * @returns {UseQueryReturnValue}
+ * @param {import("../types").QueryOptions} options - Options created with Q()
+ * @returns {import("../types").UseQueryReturnValue}
  */
-declare function useQueryAll(queryDefinition: QueryDefinition, options: QueryOptions): UseQueryReturnValue;
+declare function useQueryAll(queryDefinition: QueryDefinition, options: import("../types").QueryOptions): import("../types").UseQueryReturnValue;
 import { QueryDefinition } from "../queries/dsl";
-import { QueryOptions } from "../types";
-import { UseQueryReturnValue } from "../types";

--- a/packages/cozy-client/types/models/dacc.d.ts
+++ b/packages/cozy-client/types/models/dacc.d.ts
@@ -1,8 +1,8 @@
 export function isCorrectDateFormat(date: string): boolean;
-export function checkMeasureParams(measure: DACCMeasure): void;
-export function sendMeasureToDACC(client: CozyClient, remoteDoctype: string, measure: DACCMeasure): Promise<void>;
-export function buildAggregateParams(params: Params): DACCAggregatesParams;
-export function fetchAggregatesFromDACC(client: CozyClient, remoteDoctype: string, params: DACCAggregatesParams): Promise<DACCAggregatesResponse>;
+export function checkMeasureParams(measure: import("../types").DACCMeasure): void;
+export function sendMeasureToDACC(client: CozyClient, remoteDoctype: string, measure: import("../types").DACCMeasure): Promise<void>;
+export function buildAggregateParams(params: Params): import("../types").DACCAggregatesParams;
+export function fetchAggregatesFromDACC(client: CozyClient, remoteDoctype: string, params: import("../types").DACCAggregatesParams): Promise<import("../types").DACCAggregatesResponse>;
 /**
  * - The unformatted DACC aggregate params
  */
@@ -20,7 +20,4 @@ export type Params = {
      */
     endDate?: string;
 };
-import { DACCMeasure } from "../types";
 import CozyClient from "../CozyClient";
-import { DACCAggregatesParams } from "../types";
-import { DACCAggregatesResponse } from "../types";

--- a/packages/cozy-client/types/models/document/documentTypeData.d.ts
+++ b/packages/cozy-client/types/models/document/documentTypeData.d.ts
@@ -1,5 +1,4 @@
 /**
- * @type {ThemesList}
+ * @type {import("../../types").ThemesList}
  */
-export const themesList: ThemesList;
-import { ThemesList } from "../../types";
+export const themesList: import("../../types").ThemesList;

--- a/packages/cozy-client/types/models/document/documentTypeDataHelpers.d.ts
+++ b/packages/cozy-client/types/models/document/documentTypeDataHelpers.d.ts
@@ -1,3 +1,1 @@
-export function getThemeByItem(item: QualificationAttributes): Theme | undefined;
-import { QualificationAttributes } from "../../types";
-import { Theme } from "../../types";
+export function getThemeByItem(item: import("../../types").QualificationAttributes): import("../../types").Theme | undefined;

--- a/packages/cozy-client/types/models/file.d.ts
+++ b/packages/cozy-client/types/models/file.d.ts
@@ -25,25 +25,25 @@ export function ensureFilePath(file: object, parent: object): object;
  */
 export function getParentFolderId(file: object): string | null;
 export const ALBUMS_DOCTYPE: "io.cozy.photos.albums";
-export function splitFilename(file: IOCozyFile): object;
-export function isFile(file: IOCozyFile): boolean;
-export function isDirectory(file: IOCozyFile): boolean;
-export function isNote(file: IOCozyFile): boolean;
-export function isEncrypted(file: IOCozyFile): boolean;
-export function isOnlyOfficeFile(file: IOCozyFile): boolean;
-export function shouldBeOpenedByOnlyOffice(file: IOCozyFile): boolean;
-export function isShortcut(file: IOCozyFile): boolean;
-export function getSharingShortcutStatus(file: IOCozyFile): string;
-export function getSharingShortcutTargetMime(file: IOCozyFile): string;
-export function getSharingShortcutTargetDoctype(file: IOCozyFile): string;
-export function isSharingShortcut(file: IOCozyFile): boolean;
-export function isSharingShorcut(file: IOCozyFile): boolean;
-export function isSharingShortcutNew(file: IOCozyFile): boolean;
+export function splitFilename(file: import("../types").IOCozyFile): object;
+export function isFile(file: import("../types").IOCozyFile): boolean;
+export function isDirectory(file: import("../types").IOCozyFile): boolean;
+export function isNote(file: import("../types").IOCozyFile): boolean;
+export function isEncrypted(file: import("../types").IOCozyFile): boolean;
+export function isOnlyOfficeFile(file: import("../types").IOCozyFile): boolean;
+export function shouldBeOpenedByOnlyOffice(file: import("../types").IOCozyFile): boolean;
+export function isShortcut(file: import("../types").IOCozyFile): boolean;
+export function getSharingShortcutStatus(file: import("../types").IOCozyFile): string;
+export function getSharingShortcutTargetMime(file: import("../types").IOCozyFile): string;
+export function getSharingShortcutTargetDoctype(file: import("../types").IOCozyFile): string;
+export function isSharingShortcut(file: import("../types").IOCozyFile): boolean;
+export function isSharingShorcut(file: import("../types").IOCozyFile): boolean;
+export function isSharingShortcutNew(file: import("../types").IOCozyFile): boolean;
 export function isSharingShorcutNew(file: object): boolean;
-export function saveFileQualification(client: CozyClient, file: IOCozyFile, qualification: object): Promise<IOCozyFile>;
-export function fetchFilesByQualificationRules(client: object, docRules: object): Promise<QueryResult>;
+export function saveFileQualification(client: CozyClient, file: import("../types").IOCozyFile, qualification: object): Promise<import("../types").IOCozyFile>;
+export function fetchFilesByQualificationRules(client: object, docRules: object): Promise<import("../types").QueryResult>;
 export function hasMetadataAttribute({ file, attribute }: {
-    file: IOCozyFile;
+    file: import("../types").IOCozyFile;
     attribute: string;
 }): boolean;
 export function getFullpath(client: CozyClient, dirId: string, name: string): Promise<string>;
@@ -51,16 +51,16 @@ export function move(client: CozyClient, fileId: string, destination: {
     folderId: string;
     path: string;
 }, force?: boolean): Promise<any>;
-export function overrideFileForPath(client: CozyClient, dirPath: string, file: object, metadata: object): Promise<IOCozyFile>;
+export function overrideFileForPath(client: CozyClient, dirPath: string, file: object, metadata: object): Promise<import("../types").IOCozyFile>;
 export function generateNewFileNameOnConflict(filenameWithoutExtension: string): string;
-export function generateFileNameForRevision(file: IOCozyFile, revision: object, f: Function): string;
+export function generateFileNameForRevision(file: import("../types").IOCozyFile, revision: object, f: Function): string;
 export function uploadFileWithConflictStrategy(client: CozyClient, file: string | ArrayBuffer, options: FileUploadOptions): any;
 export function readMobileFile(fileURL: string): Promise<any>;
 export function doMobileUpload(client: CozyClient, fileURL: string, options: FileUploadOptions): Promise<any>;
 export function isPlainText(mimeType?: string, fileName?: string): boolean;
-export function hasQualifications(file: IOCozyFile): boolean;
-export function hasCertifications(file: IOCozyFile): boolean;
-export function isFromKonnector(file: IOCozyFile): boolean;
+export function hasQualifications(file: import("../types").IOCozyFile): boolean;
+export function hasCertifications(file: import("../types").IOCozyFile): boolean;
+export function isFromKonnector(file: import("../types").IOCozyFile): boolean;
 export function fetchBlobFileById(client: CozyClient, fileId: string): Promise<Blob>;
 export type FileUploadOptions = {
     /**
@@ -84,6 +84,4 @@ export type FileUploadOptions = {
      */
     conflictStrategy?: string;
 };
-import { IOCozyFile } from "../types";
 import CozyClient from "../CozyClient";
-import { QueryResult } from "../types";

--- a/packages/cozy-client/types/models/folder.d.ts
+++ b/packages/cozy-client/types/models/folder.d.ts
@@ -8,9 +8,7 @@ export namespace MAGIC_FOLDERS {
     const PAPERS: string;
     const COACH_CO2: string;
 }
-export function ensureMagicFolder(client: CozyClient, id: string, path: string): Promise<IOCozyFolder>;
-export function createFolderWithReference(client: CozyClient, path: string, document: CozyClientDocument): Promise<IOCozyFolder>;
-export function getReferencedFolder(client: CozyClient, document: CozyClientDocument): Promise<IOCozyFolder>;
+export function ensureMagicFolder(client: CozyClient, id: string, path: string): Promise<import("../types").IOCozyFolder>;
+export function createFolderWithReference(client: CozyClient, path: string, document: import("../types").CozyClientDocument): Promise<import("../types").IOCozyFolder>;
+export function getReferencedFolder(client: CozyClient, document: import("../types").CozyClientDocument): Promise<import("../types").IOCozyFolder>;
 import CozyClient from "../CozyClient";
-import { IOCozyFolder } from "../types";
-import { CozyClientDocument } from "../types";

--- a/packages/cozy-client/types/queries/dsl.d.ts
+++ b/packages/cozy-client/types/queries/dsl.d.ts
@@ -1,4 +1,4 @@
-export function Q(doctype: Doctype): QueryDefinition;
+export function Q(doctype: import('../types').Doctype): QueryDefinition;
 export function isAGetByIdQuery(queryDefinition: QueryDefinition): boolean;
 export function createDocument(document: any): {
     mutationType: string;
@@ -73,7 +73,6 @@ export type PartialQueryDefinition = {
 };
 export type MangoSelector = any;
 export type MangoPartialFilter = any;
-import { Doctype } from "../types";
 /**
  * @typedef PartialQueryDefinition
  *
@@ -100,9 +99,9 @@ export class QueryDefinition {
      * @class
      *
      * @param {object} options Initial options for the query definition
-     * @param {Doctype} [options.doctype] - The doctype of the doc.
-     * @param {DocId|null} [options.id] - The id of the doc.
-     * @param {Array<DocId>} [options.ids] - The ids of the docs.
+     * @param  {import('../types').Doctype} [options.doctype] - The doctype of the doc.
+     * @param {import('../types').DocId|null} [options.id] - The id of the doc.
+     * @param {Array<import('../types').DocId>} [options.ids] - The ids of the docs.
      * @param {MangoSelector} [options.selector] - The selector to query the docs.
      * @param {Array<string>} [options.fields] - The fields to return.
      * @param {Array<string>} [options.indexedFields] - The fields to index.
@@ -112,13 +111,13 @@ export class QueryDefinition {
      * @param {string|null} [options.referenced] - The referenced document.
      * @param {number|null} [options.limit] - The document's limit to return.
      * @param {number|null} [options.skip] - The number of docs to skip.
-     * @param {CouchDBViewCursor} [options.cursor] - The cursor to paginate views.
+     * @param {import('../types').CouchDBViewCursor} [options.cursor] - The cursor to paginate views.
      * @param {string} [options.bookmark] - The bookmark to paginate mango queries.
      */
     constructor(options?: {
-        doctype: Doctype;
-        id: DocId | null;
-        ids: Array<DocId>;
+        doctype: import('../types').Doctype;
+        id: import('../types').DocId | null;
+        ids: Array<import('../types').DocId>;
         selector: MangoSelector;
         fields: Array<string>;
         indexedFields: Array<string>;
@@ -128,7 +127,7 @@ export class QueryDefinition {
         referenced: string | null;
         limit: number | null;
         skip: number | null;
-        cursor: CouchDBViewCursor;
+        cursor: import('../types').CouchDBViewCursor;
         bookmark: string;
     });
     doctype: string;
@@ -143,7 +142,7 @@ export class QueryDefinition {
     referenced: string;
     limit: number;
     skip: number;
-    cursor: CouchDBViewCursor;
+    cursor: import("../types").CouchDBViewCursor;
     bookmark: string;
     /**
      * Checks if the sort order matches the index' fields order.
@@ -259,10 +258,10 @@ export class QueryDefinition {
      * the starting document of the query, e.g. "file-id".
      * Use the last docid of each query as startkey_docid to paginate or leave blank for the first query.
      *
-     * @param {CouchDBViewCursor} cursor The cursor for pagination.
+     * @param {import('../types').CouchDBViewCursor} cursor The cursor for pagination.
      * @returns {QueryDefinition}  The QueryDefinition object.
      */
-    offsetCursor(cursor: CouchDBViewCursor): QueryDefinition;
+    offsetCursor(cursor: import('../types').CouchDBViewCursor): QueryDefinition;
     /**
      * Use [bookmark](https://docs.couchdb.org/en/2.2.0/api/database/find.html#pagination) pagination.
      * Note this only applies for mango-queries (not views) and is way more efficient than skip pagination.
@@ -293,7 +292,7 @@ export class QueryDefinition {
         referenced: string;
         limit: number;
         skip: number;
-        cursor: CouchDBViewCursor;
+        cursor: import("../types").CouchDBViewCursor;
         bookmark: string;
     };
 }
@@ -306,6 +305,4 @@ declare const REMOVE_REFERENCES_TO: "REMOVE_REFERENCES_TO";
 declare const ADD_REFERENCED_BY: "ADD_REFERENCED_BY";
 declare const REMOVE_REFERENCED_BY: "REMOVE_REFERENCED_BY";
 declare const UPLOAD_FILE: "UPLOAD_FILE";
-import { CouchDBViewCursor } from "../types";
-import { DocId } from "../types";
 export {};

--- a/packages/cozy-client/types/store/documents.d.ts
+++ b/packages/cozy-client/types/store/documents.d.ts
@@ -1,7 +1,6 @@
-export function mergeDocumentsWithRelationships(prevDocument?: {}, nextDocument?: {}): CozyClientDocument;
+export function mergeDocumentsWithRelationships(prevDocument?: {}, nextDocument?: {}): import("../types").CozyClientDocument;
 export default documents;
 export function getDocumentFromSlice(state: {}, doctype: any, id: any): any;
 export function getCollectionFromSlice(state: {}, doctype: any): any[];
 export function extractAndMergeDocument(data: any, updatedStateWithIncluded: any): any;
-import { CozyClientDocument } from "../types";
 declare function documents(state: {}, action: any): any;

--- a/packages/cozy-client/types/store/queries.d.ts
+++ b/packages/cozy-client/types/store/queries.d.ts
@@ -1,18 +1,18 @@
 export function isQueryAction(action: any): boolean;
 export function isReceivingData(action: any): boolean;
-export function sortAndLimitDocsIds(queryState: QueryState, documents: DocumentsStateSlice, ids: Array<string>, { count, fetchedPagesCount }: {
+export function sortAndLimitDocsIds(queryState: import("../types").QueryState, documents: import("../types").DocumentsStateSlice, ids: Array<string>, { count, fetchedPagesCount }: {
     count: number;
     fetchedPagesCount: number;
 }): Array<string>;
 export function convert$gtNullSelectors(selector: any): object;
 export function mergeSelectorAndPartialIndex(queryDefinition: object): object;
-export function makeSorterFromDefinition(definition: QueryDefinition): (arg0: Array<CozyClientDocument>) => Array<CozyClientDocument>;
-export function updateData(query: QueryState, newData: Array<CozyClientDocument>, documents: DocumentsStateSlice): QueryState;
+export function makeSorterFromDefinition(definition: QueryDefinition): (arg0: Array<import("../types").CozyClientDocument>) => Array<import("../types").CozyClientDocument>;
+export function updateData(query: import("../types").QueryState, newData: Array<import("../types").CozyClientDocument>, documents: import("../types").DocumentsStateSlice): import("../types").QueryState;
 export default queries;
-export function initQuery(queryId: string, queryDefinition: QueryDefinition, options?: QueryOptions): object;
-export function loadQuery(queryId: string, options?: QueryOptions): object;
-export function receiveQueryResult(queryId: string, response: object, options?: QueryOptions): object;
-export function receiveQueryError(queryId: string, error: object, options?: QueryOptions): object;
+export function initQuery(queryId: string, queryDefinition: QueryDefinition, options?: import("../types").QueryOptions): object;
+export function loadQuery(queryId: string, options?: import("../types").QueryOptions): object;
+export function receiveQueryResult(queryId: string, response: object, options?: import("../types").QueryOptions): object;
+export function receiveQueryError(queryId: string, error: object, options?: import("../types").QueryOptions): object;
 export function getQueryFromSlice(state: any, queryId: any, documents: any): any;
 export class QueryIDGenerator {
     idCounter: number;
@@ -35,17 +35,12 @@ export class QueryIDGenerator {
 export namespace QueryIDGenerator {
     const UNNAMED: string;
 }
-import { QueryState } from "../types";
-import { DocumentsStateSlice } from "../types";
 import { QueryDefinition } from "../queries/dsl";
-import { CozyClientDocument } from "../types";
 /**
- * @param  {QueriesStateSlice}  state - Redux slice containing all the query states indexed by name
+ * @param  {import("../types").QueriesStateSlice}  state - Redux slice containing all the query states indexed by name
  * @param  {object}  action - Income redux action
- * @param  {DocumentsStateSlice}  documents - Reference to documents slice
+ * @param  {import("../types").DocumentsStateSlice}  documents - Reference to documents slice
  * @param  {boolean} haveDocumentsChanged - Has the document slice changed with current action
- * @returns {QueriesStateSlice}
+ * @returns {import("../types").QueriesStateSlice}
  */
-declare function queries(state: QueriesStateSlice, action: object, documents?: DocumentsStateSlice, haveDocumentsChanged?: boolean): QueriesStateSlice;
-import { QueryOptions } from "../types";
-import { QueriesStateSlice } from "../types";
+declare function queries(state: import("../types").QueriesStateSlice, action: object, documents?: import("../types").DocumentsStateSlice, haveDocumentsChanged?: boolean): import("../types").QueriesStateSlice;

--- a/packages/cozy-stack-client/src/Collection.js
+++ b/packages/cozy-stack-client/src/Collection.js
@@ -1,4 +1,3 @@
-import { CozyStackClient } from './types'
 /**
  * Handler for error response which return a empty value for "not found" error
  *
@@ -81,7 +80,7 @@ export class Collection {
   /**
    * Utility method aimed to return only one document.
    *
-   * @param  {CozyStackClient}  stackClient - CozyStackClient
+   * @param  {import("./types").CozyStackClient}  stackClient - CozyStackClient
    * @param  {string}  endpoint - Stack endpoint
    * @param  {object}  options - Options of the collection
    * @param  {Function}    options.normalize Callback to normalize response data

--- a/packages/cozy-stack-client/src/Collection.js
+++ b/packages/cozy-stack-client/src/Collection.js
@@ -1,3 +1,5 @@
+import { CozyStackClient } from './types'
+
 /**
  * Handler for error response which return a empty value for "not found" error
  *
@@ -80,7 +82,7 @@ export class Collection {
   /**
    * Utility method aimed to return only one document.
    *
-   * @param  {import("./types").CozyStackClient}  stackClient - CozyStackClient
+   * @param  {CozyStackClient}  stackClient - CozyStackClient
    * @param  {string}  endpoint - Stack endpoint
    * @param  {object}  options - Options of the collection
    * @param  {Function}    options.normalize Callback to normalize response data

--- a/packages/cozy-stack-client/src/getIconURL.js
+++ b/packages/cozy-stack-client/src/getIconURL.js
@@ -1,5 +1,4 @@
 import memoize, { ErrorReturned } from './memoize'
-import { CozyStackClient } from './types'
 /**
  * Get Icon source Url
  *
@@ -130,7 +129,7 @@ const fetchAppOrKonnectorViaRegistry = (stackClient, type, slug) =>
  * Get Icon URL using blob mechanism if OAuth connected
  * or using preloaded url when blob not needed
  *
- * @param  {CozyStackClient}  stackClient - CozyStackClient
+ * @param  {import("./types").CozyStackClient}  stackClient - CozyStackClient
  * @param  {object} opts - Options
  * @param  {string} opts.type - Options type
  * @param  {string|undefined} opts.slug - Options slug

--- a/packages/cozy-stack-client/src/getIconURL.js
+++ b/packages/cozy-stack-client/src/getIconURL.js
@@ -1,3 +1,5 @@
+import { CozyStackClient } from './types'
+
 import memoize, { ErrorReturned } from './memoize'
 /**
  * Get Icon source Url
@@ -129,7 +131,7 @@ const fetchAppOrKonnectorViaRegistry = (stackClient, type, slug) =>
  * Get Icon URL using blob mechanism if OAuth connected
  * or using preloaded url when blob not needed
  *
- * @param  {import("./types").CozyStackClient}  stackClient - CozyStackClient
+ * @param  {CozyStackClient}  stackClient - CozyStackClient
  * @param  {object} opts - Options
  * @param  {string} opts.type - Options type
  * @param  {string|undefined} opts.slug - Options slug


### PR DESCRIPTION
In order to avoid warning with some bundlers:
"Require circule"

First step, changed the import from 'types'. We still have work to do when we import class only for the type too. But it ll be for a next time. 