### PR TITLE
feat: Cache the result of /registry/maintenance from cozy-stack

### DIFF
--- a/packages/cozy-stack-client/src/AppsRegistryCollection.js
+++ b/packages/cozy-stack-client/src/AppsRegistryCollection.js
@@ -28,12 +28,24 @@ class AppsRegistryCollection extends DocumentCollection {
    * @throws {FetchError}
    */
   async get(slug) {
-    const app = await this.stackClient.fetchJSON(
+    const resp = await this.stackClient.fetchJSON(
       'GET',
       `${this.endpoint}${slug}`
     )
 
-    const data = transformRegistryFormatToStackFormat(app)
+    // The "maintenance" keyword calls a specific route in the stack
+    // that returns a table of all applications under maintenance.
+    // We processed it independently so that it could be stored in the cache.
+    if (slug === 'maintenance') {
+      return {
+        data: resp.map(app => ({
+          _type: APPS_REGISTRY_DOCTYPE,
+          ...app
+        }))
+      }
+    }
+
+    const data = transformRegistryFormatToStackFormat(resp)
     return { data: normalizeAppFromRegistry(data, this.doctype) }
   }
 

--- a/packages/cozy-stack-client/src/AppsRegistryCollection.spec.js
+++ b/packages/cozy-stack-client/src/AppsRegistryCollection.spec.js
@@ -43,7 +43,30 @@ describe(`AppsRegistryCollection`, () => {
       expect(resp.data).toHaveDocumentIdentity()
       expect(resp.data._type).toEqual(APPS_REGISTRY_DOCTYPE)
     })
+
+    it('should return list of apps in maintenance', async () => {
+      client.fetchJSON.mockReturnValue(
+        Promise.resolve([
+          {
+            slug: 'app1',
+            type: 'webapp',
+            maintenance_activated: true
+          },
+          {
+            maintenance_activated: true,
+            slug: 'konnector1',
+            type: 'konnector'
+          }
+        ])
+      )
+
+      const resp = await collection.get('maintenance')
+
+      expect(resp.data).toHaveLength(2)
+      expect(resp.data[0]._type).toEqual(APPS_REGISTRY_DOCTYPE)
+    })
   })
+
   describe('create', () => {
     const collection = new AppsRegistryCollection(client)
 
@@ -53,6 +76,7 @@ describe(`AppsRegistryCollection`, () => {
       )
     })
   })
+
   describe('destroy', () => {
     const collection = new AppsRegistryCollection(client)
 


### PR DESCRIPTION
This route is used to get the list of applications under maintenance. This change is a trick to cache the result in the Redux store.