### PR TITLE
feat: Allow to pass a name format regex to avoid bad renaming

### DIFF
--- a/docs/api/cozy-client/interfaces/models.file.FileUploadOptions.md
+++ b/docs/api/cozy-client/interfaces/models.file.FileUploadOptions.md
@@ -14,7 +14,7 @@ Erase / rename
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:442](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L442)
+[packages/cozy-client/src/models/file.js:455](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L455)
 
 ***
 
@@ -26,7 +26,7 @@ The file Content-Type
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:441](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L441)
+[packages/cozy-client/src/models/file.js:454](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L454)
 
 ***
 
@@ -38,7 +38,7 @@ The dirId to upload the file to
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:439](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L439)
+[packages/cozy-client/src/models/file.js:452](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L452)
 
 ***
 
@@ -50,7 +50,7 @@ An object containing the metadata to attach
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:440](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L440)
+[packages/cozy-client/src/models/file.js:453](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L453)
 
 ***
 
@@ -62,4 +62,4 @@ The file name to upload
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:438](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L438)
+[packages/cozy-client/src/models/file.js:451](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L451)

--- a/docs/api/cozy-client/modules/models.file.md
+++ b/docs/api/cozy-client/modules/models.file.md
@@ -40,7 +40,7 @@ Upload a file on a mobile
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:546](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L546)
+[packages/cozy-client/src/models/file.js:559](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L559)
 
 ***
 
@@ -86,7 +86,7 @@ file object with path attribute
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:592](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L592)
+[packages/cozy-client/src/models/file.js:605](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L605)
 
 ***
 
@@ -135,13 +135,13 @@ Generate a file name for a revision
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:428](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L428)
+[packages/cozy-client/src/models/file.js:441](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L441)
 
 ***
 
 ### generateNewFileNameOnConflict
 
-▸ **generateNewFileNameOnConflict**(`filenameWithoutExtension`): `string`
+▸ **generateNewFileNameOnConflict**(`filenameWithoutExtension`, `originalNameFormatRegex`): `string`
 
 Method to generate a new filename if there is a conflict
 
@@ -150,6 +150,7 @@ Method to generate a new filename if there is a conflict
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `filenameWithoutExtension` | `string` | A filename without the extension |
+| `originalNameFormatRegex` | `RegExp` | - |
 
 *Returns*
 
@@ -159,7 +160,7 @@ A filename with the right suffix
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:403](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L403)
+[packages/cozy-client/src/models/file.js:404](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L404)
 
 ***
 
@@ -301,7 +302,7 @@ The mime-type of the target file, or an empty string is the target is not a file
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:572](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L572)
+[packages/cozy-client/src/models/file.js:585](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L585)
 
 ***
 
@@ -345,7 +346,7 @@ Whether the file's metadata attribute exists
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:564](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L564)
+[packages/cozy-client/src/models/file.js:577](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L577)
 
 ***
 
@@ -427,7 +428,7 @@ Whether the file is client-side encrypted
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:583](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L583)
+[packages/cozy-client/src/models/file.js:596](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L596)
 
 ***
 
@@ -492,7 +493,7 @@ Whether the file is supported by Only Office
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:556](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L556)
+[packages/cozy-client/src/models/file.js:569](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L569)
 
 ***
 
@@ -710,7 +711,7 @@ Read a file on a mobile
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:499](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L499)
+[packages/cozy-client/src/models/file.js:512](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L512)
 
 ***
 
@@ -817,4 +818,4 @@ If there is a conflict, then we apply the conflict strategy : `erase` or `rename
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:460](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L460)
+[packages/cozy-client/src/models/file.js:473](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L473)

--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -398,13 +398,26 @@ export const overrideFileForPath = async (client, dirPath, file, metadata) => {
  * Method to generate a new filename if there is a conflict
  *
  * @param {string} filenameWithoutExtension - A filename without the extension
+ * @param {RegExp} [originalNameFormatRegex] - A regex to check if the name is still in his original format
  * @returns {string} A filename with the right suffix
  */
-export const generateNewFileNameOnConflict = filenameWithoutExtension => {
+export const generateNewFileNameOnConflict = (
+  filenameWithoutExtension,
+  originalNameFormatRegex
+) => {
+  let isOriginalNameFormat = false
+  if (
+    originalNameFormatRegex &&
+    originalNameFormatRegex.test(filenameWithoutExtension)
+  ) {
+    isOriginalNameFormat = true
+  }
+
   //Check if the string ends by _1
   const regex = new RegExp('(_)([0-9]+)$')
   const matches = filenameWithoutExtension.match(regex)
-  if (matches) {
+  const shouldIncrement = matches && !isOriginalNameFormat
+  if (shouldIncrement) {
     let versionNumber = parseInt(matches[2])
     //increment versionNumber
     versionNumber++

--- a/packages/cozy-client/src/models/file.spec.js
+++ b/packages/cozy-client/src/models/file.spec.js
@@ -571,6 +571,29 @@ describe('File Model', () => {
       expect(filename3).toEqual('test_1_1_test_1')
       const filename4 = fileModel.generateNewFileNameOnConflict('test_')
       expect(filename4).toEqual('test__1')
+      const filename5 = fileModel.generateNewFileNameOnConflict('test_1_1')
+      expect(filename5).toEqual('test_1_2')
+    })
+
+    it('should generate the right file name with _X when passing a format', () => {
+      const regex = new RegExp('^([a-z]+)(_)([0-9]+)$') // test_1
+
+      const filename1 = fileModel.generateNewFileNameOnConflict('test', regex)
+      expect(filename1).toEqual('test_1')
+      const filename2 = fileModel.generateNewFileNameOnConflict('test_1', regex)
+      expect(filename2).toEqual('test_1_1')
+      const filename3 = fileModel.generateNewFileNameOnConflict(
+        'test_1_1_test',
+        regex
+      )
+      expect(filename3).toEqual('test_1_1_test_1')
+      const filename4 = fileModel.generateNewFileNameOnConflict('test_', regex)
+      expect(filename4).toEqual('test__1')
+      const filename5 = fileModel.generateNewFileNameOnConflict(
+        'test_1_1',
+        regex
+      )
+      expect(filename5).toEqual('test_1_2')
     })
   })
 

--- a/packages/cozy-client/types/models/file.d.ts
+++ b/packages/cozy-client/types/models/file.d.ts
@@ -52,7 +52,7 @@ export function move(client: CozyClient, fileId: string, destination: {
     path: string;
 }, force?: boolean): Promise<any>;
 export function overrideFileForPath(client: CozyClient, dirPath: string, file: object, metadata: object): Promise<import("../types").IOCozyFile>;
-export function generateNewFileNameOnConflict(filenameWithoutExtension: string): string;
+export function generateNewFileNameOnConflict(filenameWithoutExtension: string, originalNameFormatRegex?: RegExp): string;
 export function generateFileNameForRevision(file: import("../types").IOCozyFile, revision: object, f: Function): string;
 export function uploadFileWithConflictStrategy(client: CozyClient, file: string | ArrayBuffer, options: FileUploadOptions): any;
 export function readMobileFile(fileURL: string): Promise<any>;


### PR DESCRIPTION
Sometimes, files are named like they already had a conflict like IMG_001.JPG. It is a normal name but in this case, previous implementation would consider _001 as a conflict suffix and would return IMG_2.JPG whereas we expect IMG_001_1.JPG.

By allowing to pass a name format regex, we can tell the new implementation that the name is the original one and it should not try to increment a number even if it corresponds to the conflict format.