### PR TITLE
fix: Magic Folders localization does not work with Metro

### DIFF
--- a/docs/api/cozy-client/modules/models.document.locales.md
+++ b/docs/api/cozy-client/modules/models.document.locales.md
@@ -39,7 +39,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/document/locales/index.js:23](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document/locales/index.js#L23)
+[packages/cozy-client/src/models/document/locales/index.js:21](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document/locales/index.js#L21)
 
 ***
 
@@ -61,4 +61,4 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/document/locales/index.js:43](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document/locales/index.js#L43)
+[packages/cozy-client/src/models/document/locales/index.js:41](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document/locales/index.js#L41)

--- a/packages/cozy-client/src/models/document/locales/index.js
+++ b/packages/cozy-client/src/models/document/locales/index.js
@@ -1,18 +1,16 @@
 import Polyglot from 'node-polyglot'
 
 import { getEmojiByCountry } from '../emojiCountry'
+import enLocale from './en.json'
+import frLocale from './fr.json'
+
+const locales = { en: enLocale, fr: frLocale }
 
 const polyglots = {}
 const langs = ['fr', 'en']
 for (const lang of langs) {
-  let locales = {}
-  try {
-    locales = require(`./${lang}.json`)
-  } catch (e) {
-    // eslint-disable-line no-empty-block
-  }
   const polyglot = new Polyglot()
-  polyglot.extend(locales)
+  polyglot.extend(locales[lang])
   polyglots[lang] = polyglot
 }
 


### PR DESCRIPTION
Metro does not support dynamic requires and the error was swallowed by
an empty catch.

Replaced the dynamic requires with explicit imports.

I missed this problem before because the warning was not obvious in
flagship app logs and since I did not remove magic folders for my tests
but just the destination folder, magic folders references where still
present and did their job.
