### PR TITLE
docs: Add return type to models.file.splitFilename

### DIFF
--- a/docs/api/cozy-client/modules/models.file.md
+++ b/docs/api/cozy-client/modules/models.file.md
@@ -767,7 +767,7 @@ But we want to exclude .txt and .md because the CozyUI Viewer can already show t
 
 ### splitFilename
 
-▸ **splitFilename**(`file`): `any`
+▸ **splitFilename**(`file`): `Object`
 
 Returns base filename and extension
 
@@ -779,9 +779,12 @@ Returns base filename and extension
 
 *Returns*
 
-`any`
+`Object`
 
-{filename, extension}
+| Name | Type |
+| :------ | :------ |
+| `extension` | `string` |
+| `filename` | `string` |
 
 *Defined in*
 

--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -19,7 +19,7 @@ const FILENAME_WITH_EXTENSION_REGEX = /(.+)(\..*)$/
  * Returns base filename and extension
  *
  * @param {import("../types").IOCozyFile} file An io.cozy.files
- * @returns {object}  {filename, extension}
+ * @returns {{filename: string, extension: string}}
  */
 export const splitFilename = file => {
   if (!isString(file.name)) throw new Error('file should have a name property')

--- a/packages/cozy-client/types/models/file.d.ts
+++ b/packages/cozy-client/types/models/file.d.ts
@@ -25,7 +25,10 @@ export function ensureFilePath(file: object, parent: object): object;
  */
 export function getParentFolderId(file: object): string | null;
 export const ALBUMS_DOCTYPE: "io.cozy.photos.albums";
-export function splitFilename(file: import("../types").IOCozyFile): object;
+export function splitFilename(file: import("../types").IOCozyFile): {
+    filename: string;
+    extension: string;
+};
 export function isFile(file: import("../types").IOCozyFile): boolean;
 export function isDirectory(file: import("../types").IOCozyFile): boolean;
 export function isNote(file: import("../types").IOCozyFile): boolean;


### PR DESCRIPTION
I want to reduce [cozy-client.d.ts](https://github.com/cozy/cozy-flagship-app/blob/master/src/%40types/cozy-client.d.ts) size in cozy-flagship-app.

I am currently trying to understand how it works and how to do it correctly. Here is a first very simple but working type.