### PR TITLE
fix: Document has to be wrap into a data object to update instance

### DIFF
--- a/packages/cozy-stack-client/src/SettingsCollection.js
+++ b/packages/cozy-stack-client/src/SettingsCollection.js
@@ -77,11 +77,9 @@ class SettingsCollection extends DocumentCollection {
     let resp
 
     if (document._id === 'io.cozy.settings.instance') {
-      resp = await this.stackClient.fetchJSON(
-        'PUT',
-        '/settings/instance',
-        document
-      )
+      resp = await this.stackClient.fetchJSON('PUT', '/settings/instance', {
+        data: document
+      })
     } else {
       resp = await this.stackClient.fetchJSON(
         'PUT',

--- a/packages/cozy-stack-client/src/SettingsCollection.spec.js
+++ b/packages/cozy-stack-client/src/SettingsCollection.spec.js
@@ -93,7 +93,11 @@ describe('SettingsCollection', () => {
       expect(stackClient.fetchJSON).toHaveBeenCalledWith(
         'PUT',
         '/settings/instance',
-        { _id: 'io.cozy.settings.instance' }
+        {
+          data: {
+            _id: 'io.cozy.settings.instance'
+          }
+        }
       )
 
       await collection.update({ _id: 'instance' })


### PR DESCRIPTION
When we tried to update `io.cozy.settings.instance`, the stack returns 409 errors to indicate conflicts. The problem was that we were sending the document directly, whereas the stack was looking for the document information in a data object (cf: [PUT /settings/instance](https://docs.cozy.io/en/cozy-stack/settings/#put-settingsinstance)).  Now, the `cozy-stack-client` wraps the document in a data object before sending it.

This fix has two benefits in `cozy-setting` : 
- no longer makes two requests for each profile update
- be able to use client.save to avoid using redux soon