### PR TITLE
fix(HasManyFiles): Update after removing a relation

### DIFF
--- a/packages/cozy-client/src/associations/HasManyFiles.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.js
@@ -80,24 +80,26 @@ export default class HasManyFiles extends HasMany {
 
   async addById(idsArg) {
     const ids = Array.isArray(idsArg) ? idsArg : [idsArg]
+
+    this.addTargetRelationships(ids)
+
     const relations = ids.map(id => ({
       _id: id,
       _type: this.doctype
     }))
     await this.mutate(this.addReferences(relations))
-
-    this.addTargetRelationships(ids)
   }
 
   async removeById(idsArg) {
     const ids = Array.isArray(idsArg) ? idsArg : [idsArg]
+
+    this.removeTargetRelationships(idsArg)
+
     const references = ids.map(id => ({
       _id: id,
       _type: this.doctype
     }))
     await this.mutate(this.removeReferences(references))
-
-    this.removeTargetRelationships(ids)
   }
 
   addReferences(referencedDocs) {


### PR DESCRIPTION
The interface was not updated after deleting an image because only the mutation causes React rendering. The data was updated afterwards, which is why I changed the order of execution

Before we `save` the target after remove the relationships which led to a React re-render. This mechanism has been removed because it was duplicated (cf: [PR](https://github.com/cozy/cozy-client/pull/1048))