### PR TITLE
feat: Update warning message when Flagship certification fails

### DIFF
--- a/packages/cozy-client/src/flagship-certification/flagship-certification.js
+++ b/packages/cozy-client/src/flagship-certification/flagship-certification.js
@@ -92,7 +92,7 @@ export const certifyFlagship = async (certificationConfig, client) => {
     await giveAppAttestationToStack(appAttestation, stackChallengeNonce, client)
   } catch (e) {
     console.warn(
-      `[FLAGSHIP_CERTIFICATION] Certification for URI "${client.stackClient.uri}" failed but the cozy-stack will continue with 2FA certification`
+      `[FLAGSHIP_CERTIFICATION] Automatic certification for URI "${client.stackClient.uri}" failed. This is expected on dev environments and non-official phones. Cozy-stack will continue with manual certification through 2FA`
     )
     console.warn(e.message)
   }

--- a/packages/cozy-client/src/flagship-certification/flagship-certification.spec.js
+++ b/packages/cozy-client/src/flagship-certification/flagship-certification.spec.js
@@ -145,7 +145,7 @@ describe('certifyFlagship', () => {
     )
 
     expect(console.warn).toHaveBeenCalledWith(
-      '[FLAGSHIP_CERTIFICATION] Certification for URI "http://cozy.tools:8080" failed but the cozy-stack will continue with 2FA certification'
+      '[FLAGSHIP_CERTIFICATION] Automatic certification for URI "http://cozy.tools:8080" failed. This is expected on dev environments and non-official phones. Cozy-stack will continue with manual certification through 2FA'
     )
     expect(console.warn).toHaveBeenCalledWith(
       '[FLAGSHIP_CERTIFICATION] Something went wrong while requesting a challenge from CozyStack:\nSOME_STACK_CHALLENGE_ERROR'
@@ -175,7 +175,7 @@ describe('certifyFlagship', () => {
     })
 
     expect(console.warn).toHaveBeenCalledWith(
-      '[FLAGSHIP_CERTIFICATION] Certification for URI "http://cozy.tools:8080" failed but the cozy-stack will continue with 2FA certification'
+      '[FLAGSHIP_CERTIFICATION] Automatic certification for URI "http://cozy.tools:8080" failed. This is expected on dev environments and non-official phones. Cozy-stack will continue with manual certification through 2FA'
     )
     expect(console.warn).toHaveBeenCalledWith('SOME_STORE_API_ERROR')
   })
@@ -214,7 +214,7 @@ describe('certifyFlagship', () => {
     )
 
     expect(console.warn).toHaveBeenCalledWith(
-      '[FLAGSHIP_CERTIFICATION] Certification for URI "http://cozy.tools:8080" failed but the cozy-stack will continue with 2FA certification'
+      '[FLAGSHIP_CERTIFICATION] Automatic certification for URI "http://cozy.tools:8080" failed. This is expected on dev environments and non-official phones. Cozy-stack will continue with manual certification through 2FA'
     )
     expect(console.warn).toHaveBeenCalledWith(
       '[FLAGSHIP_CERTIFICATION] Something went wrong while giving attestation to CozyStack:\nSOME_STACK_CERTIFICATION_ERROR'


### PR DESCRIPTION
Failing Flagship certification is expected when the app is run in a dev environment and when the user uses a non-official phone (i.e. alternative Android OS)

This would help developers understanding when this message is problematic and where it is not