### PR TITLE
fix: Handle maintenance app without id

### DIFF
--- a/packages/cozy-stack-client/src/AppsRegistryCollection.js
+++ b/packages/cozy-stack-client/src/AppsRegistryCollection.js
@@ -36,12 +36,18 @@ class AppsRegistryCollection extends DocumentCollection {
     // The "maintenance" keyword calls a specific route in the stack
     // that returns a table of all applications under maintenance.
     // We processed it independently so that it could be stored in the cache.
+    // The stack returns some app without an id, so we use the slug as id.
     if (slug === 'maintenance') {
       return {
-        data: resp.map(app => ({
-          _type: APPS_REGISTRY_DOCTYPE,
-          ...app
-        }))
+        data: resp.map(app =>
+          normalizeAppFromRegistry(
+            {
+              _id: app._id || app.slug,
+              ...app
+            },
+            this.doctype
+          )
+        )
       }
     }
 

--- a/packages/cozy-stack-client/src/AppsRegistryCollection.spec.js
+++ b/packages/cozy-stack-client/src/AppsRegistryCollection.spec.js
@@ -48,6 +48,7 @@ describe(`AppsRegistryCollection`, () => {
       client.fetchJSON.mockReturnValue(
         Promise.resolve([
           {
+            _id: 'app1',
             slug: 'app1',
             type: 'webapp',
             maintenance_activated: true
@@ -63,7 +64,24 @@ describe(`AppsRegistryCollection`, () => {
       const resp = await collection.get('maintenance')
 
       expect(resp.data).toHaveLength(2)
-      expect(resp.data[0]._type).toEqual(APPS_REGISTRY_DOCTYPE)
+      expect(resp.data).toStrictEqual([
+        {
+          _id: 'app1',
+          _type: 'io.cozy.apps_registry',
+          id: 'app1',
+          slug: 'app1',
+          type: 'webapp',
+          maintenance_activated: true
+        },
+        {
+          _id: 'konnector1',
+          _type: 'io.cozy.apps_registry',
+          id: 'konnector1',
+          maintenance_activated: true,
+          slug: 'konnector1',
+          type: 'konnector'
+        }
+      ])
     })
   })
 


### PR DESCRIPTION
There are two ways of maintaining an app using registry and cozy-stack.  Apps from the registry have an id that corresponds to the slug. Conversely, apps from the stack do not have an id, which causes cozy-client to crash. I've decided to create an id from the slug for those that don't have one to fix the problem temporarily.