### PR TITLE
feat: Make account model use identifier attribute

### DIFF
--- a/docs/api/cozy-client/modules/models.account.md
+++ b/docs/api/cozy-client/modules/models.account.md
@@ -27,7 +27,7 @@ io.cozy.accounts attributes
 
 *Defined in*
 
-[packages/cozy-client/src/models/account.js:110](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/account.js#L110)
+[packages/cozy-client/src/models/account.js:113](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/account.js#L113)
 
 ***
 
@@ -75,7 +75,7 @@ Get the account name from a given account
 
 *Defined in*
 
-[packages/cozy-client/src/models/account.js:94](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/account.js#L94)
+[packages/cozy-client/src/models/account.js:97](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/account.js#L97)
 
 ***
 
@@ -147,7 +147,7 @@ Look if the given account has an associated trigger or not.
 
 *Defined in*
 
-[packages/cozy-client/src/models/account.js:126](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/account.js#L126)
+[packages/cozy-client/src/models/account.js:129](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/account.js#L129)
 
 ***
 

--- a/packages/cozy-client/src/models/account.js
+++ b/packages/cozy-client/src/models/account.js
@@ -77,6 +77,9 @@ export const setContractSyncStatusInAccount = (
  * @returns {String|null} - Account login
  */
 export const getAccountLogin = account => {
+  if (account.identifier) {
+    return account.auth[account.identifier]
+  }
   if (account && account.auth) {
     for (const fieldName of legacyLoginFields) {
       if (account.auth[fieldName]) return account.auth[fieldName]

--- a/packages/cozy-client/src/models/account.spec.js
+++ b/packages/cozy-client/src/models/account.spec.js
@@ -209,6 +209,33 @@ describe('account model', () => {
     })
   })
 
+  describe('getAccountLogin', () => {
+    it('should return account.identifier field if defined', () => {
+      expect(
+        getAccountLogin({
+          _id: 'accountid',
+          auth: {
+            login: 'loginfield',
+            other: 'identifierfield'
+          },
+          identifier: 'other'
+        })
+      ).toStrictEqual('identifierfield')
+    })
+
+    it('should return login field if no identifier is defined', () => {
+      expect(
+        getAccountLogin({
+          _id: 'accountid',
+          auth: {
+            login: 'loginfield',
+            other: 'identifierfield'
+          }
+        })
+      ).toStrictEqual('loginfield')
+    })
+  })
+
   describe('getAccountName', () => {
     it('should return auth.accountName in priority', () => {
       expect(


### PR DESCRIPTION
Now models.account.getAccountLogin (and models.account.getAccountName)
will use the identifier attribute from the account to choose the right
login field, as described in the account doctype documentation.

This identifier attribute is calculated using the `role: identifier`
attribute from account.auth if any.
