### PR TITLE
fix: Handle `503 Blocked` response when calling `rootCozyUrl`

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -10,6 +10,7 @@ cozy-client
 ## Classes
 
 *   [Association](classes/Association.md)
+*   [BlockedCozyError](classes/BlockedCozyError.md)
 *   [BulkEditError](classes/BulkEditError.md)
 *   [CozyClient](classes/CozyClient.md)
 *   [CozyLink](classes/CozyLink.md)
@@ -615,7 +616,7 @@ The root Cozy URL
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:249](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L249)
+[packages/cozy-client/src/helpers/urlHelper.js:269](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L269)
 
 ***
 

--- a/docs/api/cozy-client/classes/BlockedCozyError.md
+++ b/docs/api/cozy-client/classes/BlockedCozyError.md
@@ -1,0 +1,39 @@
+[cozy-client](../README.md) / BlockedCozyError
+
+# Class: BlockedCozyError
+
+## Hierarchy
+
+*   `Error`
+
+    ↳ **`BlockedCozyError`**
+
+## Constructors
+
+### constructor
+
+• **new BlockedCozyError**(`url`)
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `url` | `any` |
+
+*Overrides*
+
+Error.constructor
+
+*Defined in*
+
+[packages/cozy-client/src/helpers/urlHelper.js:138](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L138)
+
+## Properties
+
+### url
+
+• **url**: `any`
+
+*Defined in*
+
+[packages/cozy-client/src/helpers/urlHelper.js:141](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L141)

--- a/docs/api/cozy-client/classes/InvalidCozyUrlError.md
+++ b/docs/api/cozy-client/classes/InvalidCozyUrlError.md
@@ -26,7 +26,7 @@ Error.constructor
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:138](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L138)
+[packages/cozy-client/src/helpers/urlHelper.js:146](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L146)
 
 ## Properties
 
@@ -36,4 +36,4 @@ Error.constructor
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:141](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L141)
+[packages/cozy-client/src/helpers/urlHelper.js:149](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L149)

--- a/packages/cozy-client/src/helpers/index.js
+++ b/packages/cozy-client/src/helpers/index.js
@@ -6,7 +6,8 @@ export {
   rootCozyUrl,
   InvalidRedirectLinkError,
   InvalidCozyUrlError,
-  InvalidProtocolError
+  InvalidProtocolError,
+  BlockedCozyError
 } from './urlHelper'
 
 export { dehydrate } from './dehydrateHelper'

--- a/packages/cozy-client/src/helpers/urlHelper.js
+++ b/packages/cozy-client/src/helpers/urlHelper.js
@@ -185,7 +185,8 @@ const wellKnownUrl = url => uri(url) + '/.well-known/change-password'
  *   page accessible from the given origin so we suppose it's a valid Cozy
  *   origin (i.e. it could be another site altogether though)
  * - a 401 response status means the pointed page requires authentication so the
- *   origin is probably pointing to a Cozy app
+ *   origin is probably pointing to a cozy-app. In that case we should consider this
+ *   URL to be invalid
  * - another status means there aren't any Cozy behind to the given origin
  *
  * @param {object} url          Object of URL elements

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -32,7 +32,8 @@ export {
   rootCozyUrl,
   InvalidRedirectLinkError,
   InvalidCozyUrlError,
-  InvalidProtocolError
+  InvalidProtocolError,
+  BlockedCozyError
 } from './helpers'
 export { cancelable, isQueryLoading, hasQueryBeenLoaded } from './utils'
 export { getQueryFromState } from './store'

--- a/packages/cozy-client/src/index.node.js
+++ b/packages/cozy-client/src/index.node.js
@@ -25,7 +25,8 @@ export {
   ensureFirstSlash,
   rootCozyUrl,
   InvalidCozyUrlError,
-  InvalidProtocolError
+  InvalidProtocolError,
+  BlockedCozyError
 } from './helpers'
 export { cancelable } from './utils'
 export { getQueryFromState } from './store'

--- a/packages/cozy-client/types/helpers/index.d.ts
+++ b/packages/cozy-client/types/helpers/index.d.ts
@@ -1,2 +1,2 @@
 export { dehydrate } from "./dehydrateHelper";
-export { deconstructCozyWebLinkWithSlug, deconstructRedirectLink, generateWebLink, ensureFirstSlash, rootCozyUrl, InvalidRedirectLinkError, InvalidCozyUrlError, InvalidProtocolError } from "./urlHelper";
+export { deconstructCozyWebLinkWithSlug, deconstructRedirectLink, generateWebLink, ensureFirstSlash, rootCozyUrl, InvalidRedirectLinkError, InvalidCozyUrlError, InvalidProtocolError, BlockedCozyError } from "./urlHelper";

--- a/packages/cozy-client/types/helpers/urlHelper.d.ts
+++ b/packages/cozy-client/types/helpers/urlHelper.d.ts
@@ -17,6 +17,10 @@ export class InvalidProtocolError extends Error {
     constructor(url: any);
     url: any;
 }
+export class BlockedCozyError extends Error {
+    constructor(url: any);
+    url: any;
+}
 export class InvalidCozyUrlError extends Error {
     constructor(url: any);
     url: any;

--- a/packages/cozy-client/types/index.d.ts
+++ b/packages/cozy-client/types/index.d.ts
@@ -19,6 +19,6 @@ export { manifest, models };
 export { QueryDefinition, Q, Mutations, MutationTypes, getDoctypeFromOperation } from "./queries/dsl";
 export { Association, HasMany, HasOne, HasOneInPlace, HasManyInPlace, HasManyTriggers } from "./associations";
 export { isReferencedBy, isReferencedById, getReferencedBy, getReferencedById } from "./associations/helpers";
-export { deconstructCozyWebLinkWithSlug, deconstructRedirectLink, dehydrate, generateWebLink, ensureFirstSlash, rootCozyUrl, InvalidRedirectLinkError, InvalidCozyUrlError, InvalidProtocolError } from "./helpers";
+export { deconstructCozyWebLinkWithSlug, deconstructRedirectLink, dehydrate, generateWebLink, ensureFirstSlash, rootCozyUrl, InvalidRedirectLinkError, InvalidCozyUrlError, InvalidProtocolError, BlockedCozyError } from "./helpers";
 export { cancelable, isQueryLoading, hasQueryBeenLoaded } from "./utils";
 export { queryConnect, queryConnectFlat, withClient } from "./hoc";

--- a/packages/cozy-client/types/index.node.d.ts
+++ b/packages/cozy-client/types/index.node.d.ts
@@ -14,4 +14,4 @@ import * as models from "./models";
 export { manifest, models };
 export { QueryDefinition, Mutations, MutationTypes, getDoctypeFromOperation, Q } from "./queries/dsl";
 export { Association, HasMany, HasOne, HasOneInPlace, HasManyInPlace, HasManyTriggers } from "./associations";
-export { deconstructCozyWebLinkWithSlug, deconstructRedirectLink, dehydrate, generateWebLink, ensureFirstSlash, rootCozyUrl, InvalidCozyUrlError, InvalidProtocolError } from "./helpers";
+export { deconstructCozyWebLinkWithSlug, deconstructRedirectLink, dehydrate, generateWebLink, ensureFirstSlash, rootCozyUrl, InvalidCozyUrlError, InvalidProtocolError, BlockedCozyError } from "./helpers";


### PR DESCRIPTION
When calling `rootCozyUrl` we want the method to throw a specific exception if the Cozy is in a "blocked" state

If a `503 Blocked` is returned we conclude that there is a Cozy behind the URL but we cannot check if the URL points to the Cozy's root or to a specific slug. So it is safer to throw an exception that should then be handled by the caller

BREAKING CHANGE: rootCozyUrl() can now throw a BlockedCozyError exception if the target Cozy is blocked