### PR TITLE
fix(SettingsCollection): Normalize a document spreads attributes to root

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -105,6 +105,9 @@ query to work</p>
 <dt><a href="#getPermissionsFor">getPermissionsFor</a> ⇒ <code>object</code></dt>
 <dd><p>Build a permission set</p>
 </dd>
+<dt><a href="#normalizeSettings">normalizeSettings</a> ⇒ <code>object</code></dt>
+<dd><p>Normalizing a document for SettingsCollection context</p>
+</dd>
 <dt><a href="#getSharingRules">getSharingRules</a> ⇒ <code><a href="#Rule">Array.&lt;Rule&gt;</a></code></dt>
 <dd><p>Rules determine the behavior of the sharing when changes are made to the shared document
 See <a href="https://docs.cozy.io/en/cozy-stack/sharing-design/#description-of-a-sharing">https://docs.cozy.io/en/cozy-stack/sharing-design/#description-of-a-sharing</a></p>
@@ -2135,6 +2138,18 @@ Build a permission set
 | publicLink | <code>boolean</code> | are the permissions for a public link ? |
 | options | <code>object</code> | options |
 | options.verbs | <code>Array.&lt;string&gt;</code> | explicit permissions to use |
+
+<a name="normalizeSettings"></a>
+
+## normalizeSettings ⇒ <code>object</code>
+Normalizing a document for SettingsCollection context
+
+**Kind**: global constant  
+**Returns**: <code>object</code> - normalized document  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| doc | <code>object</code> | Document to normalize |
 
 <a name="getSharingRules"></a>
 

--- a/packages/cozy-stack-client/src/SettingsCollection.js
+++ b/packages/cozy-stack-client/src/SettingsCollection.js
@@ -5,6 +5,20 @@ import { uri } from './utils'
 export const SETTINGS_DOCTYPE = 'io.cozy.settings'
 
 /**
+ * Normalizing a document for SettingsCollection context
+ *
+ * @param {object} doc - Document to normalize
+ * @returns {object} normalized document
+ */
+export const normalizeSettings = doc => {
+  const normDoc = normalizeDoc(doc, SETTINGS_DOCTYPE)
+  return {
+    ...normDoc,
+    ...normDoc.attributes
+  }
+}
+
+/**
  * Implements `DocumentCollection` API to interact with the /settings endpoint of the stack
  */
 class SettingsCollection extends DocumentCollection {
@@ -50,10 +64,7 @@ class SettingsCollection extends DocumentCollection {
 
     const resp = await this.stackClient.fetchJSON('GET', `/settings/${path}`)
     return {
-      data: DocumentCollection.normalizeDoctypeJsonApi(SETTINGS_DOCTYPE)(
-        { id: `/settings/${path}`, ...resp.data },
-        resp
-      )
+      data: normalizeSettings({ id: `/settings/${path}`, ...resp.data })
     }
   }
 
@@ -80,7 +91,7 @@ class SettingsCollection extends DocumentCollection {
     }
 
     return {
-      data: normalizeDoc(resp.data, this.doctype)
+      data: normalizeSettings(resp.data)
     }
   }
 }

--- a/packages/cozy-stack-client/src/SettingsCollection.spec.js
+++ b/packages/cozy-stack-client/src/SettingsCollection.spec.js
@@ -1,4 +1,4 @@
-import SettingsCollection from './SettingsCollection'
+import SettingsCollection, { normalizeSettings } from './SettingsCollection'
 import CozyStackClient from './CozyStackClient'
 
 describe('SettingsCollection', () => {
@@ -102,6 +102,19 @@ describe('SettingsCollection', () => {
         '/data/io.cozy.settings/instance',
         { _id: 'instance' }
       )
+    })
+  })
+
+  describe('normalize a document', () => {
+    it('should flatten attributes', () => {
+      const resp = {
+        attributes: {
+          public_name: 'John'
+        }
+      }
+      const normDoc = normalizeSettings(resp)
+      expect(normDoc.public_name).toBe('John')
+      expect(normDoc.attributes.public_name).toBe('John')
     })
   })
 })


### PR DESCRIPTION
Realtime provides an object with attributes at the root, whereas in query result, attributes are a property in themselves. When cozy-client tries to merge them, only the root attributes are updated. When normalising, I now spread attributes at the root so that I can access to a data that is always up to date.property. I decided to flatten the attributes property to have a single data source.