### PR TITLE
Move paper metadata formatting in cozy-client 

### DIFF
--- a/docs/api/cozy-client/modules/models.paper.md
+++ b/docs/api/cozy-client/modules/models.paper.md
@@ -14,6 +14,36 @@
 
 [packages/cozy-client/src/models/paper.js:5](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L5)
 
+## Variables
+
+### KNOWN_DATE_METADATA_NAMES
+
+• `Const` **KNOWN_DATE_METADATA_NAMES**: `string`\[]
+
+*Defined in*
+
+[packages/cozy-client/src/models/paper.js:18](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L18)
+
+***
+
+### KNOWN_INFORMATION_METADATA_NAMES
+
+• `Const` **KNOWN_INFORMATION_METADATA_NAMES**: `string`\[]
+
+*Defined in*
+
+[packages/cozy-client/src/models/paper.js:31](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L31)
+
+***
+
+### KNOWN_OTHER_METADATA_NAMES
+
+• `Const` **KNOWN_OTHER_METADATA_NAMES**: `string`\[]
+
+*Defined in*
+
+[packages/cozy-client/src/models/paper.js:41](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L41)
+
 ## Functions
 
 ### computeExpirationDate
@@ -36,7 +66,7 @@ Expiration date
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:91](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L91)
+[packages/cozy-client/src/models/paper.js:116](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L116)
 
 ***
 
@@ -60,7 +90,7 @@ Expiration notice date
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:127](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L127)
+[packages/cozy-client/src/models/paper.js:152](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L152)
 
 ***
 
@@ -84,7 +114,31 @@ Expiration notice link
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:146](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L146)
+[packages/cozy-client/src/models/paper.js:171](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L171)
+
+***
+
+### formatMetadataQualification
+
+▸ **formatMetadataQualification**(`metadata`): { `name`: `string` ; `value`: `string`  }\[]
+
+**`description`** Computes and returns the displayable metadata of a paper
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `metadata` | `any` | An io.cozy.files metadata object |
+
+*Returns*
+
+{ `name`: `string` ; `value`: `string`  }\[]
+
+\[]} Array of formated metadata
+
+*Defined in*
+
+[packages/cozy-client/src/models/paper.js:224](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L224)
 
 ***
 
@@ -106,7 +160,7 @@ Expiration notice link
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:158](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L158)
+[packages/cozy-client/src/models/paper.js:183](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L183)
 
 ***
 
@@ -128,7 +182,7 @@ Expiration notice link
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:73](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L73)
+[packages/cozy-client/src/models/paper.js:98](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L98)
 
 ***
 
@@ -150,4 +204,4 @@ Expiration notice link
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:170](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L170)
+[packages/cozy-client/src/models/paper.js:195](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L195)

--- a/docs/api/cozy-client/modules/models.paper.md
+++ b/docs/api/cozy-client/modules/models.paper.md
@@ -14,6 +14,16 @@
 
 [packages/cozy-client/src/models/paper.js:5](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L5)
 
+***
+
+### MetadataQualificationType
+
+Ƭ **MetadataQualificationType**<>: `"date"` | `"information"` | `"contact"` | `"other"`
+
+*Defined in*
+
+[packages/cozy-client/src/models/paper.js:263](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L263)
+
 ## Variables
 
 ### KNOWN_DATE_METADATA_NAMES
@@ -139,6 +149,30 @@ Expiration notice link
 *Defined in*
 
 [packages/cozy-client/src/models/paper.js:224](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L224)
+
+***
+
+### getMetadataQualificationType
+
+▸ **getMetadataQualificationType**(`metadataName`): [`MetadataQualificationType`](models.paper.md#metadataqualificationtype)
+
+**`description`** Computes and returns the displayable metadata of a paper
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `metadataName` | `string` | An io.cozy.files metadata object |
+
+*Returns*
+
+[`MetadataQualificationType`](models.paper.md#metadataqualificationtype)
+
+Array of formated metadata
+
+*Defined in*
+
+[packages/cozy-client/src/models/paper.js:271](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L271)
 
 ***
 

--- a/docs/api/cozy-client/modules/models.paper.md
+++ b/docs/api/cozy-client/modules/models.paper.md
@@ -12,7 +12,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:5](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L5)
+[packages/cozy-client/src/models/paper.js:7](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L7)
 
 ***
 
@@ -22,7 +22,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:263](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L263)
+[packages/cozy-client/src/models/paper.js:265](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L265)
 
 ## Variables
 
@@ -32,7 +32,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:18](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L18)
+[packages/cozy-client/src/models/paper.js:20](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L20)
 
 ***
 
@@ -42,7 +42,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:31](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L31)
+[packages/cozy-client/src/models/paper.js:33](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L33)
 
 ***
 
@@ -52,7 +52,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:41](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L41)
+[packages/cozy-client/src/models/paper.js:43](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L43)
 
 ## Functions
 
@@ -76,7 +76,7 @@ Expiration date
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:116](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L116)
+[packages/cozy-client/src/models/paper.js:118](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L118)
 
 ***
 
@@ -100,7 +100,7 @@ Expiration notice date
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:152](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L152)
+[packages/cozy-client/src/models/paper.js:154](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L154)
 
 ***
 
@@ -124,7 +124,80 @@ Expiration notice link
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:171](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L171)
+[packages/cozy-client/src/models/paper.js:173](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L173)
+
+***
+
+### formatContactValue
+
+▸ **formatContactValue**(`contacts`): `string`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `contacts` | `any`\[] | An array of contact |
+
+*Returns*
+
+`string`
+
+Formatted and translated value of an array of contact
+
+*Defined in*
+
+[packages/cozy-client/src/models/paper.js:427](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L427)
+
+***
+
+### formatDateMetadataValue
+
+▸ **formatDateMetadataValue**(`value`, `options`): `string`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `value` | `string` | The value of a metadata of type date |
+| `options` | `Object` | Options |
+| `options.f` | `Function` | Date formatting function |
+| `options.lang` | `string` | Lang requested for the translation |
+
+*Returns*
+
+`string`
+
+Formatted and translated value for the metadata
+
+*Defined in*
+
+[packages/cozy-client/src/models/paper.js:311](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L311)
+
+***
+
+### formatInformationMetadataValue
+
+▸ **formatInformationMetadataValue**(`value`, `options`): `string`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `value` | `string` | The value of a metadata of type information |
+| `options` | `Object` | Options |
+| `options.lang` | `string` | Lang requested for the translation |
+| `options.name` | `string` | The name of the metadata |
+| `options.qualificationLabel` | `string` | The qualification label of the metadata |
+
+*Returns*
+
+`string`
+
+Formatted and translated value for the metadata
+
+*Defined in*
+
+[packages/cozy-client/src/models/paper.js:354](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L354)
 
 ***
 
@@ -132,7 +205,7 @@ Expiration notice link
 
 ▸ **formatMetadataQualification**(`metadata`): { `name`: `string` ; `value`: `string`  }\[]
 
-**`description`** Computes and returns the displayable metadata of a paper
+**`description`** Select and format displayable metadata of a paper
 
 *Parameters*
 
@@ -144,11 +217,36 @@ Expiration notice link
 
 { `name`: `string` ; `value`: `string`  }\[]
 
-\[]} Array of formated metadata
+\[]} Array of displayable metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:224](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L224)
+[packages/cozy-client/src/models/paper.js:226](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L226)
+
+***
+
+### formatOtherMetadataValue
+
+▸ **formatOtherMetadataValue**(`value`, `options`): `string`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `value` | `string` | The value of a metadata of type other |
+| `options` | `Object` | Options |
+| `options.lang` | `string` | Lang requested for the translation |
+| `options.name` | `string` | The name of the metadata |
+
+*Returns*
+
+`string`
+
+Formatted and translated value for the metadata
+
+*Defined in*
+
+[packages/cozy-client/src/models/paper.js:402](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L402)
 
 ***
 
@@ -156,23 +254,119 @@ Expiration notice link
 
 ▸ **getMetadataQualificationType**(`metadataName`): [`MetadataQualificationType`](models.paper.md#metadataqualificationtype)
 
-**`description`** Computes and returns the displayable metadata of a paper
+**`description`** Returns the type of the metatada from a metadata name
 
 *Parameters*
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `metadataName` | `string` | An io.cozy.files metadata object |
+| `metadataName` | `string` | A metadata name |
 
 *Returns*
 
 [`MetadataQualificationType`](models.paper.md#metadataqualificationtype)
 
-Array of formated metadata
+The type of the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:271](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L271)
+[packages/cozy-client/src/models/paper.js:273](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L273)
+
+***
+
+### getTranslatedNameForContact
+
+▸ **getTranslatedNameForContact**(`options`): `string`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options` | `Object` | Options |
+| `options.lang` | `string` | Lang requested for the translation |
+
+*Returns*
+
+`string`
+
+Translated name for contact
+
+*Defined in*
+
+[packages/cozy-client/src/models/paper.js:417](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L417)
+
+***
+
+### getTranslatedNameForDateMetadata
+
+▸ **getTranslatedNameForDateMetadata**(`name`, `options`): `string`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | The name of a metadata of type date like 'expirationDate' or 'shootingDate' |
+| `options` | `Object` | Options |
+| `options.lang` | `string` | Lang requested for the translation like 'fr' or 'en' |
+
+*Returns*
+
+`string`
+
+Translated name for the metadata
+
+*Defined in*
+
+[packages/cozy-client/src/models/paper.js:298](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L298)
+
+***
+
+### getTranslatedNameForInformationMetadata
+
+▸ **getTranslatedNameForInformationMetadata**(`name`, `options`): `string`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | The name of a metadata of type information like 'national_id_card' or 'fine' |
+| `options` | `Object` | Options |
+| `options.lang` | `string` | Lang requested for the translation |
+| `options.qualificationLabel` | `string` | The qualification label of the metadata |
+
+*Returns*
+
+`string`
+
+Translated name for the metadata
+
+*Defined in*
+
+[packages/cozy-client/src/models/paper.js:331](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L331)
+
+***
+
+### getTranslatedNameForOtherMetadata
+
+▸ **getTranslatedNameForOtherMetadata**(`name`, `options`): `string`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | The name of a metadata of type other like 'page' or 'qualification' |
+| `options` | `Object` | Options |
+| `options.lang` | `string` | Lang requested for the translation |
+
+*Returns*
+
+`string`
+
+Translated name for the metadata
+
+*Defined in*
+
+[packages/cozy-client/src/models/paper.js:389](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L389)
 
 ***
 
@@ -194,7 +388,7 @@ Array of formated metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:183](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L183)
+[packages/cozy-client/src/models/paper.js:185](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L185)
 
 ***
 
@@ -216,7 +410,7 @@ Array of formated metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:98](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L98)
+[packages/cozy-client/src/models/paper.js:100](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L100)
 
 ***
 
@@ -238,4 +432,4 @@ Array of formated metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:195](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L195)
+[packages/cozy-client/src/models/paper.js:197](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L197)

--- a/packages/cozy-client/src/models/document/locales/en.json
+++ b/packages/cozy-client/src/models/document/locales/en.json
@@ -148,6 +148,24 @@
       "transport": "Transport",
       "undefined": "Undefined",
       "work_study": "Work & Study"
+    },
+    "qualification": {
+      "date": {
+        "title": {
+          "datetime": "Added on",
+          "AObtentionDate": "License A, delivered on",
+          "BObtentionDate": "License B, delivered on",
+          "CObtentionDate": "License C, delivered on",
+          "DObtentionDate": "License D, delivered on",
+          "issueDate": "Delivered on",
+          "expirationDate": "Expiration date",
+          "referencedDate": "Referenced date",
+          "shootingDate": "Shooting date",
+          "obtentionDate": "Date obtained",
+          "date": "Document date"
+        }
+      },
+      "noInfo": "No information"
     }
   },
   "MagicFolders": {

--- a/packages/cozy-client/src/models/document/locales/en.json
+++ b/packages/cozy-client/src/models/document/locales/en.json
@@ -165,6 +165,66 @@
           "date": "Document date"
         }
       },
+      "information": {
+        "title": {
+          "fine": {
+            "number": "Amount of the fine"
+          },
+          "fidelity_card": {
+            "number": "Card number"
+          },
+          "caf": {
+            "number": "CAF file number"
+          },
+          "payment_proof_family_allowance": {
+            "number":"CAF file number"
+          },
+          "vehicle_registration": {
+            "number": "Vehicle registration number (VIN)"
+          },
+          "national_id_card": {
+            "number": "National ID card number"
+          },
+          "bank_details": {
+            "number": "IBAN number"
+          },
+          "passport": {
+            "number": "Passport number"
+          },
+          "driver_license": {
+            "number": "License number"
+          },
+          "residence_permit": {
+            "number": "License number"
+          },
+          "national_health_insurance_card": {
+            "number": "National health insurance card number"
+          },
+          "pay_sheet": {
+            "number": "Gross remuneration"
+          },
+          "tax_return": {
+            "number": "Reference tax number"
+          },
+          "tax_notice": {
+            "number": "Reference tax number"
+          },
+          "real_estate_tax": {
+            "number": "Reference tax number"
+          },
+          "tax_timetable": {
+            "number": "Reference tax number"
+          },
+          "country": "Beneficiary nationality",
+          "refTaxIncome": "Reference tax income",
+          "contractType": "Contract type",
+          "noticePeriod": "Expiration alert",
+          "netSocialAmount": "Net social amount",
+          "employerName": "Name of employer",
+          "bicNumber": "BIC number"
+        },
+        "day": "day |||| days"
+      },
       "noInfo": "No information"
     }
   },

--- a/packages/cozy-client/src/models/document/locales/en.json
+++ b/packages/cozy-client/src/models/document/locales/en.json
@@ -225,6 +225,11 @@
         },
         "day": "day |||| days"
       },
+      "contact": "Owner",
+      "page": "Side of the document",
+      "front": "Front side",
+      "back": "Back side",
+      "qualification": "Qualification",
       "noInfo": "No information"
     }
   },

--- a/packages/cozy-client/src/models/document/locales/fr.json
+++ b/packages/cozy-client/src/models/document/locales/fr.json
@@ -225,6 +225,11 @@
         },
         "day": "jour |||| jours"
       },
+      "contact": "Titulaire",
+      "page": "Face du document",
+      "front": "Face avant",
+      "back": "Face arrière",
+      "qualification": "Qualification",
       "noInfo": "Non renseigné(e)"
     }
   },

--- a/packages/cozy-client/src/models/document/locales/fr.json
+++ b/packages/cozy-client/src/models/document/locales/fr.json
@@ -165,6 +165,66 @@
           "date": "Date du document"
         }
       },
+      "information": {
+        "title": {
+          "fine": {
+            "number": "Montant de l'amende"
+          },
+          "fidelity_card": {
+            "number": "Numéro de la carte"
+          },
+          "caf": {
+            "number": "Numéro de dossier CAF"
+          },
+          "payment_proof_family_allowance": {
+            "number":"Numéro de dossier CAF"
+          },
+          "vehicle_registration": {
+            "number": "Numéro de la carte grise (VIN)"
+          },
+          "national_id_card": {
+            "number": "Numéro de la carte d'identité"
+          },
+          "bank_details": {
+            "number": "Numéro d'IBAN"
+          },
+          "passport": {
+            "number": "Numéro du passeport"
+          },
+          "driver_license": {
+            "number": "Numéro du permis"
+          },
+          "residence_permit": {
+            "number": "Numéro du permis"
+          },
+          "national_health_insurance_card": {
+            "number": "Numéro de la carte vitale"
+          },
+          "pay_sheet": {
+            "number": "Rémunération brute"
+          },
+          "tax_return": {
+            "number": "Numéro fiscal de référence"
+          },
+          "tax_notice": {
+            "number": "Numéro fiscal de référence"
+          },
+          "real_estate_tax": {
+            "number": "Numéro fiscal de référence"
+          },
+          "tax_timetable": {
+            "number": "Numéro fiscal de référence"
+          },
+          "country": "Nationalité du bénéficiaire",
+          "refTaxIncome": "Revenu fiscal de référence",
+          "contractType": "Type de contrat",
+          "noticePeriod": "Alerte d’expiration",
+          "netSocialAmount": "Montant net social",
+          "employerName": "Nom de l'employeur",
+          "bicNumber": "Numéro BIC"
+        },
+        "day": "jour |||| jours"
+      },
       "noInfo": "Non renseigné(e)"
     }
   },

--- a/packages/cozy-client/src/models/document/locales/fr.json
+++ b/packages/cozy-client/src/models/document/locales/fr.json
@@ -148,6 +148,24 @@
       "transport": "Transport",
       "undefined": "Indéfini",
       "work_study": "Travail & Études"
+    },
+    "qualification": {
+      "date": {
+        "title": {
+          "datetime": "Ajouté le",
+          "AObtentionDate": "Permis A, délivré le",
+          "BObtentionDate": "Permis B, délivré le",
+          "CObtentionDate": "Permis C, délivré le",
+          "DObtentionDate": "Permis D, délivré le",
+          "issueDate": "Délivré le",
+          "expirationDate": "Date d'expiration",
+          "referencedDate": "Date de référence",
+          "shootingDate": "Date de prise de vue",
+          "obtentionDate": "Date d'obtention",
+          "date": "Date du document"
+        }
+      },
+      "noInfo": "Non renseigné(e)"
     }
   },
   "MagicFolders": {

--- a/packages/cozy-client/src/models/paper.js
+++ b/packages/cozy-client/src/models/paper.js
@@ -258,3 +258,31 @@ export const formatMetadataQualification = metadata => {
 
   return [...dates, ...informations, ...others]
 }
+
+/**
+ * @typedef {('date' | 'information' | 'contact' | 'other')} MetadataQualificationType
+ */
+
+/**
+ * @param {string} metadataName - A metadata name
+ * @returns {MetadataQualificationType | null} The type of the metadata
+ * @description Returns the type of the metatada from a metadata name
+ */
+export const getMetadataQualificationType = metadataName => {
+  if (KNOWN_DATE_METADATA_NAMES.includes(metadataName)) {
+    return 'date'
+  }
+
+  if (KNOWN_INFORMATION_METADATA_NAMES.includes(metadataName)) {
+    return 'information'
+  }
+
+  if (KNOWN_OTHER_METADATA_NAMES.includes(metadataName)) {
+    if (metadataName === 'contact') {
+      return 'contact'
+    }
+    return 'other'
+  }
+
+  return null
+}

--- a/packages/cozy-client/src/models/paper.js
+++ b/packages/cozy-client/src/models/paper.js
@@ -1,6 +1,7 @@
 import add from 'date-fns/add'
 import sub from 'date-fns/sub'
 import { getLocalizer } from './document/locales'
+import { getDisplayName } from './contact'
 
 /**
  * @typedef {import("../types").IOCozyFile} IOCozyFile
@@ -406,4 +407,25 @@ export const formatOtherMetadataValue = (value, { lang, name }) => {
   } else {
     return t(`Scan.qualification.${value}`)
   }
+}
+
+/**
+ * @param {Object} options - Options
+ * @param {string} options.lang - Lang requested for the translation
+ * @returns {string} Translated name for contact
+ */
+export const getTranslatedNameForContact = ({ lang }) => {
+  const t = getLocalizer(lang)
+
+  return t('Scan.qualification.contact')
+}
+
+/**
+ * @param {object[]} contacts - An array of contact
+ * @returns {string} Formatted and translated value of an array of contact
+ */
+export const formatContactValue = contacts => {
+  return contacts && contacts.length > 0
+    ? contacts.map(contact => `${getDisplayName(contact)}`).join(', ')
+    : ''
 }

--- a/packages/cozy-client/src/models/paper.js
+++ b/packages/cozy-client/src/models/paper.js
@@ -1,5 +1,6 @@
 import add from 'date-fns/add'
 import sub from 'date-fns/sub'
+import { getLocalizer } from './document/locales'
 
 /**
  * @typedef {import("../types").IOCozyFile} IOCozyFile
@@ -285,4 +286,36 @@ export const getMetadataQualificationType = metadataName => {
   }
 
   return null
+}
+
+/**
+ * @param {string} name - The name of a metadata of type date like 'expirationDate' or 'shootingDate'
+ * @param {Object} options - Options
+ * @param {string} options.lang - Lang requested for the translation like 'fr' or 'en'
+ * @returns {string} Translated name for the metadata
+ */
+export const getTranslatedNameForDateMetadata = (name, { lang }) => {
+  const t = getLocalizer(lang)
+
+  return t(`Scan.qualification.date.title.${name}`)
+}
+
+/**
+ * @param {string} value - The value of a metadata of type date
+ * @param {Object} options - Options
+ * @param {string} options.lang - Lang requested for the translation
+ * @param {function} options.f - Date formatting function
+ * @returns {string} Formatted and translated value for the metadata
+ */
+export const formatDateMetadataValue = (value, { lang, f }) => {
+  const t = getLocalizer(lang)
+
+  if (value) {
+    if (lang === 'en') {
+      return f(value, 'MM/DD/YYYY')
+    }
+    return f(value, 'DD/MM/YYYY')
+  } else {
+    return t('Scan.qualification.noInfo')
+  }
 }

--- a/packages/cozy-client/src/models/paper.js
+++ b/packages/cozy-client/src/models/paper.js
@@ -378,3 +378,32 @@ export const formatInformationMetadataValue = (
 
   return value
 }
+
+/**
+ * @param {string} name - The name of a metadata of type other like 'page' or 'qualification'
+ * @param {Object} options - Options
+ * @param {string} options.lang - Lang requested for the translation
+ * @returns {string} Translated name for the metadata
+ */
+export const getTranslatedNameForOtherMetadata = (name, { lang }) => {
+  const t = getLocalizer(lang)
+
+  return t(`Scan.qualification.${name}`)
+}
+
+/**
+ * @param {string} value - The value of a metadata of type other
+ * @param {Object} options - Options
+ * @param {string} options.lang - Lang requested for the translation
+ * @param {string} options.name - The name of the metadata
+ * @returns {string} Formatted and translated value for the metadata
+ */
+export const formatOtherMetadataValue = (value, { lang, name }) => {
+  const t = getLocalizer(lang)
+
+  if (name === 'qualification') {
+    return t(`Scan.items.${value}`, { smart_count: 1 })
+  } else {
+    return t(`Scan.qualification.${value}`)
+  }
+}

--- a/packages/cozy-client/src/models/paper.js
+++ b/packages/cozy-client/src/models/paper.js
@@ -319,3 +319,62 @@ export const formatDateMetadataValue = (value, { lang, f }) => {
     return t('Scan.qualification.noInfo')
   }
 }
+
+/**
+ * @param {string} name - The name of a metadata of type information like 'national_id_card' or 'fine'
+ * @param {Object} options - Options
+ * @param {string} options.lang - Lang requested for the translation
+ * @param {string} options.qualificationLabel - The qualification label of the metadata
+ * @returns {string} Translated name for the metadata
+ */
+export const getTranslatedNameForInformationMetadata = (
+  name,
+  { lang, qualificationLabel }
+) => {
+  const t = getLocalizer(lang)
+
+  if (name === 'number') {
+    return t(
+      `Scan.qualification.information.title.${qualificationLabel}.${name}`
+    )
+  } else {
+    return t(`Scan.qualification.information.title.${name}`)
+  }
+}
+
+/**
+ * @param {string} value - The value of a metadata of type information
+ * @param {Object} options - Options
+ * @param {string} options.lang - Lang requested for the translation
+ * @param {string} options.name - The name of the metadata
+ * @param {string} options.qualificationLabel - The qualification label of the metadata
+ * @returns {string} Formatted and translated value for the metadata
+ */
+export const formatInformationMetadataValue = (
+  value,
+  { lang, name, qualificationLabel }
+) => {
+  const t = getLocalizer(lang)
+
+  if (typeof value !== 'number' && !value) {
+    return t('Scan.qualification.noInfo')
+  }
+
+  if (name === 'noticePeriod') {
+    return `${value} ${t('Scan.qualification.information.day', {
+      smart_count: value
+    })}`
+  }
+  if (name === 'contractType') {
+    return t(`Scan.attributes.contractType.${value}`, { _: value })
+  }
+  if (
+    name === 'refTaxIncome' ||
+    name === 'netSocialAmount' ||
+    (name === 'number' && qualificationLabel === 'pay_sheet')
+  ) {
+    return `${value} €`
+  }
+
+  return value
+}

--- a/packages/cozy-client/src/models/paper.spec.js
+++ b/packages/cozy-client/src/models/paper.spec.js
@@ -179,4 +179,44 @@ describe('Expiration', () => {
       }
     )
   })
+
+  describe('formatMetadataQualification', () => {
+    it('should return correctly formatted metadata', () => {
+      const fakeMetadata = {
+        number: '111111',
+        AObtentionDate: '2029-12-01T23:00:00.000Z',
+        BObtentionDate: '2029-12-02T23:00:00.000Z',
+        CObtentionDate: '2029-12-03T23:00:00.000Z',
+        DObtentionDate: '2029-12-04T23:00:00.000Z',
+        expirationDate: '2029-12-05T23:00:00.000Z',
+        referencedDate: '2029-12-06T23:00:00.000Z',
+        issueDate: '2029-12-07T23:00:00.000Z',
+        shootingDate: '2029-12-08T23:00:00.000Z',
+        date: '2029-12-09T23:00:00.000Z',
+        datetime: '2029-12-10T23:00:00.000Z',
+        qualification: { label: 'fake_label' },
+        page: 'front',
+        contact: 'Alice Durand'
+      }
+
+      const computedMetadata = [
+        { name: 'AObtentionDate', value: '2029-12-01T23:00:00.000Z' },
+        { name: 'BObtentionDate', value: '2029-12-02T23:00:00.000Z' },
+        { name: 'CObtentionDate', value: '2029-12-03T23:00:00.000Z' },
+        { name: 'DObtentionDate', value: '2029-12-04T23:00:00.000Z' },
+        { name: 'expirationDate', value: '2029-12-05T23:00:00.000Z' },
+        { name: 'referencedDate', value: '2029-12-06T23:00:00.000Z' },
+        { name: 'issueDate', value: '2029-12-07T23:00:00.000Z' },
+        { name: 'shootingDate', value: '2029-12-08T23:00:00.000Z' },
+        { name: 'date', value: '2029-12-09T23:00:00.000Z' },
+        { name: 'number', value: '111111' },
+        { name: 'contact', value: 'Alice Durand' },
+        { name: 'page', value: 'front' },
+        { name: 'qualification', value: 'fake_label' }
+      ]
+
+      const res = paperModel.formatMetadataQualification(fakeMetadata)
+      expect(res).toEqual(computedMetadata)
+    })
+  })
 })

--- a/packages/cozy-client/src/models/paper.spec.js
+++ b/packages/cozy-client/src/models/paper.spec.js
@@ -219,4 +219,33 @@ describe('Expiration', () => {
       expect(res).toEqual(computedMetadata)
     })
   })
+
+  describe('formatInformationMetadataValue', () => {
+    it('should return value with suffix locale', () => {
+      const res = paperModel.formatInformationMetadataValue('88', {
+        name: 'noticePeriod',
+        lang: 'en'
+      })
+
+      expect(res).toEqual('88 days')
+    })
+
+    it('should return "noInfo" value', () => {
+      const res = paperModel.formatInformationMetadataValue('', {
+        name: 'metadataName',
+        lang: 'en'
+      })
+
+      expect(res).toEqual('No information')
+    })
+
+    it('should return value if not in other case', () => {
+      const res = paperModel.formatInformationMetadataValue('metadataValue', {
+        name: 'metadataName',
+        lang: 'en'
+      })
+
+      expect(res).toEqual('metadataValue')
+    })
+  })
 })

--- a/packages/cozy-client/types/models/paper.d.ts
+++ b/packages/cozy-client/types/models/paper.d.ts
@@ -12,5 +12,32 @@ export function formatMetadataQualification(metadata: any): {
     value: string | null;
 }[];
 export function getMetadataQualificationType(metadataName: string): MetadataQualificationType | null;
+export function getTranslatedNameForDateMetadata(name: string, { lang }: {
+    lang: string;
+}): string;
+export function formatDateMetadataValue(value: string, { lang, f }: {
+    lang: string;
+    f: Function;
+}): string;
+export function getTranslatedNameForInformationMetadata(name: string, { lang, qualificationLabel }: {
+    lang: string;
+    qualificationLabel: string;
+}): string;
+export function formatInformationMetadataValue(value: string, { lang, name, qualificationLabel }: {
+    lang: string;
+    name: string;
+    qualificationLabel: string;
+}): string;
+export function getTranslatedNameForOtherMetadata(name: string, { lang }: {
+    lang: string;
+}): string;
+export function formatOtherMetadataValue(value: string, { lang, name }: {
+    lang: string;
+    name: string;
+}): string;
+export function getTranslatedNameForContact({ lang }: {
+    lang: string;
+}): string;
+export function formatContactValue(contacts: object[]): string;
 export type IOCozyFile = import("../types").CozyClientDocument & import("../types").FileDocument;
 export type MetadataQualificationType = "other" | "date" | "contact" | "information";

--- a/packages/cozy-client/types/models/paper.d.ts
+++ b/packages/cozy-client/types/models/paper.d.ts
@@ -1,7 +1,14 @@
+export const KNOWN_DATE_METADATA_NAMES: string[];
+export const KNOWN_INFORMATION_METADATA_NAMES: string[];
+export const KNOWN_OTHER_METADATA_NAMES: string[];
 export function isExpiring(file: IOCozyFile): boolean;
 export function computeExpirationDate(file: IOCozyFile): Date | null;
 export function computeExpirationNoticeDate(file: IOCozyFile): Date | null;
 export function computeExpirationNoticeLink(file: IOCozyFile): string | null;
 export function isExpired(file: IOCozyFile): boolean;
 export function isExpiringSoon(file: IOCozyFile): boolean;
+export function formatMetadataQualification(metadata: any): {
+    name: string;
+    value: string | null;
+}[];
 export type IOCozyFile = import("../types").CozyClientDocument & import("../types").FileDocument;

--- a/packages/cozy-client/types/models/paper.d.ts
+++ b/packages/cozy-client/types/models/paper.d.ts
@@ -11,4 +11,6 @@ export function formatMetadataQualification(metadata: any): {
     name: string;
     value: string | null;
 }[];
+export function getMetadataQualificationType(metadataName: string): MetadataQualificationType | null;
 export type IOCozyFile = import("../types").CozyClientDocument & import("../types").FileDocument;
+export type MetadataQualificationType = "other" | "date" | "contact" | "information";


### PR DESCRIPTION
The Viewer component in cozy-ui displays paper metadata in the side panel. 

We need to display the same paper metadata in cozy-keys-browser which is written in Angular so we can not benefit as is from the Viewer component.

So in this PR, I extract the logic from the Viewer component in cozy-ui to select, format and translate paper metadata to cozy-client so that : 
- cozy-ui will use the logic to create React component (no behavior changes)
- cozy-keys-browser will use the logic to create Angular component




