### PR TITLE
feat: Add diskUsage helper

### DIFF
--- a/docs/api/cozy-client/interfaces/models.instance.DiskInfos.md
+++ b/docs/api/cozy-client/interfaces/models.instance.DiskInfos.md
@@ -1,0 +1,41 @@
+[cozy-client](../README.md) / [models](../modules/models.md) / [instance](../modules/models.instance.md) / DiskInfos
+
+# Interface: DiskInfos<>
+
+[models](../modules/models.md).[instance](../modules/models.instance.md).DiskInfos
+
+## Properties
+
+### humanDiskQuota
+
+• **humanDiskQuota**: `string`
+
+Space used in GB rounded
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:121](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L121)
+
+***
+
+### humanDiskUsage
+
+• **humanDiskUsage**: `string`
+
+Maximum space available in GB rounded
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:122](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L122)
+
+***
+
+### percentUsage
+
+• **percentUsage**: `string`
+
+Usage percent of the disk rounded
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:123](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L123)

--- a/docs/api/cozy-client/interfaces/models.instance.DiskInfosRaw.md
+++ b/docs/api/cozy-client/interfaces/models.instance.DiskInfosRaw.md
@@ -1,0 +1,41 @@
+[cozy-client](../README.md) / [models](../modules/models.md) / [instance](../modules/models.instance.md) / DiskInfosRaw
+
+# Interface: DiskInfosRaw<>
+
+[models](../modules/models.md).[instance](../modules/models.instance.md).DiskInfosRaw
+
+## Properties
+
+### diskQuota
+
+• **diskQuota**: `number`
+
+Space used in GB
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:114](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L114)
+
+***
+
+### diskUsage
+
+• **diskUsage**: `number`
+
+Maximum space available in GB
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:115](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L115)
+
+***
+
+### percentUsage
+
+• **percentUsage**: `number`
+
+Usage percent of the disk
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:116](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L116)

--- a/docs/api/cozy-client/interfaces/models.instance.SettingsInfo.md
+++ b/docs/api/cozy-client/interfaces/models.instance.SettingsInfo.md
@@ -14,7 +14,7 @@ Object returned by /settings/context
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:15](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L15)
+[packages/cozy-client/src/models/instance.js:16](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L16)
 
 ***
 
@@ -26,7 +26,7 @@ Object returned by /settings/disk-usage
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:17](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L17)
+[packages/cozy-client/src/models/instance.js:18](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L18)
 
 ***
 
@@ -38,4 +38,4 @@ Object returned by /settings/instance
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:16](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L16)
+[packages/cozy-client/src/models/instance.js:17](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L17)

--- a/docs/api/cozy-client/modules/models.instance.md
+++ b/docs/api/cozy-client/modules/models.instance.md
@@ -6,6 +6,8 @@
 
 ## Interfaces
 
+*   [DiskInfos](../interfaces/models.instance.DiskInfos.md)
+*   [DiskInfosRaw](../interfaces/models.instance.DiskInfosRaw.md)
 *   [SettingsInfo](../interfaces/models.instance.SettingsInfo.md)
 
 ## Type aliases
@@ -16,7 +18,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:9](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L9)
+[packages/cozy-client/src/models/instance.js:10](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L10)
 
 ***
 
@@ -26,7 +28,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:10](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L10)
+[packages/cozy-client/src/models/instance.js:11](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L11)
 
 ***
 
@@ -36,7 +38,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:8](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L8)
+[packages/cozy-client/src/models/instance.js:9](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L9)
 
 ## Functions
 
@@ -56,7 +58,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:24](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L24)
+[packages/cozy-client/src/models/instance.js:25](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L25)
 
 ***
 
@@ -78,7 +80,7 @@ Returns the link to the Premium page on the Cozy's Manager
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:71](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L71)
+[packages/cozy-client/src/models/instance.js:72](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L72)
 
 ***
 
@@ -98,7 +100,7 @@ Returns the link to the Premium page on the Cozy's Manager
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:33](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L33)
+[packages/cozy-client/src/models/instance.js:34](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L34)
 
 ***
 
@@ -122,7 +124,7 @@ Does the cozy have offers
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:57](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L57)
+[packages/cozy-client/src/models/instance.js:58](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L58)
 
 ***
 
@@ -146,7 +148,7 @@ Checks the value of the password_defined attribute
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:91](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L91)
+[packages/cozy-client/src/models/instance.js:92](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L92)
 
 ***
 
@@ -166,7 +168,7 @@ Checks the value of the password_defined attribute
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:29](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L29)
+[packages/cozy-client/src/models/instance.js:30](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L30)
 
 ***
 
@@ -192,7 +194,32 @@ Checks the value of the password_defined attribute
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:21](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L21)
+[packages/cozy-client/src/models/instance.js:22](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L22)
+
+***
+
+### makeDiskInfos
+
+▸ **makeDiskInfos**(`usage`, `quota`): [`DiskInfos`](../interfaces/models.instance.DiskInfos.md)
+
+Make human readable information from disk information (usage, quota)
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `usage` | `string` | `number` | Value in bytes representing the space used |
+| `quota` | `string` | `number` | - |
+
+*Returns*
+
+[`DiskInfos`](../interfaces/models.instance.DiskInfos.md)
+
+*   Return a set of human readable information about disk
+
+*Defined in*
+
+[packages/cozy-client/src/models/instance.js:164](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L164)
 
 ***
 
@@ -216,4 +243,4 @@ Should we display offers
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:43](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L43)
+[packages/cozy-client/src/models/instance.js:44](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L44)

--- a/docs/api/cozy-client/modules/models.md
+++ b/docs/api/cozy-client/modules/models.md
@@ -18,6 +18,7 @@
 *   [sharing](models.sharing.md)
 *   [timeseries](models.timeseries.md)
 *   [trigger](models.trigger.md)
+*   [user](models.user.md)
 *   [utils](models.utils.md)
 
 ## Variables
@@ -28,7 +29,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/index.js:19](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/index.js#L19)
+[packages/cozy-client/src/models/index.js:20](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/index.js#L20)
 
 ***
 
@@ -38,4 +39,4 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/index.js:18](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/index.js#L18)
+[packages/cozy-client/src/models/index.js:19](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/index.js#L19)

--- a/docs/api/cozy-client/modules/models.user.md
+++ b/docs/api/cozy-client/modules/models.user.md
@@ -1,0 +1,29 @@
+[cozy-client](../README.md) / [models](models.md) / user
+
+# Namespace: user
+
+[models](models.md).user
+
+## Functions
+
+### hasPassword
+
+▸ **hasPassword**(`client`): `Promise`<`boolean`>
+
+Checks whether the user has a password
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`CozyClient`](../classes/CozyClient.md) | The CozyClient instance |
+
+*Returns*
+
+`Promise`<`boolean`>
+
+*   Returns true if the user has a password
+
+*Defined in*
+
+[packages/cozy-client/src/models/user.js:11](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/user.js#L11)

--- a/packages/cozy-client/src/models/index.js
+++ b/packages/cozy-client/src/models/index.js
@@ -13,6 +13,7 @@ import * as timeseries from './timeseries'
 import * as sharing from './sharing'
 import * as dacc from './dacc'
 import * as paper from './paper'
+import * as user from './user'
 
 // For backward compatibility before 9.0.0
 const triggers = trigger
@@ -35,5 +36,6 @@ export {
   timeseries,
   sharing,
   dacc,
-  paper
+  paper,
+  user
 }

--- a/packages/cozy-client/src/models/instance.spec.js
+++ b/packages/cozy-client/src/models/instance.spec.js
@@ -102,4 +102,49 @@ describe('instance', () => {
     expect(instance.hasAnOffer(hadAnOfferInstance)).toBe(true)
     expect(instance.hasAnOffer(selftHostedInstance)).toBe(false)
   })
+
+  describe('makeDiskInfos', () => {
+    it('computes disk percent with a quota', () => {
+      expect(instance.makeDiskInfos('0', '5000000000')).toStrictEqual({
+        humanDiskQuota: '5',
+        humanDiskUsage: '0',
+        percentUsage: '0'
+      })
+      expect(instance.makeDiskInfos('115600793', '5000000000')).toStrictEqual({
+        humanDiskQuota: '5',
+        humanDiskUsage: '0.12',
+        percentUsage: '2'
+      })
+      expect(
+        instance.makeDiskInfos('22115600793', '90000000000')
+      ).toStrictEqual({
+        humanDiskQuota: '90',
+        humanDiskUsage: '22.12',
+        percentUsage: '25'
+      })
+      expect(instance.makeDiskInfos('5000000000', '5000000000')).toStrictEqual({
+        humanDiskQuota: '5',
+        humanDiskUsage: '5',
+        percentUsage: '100'
+      })
+    })
+
+    it('computes disk percent without a quota', () => {
+      expect(instance.makeDiskInfos('1156007930', '')).toStrictEqual({
+        humanDiskQuota: '100',
+        humanDiskUsage: '1.16',
+        percentUsage: '1'
+      })
+      expect(instance.makeDiskInfos('0', undefined)).toStrictEqual({
+        humanDiskQuota: '100',
+        humanDiskUsage: '0',
+        percentUsage: '0'
+      })
+      expect(instance.makeDiskInfos('0', 0)).toStrictEqual({
+        humanDiskQuota: '100',
+        humanDiskUsage: '0',
+        percentUsage: '0'
+      })
+    })
+  })
 })

--- a/packages/cozy-client/types/models/index.d.ts
+++ b/packages/cozy-client/types/models/index.d.ts
@@ -15,4 +15,5 @@ import * as timeseries from "./timeseries";
 import * as sharing from "./sharing";
 import * as dacc from "./dacc";
 import * as paper from "./paper";
-export { trigger, instance, applications, file, folder, note, account, permission, utils, contact, document, timeseries, sharing, dacc, paper };
+import * as user from "./user";
+export { trigger, instance, applications, file, folder, note, account, permission, utils, contact, document, timeseries, sharing, dacc, paper, user };

--- a/packages/cozy-client/types/models/instance.d.ts
+++ b/packages/cozy-client/types/models/instance.d.ts
@@ -6,6 +6,7 @@ export function shouldDisplayOffers(data: SettingsInfo): boolean;
 export function hasAnOffer(data: SettingsInfo): boolean;
 export function buildPremiumLink(instanceInfo: InstanceInfo): string;
 export function hasPasswordDefinedAttribute(client: import("../CozyClient").default): Promise<boolean>;
+export function makeDiskInfos(usage: number | string, quota?: number | string): DiskInfos;
 export type InstanceInfo = any;
 export type ContextInfo = any;
 export type DiskUsageInfo = any;
@@ -22,4 +23,32 @@ export type SettingsInfo = {
      * - Object returned by /settings/disk-usage
      */
     diskUsage: DiskUsageInfo;
+};
+export type DiskInfosRaw = {
+    /**
+     * - Space used in GB
+     */
+    diskQuota: number;
+    /**
+     * -  Maximum space available in GB
+     */
+    diskUsage: number;
+    /**
+     * - Usage percent of the disk
+     */
+    percentUsage: number;
+};
+export type DiskInfos = {
+    /**
+     * - Space used in GB rounded
+     */
+    humanDiskQuota: string;
+    /**
+     * - Maximum space available in GB rounded
+     */
+    humanDiskUsage: string;
+    /**
+     * - Usage percent of the disk rounded
+     */
+    percentUsage: string;
 };


### PR DESCRIPTION
These helpers originally come from cozy-settings (cf: [code](https://github.com/cozy/cozy-settings/blob/master/src/lib/makeDiskInfos.ts)), I imported them to share the code with cozy-drive
