### PR TITLE
feat: Apply data enhancement to realtime results for specific doctypes

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -336,7 +336,7 @@ Deconstructed link
 
 ### dispatchCreate
 
-▸ **dispatchCreate**(`client`, `doctype`, `couchDBDoc`): `void`
+▸ **dispatchCreate**(`client`, `doctype`, `couchDBDoc`, `options?`): `Promise`<`void`>
 
 Dispatches a create action for a document to update CozyClient store from realtime callbacks.
 
@@ -347,20 +347,21 @@ Dispatches a create action for a document to update CozyClient store from realti
 | `client` | `any` | CozyClient instance |
 | `doctype` | `string` | Doctype of the document to create |
 | `couchDBDoc` | `CouchDBDocument` | Document to create |
+| `options` | `DispatchOptions` | - |
 
 *Returns*
 
-`void`
+`Promise`<`void`>
 
 *Defined in*
 
-[packages/cozy-client/src/store/realtime.js:58](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/store/realtime.js#L58)
+[packages/cozy-client/src/store/realtime.js:76](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/store/realtime.js#L76)
 
 ***
 
 ### dispatchDelete
 
-▸ **dispatchDelete**(`client`, `doctype`, `couchDBDoc`): `void`
+▸ **dispatchDelete**(`client`, `doctype`, `couchDBDoc`, `options?`): `Promise`<`void`>
 
 Dispatches a delete action for a document to update CozyClient store from realtime callbacks.
 
@@ -371,20 +372,21 @@ Dispatches a delete action for a document to update CozyClient store from realti
 | `client` | `any` | CozyClient instance |
 | `doctype` | `string` | Doctype of the document to create |
 | `couchDBDoc` | `CouchDBDocument` | Document to create |
+| `options` | `DispatchOptions` | - |
 
 *Returns*
 
-`void`
+`Promise`<`void`>
 
 *Defined in*
 
-[packages/cozy-client/src/store/realtime.js:80](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/store/realtime.js#L80)
+[packages/cozy-client/src/store/realtime.js:120](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/store/realtime.js#L120)
 
 ***
 
 ### dispatchUpdate
 
-▸ **dispatchUpdate**(`client`, `doctype`, `couchDBDoc`): `void`
+▸ **dispatchUpdate**(`client`, `doctype`, `couchDBDoc`, `options?`): `Promise`<`void`>
 
 Dispatches a update action for a document to update CozyClient store from realtime callbacks.
 
@@ -395,14 +397,15 @@ Dispatches a update action for a document to update CozyClient store from realti
 | `client` | `any` | CozyClient instance |
 | `doctype` | `string` | Doctype of the document to create |
 | `couchDBDoc` | `CouchDBDocument` | Document to create |
+| `options` | `DispatchOptions` | - |
 
 *Returns*
 
-`void`
+`Promise`<`void`>
 
 *Defined in*
 
-[packages/cozy-client/src/store/realtime.js:69](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/store/realtime.js#L69)
+[packages/cozy-client/src/store/realtime.js:98](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/store/realtime.js#L98)
 
 ***
 

--- a/packages/cozy-client/src/RealTimeQueries.spec.jsx
+++ b/packages/cozy-client/src/RealTimeQueries.spec.jsx
@@ -6,7 +6,26 @@ import CozyProvider from './Provider'
 
 const setup = async doctype => {
   const realtimeCallbacks = {}
-  const client = new createMockClient({})
+  const client = new createMockClient({
+    queries: {
+      'io.cozy.files/parent': {
+        doctype: 'io.cozy.files',
+        definition: {
+          doctype: 'io.cozy.files',
+          id: 'parent'
+        },
+        data: [
+          {
+            _id: 'parent',
+            _type: 'io.cozy.files',
+            name: 'Parent folder',
+            path: '/Parent'
+          }
+        ]
+      }
+    }
+  })
+
   client.plugins.realtime = {
     subscribe: jest.fn((event, doctype, callback) => {
       realtimeCallbacks[event] = callback
@@ -29,17 +48,26 @@ const setup = async doctype => {
 }
 
 describe('RealTimeQueries', () => {
-  it('notifies the cozy-client store', async () => {
+  it('should dispatch CREATE_DOCUMENT mutation for created io.cozy.files', async () => {
     const { client, realtimeCallbacks, unmount } = await setup('io.cozy.files')
 
-    realtimeCallbacks['created']({ _id: 'mock-created', type: 'file' })
-    expect(client.dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({
+    realtimeCallbacks['created']({
+      _id: 'mock-created',
+      type: 'file',
+      name: 'mock-created',
+      dir_id: 'parent'
+    })
+
+    await waitFor(() => {
+      expect(client.dispatch).toHaveBeenCalledWith({
         definition: {
           document: {
             _id: 'mock-created',
-            id: 'mock-created',
             _type: 'io.cozy.files',
+            dir_id: 'parent',
+            id: 'mock-created',
+            name: 'mock-created',
+            path: '/Parent/mock-created',
             type: 'file'
           },
           mutationType: 'CREATE_DOCUMENT'
@@ -48,68 +76,115 @@ describe('RealTimeQueries', () => {
         response: {
           data: {
             _id: 'mock-created',
-            id: 'mock-created',
             _type: 'io.cozy.files',
+            dir_id: 'parent',
+            id: 'mock-created',
+            name: 'mock-created',
+            path: '/Parent/mock-created',
             type: 'file'
           }
         },
         type: 'RECEIVE_MUTATION_RESULT'
       })
-    )
-
-    realtimeCallbacks['updated']({ _id: 'mock-updated', type: 'file' })
-    expect(client.dispatch).toHaveBeenCalledWith({
-      definition: {
-        document: {
-          _id: 'mock-updated',
-          id: 'mock-updated',
-          _type: 'io.cozy.files',
-          type: 'file'
-        },
-        mutationType: 'UPDATE_DOCUMENT'
-      },
-      mutationId: '2',
-      response: {
-        data: {
-          _id: 'mock-updated',
-          id: 'mock-updated',
-          _type: 'io.cozy.files',
-          type: 'file'
-        }
-      },
-      type: 'RECEIVE_MUTATION_RESULT'
     })
 
-    realtimeCallbacks['deleted']({ _id: 'mock-deleted', type: 'file' })
-    expect(client.dispatch).toHaveBeenCalledWith({
-      definition: {
-        document: {
-          _id: 'mock-deleted',
-          id: 'mock-deleted',
-          _type: 'io.cozy.files',
-          type: 'file',
-          _deleted: true
+    unmount()
+    await waitFor(() => {
+      expect(client.plugins.realtime.unsubscribe).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  it('should dispatch UPDATE_DOCUMENT mutation for updated io.cozy.files', async () => {
+    const { client, realtimeCallbacks, unmount } = await setup('io.cozy.files')
+
+    realtimeCallbacks['updated']({
+      _id: 'mock-updated',
+      type: 'file',
+      name: 'mock-updated',
+      dir_id: 'parent'
+    })
+
+    await waitFor(() => {
+      expect(client.dispatch).toHaveBeenCalledWith({
+        definition: {
+          document: {
+            _id: 'mock-updated',
+            _type: 'io.cozy.files',
+            dir_id: 'parent',
+            id: 'mock-updated',
+            name: 'mock-updated',
+            path: '/Parent/mock-updated',
+            type: 'file'
+          },
+          mutationType: 'UPDATE_DOCUMENT'
         },
-        mutationType: 'DELETE_DOCUMENT'
-      },
-      mutationId: '3',
-      response: {
-        data: {
-          _id: 'mock-deleted',
-          id: 'mock-deleted',
-          _type: 'io.cozy.files',
-          type: 'file',
-          _deleted: true
-        }
-      },
-      type: 'RECEIVE_MUTATION_RESULT'
+        mutationId: '1',
+        response: {
+          data: {
+            _id: 'mock-updated',
+            _type: 'io.cozy.files',
+            dir_id: 'parent',
+            id: 'mock-updated',
+            name: 'mock-updated',
+            path: '/Parent/mock-updated',
+            type: 'file'
+          }
+        },
+        type: 'RECEIVE_MUTATION_RESULT'
+      })
     })
 
     unmount()
     expect(client.plugins.realtime.unsubscribe).toHaveBeenCalledTimes(3)
   })
 
-  it('deals with other doctypes than io.cozy.files', async () => {
+  it('should dispatch DELETE_DOCUMENT mutation for deleted io.cozy.files', async () => {
+    const { client, realtimeCallbacks, unmount } = await setup('io.cozy.files')
+
+    realtimeCallbacks['deleted']({
+      _id: 'mock-deleted',
+      type: 'file',
+      name: 'mock-deleted',
+      dir_id: 'parent'
+    })
+
+    await waitFor(() => {
+      expect(client.dispatch).toHaveBeenCalledWith({
+        definition: {
+          document: {
+            _deleted: true,
+            _type: 'io.cozy.files',
+            _id: 'mock-deleted',
+            dir_id: 'parent',
+            id: 'mock-deleted',
+            name: 'mock-deleted',
+            path: '/Parent/mock-deleted',
+            type: 'file'
+          },
+          mutationType: 'DELETE_DOCUMENT'
+        },
+        mutationId: '1',
+        response: {
+          data: {
+            _deleted: true,
+            _type: 'io.cozy.files',
+            _id: 'mock-deleted',
+            dir_id: 'parent',
+            id: 'mock-deleted',
+            name: 'mock-deleted',
+            path: '/Parent/mock-deleted',
+            type: 'file'
+          }
+        },
+        type: 'RECEIVE_MUTATION_RESULT'
+      })
+    })
+
+    unmount()
+    expect(client.plugins.realtime.unsubscribe).toHaveBeenCalledTimes(3)
+  })
+
+  it('should handle realtime events for other doctypes than io.cozy.files', async () => {
     const { client, realtimeCallbacks, unmount } = await setup(
       'io.cozy.oauth.clients'
     )
@@ -119,31 +194,33 @@ describe('RealTimeQueries', () => {
       client_kind: 'desktop',
       client_name: 'Cozy Drive (hostname)'
     })
-    expect(client.dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        definition: {
-          document: {
-            _id: 'mock-created',
-            id: 'mock-created',
-            _type: 'io.cozy.oauth.clients',
-            client_kind: 'desktop',
-            client_name: 'Cozy Drive (hostname)'
+    await waitFor(() => {
+      expect(client.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          definition: {
+            document: {
+              _id: 'mock-created',
+              id: 'mock-created',
+              _type: 'io.cozy.oauth.clients',
+              client_kind: 'desktop',
+              client_name: 'Cozy Drive (hostname)'
+            },
+            mutationType: 'CREATE_DOCUMENT'
           },
-          mutationType: 'CREATE_DOCUMENT'
-        },
-        mutationId: '1',
-        response: {
-          data: {
-            _id: 'mock-created',
-            id: 'mock-created',
-            _type: 'io.cozy.oauth.clients',
-            client_kind: 'desktop',
-            client_name: 'Cozy Drive (hostname)'
-          }
-        },
-        type: 'RECEIVE_MUTATION_RESULT'
-      })
-    )
+          mutationId: '1',
+          response: {
+            data: {
+              _id: 'mock-created',
+              id: 'mock-created',
+              _type: 'io.cozy.oauth.clients',
+              client_kind: 'desktop',
+              client_name: 'Cozy Drive (hostname)'
+            }
+          },
+          type: 'RECEIVE_MUTATION_RESULT'
+        })
+      )
+    })
 
     unmount()
   })

--- a/packages/cozy-client/src/helpers/realtime.js
+++ b/packages/cozy-client/src/helpers/realtime.js
@@ -1,0 +1,39 @@
+import { Q } from '../queries/dsl'
+import CozyClient from '../CozyClient'
+
+const buildFileByIdQuery = id => ({
+  definition: () => Q('io.cozy.files').getById(id),
+  options: {
+    as: `io.cozy.files/${id}`,
+    singleDocData: true,
+    fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000)
+  }
+})
+
+/**
+ * Ensures existence of `path` inside the io.cozy.files document
+ *
+ * @public
+ * @param {import("../types").IOCozyFile} couchDBDoc - object representing the document
+ * @param {object} options Options
+ * @param {string} [options.doctype] - Doctype of the document
+ * @param {CozyClient} [options.client] - CozyClient instance
+ *
+ * @returns {Promise<import("../types").CozyClientDocument>} full normalized document
+ */
+export const ensureFilePath = async (couchDBDoc, options = {}) => {
+  if (couchDBDoc.path) return couchDBDoc
+
+  const parentQuery = buildFileByIdQuery(couchDBDoc.dir_id)
+  const parentResult = await options.client.fetchQueryAndGetFromState({
+    definition: parentQuery.definition(),
+    options: parentQuery.options
+  })
+
+  if (!parentResult.data || !parentResult.data.path)
+    throw new Error(
+      `Could not define a file path for ${couchDBDoc._id || couchDBDoc.id}`
+    )
+  const path = parentResult.data.path + '/' + couchDBDoc.name
+  return { path, ...couchDBDoc }
+}

--- a/packages/cozy-client/types/helpers/realtime.d.ts
+++ b/packages/cozy-client/types/helpers/realtime.d.ts
@@ -1,0 +1,5 @@
+export function ensureFilePath(couchDBDoc: import("../types").IOCozyFile, options?: {
+    doctype: string;
+    client: CozyClient;
+}): Promise<import("../types").CozyClientDocument>;
+import CozyClient from "../CozyClient";

--- a/packages/cozy-client/types/store/realtime.d.ts
+++ b/packages/cozy-client/types/store/realtime.d.ts
@@ -1,3 +1,9 @@
-export function dispatchCreate(client: object, doctype: import("../types").Doctype, couchDBDoc: import("../types").CouchDBDocument): void;
-export function dispatchUpdate(client: object, doctype: import("../types").Doctype, couchDBDoc: import("../types").CouchDBDocument): void;
-export function dispatchDelete(client: object, doctype: import("../types").Doctype, couchDBDoc: import("../types").CouchDBDocument): void;
+export function dispatchCreate(client: object, doctype: import("../types").Doctype, couchDBDoc: import("../types").CouchDBDocument, options?: DispatchOptions): Promise<void>;
+export function dispatchUpdate(client: object, doctype: import("../types").Doctype, couchDBDoc: import("../types").CouchDBDocument, options?: DispatchOptions): Promise<void>;
+export function dispatchDelete(client: object, doctype: import("../types").Doctype, couchDBDoc: import("../types").CouchDBDocument, options?: DispatchOptions): Promise<void>;
+export type DispatchOptions = {
+    /**
+     * Optional function to enhance the document attributes before dispatch
+     */
+    enhanceDocFn?: Function;
+};


### PR DESCRIPTION
This enrichment closes the gap between the results of queries from the cozy-stack and realtime. In fact, realtime returns the document directly from the database, unlike the stack, which can add computed fields. Without them, it can lead to instable behaviour in applications. Some applications fix some issue by reimplementing the RealTimeQueries component.

This commit aims to provide unifed api to avoid duplicated code. It can also be used as a reference when we want to close the gap. 

**Applications reimplementation :**
- cozy-settings : [SettingsRealTimeQueries](https://github.com/cozy/cozy-settings/blob/master/src/components/SettingsRealTimeQueries.jsx)
- cozy-drive : [FilesRealTimeQueries](https://github.com/cozy/cozy-drive/blob/master/src/components/FilesRealTimeQueries.jsx)

**Note :**
A function similar to `ensureFilePath` exists in the models, but I chose to implement a new one to avoid dependencies with the models because we want to extract them from cozy-client