### PR TITLE
feat: Rename FR translation of real_estate_tax

### DIFF
--- a/packages/cozy-client/src/models/document/locales/fr.json
+++ b/packages/cozy-client/src/models/document/locales/fr.json
@@ -95,7 +95,7 @@
       "pregnancy_medical_certificate": "Certificat de grossesse |||| Certificats de grossesse",
       "prescription": "Ordonnance |||| Ordonnances",
       "real_estate_insurance" : "Attestation d'assurance immobilière |||| Attestations d'assurance immobilière",
-      "real_estate_tax": "Taxe foncière |||| Taxes foncières",
+      "real_estate_tax": "Impôts - Taxe foncière |||| Impôts - Taxes foncières",
       "receipt": "Accusé de réception |||| Accusés de réception",
       "rent_receipt": "Quittance de loyer |||| Quittances de loyer",
       "residence_permit": "Titre de séjour |||| Titres de séjour",


### PR DESCRIPTION
In order to be more homogeneous with the other qualifications concerning taxes