### PR TITLE
feat: Do not throw when an app or konnector is not installed

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -315,6 +315,7 @@ document as data attribute
 | options | <code>object</code> |  | Options of the collection |
 | options.normalize | <code>function</code> |  | Callback to normalize response data (default `data => data`) |
 | [options.method] | <code>string</code> | <code>&quot;GET&quot;</code> | HTTP method |
+| [options.dataForNotFound] | <code>object</code> |  | Data to return in case of not found |
 
 <a name="CozyStackClient"></a>
 

--- a/packages/cozy-stack-client/src/Collection.js
+++ b/packages/cozy-stack-client/src/Collection.js
@@ -9,7 +9,8 @@ import { CozyStackClient } from './types'
  * found" error.
  */
 export const dontThrowNotFoundError = (error, data = []) => {
-  if (error.message.match(/not_found/)) {
+  // not_found is for JSON API response, Not Found is for /apps or /konnectors route
+  if (error.message.match(/not_found/) || error.toString().match(/Not Found/)) {
     const expectsCollection = Array.isArray(data)
     // Return expected JsonAPI attributes : collections are expecting
     // meta, skip and next attribute
@@ -88,13 +89,18 @@ export class Collection {
    * @param  {Function}    options.normalize Callback to normalize response data
    * (default `data => data`)
    * @param  {string}  [options.method=GET]  -  HTTP method
+   * @param {object} [options.dataForNotFound] - Data to return in case of not found
    * @returns {Promise<object>}  JsonAPI response containing normalized
    * document as data attribute
    */
   static async get(
     stackClient,
     endpoint,
-    { normalize = (data, response) => data, method = 'GET' }
+    {
+      normalize = (data, response) => data,
+      method = 'GET',
+      dataForNotFound = null
+    }
   ) {
     try {
       const resp = await stackClient.fetchJSON(method, endpoint)
@@ -102,7 +108,7 @@ export class Collection {
         data: normalize(resp.data, resp)
       }
     } catch (error) {
-      return dontThrowNotFoundError(error, null)
+      return dontThrowNotFoundError(error, dataForNotFound)
     }
   }
 }


### PR DESCRIPTION
Instead, we return data: null

BREAKING CHANGE: before this change AppCollection.getById() and KonnectorCollection.getById() were throwing an error if the stack responded a 404 Application not installed. Now it returns a `data: null`.