### PR TITLE
feat: Add link for driver_license expiration note

### DIFF
--- a/docs/api/cozy-client/modules/models.paper.md
+++ b/docs/api/cozy-client/modules/models.paper.md
@@ -36,7 +36,7 @@ Expiration date
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:89](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L89)
+[packages/cozy-client/src/models/paper.js:91](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L91)
 
 ***
 
@@ -60,7 +60,7 @@ Expiration notice date
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L125)
+[packages/cozy-client/src/models/paper.js:127](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L127)
 
 ***
 
@@ -84,7 +84,7 @@ Expiration notice link
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:144](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L144)
+[packages/cozy-client/src/models/paper.js:146](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L146)
 
 ***
 
@@ -106,7 +106,7 @@ Expiration notice link
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:156](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L156)
+[packages/cozy-client/src/models/paper.js:158](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L158)
 
 ***
 
@@ -128,7 +128,7 @@ Expiration notice link
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:71](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L71)
+[packages/cozy-client/src/models/paper.js:73](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L73)
 
 ***
 
@@ -150,4 +150,4 @@ Expiration notice link
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:168](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L168)
+[packages/cozy-client/src/models/paper.js:170](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L170)

--- a/packages/cozy-client/src/models/paper.js
+++ b/packages/cozy-client/src/models/paper.js
@@ -10,7 +10,9 @@ const PERSONAL_SPORTING_LICENCE_NOTICE_PERIOD_DAYS = 15
 const EXPIRATION_LINK_BY_LABEL = {
   national_id_card: 'https://www.service-public.fr/particuliers/vosdroits/N358',
   residence_permit: 'https://www.service-public.fr/particuliers/vosdroits/N110',
-  passport: 'https://www.service-public.fr/particuliers/vosdroits/N360'
+  passport: 'https://www.service-public.fr/particuliers/vosdroits/N360',
+  driver_license:
+    'https://permisdeconduire.ants.gouv.fr/demarches-en-ligne/perte-vol-deterioration-fin-de-validite-ou-changement-d-etat-civil'
 }
 
 /**

--- a/packages/cozy-client/src/models/paper.spec.js
+++ b/packages/cozy-client/src/models/paper.spec.js
@@ -59,6 +59,11 @@ describe('Expiration', () => {
     expirationDate: '2022-09-23T11:35:58.118Z',
     noticePeriod: '90'
   })
+  const fakeDriverLicense = buildMockFile({
+    qualificationLabel: 'driver_license',
+    expirationDate: '2022-09-23T11:35:58.118Z',
+    noticePeriod: '90'
+  })
 
   describe('computeExpirationDate', () => {
     it('should return expirationDate', () => {
@@ -109,6 +114,7 @@ describe('Expiration', () => {
       ${fakeNationalIdCardFile}  | ${'https://www.service-public.fr/particuliers/vosdroits/N358'}
       ${fakeResidencePermitFile} | ${'https://www.service-public.fr/particuliers/vosdroits/N110'}
       ${fakePassportFile}        | ${'https://www.service-public.fr/particuliers/vosdroits/N360'}
+      ${fakeDriverLicense}       | ${'https://permisdeconduire.ants.gouv.fr/demarches-en-ligne/perte-vol-deterioration-fin-de-validite-ou-changement-d-etat-civil'}
     `(
       `should return "$link" link for an file with "$file.metadata.qualification.label" qualification label`,
       ({ file, link }) => {


### PR DESCRIPTION
Pour les permis de conduire, on souhaite afficher un lien dans la note 
d'expiration comme on le fait pour le passeport ou la carte d'identité