### PR TITLE
feat: Add email_verified_code in loginFlagship (VO-380)

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -2817,6 +2817,7 @@ Attributes representing a design doc
 
 | Name | Type | Description |
 | --- | --- | --- |
+| email_verified_code | <code>string</code> | The email verified code to skip 2FA |
 | access_token | <code>string</code> | The OAuth access token |
 | refresh_token | <code>string</code> | The OAuth refresh token |
 | token_type | <code>string</code> | The OAuth token type |

--- a/packages/cozy-stack-client/src/OAuthClient.js
+++ b/packages/cozy-stack-client/src/OAuthClient.js
@@ -451,6 +451,7 @@ class OAuthClient extends CozyStackClient {
 
   /**
    * @typedef AccessTokenRes
+   * @property {string} email_verified_code The email verified code to skip 2FA
    * @property {string} access_token The OAuth access token
    * @property {string} refresh_token The OAuth refresh token
    * @property {string} token_type The OAuth token type
@@ -474,6 +475,7 @@ class OAuthClient extends CozyStackClient {
    * @returns {Promise<AccessTokenRes|TwoFactorNeededRes|SessionCodeRes>} A promise that resolves with an access token, a session_code or a 2FA code
    */
   async loginFlagship({
+    emailVerifiedCode = undefined,
     passwordHash,
     twoFactorToken = undefined,
     twoFactorPasscode = undefined
@@ -481,6 +483,7 @@ class OAuthClient extends CozyStackClient {
     return this.fetchJSON('POST', '/auth/login/flagship', {
       client_id: this.oauthOptions.clientID,
       client_secret: this.oauthOptions.clientSecret,
+      email_verified_code: emailVerifiedCode,
       passphrase: passwordHash,
       two_factor_token: twoFactorToken,
       two_factor_passcode: twoFactorPasscode


### PR DESCRIPTION
This will allow skipping 2FA when logging from email in Flagship