### PR TITLE
fix(getBoundT): Propagate polyglot options

### DIFF
--- a/packages/cozy-client/src/models/document/locales/index.js
+++ b/packages/cozy-client/src/models/document/locales/index.js
@@ -26,6 +26,7 @@ const getBoundT = lang => {
 
   return (label, opts = {}) => {
     const newOpts = {
+      ...opts,
       smart_count: opts?.smart_count || 1
     }
     const emojiCountry = getEmojiByCountry(opts?.country, t)

--- a/packages/cozy-client/src/models/document/locales/index.spec.js
+++ b/packages/cozy-client/src/models/document/locales/index.spec.js
@@ -13,6 +13,11 @@ describe('getBoundT', () => {
 
     expect(res).toBe('IBAN')
   })
+  it('should return "default value" option', () => {
+    const res = t('Scan.items.unknown_key', { _: 'default value' })
+
+    expect(res).toBe('default value')
+  })
 
   it.each`
     translationKey                   | country       | smart_count  | lang    | expected


### PR DESCRIPTION
Currently useful for passing an optional default value, if the translation key is not found.