### PR TITLE
fix: Preview URL for notes

### DIFF
--- a/docs/api/cozy-client/modules/models.note.md
+++ b/docs/api/cozy-client/modules/models.note.md
@@ -8,7 +8,7 @@
 
 ### fetchURL
 
-▸ **fetchURL**(`client`, `file`): `Promise`<`string`>
+▸ **fetchURL**(`client`, `file`, `options?`): `Promise`<`string`>
 
 Fetch and build an URL to open a note.
 
@@ -18,6 +18,8 @@ Fetch and build an URL to open a note.
 | :------ | :------ | :------ |
 | `client` | `any` | CozyClient instance |
 | `file` | `any` | io.cozy.file object |
+| `options` | `Object` | Options |
+| `options.pathname` | `string` | - |
 
 *Returns*
 
@@ -27,7 +29,7 @@ url
 
 *Defined in*
 
-[packages/cozy-client/src/models/note.js:31](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L31)
+[packages/cozy-client/src/models/note.js:33](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L33)
 
 ***
 

--- a/packages/cozy-client/src/models/note.js
+++ b/packages/cozy-client/src/models/note.js
@@ -26,9 +26,11 @@ export const generateUrlForNote = (notesAppUrl, file) => {
  *
  * @param {object} client CozyClient instance
  * @param {object} file io.cozy.file object
+ * @param {object} options Options
+ * @param {string} [options.pathname] Pathname to use in the URL
  * @returns {Promise<string>} url
  */
-export const fetchURL = async (client, file) => {
+export const fetchURL = async (client, file, options = {}) => {
   const {
     data: { note_id, subdomain, protocol, instance, sharecode, public_name }
   } = await client
@@ -42,14 +44,14 @@ export const fetchURL = async (client, file) => {
     return generateWebLink({
       cozyUrl: `${protocol}://${instance}`,
       searchParams,
-      pathname: '/public/',
+      pathname: options.pathname ?? '/public/',
       slug: 'notes',
       subDomainType: subdomain
     })
   } else {
     return generateWebLink({
       cozyUrl: `${protocol}://${instance}`,
-      pathname: '',
+      pathname: options.pathname ?? '',
       slug: 'notes',
       subDomainType: subdomain,
       hash: `/n/${note_id}`

--- a/packages/cozy-client/types/devtools/Flags/FlagEdit.d.ts
+++ b/packages/cozy-client/types/devtools/Flags/FlagEdit.d.ts
@@ -1,0 +1,3 @@
+export function FlagEdit({ flag: editedFlag }: {
+    flag: any;
+}): JSX.Element;

--- a/packages/cozy-client/types/devtools/Flags/FlagItem.d.ts
+++ b/packages/cozy-client/types/devtools/Flags/FlagItem.d.ts
@@ -1,0 +1,6 @@
+export default FlagItem;
+declare function FlagItem({ flag, onEdit, onTrash }: {
+    flag: any;
+    onEdit: any;
+    onTrash: any;
+}): JSX.Element;

--- a/packages/cozy-client/types/devtools/Flags/Flags.d.ts
+++ b/packages/cozy-client/types/devtools/Flags/Flags.d.ts
@@ -1,0 +1,2 @@
+export default Flags;
+declare function Flags(): JSX.Element;

--- a/packages/cozy-client/types/devtools/Flags/helpers.d.ts
+++ b/packages/cozy-client/types/devtools/Flags/helpers.d.ts
@@ -1,0 +1,3 @@
+export function makeHumanValue(value: any): any;
+export function computeFlags(): any;
+export function isJSONString(str: any): boolean;

--- a/packages/cozy-client/types/models/note.d.ts
+++ b/packages/cozy-client/types/models/note.d.ts
@@ -1,3 +1,5 @@
 export function generatePrivateUrl(notesAppUrl: string, file: object, options?: {}): string;
 export function generateUrlForNote(notesAppUrl: any, file: any): string;
-export function fetchURL(client: object, file: object): Promise<string>;
+export function fetchURL(client: object, file: object, options?: {
+    pathname: string;
+}): Promise<string>;


### PR DESCRIPTION
Each time we create a link, we redirect the user to /public/ outside of a cozy to cozy share, we want to access /preview/. This commit allows you to pass a pathname as an option in order to manage this case
