### PR TITLE
feat: Add parenthesis option to generateNewFileNameOnConflict

### DIFF
--- a/docs/api/cozy-client/interfaces/models.file.FileUploadOptions.md
+++ b/docs/api/cozy-client/interfaces/models.file.FileUploadOptions.md
@@ -14,7 +14,7 @@ Erase / rename
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:442](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L442)
+[packages/cozy-client/src/models/file.js:464](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L464)
 
 ***
 
@@ -26,7 +26,7 @@ The file Content-Type
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:441](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L441)
+[packages/cozy-client/src/models/file.js:463](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L463)
 
 ***
 
@@ -38,7 +38,7 @@ The dirId to upload the file to
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:439](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L439)
+[packages/cozy-client/src/models/file.js:461](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L461)
 
 ***
 
@@ -50,7 +50,7 @@ An object containing the metadata to attach
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:440](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L440)
+[packages/cozy-client/src/models/file.js:462](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L462)
 
 ***
 
@@ -62,4 +62,4 @@ The file name to upload
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:438](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L438)
+[packages/cozy-client/src/models/file.js:460](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L460)

--- a/docs/api/cozy-client/modules/models.file.md
+++ b/docs/api/cozy-client/modules/models.file.md
@@ -40,7 +40,7 @@ Upload a file on a mobile
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:546](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L546)
+[packages/cozy-client/src/models/file.js:568](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L568)
 
 ***
 
@@ -86,7 +86,7 @@ file object with path attribute
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:592](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L592)
+[packages/cozy-client/src/models/file.js:614](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L614)
 
 ***
 
@@ -135,13 +135,13 @@ Generate a file name for a revision
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:428](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L428)
+[packages/cozy-client/src/models/file.js:450](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L450)
 
 ***
 
 ### generateNewFileNameOnConflict
 
-▸ **generateNewFileNameOnConflict**(`filenameWithoutExtension`): `string`
+▸ **generateNewFileNameOnConflict**(`filenameWithoutExtension`, `type`): `string`
 
 Method to generate a new filename if there is a conflict
 
@@ -150,6 +150,7 @@ Method to generate a new filename if there is a conflict
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `filenameWithoutExtension` | `string` | A filename without the extension |
+| `type` | `string` | - |
 
 *Returns*
 
@@ -159,7 +160,7 @@ A filename with the right suffix
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:403](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L403)
+[packages/cozy-client/src/models/file.js:404](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L404)
 
 ***
 
@@ -301,7 +302,7 @@ The mime-type of the target file, or an empty string is the target is not a file
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:572](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L572)
+[packages/cozy-client/src/models/file.js:594](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L594)
 
 ***
 
@@ -345,7 +346,7 @@ Whether the file's metadata attribute exists
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:564](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L564)
+[packages/cozy-client/src/models/file.js:586](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L586)
 
 ***
 
@@ -427,7 +428,7 @@ Whether the file is client-side encrypted
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:583](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L583)
+[packages/cozy-client/src/models/file.js:605](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L605)
 
 ***
 
@@ -492,7 +493,7 @@ Whether the file is supported by Only Office
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:556](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L556)
+[packages/cozy-client/src/models/file.js:578](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L578)
 
 ***
 
@@ -710,7 +711,7 @@ Read a file on a mobile
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:499](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L499)
+[packages/cozy-client/src/models/file.js:521](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L521)
 
 ***
 
@@ -817,4 +818,4 @@ If there is a conflict, then we apply the conflict strategy : `erase` or `rename
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:460](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L460)
+[packages/cozy-client/src/models/file.js:482](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L482)

--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -398,9 +398,31 @@ export const overrideFileForPath = async (client, dirPath, file, metadata) => {
  * Method to generate a new filename if there is a conflict
  *
  * @param {string} filenameWithoutExtension - A filename without the extension
+ * @param {string} [type] - 'parenthesis' to add " (X)" default to "_X"
  * @returns {string} A filename with the right suffix
  */
-export const generateNewFileNameOnConflict = filenameWithoutExtension => {
+export const generateNewFileNameOnConflict = (
+  filenameWithoutExtension,
+  type
+) => {
+  if (type === 'parenthesis') {
+    //Check if the string ends by (1)
+    const regex = new RegExp(' [(]([0-9]+)[)]$')
+    const matches = filenameWithoutExtension.match(regex)
+    if (matches) {
+      let versionNumber = parseInt(matches[1])
+      //increment versionNumber
+      versionNumber++
+      const newFilenameWithoutExtension = filenameWithoutExtension.replace(
+        new RegExp(' [(]([0-9]+)[)]$'),
+        ` (${versionNumber})`
+      )
+      return newFilenameWithoutExtension
+    } else {
+      return `${filenameWithoutExtension} (1)`
+    }
+  }
+
   //Check if the string ends by _1
   const regex = new RegExp('(_)([0-9]+)$')
   const matches = filenameWithoutExtension.match(regex)

--- a/packages/cozy-client/src/models/file.spec.js
+++ b/packages/cozy-client/src/models/file.spec.js
@@ -561,7 +561,7 @@ describe('File Model', () => {
     })
   })
 
-  describe('generateNewFileNameOnConflict', () => {
+  describe('generateNewFileNameOnConflict with underscore', () => {
     it('should generate the right file name with _X', () => {
       const filename1 = fileModel.generateNewFileNameOnConflict('test')
       expect(filename1).toEqual('test_1')
@@ -571,6 +571,31 @@ describe('File Model', () => {
       expect(filename3).toEqual('test_1_1_test_1')
       const filename4 = fileModel.generateNewFileNameOnConflict('test_')
       expect(filename4).toEqual('test__1')
+    })
+  })
+
+  describe('generateNewFileNameOnConflict with parenthesis', () => {
+    it('should generate the right file name with (X)', () => {
+      const filename1 = fileModel.generateNewFileNameOnConflict(
+        'test',
+        'parenthesis'
+      )
+      expect(filename1).toEqual('test (1)')
+      const filename2 = fileModel.generateNewFileNameOnConflict(
+        'test (1)',
+        'parenthesis'
+      )
+      expect(filename2).toEqual('test (2)')
+      const filename3 = fileModel.generateNewFileNameOnConflict(
+        'test(1)test',
+        'parenthesis'
+      )
+      expect(filename3).toEqual('test(1)test (1)')
+      const filename4 = fileModel.generateNewFileNameOnConflict(
+        'test(',
+        'parenthesis'
+      )
+      expect(filename4).toEqual('test( (1)')
     })
   })
 

--- a/packages/cozy-client/types/models/file.d.ts
+++ b/packages/cozy-client/types/models/file.d.ts
@@ -52,7 +52,7 @@ export function move(client: CozyClient, fileId: string, destination: {
     path: string;
 }, force?: boolean): Promise<any>;
 export function overrideFileForPath(client: CozyClient, dirPath: string, file: object, metadata: object): Promise<import("../types").IOCozyFile>;
-export function generateNewFileNameOnConflict(filenameWithoutExtension: string): string;
+export function generateNewFileNameOnConflict(filenameWithoutExtension: string, type?: string): string;
 export function generateFileNameForRevision(file: import("../types").IOCozyFile, revision: object, f: Function): string;
 export function uploadFileWithConflictStrategy(client: CozyClient, file: string | ArrayBuffer, options: FileUploadOptions): any;
 export function readMobileFile(fileURL: string): Promise<any>;


### PR DESCRIPTION
For photo backup feature, we often have name issues with underscore renaming. For example, an image named IMG_768.JPG will be renamed IMG_769.JPG instead of IMG_768_1.JPG.

We choose to implement a new version of generateNewFileNameOnConflict more adapted to pictures :
- avoid any problems with _X which are regular on pictures by using (X)
- return a more readable name : IMG_768 (1).JPG is more readable than IMG_768_1.JPG