### PR TITLE
Feat: Add `all` & `getAll` methods to `AppsRegistryCollection`

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -276,6 +276,28 @@ The returned documents are not paginated by the stack.
 Extends `DocumentCollection` API along with specific methods for `io.cozy.apps_registry`.
 
 **Kind**: global class  
+
+* [AppsRegistryCollection](#AppsRegistryCollection)
+    * [.all([option])](#AppsRegistryCollection+all) ⇒ <code>Promise.&lt;{data, meta, skip, next}&gt;</code>
+    * [.get(slug)](#AppsRegistryCollection+get) ⇒ <code>Promise.&lt;{data: object}&gt;</code>
+
+<a name="AppsRegistryCollection+all"></a>
+
+### appsRegistryCollection.all([option]) ⇒ <code>Promise.&lt;{data, meta, skip, next}&gt;</code>
+Fetches all apps from the registry.
+
+**Kind**: instance method of [<code>AppsRegistryCollection</code>](#AppsRegistryCollection)  
+**Returns**: <code>Promise.&lt;{data, meta, skip, next}&gt;</code> - The JSON API conformant response.  
+**Throws**:
+
+- <code>FetchError</code> 
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| [option] | <code>object</code> | The fetch option |
+| [option.limit] | <code>number</code> | Limit of apps to fetch |
+
 <a name="AppsRegistryCollection+get"></a>
 
 ### appsRegistryCollection.get(slug) ⇒ <code>Promise.&lt;{data: object}&gt;</code>

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -279,6 +279,7 @@ Extends `DocumentCollection` API along with specific methods for `io.cozy.apps_r
 
 * [AppsRegistryCollection](#AppsRegistryCollection)
     * [.all([option])](#AppsRegistryCollection+all) ⇒ <code>Promise.&lt;{data, meta, skip, next}&gt;</code>
+    * [.getAll(slugs)](#AppsRegistryCollection+getAll) ⇒ <code>Promise.&lt;{data, meta, skip, next}&gt;</code>
     * [.get(slug)](#AppsRegistryCollection+get) ⇒ <code>Promise.&lt;{data: object}&gt;</code>
 
 <a name="AppsRegistryCollection+all"></a>
@@ -297,6 +298,22 @@ Fetches all apps from the registry.
 | --- | --- | --- |
 | [option] | <code>object</code> | The fetch option |
 | [option.limit] | <code>number</code> | Limit of apps to fetch |
+
+<a name="AppsRegistryCollection+getAll"></a>
+
+### appsRegistryCollection.getAll(slugs) ⇒ <code>Promise.&lt;{data, meta, skip, next}&gt;</code>
+Fetches many apps from the registry by ids.
+
+**Kind**: instance method of [<code>AppsRegistryCollection</code>](#AppsRegistryCollection)  
+**Returns**: <code>Promise.&lt;{data, meta, skip, next}&gt;</code> - The JSON API conformant response.  
+**Throws**:
+
+- <code>FetchError</code> 
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| slugs | <code>Array.&lt;string&gt;</code> | The slugs of the apps to fetch |
 
 <a name="AppsRegistryCollection+get"></a>
 

--- a/packages/cozy-stack-client/src/AppsRegistryCollection.js
+++ b/packages/cozy-stack-client/src/AppsRegistryCollection.js
@@ -21,6 +21,36 @@ class AppsRegistryCollection extends DocumentCollection {
   }
 
   /**
+   * Fetches all apps from the registry.
+   *
+   * @param  {object} [option] - The fetch option
+   * @param  {number} [option.limit] - Limit of apps to fetch
+   * @returns {Promise<{data, meta, skip, next}>} The JSON API conformant response.
+   * @throws {FetchError}
+   */
+  async all({ limit = 1000 } = {}) {
+    const resp = await this.stackClient.fetchJSON(
+      'GET',
+      `${this.endpoint}?limit=${limit}`
+    )
+    const dataNormalized = resp.data.map(d => {
+      return normalizeAppFromRegistry(
+        transformRegistryFormatToStackFormat(d),
+        this.doctype
+      )
+    })
+
+    return {
+      data: dataNormalized,
+      meta: {
+        count: resp.meta.count
+      },
+      skip: 0,
+      next: false
+    }
+  }
+
+  /**
    * Fetches an app from the registry.
    *
    * @param  {string} slug - Slug of the app

--- a/packages/cozy-stack-client/src/AppsRegistryCollection.spec.js
+++ b/packages/cozy-stack-client/src/AppsRegistryCollection.spec.js
@@ -8,6 +8,66 @@ import AppsRegistryCollection, {
 describe(`AppsRegistryCollection`, () => {
   const client = new CozyStackClient()
 
+  describe('getAll', () => {
+    const collection = new AppsRegistryCollection(client)
+    const slugs = ['alan', 'caf']
+
+    beforeAll(() => {
+      client.fetchJSON.mockReturnValue(
+        Promise.resolve({
+          data: [
+            {
+              id: 'git://github.com/konnectors/alan.git',
+              slug: 'alan',
+              _type: 'io.cozy.apps_registry',
+              latest_version: {
+                manifest: {
+                  source: 'git://github.com/konnectors/alan.git'
+                }
+              }
+            },
+            {
+              id: 'git://github.com/konnectors/caf.git',
+              slug: 'caf',
+              _type: 'io.cozy.apps_registry',
+              latest_version: {
+                manifest: {
+                  source: 'git://github.com/konnectors/caf.git'
+                }
+              }
+            }
+          ],
+          meta: { count: 2 }
+        })
+      )
+    })
+
+    it('should call the right route', async () => {
+      await collection.getAll(slugs)
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'GET',
+        '/registry/?limit=1000'
+      )
+    })
+
+    it('should return the correct data', async () => {
+      const resp = await collection.getAll(slugs)
+      expect(resp.data.length).toBeLessThanOrEqual(slugs.length)
+      expect(resp.data.every(d => slugs.includes(d.slug))).toBe(true)
+    })
+
+    it('should return a correct JSON API response', async () => {
+      const resp = await collection.getAll(slugs)
+      expect(resp).toConformToJSONAPI()
+    })
+
+    it('should return normalized documents', async () => {
+      const resp = await collection.getAll(slugs)
+      expect(resp.data[0]).toHaveDocumentIdentity()
+      expect(resp.data[0]._type).toEqual(APPS_REGISTRY_DOCTYPE)
+    })
+  })
+
   describe('all', () => {
     const collection = new AppsRegistryCollection(client)
 

--- a/packages/cozy-stack-client/src/AppsRegistryCollection.spec.js
+++ b/packages/cozy-stack-client/src/AppsRegistryCollection.spec.js
@@ -8,6 +8,57 @@ import AppsRegistryCollection, {
 describe(`AppsRegistryCollection`, () => {
   const client = new CozyStackClient()
 
+  describe('all', () => {
+    const collection = new AppsRegistryCollection(client)
+
+    beforeAll(() => {
+      client.fetchJSON.mockReturnValue(
+        Promise.resolve({
+          data: [
+            {
+              id: 'git://github.com/konnectors/alan.git',
+              _id: 'git://github.com/konnectors/alan.git',
+              _type: 'io.cozy.apps_registry',
+              latest_version: {
+                manifest: {
+                  source: 'git://github.com/konnectors/alan.git'
+                }
+              }
+            }
+          ],
+          meta: { count: 1 }
+        })
+      )
+    })
+
+    it('should call the right default route', async () => {
+      await collection.all()
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'GET',
+        '/registry/?limit=1000'
+      )
+    })
+
+    it('should call the right route with custom limit', async () => {
+      await collection.all({ limit: 10 })
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'GET',
+        '/registry/?limit=10'
+      )
+    })
+
+    it('should return a correct JSON API response', async () => {
+      const resp = await collection.all()
+      expect(resp).toConformToJSONAPI()
+    })
+
+    it('should return normalized documents', async () => {
+      const resp = await collection.all()
+      expect(resp.data[0]).toHaveDocumentIdentity()
+      expect(resp.data[0]._type).toEqual(APPS_REGISTRY_DOCTYPE)
+    })
+  })
+
   describe('get', () => {
     const collection = new AppsRegistryCollection(client)
 


### PR DESCRIPTION
For an initial need in the `cozy-banks` app, we need to add the `all` & `getAll` methods to the `AppsRegistryCollection` collection.