### PR TITLE
feat: Add createDemoClient to help with demo

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -201,9 +201,39 @@ Rejects with canceled: true as soon as cancel is called
 
 ***
 
+### createFakeClient
+
+▸ **createFakeClient**(`options?`): [`CozyClient`](classes/CozyClient.md)
+
+Creates a client with pre-filled store
+This can be useful for demo in documentation (e.g. storybook)
+
+*   client.{query,save} are replaced with empty functions
+*   client.stackClient.fetchJSON is replaced with empty functions
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options` | `Object` | Options |
+| `options.clientFunctions` | `any` | - |
+| `options.clientOptions` | `any` | - |
+| `options.queries` | `any` | - |
+| `options.remote` | `any` | - |
+
+*Returns*
+
+[`CozyClient`](classes/CozyClient.md)
+
+*Defined in*
+
+[packages/cozy-client/src/mock.js:92](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/mock.js#L92)
+
+***
+
 ### createMockClient
 
-▸ **createMockClient**(`options`): [`CozyClient`](classes/CozyClient.md)
+▸ **createMockClient**(`options?`): [`CozyClient`](classes/CozyClient.md)
 
 Creates a client suitable for use in tests
 
@@ -215,6 +245,7 @@ Creates a client suitable for use in tests
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `options` | `Object` | Options |
+| `options.clientFunctions` | `any` | - |
 | `options.clientOptions` | `any` | - |
 | `options.queries` | `any` | - |
 | `options.remote` | `any` | - |
@@ -225,7 +256,7 @@ Creates a client suitable for use in tests
 
 *Defined in*
 
-[packages/cozy-client/src/mock.js:45](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/mock.js#L45)
+[packages/cozy-client/src/mock.js:48](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/mock.js#L48)
 
 ***
 

--- a/packages/cozy-client/types/mock.d.ts
+++ b/packages/cozy-client/types/mock.d.ts
@@ -8,11 +8,33 @@
  * @param  {object} [options.queries] Prefill queries inside the store
  * @param  {object} [options.remote] Mock data from the server
  * @param  {object} [options.clientOptions] Options passed to the client
+ * @param  {object} [options.clientFunctions] Functions to overide client functions
  * @returns {CozyClient}
  */
-export function createMockClient({ queries, remote, clientOptions }: {
+export function createMockClient({ queries, remote, clientOptions, clientFunctions }?: {
     queries: object;
     remote: object;
     clientOptions: object;
+    clientFunctions: object;
+}): CozyClient;
+/**
+ * Creates a client with pre-filled store
+ * This can be useful for demo in documentation (e.g. storybook)
+ *
+ * - client.{query,save} are replaced with empty functions
+ * - client.stackClient.fetchJSON is replaced with empty functions
+ *
+ * @param  {object} options Options
+ * @param  {object} [options.queries] Prefill queries inside the store
+ * @param  {object} [options.remote] Mock data from the server
+ * @param  {object} [options.clientOptions] Options passed to the client
+ * @param  {object} [options.clientFunctions] Functions to overide client functions useful for testing
+ * @returns {CozyClient}
+ */
+export function createFakeClient({ queries, remote, clientOptions, clientFunctions }?: {
+    queries: object;
+    remote: object;
+    clientOptions: object;
+    clientFunctions: object;
 }): CozyClient;
 import CozyClient from "./CozyClient";


### PR DESCRIPTION
This new function will create a client like createMockClient but without the jest mock. It will be useful for demo in documentation because isn't defined in there context. Two usecases are in storybook and in the cozy-ui documentation.

**Remaining work:**
- ~~make unit tests~~