### PR TITLE
feat: Benefit from the cache for the apps in maintenance

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -687,15 +687,9 @@ The root Cozy URL
 
 ### useAppsInMaintenance
 
-▸ **useAppsInMaintenance**(`client`): `"io.cozy.apps"`\[]
+▸ **useAppsInMaintenance**(): `"io.cozy.apps"`\[]
 
 Returns all apps in maintenance
-
-*Parameters*
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `client` | [`CozyClient`](classes/CozyClient.md) | CozyClient instance |
 
 *Returns*
 

--- a/packages/cozy-client/src/hooks/useAppsInMaintenance.jsx
+++ b/packages/cozy-client/src/hooks/useAppsInMaintenance.jsx
@@ -1,30 +1,27 @@
-import { useState, useEffect } from 'react'
-import Registry from '../registry'
+import useQuery from './useQuery'
+import { Q } from '../queries/dsl'
 import CozyClient from '../CozyClient'
+
+const DEFAULT_CACHE_TIMEOUT_QUERIES = 10 * 60 * 1000 // 10 minutes
 
 /**
  * Returns all apps in maintenance
  *
- * @param {CozyClient} client CozyClient instance
- *
  * @returns {import("../types").AppsDoctype[]} An array with all apps in maintenance
  */
-const useAppsInMaintenance = client => {
-  const [appsInMaintenance, setAppsInMaintenance] = useState([])
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const registry = new Registry({
-        client
-      })
-
-      const newAppsInMaintenance = await registry.fetchAppsInMaintenance()
-      setAppsInMaintenance(newAppsInMaintenance || [])
+const useAppsInMaintenance = () => {
+  const { data: appsInMaintenance } = useQuery(
+    Q('io.cozy.apps_registry').getById('maintenance'),
+    {
+      as: 'io.cozy.apps_registry/maintenance',
+      fetchPolicy: CozyClient.fetchPolicies.olderThan(
+        DEFAULT_CACHE_TIMEOUT_QUERIES
+      ),
+      singleDocData: false
     }
-    fetchData()
-  }, [client])
+  )
 
-  return appsInMaintenance
+  return appsInMaintenance || []
 }
 
 export default useAppsInMaintenance

--- a/packages/cozy-client/src/hooks/useAppsInMaintenance.spec.jsx
+++ b/packages/cozy-client/src/hooks/useAppsInMaintenance.spec.jsx
@@ -1,32 +1,34 @@
 import { renderHook } from '@testing-library/react-hooks'
 import useAppsInMaintenance from './useAppsInMaintenance'
-import CozyClient from '../CozyClient'
+import { createMockClient } from '../mock'
+import { makeWrapper } from '../testing/utils'
 
 const appsInMaintenance = [
   {
+    _id: 'caissedepargne1',
     slug: 'caissedepargne1'
   },
-  { slug: 'boursorama' }
+  {
+    _id: 'boursorama',
+    slug: 'boursorama'
+  }
 ]
 
-const mockClient = new CozyClient({
-  stackClient: {
-    on: jest.fn(),
-    fetchJSON: jest.fn().mockResolvedValue([
-      {
-        slug: 'caissedepargne1'
-      },
-      { slug: 'boursorama' }
-    ])
+const mockClient = createMockClient({
+  queries: {
+    'io.cozy.apps_registry/maintenance': {
+      data: appsInMaintenance,
+      doctype: 'io.cozy.apps_registry'
+    }
   }
 })
 
 describe('useAppsInMaintenance', () => {
-  it('should return apps in maintenance', async () => {
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useAppsInMaintenance(mockClient)
-    )
-    await waitForNextUpdate()
-    expect(result.current).toEqual(appsInMaintenance)
+  it('should return apps in maintenance', () => {
+    const { result } = renderHook(() => useAppsInMaintenance(), {
+      wrapper: makeWrapper(mockClient)
+    })
+
+    expect(result.current).toMatchObject(appsInMaintenance)
   })
 })

--- a/packages/cozy-client/types/hooks/useAppsInMaintenance.d.ts
+++ b/packages/cozy-client/types/hooks/useAppsInMaintenance.d.ts
@@ -2,9 +2,6 @@ export default useAppsInMaintenance;
 /**
  * Returns all apps in maintenance
  *
- * @param {CozyClient} client CozyClient instance
- *
  * @returns {import("../types").AppsDoctype[]} An array with all apps in maintenance
  */
-declare function useAppsInMaintenance(client: CozyClient): import("../types").AppsDoctype[];
-import CozyClient from "../CozyClient";
+declare function useAppsInMaintenance(): import("../types").AppsDoctype[];


### PR DESCRIPTION
Since cozy-client 41.9.0 release, we can benefit from the cache for the request to get the apps in maintenance using
Q('io.cozy.apps_registry').getById('maintenance'). This commit updates the useAppsInMaintenance hook to use this request with useQuery. As a result, the hook no longer needs a cozy-client instance.