### PR TITLE
fix: Set the fresh data after getting a new query result

### DIFF
--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -199,6 +199,17 @@ const query = (state = queryInitialState, action, documents) => {
         response.meta && response.meta.count
           ? response.meta.count
           : response.data.length
+      if (action.backgroundFetching) {
+        return {
+          ...state,
+          ...common,
+          bookmark: response.bookmark || null,
+          hasMore: response.next !== undefined ? response.next : state.hasMore,
+          count,
+          data: response.data.map(properId)
+        }
+      }
+
       const fetchedPagesCount = state.fetchedPagesCount + 1
       const data = updateQueryDataFromResponse(state, response, documents, {
         count,

--- a/packages/cozy-client/src/store/queries.spec.js
+++ b/packages/cozy-client/src/store/queries.spec.js
@@ -111,6 +111,33 @@ describe('queries reducer', () => {
       // Then
       expect(state.a.isFetching).toBe(null)
     })
+
+    it('should override the previous result if the querie is refetched when backgroundFetching is enabled', () => {
+      // Given
+      const queryDefinition = Q('io.cozy.todos')
+      applyAction(initQuery('a', queryDefinition))
+
+      // When
+      applyAction(
+        receiveQueryResult('a', {
+          data: [TODO_1, TODO_2]
+        })
+      )
+      // Then
+      expect(state.a.data).toEqual([TODO_1._id, TODO_2._id])
+
+      applyAction(
+        receiveQueryResult(
+          'a',
+          {
+            data: [TODO_1]
+          },
+          { backgroundFetching: true }
+        )
+      )
+
+      expect(state.a.data).toEqual([TODO_1._id])
+    })
   })
 
   describe('RECEIVE_QUERY_ERROR', () => {


### PR DESCRIPTION
Currently, when we receive a `RECEIVE_QUERY_RESULT`, we merge the received data with the previous data. It works well because the only use case we have for receiving multiple  `RECEIVE_QUERY_RESULT` on the same query is when we use the `fetchMore()` method. And in that case, we indeed want to merge the data.

However, with background fetching, we have already received a result for the query, and in parallel, we send the request to get fresh data. And in this case, we don't want to merge the data; we want to replace it.

I'm not very fan of the current solution, so I will create an issue to explain the entire problem.