### PR TITLE
feat: Allow to mock query in error

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -225,7 +225,7 @@ Creates a client suitable for use in tests
 
 *Defined in*
 
-[packages/cozy-client/src/mock.js:41](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/mock.js#L41)
+[packages/cozy-client/src/mock.js:45](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/mock.js#L45)
 
 ***
 

--- a/packages/cozy-client/src/mock.js
+++ b/packages/cozy-client/src/mock.js
@@ -1,18 +1,22 @@
 import CozyClient from './CozyClient'
-import { receiveQueryResult, initQuery } from './store'
+import { receiveQueryResult, receiveQueryError, initQuery } from './store'
 import { normalizeDoc } from 'cozy-stack-client'
 
 import { Q } from './queries/dsl'
 
 const fillQueryInsideClient = (client, queryName, queryOptions) => {
-  const { definition, doctype, data, ...queryResult } = queryOptions
+  const { definition, doctype, data, queryError, ...queryResult } = queryOptions
   client.store.dispatch(initQuery(queryName, definition || Q(doctype)))
-  client.store.dispatch(
-    receiveQueryResult(queryName, {
-      data: data ? data.map(doc => normalizeDoc(doc, doctype)) : data,
-      ...queryResult
-    })
-  )
+  if (queryError) {
+    client.store.dispatch(receiveQueryError(queryName, queryError))
+  } else {
+    client.store.dispatch(
+      receiveQueryResult(queryName, {
+        data: data ? data.map(doc => normalizeDoc(doc, doctype)) : data,
+        ...queryResult
+      })
+    )
+  }
 }
 
 const mockedQueryFromMockedRemoteData = remoteData => qdef => {

--- a/packages/cozy-client/src/mock.spec.js
+++ b/packages/cozy-client/src/mock.spec.js
@@ -14,6 +14,10 @@ describe('createMockClient', () => {
         simpsons: {
           data: simpsonsFixture,
           doctype: 'io.cozy.simpsons'
+        },
+        simpsonsError: {
+          doctype: 'io.cozy.simpsons',
+          queryError: new Error('some error')
         }
       }
     })
@@ -24,6 +28,9 @@ describe('createMockClient', () => {
       'homer',
       'marge'
     ])
+    const errorQuery = client.getQueryFromState('simpsonsError')
+    expect(errorQuery.fetchStatus).toBe('failed')
+    expect(errorQuery.lastError).toStrictEqual(new Error('some error'))
   })
 
   it('should mock query with data passed in "remote" option', async () => {


### PR DESCRIPTION
This facilitates the development of test cases for error handling with queries. An example of a test is available in the react-integration documentation