### PR TITLE
feat: Add geo model

### DIFF
--- a/packages/cozy-client/src/models/geo.js
+++ b/packages/cozy-client/src/models/geo.js
@@ -1,0 +1,60 @@
+/**
+ * Compute the speed from distance and duration
+ *
+ * @param {number} distance - The distance in meters
+ * @param {number} duration - The duration in seconds
+ * @returns {number} - The speed, in m/s, rounded to 2 decimals
+ */
+export const computeSpeed = (distance, duration) => {
+  if (!distance || !duration) {
+    return 0
+  }
+  return Math.round((distance / duration) * 100) / 100
+}
+
+const degreesToRadians = degrees => {
+  return (degrees * Math.PI) / 180
+}
+
+/**
+ * Compute the distance between 2 geographic points, in meters.
+ *
+ * This is an implementation of the Haversine formula, that
+ * supposes a perfect sphere. We know this is not exactly the case
+ * for Earth, especially at the poles, but this approximation is good enough.
+ * More complex methods do exist, such as Vincenty formula, but we prefer
+ * simplicity over precision here.
+ * See https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid
+ *
+ * @param {import("../types").Coordinates} point1 - The first point coordinates, in decimal degrees
+ * @param {import("../types").Coordinates} point2 - The second point coordinates, in decimal degrees
+ * @returns {number} The distance between the points, in meters, rounded to 2 decimals
+ */
+export const geodesicDistance = (point1, point2) => {
+  if (
+    point1?.lon === undefined ||
+    point1?.lat === undefined ||
+    point2?.lon === undefined ||
+    point2?.lat === undefined
+  ) {
+    return null
+  }
+  const lon1 = degreesToRadians(point1.lon)
+  const lat1 = degreesToRadians(point1.lat)
+
+  const lon2 = degreesToRadians(point2.lon)
+  const lat2 = degreesToRadians(point2.lat)
+
+  const diffLon = lon2 - lon1
+  const diffLat = lat2 - lat1
+
+  const aLat = Math.pow(Math.sin(diffLat / 2), 2)
+  const aLon = Math.pow(Math.sin(diffLon / 2), 2)
+
+  const a = aLat + Math.cos(lat1) * Math.cos(lat2) * aLon
+  const c = 2 * Math.asin(Math.sqrt(a))
+
+  // Radius of earth is 6371 km
+  const distance = 6371 * 1000 * c
+  return Math.round(distance * 100) / 100
+}

--- a/packages/cozy-client/src/models/geo.spec.js
+++ b/packages/cozy-client/src/models/geo.spec.js
@@ -1,0 +1,32 @@
+const { geodesicDistance, computeSpeed } = require('./geo')
+
+describe('geodesicDistance', () => {
+  it('should return 0 for 2 points with same coordinates', () => {
+    const p1 = { lat: 0.0, lon: 0.0 }
+    const p2 = { lat: 0.0, lon: 0.0 }
+    expect(geodesicDistance(p1, p2)).toEqual(0)
+  })
+
+  it('should return null when points are not properly formatted', () => {
+    expect(geodesicDistance(null, null)).toEqual(null)
+    expect(geodesicDistance({ lat: 1.0 }, { lon: 5.6 })).toEqual(null)
+  })
+
+  it('should return the correct Paris-NY distance', () => {
+    const paris = { lat: 48.8566, lon: 2.3522 }
+    const NY = { lat: 40.7128, lon: -74.006 }
+    expect(geodesicDistance(paris, NY)).toEqual(5837240.9)
+  })
+})
+
+describe('speed', () => {
+  it('should return 0 when the speed or distance is not set or 0', () => {
+    expect(computeSpeed(0, 0)).toEqual(0)
+    expect(computeSpeed(10, 0)).toEqual(0)
+    expect(computeSpeed(0, 10)).toEqual(0)
+    expect(computeSpeed()).toEqual(0)
+  })
+  it('should return the correct running speed of the developer', () => {
+    expect(computeSpeed(10000, 1800)).toEqual(5.56)
+  })
+})

--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -486,6 +486,12 @@ import { QueryDefinition } from './queries/dsl'
  */
 
 /**
+ * @typedef {object} Coordinates
+ * @property {number} lat - The latitude, in decimal degrees
+ * @property {number} lon - The longitude, in decimal degrees
+ */
+
+/**
  * Receives the URL to present to the user as a parameter, and should return a promise that resolves with the URL the user was redirected to after accepting the permissions.
  *
  * @callback OpenURLCallback

--- a/packages/cozy-client/types/models/geo.d.ts
+++ b/packages/cozy-client/types/models/geo.d.ts
@@ -1,0 +1,2 @@
+export function computeSpeed(distance: number, duration: number): number;
+export function geodesicDistance(point1: import("../types").Coordinates, point2: import("../types").Coordinates): number;

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -820,6 +820,16 @@ export type DACCAggregate = {
      */
     std: number;
 };
+export type Coordinates = {
+    /**
+     * - The latitude, in decimal degrees
+     */
+    lat: number;
+    /**
+     * - The longitude, in decimal degrees
+     */
+    lon: number;
+};
 /**
  * Receives the URL to present to the user as a parameter, and should return a promise that resolves with the URL the user was redirected to after accepting the permissions.
  */


### PR DESCRIPTION
This is useful for geo computations, such as geodesic distance. This distance is typically required in Photos, for spatial clustering, in CoachCO2, to find close locations, or flagship app, for optional GPS tracking.