### PR TITLE
feat: Export getReferencedBy for node process

### DIFF
--- a/packages/cozy-client/src/index.node.js
+++ b/packages/cozy-client/src/index.node.js
@@ -17,6 +17,7 @@ export {
   HasManyInPlace,
   HasManyTriggers
 } from './associations'
+export { getReferencedBy } from './associations/helpers'
 export {
   deconstructCozyWebLinkWithSlug,
   deconstructRedirectLink,

--- a/packages/cozy-client/types/index.node.d.ts
+++ b/packages/cozy-client/types/index.node.d.ts
@@ -2,6 +2,7 @@ export { default } from "./CozyClient";
 export { default as CozyLink } from "./CozyLink";
 export { default as StackLink } from "./StackLink";
 export { default as compose } from "lodash/flow";
+export { getReferencedBy } from "./associations/helpers";
 export { cancelable } from "./utils";
 export { getQueryFromState } from "./store";
 export { default as Registry } from "./registry";


### PR DESCRIPTION
To develop a service on Photos, I need the getReferencedBy function to be available in a node process