### PR TITLE
feat: Now allow to update a trigger with cozy-client

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -1879,6 +1879,7 @@ Implements `DocumentCollection` API along with specific methods for `io.cozy.tri
     * [.destroy(document)](#TriggerCollection+destroy) ⇒ <code>object</code>
     * [.find(selector, options)](#TriggerCollection+find) ⇒ <code>Object</code>
     * [.launch(trigger)](#TriggerCollection+launch) ⇒ <code>object</code>
+    * [.update(trigger)](#TriggerCollection+update) ⇒ <code>object</code>
 
 <a name="TriggerCollection+all"></a>
 
@@ -1955,6 +1956,18 @@ Force given trigger execution.
 | Param | Type | Description |
 | --- | --- | --- |
 | trigger | <code>object</code> | Trigger to launch |
+
+<a name="TriggerCollection+update"></a>
+
+### triggerCollection.update(trigger) ⇒ <code>object</code>
+Updates a Trigger document. Only updatable attributes plus _id are allowed.
+
+**Kind**: instance method of [<code>TriggerCollection</code>](#TriggerCollection)  
+**Returns**: <code>object</code> - Stack response, containing resulting trigger document under `data` attribute.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| trigger | <code>object</code> | Trigger's attributes to update + id |
 
 <a name="dontThrowNotFoundError"></a>
 

--- a/packages/cozy-stack-client/src/TriggerCollection.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.js
@@ -171,8 +171,47 @@ class TriggerCollection extends DocumentCollection {
     }
   }
 
-  async update() {
-    throw new Error('update() method is not available for triggers')
+  /**
+   * Updates a Trigger document. Only updatable attributes plus _id are allowed.
+   *
+   * @param  {object}  trigger Trigger's attributes to update + id
+   * @returns {object}  Stack response, containing resulting trigger document under `data` attribute.
+   */
+  async update(trigger) {
+    for (const key in trigger) {
+      if (
+        ![
+          '_id',
+          '_rev',
+          '_type',
+          'arguments',
+          'message',
+          'cozyMetadata'
+        ].includes(key)
+      ) {
+        throw new Error(
+          `TriggerCollection.update only works for 'arguments', and 'message' attributes.`
+        )
+      }
+    }
+
+    const attributes = {
+      ...(trigger.arguments ? { arguments: trigger.arguments } : {}),
+      ...(trigger.message ? { message: trigger.message } : {})
+    }
+
+    const triggerUpdateResult = await this.stackClient.fetchJSON(
+      'PATCH',
+      `/jobs/triggers/${trigger._id}`,
+      {
+        data: {
+          attributes
+        }
+      }
+    )
+    return {
+      data: normalizeTrigger(triggerUpdateResult.data)
+    }
   }
 }
 

--- a/packages/cozy-stack-client/src/TriggerCollection.spec.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.spec.js
@@ -98,6 +98,25 @@ const CREATE_RESPONSE_FIXTURE = {
   }
 }
 
+const UPDATE_RESPONSE_FIXTURE = {
+  data: {
+    type: 'io.cozy.triggers',
+    id: 'b926bd6657614b82b7d6d4e63bd7c0c0',
+    attributes: {
+      type: '@client',
+      worker: 'client',
+      message: {
+        konnector: 'edf',
+        account: 'accountid',
+        folder_to_save: 'newfolderid'
+      }
+    },
+    links: {
+      self: '/jobs/triggers/b926bd6657614b82b7d6d4e63bd7c0c0'
+    }
+  }
+}
+
 describe('TriggerCollection', () => {
   const stackClient = new CozyStackClient()
   const collection = new TriggerCollection(stackClient)
@@ -332,6 +351,70 @@ describe('TriggerCollection', () => {
     })
   })
 
+  describe('update', () => {
+    const collection = new TriggerCollection(stackClient)
+
+    beforeEach(() => {
+      stackClient.fetchJSON.mockResolvedValue(UPDATE_RESPONSE_FIXTURE)
+    })
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    it('should call the right route', async () => {
+      await collection.update({
+        _id: 'b926bd6657614b82b7d6d4e63bd7c0c0',
+        message: {
+          konnector: 'edf',
+          account: 'accountid',
+          folder_to_save: 'newfolderid'
+        }
+      })
+      expect(stackClient.fetchJSON).toHaveBeenCalledWith(
+        'PATCH',
+        '/jobs/triggers/b926bd6657614b82b7d6d4e63bd7c0c0',
+        {
+          data: {
+            attributes: {
+              message: {
+                konnector: 'edf',
+                account: 'accountid',
+                folder_to_save: 'newfolderid'
+              }
+            }
+          }
+        }
+      )
+    })
+
+    it('should return a correct JSON API response', async () => {
+      const resp = await collection.update({
+        message: {
+          konnector: 'edf',
+          account: 'accountid',
+          folder_to_save: 'newfolderid'
+        }
+      })
+      expect(resp).toConformToJSONAPI()
+    })
+
+    it('should return normalized documents', async () => {
+      const resp = await collection.update({
+        message: {
+          konnector: 'edf',
+          account: 'accountid',
+          folder_to_save: 'newfolderid'
+        }
+      })
+      expect(resp.data).toHaveDocumentIdentity()
+    })
+    it('should refuse to update a document with non conform attributes', async () => {
+      await expect(
+        collection.update({ _id: 'triggerid', notaccepted: 'anyvalue' })
+      ).rejects.toThrowError()
+    })
+  })
+
   describe('launch', () => {
     const LAUNCH_RESPONSE_FIXTURE = {
       data: {
@@ -388,14 +471,6 @@ describe('TriggerCollection', () => {
     it('should return normalized documents', async () => {
       const resp = await collection.launch(trigger)
       expect(resp.data).toHaveDocumentIdentity()
-    })
-  })
-
-  describe('update', () => {
-    it('should throw error', async () => {
-      expect(collection.update()).rejects.toThrowError(
-        'update() method is not available for triggers'
-      )
     })
   })
 })


### PR DESCRIPTION
To use it :

```javascript
await client.save({
  _id: 'triggerid',
  _rev: 'triggerrev',
  message: {
    konnector: 'konnectorslug',
    account: 'accountid',
    folder_to_save: 'folderid'
  }  
})
```

Only 'arguments' and message attributes are allowed to be modified other attributes will trigger an error.
