### PR TITLE
feat: Add AppsRegistryCollection

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -4,6 +4,9 @@
 <dt><a href="#AppCollection">AppCollection</a></dt>
 <dd><p>Extends <code>DocumentCollection</code> API along with specific methods for <code>io.cozy.apps</code>.</p>
 </dd>
+<dt><a href="#AppsRegistryCollection">AppsRegistryCollection</a></dt>
+<dd><p>Extends <code>DocumentCollection</code> API along with specific methods for <code>io.cozy.apps_registry</code>.</p>
+</dd>
 <dt><a href="#Collection">Collection</a></dt>
 <dd><p>Utility class to abstract an regroup identical methods and logics for
 specific collections.</p>
@@ -266,6 +269,28 @@ The returned documents are not paginated by the stack.
 **Throws**:
 
 - <code>FetchError</code> 
+
+<a name="AppsRegistryCollection"></a>
+
+## AppsRegistryCollection
+Extends `DocumentCollection` API along with specific methods for `io.cozy.apps_registry`.
+
+**Kind**: global class  
+<a name="AppsRegistryCollection+get"></a>
+
+### appsRegistryCollection.get(slug) ⇒ <code>Promise.&lt;{data: object}&gt;</code>
+Fetches an app from the registry.
+
+**Kind**: instance method of [<code>AppsRegistryCollection</code>](#AppsRegistryCollection)  
+**Returns**: <code>Promise.&lt;{data: object}&gt;</code> - JsonAPI response containing normalized document as data attribute  
+**Throws**:
+
+- <code>FetchError</code> 
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| slug | <code>string</code> | Slug of the app |
 
 <a name="Collection"></a>
 

--- a/packages/cozy-stack-client/src/AppCollection.js
+++ b/packages/cozy-stack-client/src/AppCollection.js
@@ -73,6 +73,11 @@ class AppCollection extends DocumentCollection {
           return res
         }
 
+        logger.warn(
+          `The use of source registry is deprecated since it can polute the io.cozy.apps slice. For exemple, if we request data from the registry, than the app will be present in the io.cozy.apps slice and then the isInstalled() will return true.\n
+            Use Q('io.cozy.apps_registry) instead`
+        )
+
         const data = transformRegistryFormatToStackFormat(res)
         return { data: normalizeApp(data, this.doctype) }
       } catch (err) {

--- a/packages/cozy-stack-client/src/AppCollection.spec.js
+++ b/packages/cozy-stack-client/src/AppCollection.spec.js
@@ -188,6 +188,24 @@ describe(`AppCollection`, () => {
         expect(data.id).toBe('fromRegistry')
       })
     })
+
+    describe('deprecated get call with "registry" source', () => {
+      beforeEach(() => {
+        jest.spyOn(logger, 'warn').mockImplementation(() => {})
+      })
+      afterEach(() => {
+        logger.warn.mockRestore()
+      })
+
+      it('should call the right route (deprecated call with registry source)', async () => {
+        await collection.get('io.cozy.apps/fakeid', { sources: ['registry'] })
+        expect(client.fetchJSON).toHaveBeenCalledWith('GET', '/registry/fakeid')
+        expect(logger.warn).toHaveBeenCalledWith(
+          `The use of source registry is deprecated since it can polute the io.cozy.apps slice. For exemple, if we request data from the registry, than the app will be present in the io.cozy.apps slice and then the isInstalled() will return true.\n
+            Use Q('io.cozy.apps_registry) instead`
+        )
+      })
+    })
   })
 
   describe('create', () => {

--- a/packages/cozy-stack-client/src/AppsRegistryCollection.js
+++ b/packages/cozy-stack-client/src/AppsRegistryCollection.js
@@ -1,0 +1,53 @@
+import { transformRegistryFormatToStackFormat } from 'cozy-client/dist/registry'
+
+import DocumentCollection, { normalizeDoc } from './DocumentCollection'
+import { FetchError } from './errors'
+
+export const APPS_REGISTRY_DOCTYPE = 'io.cozy.apps_registry'
+
+export const normalizeAppFromRegistry = (app, doctype) => {
+  return {
+    ...normalizeDoc(app, doctype)
+  }
+}
+
+/**
+ * Extends `DocumentCollection` API along with specific methods for `io.cozy.apps_registry`.
+ */
+class AppsRegistryCollection extends DocumentCollection {
+  constructor(stackClient) {
+    super(APPS_REGISTRY_DOCTYPE, stackClient)
+    this.endpoint = '/registry/'
+  }
+
+  /**
+   * Fetches an app from the registry.
+   *
+   * @param  {string} slug - Slug of the app
+   * @returns {Promise<{data: object}>} JsonAPI response containing normalized document as data attribute
+   * @throws {FetchError}
+   */
+  async get(slug) {
+    const app = await this.stackClient.fetchJSON(
+      'GET',
+      `${this.endpoint}${slug}`
+    )
+
+    const data = transformRegistryFormatToStackFormat(app)
+    return { data: normalizeAppFromRegistry(data, this.doctype) }
+  }
+
+  async create() {
+    throw new Error(
+      'create() method is not available for AppsRegistryCollection'
+    )
+  }
+
+  async destroy() {
+    throw new Error(
+      'destroy() method is not available for AppsRegistryCollection'
+    )
+  }
+}
+
+export default AppsRegistryCollection

--- a/packages/cozy-stack-client/src/AppsRegistryCollection.spec.js
+++ b/packages/cozy-stack-client/src/AppsRegistryCollection.spec.js
@@ -1,0 +1,65 @@
+jest.mock('./CozyStackClient')
+
+import CozyStackClient from './CozyStackClient'
+import AppsRegistryCollection, {
+  APPS_REGISTRY_DOCTYPE
+} from './AppsRegistryCollection'
+
+describe(`AppsRegistryCollection`, () => {
+  const client = new CozyStackClient()
+
+  describe('get', () => {
+    const collection = new AppsRegistryCollection(client)
+
+    beforeAll(() => {
+      client.fetchJSON.mockReturnValue(
+        Promise.resolve({
+          type: 'io.cozy.apps_registry',
+          id: '5396fc6',
+          latest_version: {
+            manifest: {
+              source: 'source.notes'
+            }
+          }
+        })
+      )
+    })
+
+    it('should call the right route', async () => {
+      await collection.get('io.cozy.apps_registry/fakeid')
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'GET',
+        '/registry/io.cozy.apps_registry/fakeid'
+      )
+    })
+
+    it('should return a correct JSON API response', async () => {
+      const resp = await collection.get('io.cozy.apps_registry/fakeid')
+      expect(resp).toConformToJSONAPI()
+    })
+
+    it('should return normalized document', async () => {
+      const resp = await collection.get('io.cozy.apps_registry/fakeid')
+      expect(resp.data).toHaveDocumentIdentity()
+      expect(resp.data._type).toEqual(APPS_REGISTRY_DOCTYPE)
+    })
+  })
+  describe('create', () => {
+    const collection = new AppsRegistryCollection(client)
+
+    it('should throw error', async () => {
+      await expect(collection.create()).rejects.toThrowError(
+        'create() method is not available for AppsRegistryCollection'
+      )
+    })
+  })
+  describe('destroy', () => {
+    const collection = new AppsRegistryCollection(client)
+
+    it('should throw error', async () => {
+      await expect(collection.destroy()).rejects.toThrowError(
+        'destroy() method is not available for AppsRegistryCollection'
+      )
+    })
+  })
+})

--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -16,6 +16,9 @@ import OAuthClientsCollection, {
 } from './OAuthClientsCollection'
 import ShortcutsCollection, { SHORTCUTS_DOCTYPE } from './ShortcutsCollection'
 import ContactsCollection, { CONTACTS_DOCTYPE } from './ContactsCollection'
+import AppsRegistryCollection, {
+  APPS_REGISTRY_DOCTYPE
+} from './AppsRegistryCollection'
 import getIconURL from './getIconURL'
 import logDeprecate from './logDeprecate'
 import { fetchWithXMLHttpRequest, shouldXMLHTTPRequestBeUsed } from './xhrFetch'
@@ -95,6 +98,8 @@ class CozyStackClient {
         return new OAuthClientsCollection(this)
       case SHORTCUTS_DOCTYPE:
         return new ShortcutsCollection(this)
+      case APPS_REGISTRY_DOCTYPE:
+        return new AppsRegistryCollection(this)
       default:
         return new DocumentCollection(doctype, this)
     }


### PR DESCRIPTION
Using the "registry" source via the `io.cozy.apps` doctype is discouraged as it may skew the `io.cozy.apps` entry of the `cozy->documents` store.

For example, if we request data from the registry, the application will be present in `cozy->documents->io.cozy.apps`, which will falsify the return of the `isInstalled()` helper.

That's why we add `AppsRegistryCollection`, in order to separate the 2 sources in 2 different store entries `cozy.documents['io.cozy.apps']` & `cozy.documents['io.cozy.apps_registry']`