### PR TITLE
fix: Handle URLs that redirect in rootCozyUrl

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -697,7 +697,7 @@ The root Cozy URL
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:266](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L266)
+[packages/cozy-client/src/helpers/urlHelper.js:268](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L268)
 
 ***
 

--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -697,7 +697,7 @@ The root Cozy URL
 
 *Defined in*
 
-[packages/cozy-client/src/helpers/urlHelper.js:269](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L269)
+[packages/cozy-client/src/helpers/urlHelper.js:266](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L266)
 
 ***
 

--- a/packages/cozy-client/src/helpers/urlHelper.js
+++ b/packages/cozy-client/src/helpers/urlHelper.js
@@ -209,7 +209,7 @@ const wellKnownUrl = url => uri(url) + '/.well-known/change-password'
  */
 const isValidOrigin = async url => {
   const response = await fetch(wellKnownUrl(url))
-  const { status } = response
+  const { status, url: responseUri } = response
 
   if (status === 404) {
     throw new InvalidCozyUrlError(url)
@@ -219,7 +219,9 @@ const isValidOrigin = async url => {
     throw new BlockedCozyError(url)
   }
 
-  return status === 200
+  const wasRedirected = url.origin !== new URL(responseUri).origin
+
+  return status === 200 && !wasRedirected
 }
 
 /**

--- a/packages/cozy-client/src/helpers/urlHelper.spec.js
+++ b/packages/cozy-client/src/helpers/urlHelper.spec.js
@@ -210,7 +210,7 @@ describe('rootCozyUrl', () => {
 
     await expect(
       rootCozyUrl(new URL('https://camillenimbus.mycozy.cloud'))
-    ).resolves.toEqual(new URL('https://camillenimbus.mycozy.cloud'))
+    ).resolves.toHaveProperty('href', 'https://camillenimbus.mycozy.cloud/')
   })
 
   it('should handle cozy-hosted https trailing slash', async () => {
@@ -222,7 +222,7 @@ describe('rootCozyUrl', () => {
 
     await expect(
       rootCozyUrl(new URL('https://camillenimbus.mycozy.cloud/'))
-    ).resolves.toEqual(new URL('https://camillenimbus.mycozy.cloud'))
+    ).resolves.toHaveProperty('href', 'https://camillenimbus.mycozy.cloud/')
   })
 
   it('should handle cozy-hosted https trailing path', async () => {
@@ -234,7 +234,7 @@ describe('rootCozyUrl', () => {
 
     await expect(
       rootCozyUrl(new URL('https://camillenimbus.mycozy.cloud/some-path'))
-    ).resolves.toEqual(new URL('https://camillenimbus.mycozy.cloud'))
+    ).resolves.toHaveProperty('href', 'https://camillenimbus.mycozy.cloud/')
   })
 
   it('should handle cozy-hosted drive web app url', async () => {
@@ -251,7 +251,7 @@ describe('rootCozyUrl', () => {
 
     await expect(
       rootCozyUrl(new URL('https://camillenimbus-drive.mycozy.cloud/#/folder'))
-    ).resolves.toEqual(new URL('https://camillenimbus.mycozy.cloud'))
+    ).resolves.toHaveProperty('href', 'https://camillenimbus.mycozy.cloud/')
   })
 
   it('should handle cozy-hosted photos album url', async () => {
@@ -272,7 +272,7 @@ describe('rootCozyUrl', () => {
           'https://camillenimbus-photos.mycozy.cloud/#/albums/68b5cda502ae29f5fa73fd89f1be4f92'
         )
       )
-    ).resolves.toEqual(new URL('https://camillenimbus.mycozy.cloud'))
+    ).resolves.toHaveProperty('href', 'https://camillenimbus.mycozy.cloud/')
   })
 
   it('should handle cozy-hosted app name', async () => {
@@ -289,7 +289,7 @@ describe('rootCozyUrl', () => {
 
     await expect(
       rootCozyUrl(new URL('https://camillenimbus-drive.mycozy.cloud'))
-    ).resolves.toEqual(new URL('https://camillenimbus.mycozy.cloud'))
+    ).resolves.toHaveProperty('href', 'https://camillenimbus.mycozy.cloud/')
   })
 
   it('should handle self-hosted https', async () => {
@@ -301,7 +301,7 @@ describe('rootCozyUrl', () => {
 
     await expect(
       rootCozyUrl(new URL('https://camillenimbus.com'))
-    ).resolves.toEqual(new URL('https://camillenimbus.com'))
+    ).resolves.toHaveProperty('href', 'https://camillenimbus.com/')
   })
 
   it('should handle self-hosted with dash', async () => {
@@ -315,7 +315,7 @@ describe('rootCozyUrl', () => {
 
     await expect(
       rootCozyUrl(new URL('https://camille-nimbus.com'))
-    ).resolves.toEqual(new URL('https://camille-nimbus.com'))
+    ).resolves.toHaveProperty('href', 'https://camille-nimbus.com/')
   })
 
   it('should handle self-hosted http', async () => {
@@ -329,7 +329,7 @@ describe('rootCozyUrl', () => {
 
     await expect(
       rootCozyUrl(new URL('http://camille-nimbus.com'))
-    ).resolves.toEqual(new URL('http://camille-nimbus.com'))
+    ).resolves.toHaveProperty('href', 'http://camille-nimbus.com/')
   })
 
   it('should handle self-hosted https with port', async () => {
@@ -343,7 +343,7 @@ describe('rootCozyUrl', () => {
 
     await expect(
       rootCozyUrl(new URL('https://camillenimbus.com:666'))
-    ).resolves.toEqual(new URL('https://camillenimbus.com:666'))
+    ).resolves.toHaveProperty('href', 'https://camillenimbus.com:666/')
   })
 
   it('should handle self-hosted nested drive web app url', async () => {
@@ -364,7 +364,7 @@ describe('rootCozyUrl', () => {
 
     await expect(
       rootCozyUrl(new URL('https://drive.camillenimbus.com/#/folder'))
-    ).resolves.toEqual(new URL('https://camillenimbus.com'))
+    ).resolves.toHaveProperty('href', 'https://camillenimbus.com/')
   })
 
   it('should handle self-hosted flat drive web app url', async () => {
@@ -385,13 +385,13 @@ describe('rootCozyUrl', () => {
 
     await expect(
       rootCozyUrl(new URL('https://camille-drive.nimbus.com/#/folder'))
-    ).resolves.toEqual(new URL('https://camille.nimbus.com'))
+    ).resolves.toHaveProperty('href', 'https://camille.nimbus.com/')
   })
 
   it('should handle cozy.localhost', async () => {
     await expect(
       rootCozyUrl(new URL('http://cozy.localhost:8080'))
-    ).resolves.toEqual(new URL('http://cozy.localhost:8080'))
+    ).resolves.toHaveProperty('href', 'http://cozy.localhost:8080/')
   })
 
   it('expects an http or https protocol', async () => {

--- a/packages/cozy-client/src/helpers/urlHelper.spec.js
+++ b/packages/cozy-client/src/helpers/urlHelper.spec.js
@@ -205,7 +205,10 @@ describe('rootCozyUrl', () => {
     fetch.mockOnceIf(
       'https://camillenimbus.mycozy.cloud/.well-known/change-password',
       {},
-      { status: 200 }
+      {
+        status: 200,
+        url: 'https://camillenimbus.mycozy.cloud/.well-known/change-password'
+      }
     )
 
     await expect(
@@ -217,7 +220,10 @@ describe('rootCozyUrl', () => {
     fetch.mockOnceIf(
       'https://camillenimbus.mycozy.cloud/.well-known/change-password',
       {},
-      { status: 200 }
+      {
+        status: 200,
+        url: 'https://camillenimbus.mycozy.cloud/.well-known/change-password'
+      }
     )
 
     await expect(
@@ -229,7 +235,10 @@ describe('rootCozyUrl', () => {
     fetch.mockOnceIf(
       'https://camillenimbus.mycozy.cloud/.well-known/change-password',
       {},
-      { status: 200 }
+      {
+        status: 200,
+        url: 'https://camillenimbus.mycozy.cloud/.well-known/change-password'
+      }
     )
 
     await expect(
@@ -241,12 +250,19 @@ describe('rootCozyUrl', () => {
     fetch.mockOnceIf(
       'https://camillenimbus-drive.mycozy.cloud/.well-known/change-password',
       {},
-      { status: 401 }
+      {
+        status: 401,
+        url:
+          'https://camillenimbus-drive.mycozy.cloud/.well-known/change-password'
+      }
     )
     fetch.mockOnceIf(
       'https://camillenimbus.mycozy.cloud/.well-known/change-password',
       {},
-      { status: 200 }
+      {
+        status: 200,
+        url: 'https://camillenimbus.mycozy.cloud/.well-known/change-password'
+      }
     )
 
     await expect(
@@ -258,12 +274,19 @@ describe('rootCozyUrl', () => {
     fetch.mockOnceIf(
       'https://camillenimbus-photos.mycozy.cloud/.well-known/change-password',
       {},
-      { status: 401 }
+      {
+        status: 401,
+        url:
+          'https://camillenimbus-photos.mycozy.cloud/.well-known/change-password'
+      }
     )
     fetch.mockOnceIf(
       'https://camillenimbus.mycozy.cloud/.well-known/change-password',
       {},
-      { status: 200 }
+      {
+        status: 200,
+        url: 'https://camillenimbus.mycozy.cloud/.well-known/change-password'
+      }
     )
 
     await expect(
@@ -279,12 +302,19 @@ describe('rootCozyUrl', () => {
     fetch.mockOnceIf(
       'https://camillenimbus-drive.mycozy.cloud/.well-known/change-password',
       {},
-      { status: 401 }
+      {
+        status: 401,
+        url:
+          'https://camillenimbus-drive.mycozy.cloud/.well-known/change-password'
+      }
     )
     fetch.mockOnceIf(
       'https://camillenimbus.mycozy.cloud/.well-known/change-password',
       {},
-      { status: 200 }
+      {
+        status: 200,
+        url: 'https://camillenimbus.mycozy.cloud/.well-known/change-password'
+      }
     )
 
     await expect(
@@ -292,11 +322,41 @@ describe('rootCozyUrl', () => {
     ).resolves.toHaveProperty('href', 'https://camillenimbus.mycozy.cloud/')
   })
 
+  it('should handle cozy-hosted special app name', async () => {
+    // XXX: `cozy-stack` redirects requests for deprecated apps (e.g.
+    // `onboarding`) to the Home app (via the login page if the user is not
+    // logged in).
+    fetch.mockOnceIf(
+      'https://camillenimbus-onboarding.mycozy.cloud/.well-known/change-password',
+      {},
+      {
+        status: 200,
+        url:
+          'https://camillenimbus.mycozy.cloud/auth/login?redirect=https%3A%2F%2Fcamillenimbus-home.mycozy.cloud%2F'
+      }
+    )
+    fetch.mockOnceIf(
+      'https://camillenimbus.mycozy.cloud/.well-known/change-password',
+      {},
+      {
+        status: 200,
+        url: 'https://camillenimbus.mycozy.cloud/.well-known/change-password'
+      }
+    )
+
+    await expect(
+      rootCozyUrl(new URL('https://camillenimbus-onboarding.mycozy.cloud'))
+    ).resolves.toHaveProperty('href', 'https://camillenimbus.mycozy.cloud/')
+  })
+
   it('should handle self-hosted https', async () => {
     fetch.mockOnceIf(
       'https://camillenimbus.com/.well-known/change-password',
       {},
-      { status: 200 }
+      {
+        status: 200,
+        url: 'https://camillenimbus.com/.well-known/change-password'
+      }
     )
 
     await expect(
@@ -309,7 +369,8 @@ describe('rootCozyUrl', () => {
       'https://camille-nimbus.com/.well-known/change-password',
       {},
       {
-        status: 200
+        status: 200,
+        url: 'https://camille-nimbus.com/.well-known/change-password'
       }
     )
 
@@ -323,7 +384,8 @@ describe('rootCozyUrl', () => {
       'http://camille-nimbus.com/.well-known/change-password',
       {},
       {
-        status: 200
+        status: 200,
+        url: 'http://camille-nimbus.com/.well-known/change-password'
       }
     )
 
@@ -337,7 +399,8 @@ describe('rootCozyUrl', () => {
       'https://camillenimbus.com:666/.well-known/change-password',
       {},
       {
-        status: 200
+        status: 200,
+        url: 'https://camillenimbus.com:666/.well-known/change-password'
       }
     )
 
@@ -351,14 +414,16 @@ describe('rootCozyUrl', () => {
       'https://drive.camillenimbus.com/.well-known/change-password',
       {},
       {
-        status: 401
+        status: 401,
+        url: 'https://drive.camillenimbus.com/.well-known/change-password'
       }
     )
     fetch.mockOnceIf(
       'https://camillenimbus.com/.well-known/change-password',
       {},
       {
-        status: 200
+        status: 200,
+        url: 'https://camillenimbus.com/.well-known/change-password'
       }
     )
 
@@ -372,14 +437,16 @@ describe('rootCozyUrl', () => {
       'https://camille-drive.nimbus.com/.well-known/change-password',
       {},
       {
-        status: 401
+        status: 401,
+        url: 'https://camille-drive.nimbus.com/.well-known/change-password'
       }
     )
     fetch.mockOnceIf(
       'https://camille.nimbus.com/.well-known/change-password',
       {},
       {
-        status: 200
+        status: 200,
+        url: 'https://camille.nimbus.com/.well-known/change-password'
       }
     )
 
@@ -389,6 +456,14 @@ describe('rootCozyUrl', () => {
   })
 
   it('should handle cozy.localhost', async () => {
+    fetch.mockOnceIf(
+      'http://cozy.localhost:8080/.well-known/change-password',
+      {},
+      {
+        status: 200,
+        url: 'http://cozy.localhost:8080/.well-known/change-password'
+      }
+    )
     await expect(
       rootCozyUrl(new URL('http://cozy.localhost:8080'))
     ).resolves.toHaveProperty('href', 'http://cozy.localhost:8080/')
@@ -399,7 +474,8 @@ describe('rootCozyUrl', () => {
       'ftp://camillenimbus.com/.well-known/change-password',
       {},
       {
-        status: 200
+        status: 200,
+        url: 'ftp://camillenimbus.com/.well-known/change-password'
       }
     )
 
@@ -413,7 +489,8 @@ describe('rootCozyUrl', () => {
       'https://missing.mycozy.cloud/.well-known/change-password',
       {},
       {
-        status: 404
+        status: 404,
+        url: 'https://missing.mycozy.cloud/.well-known/change-password'
       }
     )
 


### PR DESCRIPTION
To infer the root Cozy URL from a given URL, we can go through up to 3
steps:
1. we try to fetch the well known change password URL with the given
   URL's origin
2. if that requests fails, we try to remove any potential app slugs
   from the origin and try again
3. if that fails as well, we try to remove the first sub-domain from
   the origin and try again

However, `cozy-stack` treats some deprecated apps URLs in a different
manner. Specifically, it will redirect requests to the Home app for
any URL with these deprecated apps origin no matter what the requested
path is.
See https://github.com/cozy/cozy-stack/blob/299968d43914066c3147276eea2463ebb292d527/web/apps/serve.go#L101-L108

This results in a successful request at step 1 instead of the expected
error (i.e. we remove app slugs at step 2) and thus considering that
these app URLs are root Cozy URLs.

We now make sure that redirections are considered as successful
requests to validate the origin of a given URL only if the destination
URL as the same origin as the source one.

e.g. :
```javascript
// Before
await rootCozyUrl(new URL('https://example-onboarding.mycozy.cloud/'))
// → URL('https://example-onboarding.mycozy.cloud/')

// Now
await rootCozyUrl(new URL('https://example-onboarding.mycozy.cloud/'))
// → URL('https://example.mycozy.cloud/')
```