### PR TITLE
feat: Add getFlagshipDownloadLink function

### DIFF
--- a/docs/api/cozy-client/modules/models.utils.md
+++ b/docs/api/cozy-client/modules/models.utils.md
@@ -8,21 +8,49 @@
 
 ### getCreatedByApp
 
-▸ **getCreatedByApp**(`doc`): `any`
+▸ **getCreatedByApp**(`doc`): `string`
+
+Gets the app that created a document
 
 *Parameters*
 
-| Name | Type |
-| :------ | :------ |
-| `doc` | `any` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `doc` | `any` | The document to check |
 
 *Returns*
 
-`any`
+`string`
+
+*   The slug of the app that created the document
 
 *Defined in*
 
-[packages/cozy-client/src/models/utils.js:8](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/utils.js#L8)
+[packages/cozy-client/src/models/utils.js:23](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/utils.js#L23)
+
+***
+
+### getFlagshipDownloadLink
+
+▸ **getFlagshipDownloadLink**(`lang`): `string`
+
+Gets the download link for the Cozy Flagship app and his white-labels versions
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `lang` | `string` | The language code for the download page |
+
+*Returns*
+
+`string`
+
+*   The URL of the download page
+
+*Defined in*
+
+[packages/cozy-client/src/models/utils.js:31](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/utils.js#L31)
 
 ***
 
@@ -30,17 +58,21 @@
 
 ▸ **hasBeenUpdatedByApp**(`doc`, `appSlug`): `boolean`
 
+Checks if a document has been updated by a specific app
+
 *Parameters*
 
-| Name | Type |
-| :------ | :------ |
-| `doc` | `any` |
-| `appSlug` | `any` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `doc` | `any` | The document to check |
+| `appSlug` | `string` | The slug of the app to check |
 
 *Returns*
 
 `boolean`
 
+*   True if the document has been updated by the app, false otherwise
+
 *Defined in*
 
-[packages/cozy-client/src/models/utils.js:3](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/utils.js#L3)
+[packages/cozy-client/src/models/utils.js:12](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/utils.js#L12)

--- a/packages/cozy-client/src/models/utils.js
+++ b/packages/cozy-client/src/models/utils.js
@@ -1,8 +1,42 @@
 import get from 'lodash/get'
+import { isAndroid, isIOS } from 'cozy-device-helper'
+import flag from 'cozy-flags'
 
+/**
+ * Checks if a document has been updated by a specific app
+ *
+ * @param {object} doc - The document to check
+ * @param {string} appSlug - The slug of the app to check
+ * @returns {boolean} - True if the document has been updated by the app, false otherwise
+ */
 export const hasBeenUpdatedByApp = (doc, appSlug) => {
   const updatedByApps = get(doc, 'cozyMetadata.updatedByApps')
   return Boolean(updatedByApps && updatedByApps.find(x => x.slug === appSlug))
 }
 
+/**
+ * Gets the app that created a document
+ *
+ * @param {object} doc - The document to check
+ * @returns {string} - The slug of the app that created the document
+ */
 export const getCreatedByApp = doc => get(doc, 'cozyMetadata.createdByApp')
+
+/**
+ * Gets the download link for the Cozy Flagship app and his white-labels versions
+ *
+ * @param {string} lang - The language code for the download page
+ * @returns {string} - The URL of the download page
+ */
+export const getFlagshipDownloadLink = lang => {
+  if (isAndroid()) {
+    const id = flag('flagship.playstore_id') || 'io.cozy.flagship.mobile'
+    return `https://play.google.com/store/apps/details?id=${id}&hl=${lang}`
+  }
+  if (isIOS()) {
+    const id = flag('flagship.appstore_id') || 'id1600636174'
+    return `https://apps.apple.com/${lang}/app/${id}`
+  }
+
+  return flag('flagship.download_link') || `https://cozy.io/${lang}/download`
+}

--- a/packages/cozy-client/src/models/utils.spec.js
+++ b/packages/cozy-client/src/models/utils.spec.js
@@ -1,4 +1,17 @@
-import { getCreatedByApp, hasBeenUpdatedByApp } from './utils'
+import {
+  getCreatedByApp,
+  hasBeenUpdatedByApp,
+  getFlagshipDownloadLink
+} from './utils'
+import { isAndroid, isIOS } from 'cozy-device-helper'
+import flag from 'cozy-flags'
+
+jest.mock('cozy-device-helper', () => ({
+  isAndroid: jest.fn(),
+  isIOS: jest.fn()
+}))
+
+jest.mock('cozy-flags')
 
 test('getCreatedByApp', () => {
   expect(getCreatedByApp({ cozyMetadata: { createdByApp: 'banks' } })).toBe(
@@ -21,4 +34,69 @@ test('hasBeenUpdatedByApp', () => {
     )
   ).toBe(false)
   expect(hasBeenUpdatedByApp({}, 'drive')).toBe(false)
+})
+
+describe('getFlagshipDownloadLink', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should return the Android download link with the correct ID and language', () => {
+    // @ts-ignore
+    isAndroid.mockReturnValueOnce(true)
+    flag.mockReturnValueOnce('com.example.app')
+    const lang = 'fr'
+    expect(getFlagshipDownloadLink(lang)).toBe(
+      'https://play.google.com/store/apps/details?id=com.example.app&hl=fr'
+    )
+  })
+
+  it('should return the default Android download link if no ID is provided', () => {
+    // @ts-ignore
+    isAndroid.mockReturnValueOnce(true)
+    flag.mockReturnValueOnce(null)
+    const lang = 'en'
+    expect(getFlagshipDownloadLink(lang)).toBe(
+      'https://play.google.com/store/apps/details?id=io.cozy.flagship.mobile&hl=en'
+    )
+  })
+
+  it('should return the iOS download link with the correct ID and language', () => {
+    // @ts-ignore
+    isIOS.mockReturnValueOnce(true)
+    flag.mockReturnValueOnce('id123456')
+    const lang = 'es'
+    expect(getFlagshipDownloadLink(lang)).toBe(
+      'https://apps.apple.com/es/app/id123456'
+    )
+  })
+
+  it('should return the default iOS download link if no ID is provided', () => {
+    // @ts-ignore
+    isIOS.mockReturnValueOnce(true)
+    flag.mockReturnValueOnce(null)
+    const lang = 'en'
+    expect(getFlagshipDownloadLink(lang)).toBe(
+      'https://apps.apple.com/en/app/id1600636174'
+    )
+  })
+
+  it('should return the download link from the flag for other platforms', () => {
+    // @ts-ignore
+    isAndroid.mockReturnValueOnce(false)
+    // @ts-ignore
+    isIOS.mockReturnValueOnce(false)
+    flag.mockReturnValueOnce('https://other.site/download')
+    const lang = 'fr'
+    expect(getFlagshipDownloadLink(lang)).toBe('https://other.site/download')
+  })
+
+  it('should return the default download link for other platforms', () => {
+    // @ts-ignore
+    isAndroid.mockReturnValueOnce(false)
+    // @ts-ignore
+    isIOS.mockReturnValueOnce(false)
+    const lang = 'fr'
+    expect(getFlagshipDownloadLink(lang)).toBe('https://cozy.io/fr/download')
+  })
 })

--- a/packages/cozy-client/types/models/utils.d.ts
+++ b/packages/cozy-client/types/models/utils.d.ts
@@ -1,2 +1,3 @@
-export function hasBeenUpdatedByApp(doc: any, appSlug: any): boolean;
-export function getCreatedByApp(doc: any): any;
+export function hasBeenUpdatedByApp(doc: object, appSlug: string): boolean;
+export function getCreatedByApp(doc: object): string;
+export function getFlagshipDownloadLink(lang: string): string;


### PR DESCRIPTION
The aim of this function is to provide a link to the download page for the flagship application and its white-label versions. It is used in Harvest but purpose is to share it so that it can also be used in store. I put it in the `utils` model because it seemed the most relevant, but if you have a better place I'd be happy to change it.