### PR TITLE
fix: Get shortcut img for links from applications in the same cozy

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -813,7 +813,7 @@ Returns the cozy client from the context
 
 *Defined in*
 
-[packages/cozy-client/src/hooks/useFetchShortcut.jsx:3](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hooks/useFetchShortcut.jsx#L3)
+[packages/cozy-client/src/hooks/useFetchShortcut.jsx:8](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/hooks/useFetchShortcut.jsx#L8)
 
 ***
 

--- a/packages/cozy-client/src/hooks/useFetchShortcut.jsx
+++ b/packages/cozy-client/src/hooks/useFetchShortcut.jsx
@@ -24,15 +24,26 @@ const useFetchShortcut = (client, id) => {
           }
         })
 
-        const shortcutRemoteUrl = new URL(
-          shortcutInfosResult.data.attributes.url
-        )
+        const targetApp =
+          shortcutInfosResult?.data?.attributes?.metadata?.target?.app
+        if (targetApp) {
+          const targetAppIconUrl = await client.getStackClient().getIconURL({
+            type: 'app',
+            slug: targetApp,
+            priority: 'stack'
+          })
+          setShortcutImg(targetAppIconUrl)
+        } else {
+          const shortcutRemoteUrl = new URL(
+            shortcutInfosResult.data.attributes.url
+          )
 
-        const imgUrl = `${client.getStackClient().uri}/bitwarden/icons/${
-          shortcutRemoteUrl.host
-        }/icon.png`
+          const imgUrl = `${client.getStackClient().uri}/bitwarden/icons/${
+            shortcutRemoteUrl.host
+          }/icon.png`
 
-        setShortcutImg(imgUrl)
+          setShortcutImg(imgUrl)
+        }
         setShortcutInfos({ data: shortcutInfosResult.data })
         setFetchStatus('loaded')
       } catch (e) {

--- a/packages/cozy-client/src/hooks/useFetchShortcut.spec.jsx
+++ b/packages/cozy-client/src/hooks/useFetchShortcut.spec.jsx
@@ -1,19 +1,45 @@
 import { renderHook } from '@testing-library/react-hooks'
+
 import useFetchShortcut from './useFetchShortcut'
 import { createMockClient } from '../../dist/mock'
+
 describe('useFetchShortcut', () => {
-  const mockClient = createMockClient({})
-  const id = '1'
-  it('should change loading status', async () => {
-    mockClient.stackClient.fetchJSON.mockResolvedValue({
-      data: {
-        attributes: {
-          url: 'http://foo.cozy.bar'
-        }
+  const mockClient = createMockClient({
+    queries: {
+      'io.cozy.files.shortcuts/123': {
+        doctype: 'io.cozy.files.shortcuts',
+        definition: {
+          doctype: 'io.cozy.files.shortcuts',
+          id: 'io.cozy.files.shortcuts/123'
+        },
+        data: [
+          {
+            type: 'io.cozy.files.shortcuts',
+            id: 'b7470059d40c88e4bd30031d5e0109d3',
+            attributes: {
+              _id: '',
+              name: 'cozy.url',
+              dir_id: '8034db0016d0548ded99b9627e003270',
+              url: 'https://cozy.io',
+              metadata: { extractor_version: 2 }
+            },
+            meta: { rev: '1-60e1359e63fa7fa9fa000a2726d5d4c7' }
+          }
+        ]
+      },
+      'io.cozy.files.shortcuts/no-found': {
+        doctype: 'io.cozy.files.shortcuts',
+        queryError: new Error('not found')
       }
-    })
+    },
+    clientOptions: {
+      uri: 'https://test.mycozy.cloud'
+    }
+  })
+
+  it('should change loading status', async () => {
     const { result, waitForNextUpdate } = renderHook(() =>
-      useFetchShortcut(mockClient, id)
+      useFetchShortcut(mockClient, '123')
     )
     expect(result.current.fetchStatus).toEqual('loading')
     await waitForNextUpdate()
@@ -24,7 +50,7 @@ describe('useFetchShortcut', () => {
     mockClient.stackClient.fetchJSON.mockRejectedValue('error')
 
     const { result, waitForNextUpdate } = renderHook(() =>
-      useFetchShortcut(mockClient, id)
+      useFetchShortcut(mockClient, 'no-found')
     )
     expect(result.current.fetchStatus).toEqual('loading')
     await waitForNextUpdate()
@@ -32,27 +58,15 @@ describe('useFetchShortcut', () => {
   })
 
   it('should return the data of a shortcut and change the display value', async () => {
-    mockClient.stackClient.fetchJSON.mockResolvedValue({
-      data: {
-        type: 'io.cozy.files.shortcuts',
-        id: 'b7470059d40c88e4bd30031d5e0109d3',
-        attributes: {
-          _id: '',
-          name: 'cozy.url',
-          dir_id: '8034db0016d0548ded99b9627e003270',
-          url: 'https://cozy.io',
-          metadata: { extractor_version: 2 }
-        },
-        meta: { rev: '1-60e1359e63fa7fa9fa000a2726d5d4c7' }
-      }
-    })
     const { result, waitForNextUpdate } = renderHook(() =>
-      useFetchShortcut(mockClient, id)
+      useFetchShortcut(mockClient, '123')
     )
 
     await waitForNextUpdate()
     expect(result.current.shortcutInfos).toEqual({
       data: {
+        _id: 'b7470059d40c88e4bd30031d5e0109d3',
+        _type: 'io.cozy.files.shortcuts',
         type: 'io.cozy.files.shortcuts',
         id: 'b7470059d40c88e4bd30031d5e0109d3',
         attributes: {

--- a/packages/cozy-client/src/hooks/useFetchShortcut.spec.jsx
+++ b/packages/cozy-client/src/hooks/useFetchShortcut.spec.jsx
@@ -27,6 +27,32 @@ describe('useFetchShortcut', () => {
           }
         ]
       },
+      'io.cozy.files.shortcuts/linkToCozyApp': {
+        doctype: 'io.cozy.files.shortcuts',
+        definition: {
+          doctype: 'io.cozy.files.shortcuts',
+          id: 'io.cozy.files.shortcuts/linkToCozyApp'
+        },
+        data: [
+          {
+            type: 'io.cozy.files.shortcuts',
+            id: 'linkToCozyApp',
+            attributes: {
+              _id: '',
+              name: 'cozy.url',
+              dir_id: '8034db0016d0548ded99b9627e003270',
+              url: 'https://cozy.io',
+              metadata: {
+                extractor_version: 2,
+                target: {
+                  app: 'notes'
+                }
+              }
+            },
+            meta: { rev: '1-60e1359e63fa7fa9fa000a2726d5d4c7' }
+          }
+        ]
+      },
       'io.cozy.files.shortcuts/no-found': {
         doctype: 'io.cozy.files.shortcuts',
         queryError: new Error('not found')
@@ -81,6 +107,17 @@ describe('useFetchShortcut', () => {
     })
     expect(result.current.shortcutImg).toEqual(
       `${mockClient.getStackClient().uri}/bitwarden/icons/cozy.io/icon.png`
+    )
+  })
+
+  it('should return shortcutImg for the targeted application icon when available', async () => {
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useFetchShortcut(mockClient, 'linkToCozyApp')
+    )
+
+    await waitForNextUpdate()
+    expect(result.current.shortcutImg).toEqual(
+      `${mockClient.getStackClient().uri}/registry/notes/icon`
     )
   })
 })


### PR DESCRIPTION
Cozy applications only make their assets available if you are authenticated. As a result, the stack cannot retrieve the favicon. When a link comes from an application in the same Cozy, we can find out its slug and deduce its icon. For the moment, we can't do this for third-party Cozy applications because the URL formats are too diverse