### PR TITLE
feat: Add `can_auth_with_magic_links` to `ClientCapabilities` type

### DIFF
--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -310,7 +310,8 @@ import { QueryDefinition } from './queries/dsl'
 /**
  * @typedef {object} ClientCapabilities
  * @property {boolean} [can_auth_with_oidc] - Whether OIDC login is possible with this Cozy
- * @property {boolean} [can_auth_with_password] - Whether  password login is possible with this Cozy
+ * @property {boolean} [can_auth_with_password] - Whether password login is possible with this Cozy
+ * @property {boolean} [can_auth_with_magic_links] - Whether magic-link login is possible with this Cozy
  * @property {boolean} [file_versioning] - Whether file versioning is active on this Cozy
  * @property {boolean} [flat_subdomains] - Whether the stack has been configured to use flat subdomains
  * @description Read more about client capabilities here https://docs.cozy.io/en/cozy-stack/settings/#get-settingscapabilities.

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -491,9 +491,13 @@ export type ClientCapabilities = {
      */
     can_auth_with_oidc?: boolean;
     /**
-     * - Whether  password login is possible with this Cozy
+     * - Whether password login is possible with this Cozy
      */
     can_auth_with_password?: boolean;
+    /**
+     * - Whether magic-link login is possible with this Cozy
+     */
+    can_auth_with_magic_links?: boolean;
     /**
      * - Whether file versioning is active on this Cozy
      */


### PR DESCRIPTION
Since we can now Onboard by Magic Link the ClientCapabilities now contains `can_auth_with_magic_links` prop

Related PR: cozy/cozy-stack#3872