### PR TITLE
feat: Add generateReturnUrlToNotesIndex from Notes

### DIFF
--- a/docs/api/cozy-client/modules/models.note.md
+++ b/docs/api/cozy-client/modules/models.note.md
@@ -4,6 +4,16 @@
 
 [models](models.md).note
 
+## Variables
+
+### RETURN_URL_KEY
+
+• `Const` **RETURN_URL_KEY**: `"returnUrl"`
+
+*Defined in*
+
+[packages/cozy-client/src/models/note.js:4](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L4)
+
 ## Functions
 
 ### fetchURL
@@ -27,7 +37,7 @@ url
 
 *Defined in*
 
-[packages/cozy-client/src/models/note.js:31](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L31)
+[packages/cozy-client/src/models/note.js:33](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L33)
 
 ***
 
@@ -49,7 +59,33 @@ url
 
 *Defined in*
 
-[packages/cozy-client/src/models/note.js:9](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L9)
+[packages/cozy-client/src/models/note.js:11](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L11)
+
+***
+
+### generateReturnUrlToNotesIndex
+
+▸ **generateReturnUrlToNotesIndex**(`client`, `file`, `returnUrl`): `Promise`<`string`>
+
+Create the URL to be used to edit a note
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | `any` | CozyClient instance |
+| `file` | `any` | io.cozy.file object |
+| `returnUrl` | `string` | URL to use as returnUrl if you don't want the current location |
+
+*Returns*
+
+`Promise`<`string`>
+
+URL where one can edit the note
+
+*Defined in*
+
+[packages/cozy-client/src/models/note.js:70](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L70)
 
 ***
 
@@ -70,4 +106,4 @@ url
 
 *Defined in*
 
-[packages/cozy-client/src/models/note.js:18](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L18)
+[packages/cozy-client/src/models/note.js:20](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L20)

--- a/packages/cozy-client/src/models/note.js
+++ b/packages/cozy-client/src/models/note.js
@@ -1,6 +1,8 @@
 import { generateWebLink } from '../helpers'
 import logger from '../logger'
 
+export const RETURN_URL_KEY = 'returnUrl'
+
 /**
  *
  * @param {string} notesAppUrl URL to the Notes App (https://notes.foo.mycozy.cloud)
@@ -55,4 +57,24 @@ export const fetchURL = async (client, file) => {
       hash: `/n/${note_id}`
     })
   }
+}
+
+/**
+ * Create the URL to be used to edit a note
+ *
+ * @param {object} client CozyClient instance
+ * @param {object} file io.cozy.file object
+ * @param {string} returnUrl URL to use as returnUrl if you don't want the current location
+ * @returns {Promise<string>} URL where one can edit the note
+ */
+export const generateReturnUrlToNotesIndex = async (
+  client,
+  file,
+  returnUrl
+) => {
+  const rawUrl = fetchURL(client, file)
+  const back = window.location.toString()
+  const dest = new URL(await rawUrl)
+  dest.searchParams.set(RETURN_URL_KEY, returnUrl || back)
+  return dest.toString()
 }

--- a/packages/cozy-client/types/models/note.d.ts
+++ b/packages/cozy-client/types/models/note.d.ts
@@ -1,3 +1,5 @@
+export const RETURN_URL_KEY: "returnUrl";
 export function generatePrivateUrl(notesAppUrl: string, file: object, options?: {}): string;
 export function generateUrlForNote(notesAppUrl: any, file: any): string;
 export function fetchURL(client: object, file: object): Promise<string>;
+export function generateReturnUrlToNotesIndex(client: object, file: object, returnUrl: string): Promise<string>;


### PR DESCRIPTION
Depuis l'app MesPapiers, on souhaite pouvoir cliquer sur une aide-mémoire, et si c'est une note, ouvrir l'applicaition Notes avec un lien de redirection qui permet de revenir sur l'app MesPapiers. C'est exactement ce qu'on fait dans l'app Notes, via cette méthode. On l'ajoute donc à cozy-client pour mutualiser.