### PR TITLE
fix: Stop destroying inconsistent index

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -92,13 +92,6 @@ Serves to dedupe equal queries requested at the same time</p>
 <dd><p>Compute fields that should be indexed for a mango
 query to work</p>
 </dd>
-<dt><a href="#isInconsistentIndex">isInconsistentIndex</a> ⇒ <code>boolean</code></dt>
-<dd><p>Check if an index is in an inconsistent state, i.e. it evaluates one of these:</p>
-<ul>
-<li>its name contains the indexed attributes which are not in correct order</li>
-<li>it contains a partial filter, but the fields are not in the name</li>
-</ul>
-</dd>
 <dt><a href="#isMatchingIndex">isMatchingIndex</a> ⇒ <code>boolean</code></dt>
 <dd><p>Check if an index is matching the given fields</p>
 </dd>
@@ -423,7 +416,6 @@ Abstracts a collection of documents of the same doctype, providing CRUD methods 
         * [.fetchAllMangoIndexes()](#DocumentCollection+fetchAllMangoIndexes) ⇒ <code>Promise.&lt;Array.&lt;DesignDoc&gt;&gt;</code>
         * [.destroyIndex(index)](#DocumentCollection+destroyIndex) ⇒ <code>Promise.&lt;object&gt;</code>
         * [.copyIndex(existingIndex, newIndexName)](#DocumentCollection+copyIndex) ⇒ [<code>Promise.&lt;DesignDoc&gt;</code>](#DesignDoc)
-        * [.removeInconsistentIndex(indexes)](#DocumentCollection+removeInconsistentIndex)
         * [.fetchChangesRaw(couchOptions)](#DocumentCollection+fetchChangesRaw)
     * _static_
         * [.normalizeDoctype(doctype)](#DocumentCollection.normalizeDoctype) ⇒ <code>function</code>
@@ -657,15 +649,6 @@ having to recompute the existing index.
 | --- | --- | --- |
 | existingIndex | [<code>DesignDoc</code>](#DesignDoc) | The design doc to copy |
 | newIndexName | <code>string</code> | The name of the copy |
-
-<a name="DocumentCollection+removeInconsistentIndex"></a>
-
-### documentCollection.removeInconsistentIndex(indexes)
-**Kind**: instance method of [<code>DocumentCollection</code>](#DocumentCollection)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| indexes | [<code>Array.&lt;DesignDoc&gt;</code>](#DesignDoc) | Index to remove |
 
 <a name="DocumentCollection+fetchChangesRaw"></a>
 
@@ -2096,20 +2079,6 @@ query to work
 
 **Kind**: global constant  
 **Returns**: <code>Array</code> - - Fields to index  
-<a name="isInconsistentIndex"></a>
-
-## isInconsistentIndex ⇒ <code>boolean</code>
-Check if an index is in an inconsistent state, i.e. it evaluates one of these:
-- its name contains the indexed attributes which are not in correct order
-- it contains a partial filter, but the fields are not in the name
-
-**Kind**: global constant  
-**Returns**: <code>boolean</code> - True if the index is inconsistent  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| index | [<code>DesignDoc</code>](#DesignDoc) | The index to check |
-
 <a name="isMatchingIndex"></a>
 
 ## isMatchingIndex ⇒ <code>boolean</code>

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -26,7 +26,6 @@ import {
   transformSort,
   getIndexFields,
   isMatchingIndex,
-  isInconsistentIndex,
   normalizeDesignDoc
 } from './mangoIndex'
 import * as querystring from './querystring'
@@ -726,32 +725,9 @@ The returned documents are paginated by the stack.
     const existingIndex = indexes.find(index => {
       return isMatchingIndex(index, fieldsToIndex, partialFilter)
     })
-    // Since we have fetched all the existing indexes
-    // let's clean them up.
-    // This is a safeguard for potential inconsistent indexes
-    this.removeInconsistentIndex(indexes)
     return existingIndex
   }
-  /**
-   *
-   * @param {DesignDoc[]} indexes Index to remove
-   */
-  async removeInconsistentIndex(indexes) {
-    for (const index of indexes) {
-      // Since we use this as a safeguard and only for
-      // this case, then we don't want to throw if an
-      // error is raised.
-      if (isInconsistentIndex(index)) {
-        try {
-          await this.destroyIndex(index)
-        } catch (error) {
-          logger.warn(
-            `Destroy index has errored for ${index} with the following error: ${error?.toString()}`
-          )
-        }
-      }
-    }
-  }
+
   /**
    * Calls _changes route from CouchDB
    * No further treatment is done contrary to fetchchanges

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -1376,27 +1376,6 @@ describe('DocumentCollection', () => {
     })
   })
 
-  describe('removeInconsistentIndex', () => {
-    const collection = new DocumentCollection('io.cozy.triggers', client)
-    const inconsistentIndex = {
-      _id: '_design/by_aaaaa',
-      views: {
-        '123': {
-          map: {
-            fields: {
-              'cozyMetadata.createdAt': 'desc'
-            }
-          }
-        }
-      }
-    }
-    it('should not throw an error if the deletion failed', async () => {
-      client.fetchJSON.mockRejectedValue()
-      await expect(
-        collection.removeInconsistentIndex([inconsistentIndex])
-      ).resolves.not.toThrowError()
-    })
-  })
   describe('findExistingIndex', () => {
     const collection = new DocumentCollection('io.cozy.triggers', client)
     const selector = {

--- a/packages/cozy-stack-client/src/mangoIndex.js
+++ b/packages/cozy-stack-client/src/mangoIndex.js
@@ -99,40 +99,6 @@ export const getIndexFields = (
 }
 
 /**
- * Check if an index is in an inconsistent state, i.e. it evaluates one of these:
- * - its name contains the indexed attributes which are not in correct order
- * - it contains a partial filter, but the fields are not in the name
- *
- * @param {DesignDoc} index - The index to check
- * @returns {boolean} True if the index is inconsistent
- */
-export const isInconsistentIndex = index => {
-  const indexId = index._id
-  if (!indexId.startsWith('_design/by_')) {
-    return false
-  }
-  const fieldsInName = indexId
-    .split('_design/by_')[1]
-    .split('_filter_')[0]
-    .split('_and_')
-  const viewId = Object.keys(get(index, `views`))[0]
-  const fieldsInIndex = Object.keys(get(index, `views.${viewId}.map.fields`))
-  if (!isEqual(fieldsInName, fieldsInIndex)) {
-    return true
-  }
-  const partialFilter = get(
-    index,
-    `views.${viewId}.map.partial_filter_selector`
-  )
-  const partialFilterFields = partialFilter ? Object.keys(partialFilter) : []
-  const filteredName = indexId.split('_filter_')
-  const partialFilterFieldsInName =
-    filteredName.length > 1 ? filteredName[1].split('_and_') : []
-
-  return !isEqual(partialFilterFields, partialFilterFieldsInName)
-}
-
-/**
  * Check if an index is matching the given fields
  *
  * @param {DesignDoc} index - The index to check

--- a/packages/cozy-stack-client/src/mangoIndex.spec.js
+++ b/packages/cozy-stack-client/src/mangoIndex.spec.js
@@ -1,6 +1,5 @@
 import {
   isMatchingIndex,
-  isInconsistentIndex,
   getIndexFields,
   getIndexNameFromFields
 } from './mangoIndex'
@@ -100,49 +99,6 @@ describe('matching index', () => {
       { partialFilter }
     )
     expect(isMatchingIndex(matchingIndex, ['foo', 'bar'])).toEqual(false)
-  })
-})
-
-describe('inconsistent index', () => {
-  it('should detect inconsistent index', () => {
-    const index = buildDesignDoc(
-      { foo: 'asc', bar: 'asc' },
-      { id: '_design/by_bar_and_foo' }
-    )
-    expect(isInconsistentIndex(index)).toBe(true)
-  })
-
-  it('should not detect consistent index', () => {
-    const index1 = buildDesignDoc(
-      { bar: 'asc', foo: 'asc' },
-      { id: '_design/by_bar_and_foo' }
-    )
-    const index2 = buildDesignDoc(
-      { foo: 'asc', bar: 'asc' },
-      { id: '/design/1234' }
-    )
-    expect(isInconsistentIndex(index1)).toBe(false)
-    expect(isInconsistentIndex(index2)).toBe(false)
-  })
-  it('should not detect consistent index with partial filter', () => {
-    const index = buildDesignDoc(
-      { bar: 'asc', foo: 'asc' },
-      {
-        id: '_design/by_bar_and_foo_filter_trashed',
-        partialFilter: { trashed: { $ne: false } }
-      }
-    )
-    expect(isInconsistentIndex(index)).toBe(false)
-  })
-  it('should detect index with partial filter but without fields in name', () => {
-    const index = buildDesignDoc(
-      { bar: 'asc', foo: 'asc' },
-      {
-        id: '_design/by_bar_and_foo',
-        partialFilter: { trashed: { $ne: false } }
-      }
-    )
-    expect(isInconsistentIndex(index)).toBe(true)
   })
 })
 


### PR DESCRIPTION
We have two issues with indexes in Cozy-Client:

The first one is related to the usage of logical mango operators ($or, $and, $in, etc.) at the top level.Cozy-Client doesn't handle them properly and creates indexes named $or/$and/$etc
(see https://github.com/cozy/cozy-client/issues/1270). This can lead to conflicts with the indexes.

Even worse, when we create a partialFilter without declaring a top-level $and, like [{foo: bar, truc:muche}], the index name on the Cozy-Client side is correct (`foo_truc`). However, when we inspect the design doc, CouchDB automatically adds the $and, and it becomes `$and: [{foo: bar}, {truc: muche}]`

The second issue is the automatic deletion of what Cozy-Client considers "inconsistent" indexes. When Cozy-Client receives an event of type `index_not_found` or `not_usable_index`, it performs some leanup by querying all the indexes on the relevant doctype and checks if the index name matches the indexed fields in the design doc. Due to CouchDB's automatic addition of a top-level logical operator with an implicit $and, Cozy-Client doesn't handle this well and considers the index as "inconsistent," leading to its deletion.

The real solution is to make Cozy-Client capable of handling logical operators at the top level of indexes / partialFilters. To achieve this, we need to rename all the indexes. However, doing so would result in the deletion of indexes judged inconsistent by the current Cozy-Client version. Newer versions of Cozy-Client will create new, correct indexes, but older apps will delete them as they won't correspond to the previous logic. This process of create / delete / create / delete will become a nightmare.

Therefore, before changing the way we name indexes, we will remove the deletion of indexes judged "inconsistent." This simplifies the app update process. Once the apps are updated with this modification, we can proceed with renaming the indexes.

We will no longer perform cleanup via Cozy-Client in the future and will use ad-hoc scripts for that purpose.

This commit represents the first step: we stop deleting "inconsistent" indexes.