### PR TITLE
[VO-524] feat: Prevent array selector without operator before

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -57,7 +57,7 @@ cozy-client
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:495](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L495)
+[packages/cozy-client/src/queries/dsl.js:510](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L510)
 
 ***
 
@@ -81,7 +81,7 @@ cozy-client
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:483](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L483)
+[packages/cozy-client/src/queries/dsl.js:498](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L498)
 
 ***
 
@@ -171,7 +171,7 @@ query definitions.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:379](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L379)
+[packages/cozy-client/src/queries/dsl.js:394](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L394)
 
 ***
 
@@ -404,7 +404,7 @@ Generated URL
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:459](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L459)
+[packages/cozy-client/src/queries/dsl.js:474](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L474)
 
 ***
 

--- a/docs/api/cozy-client/classes/QueryDefinition.md
+++ b/docs/api/cozy-client/classes/QueryDefinition.md
@@ -187,7 +187,7 @@ from a Cozy. `QueryDefinition`s are sent to links.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:276](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L276)
+[packages/cozy-client/src/queries/dsl.js:291](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L291)
 
 ***
 
@@ -209,7 +209,7 @@ Check if the selected fields are all included in the selectors
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L139)
+[packages/cozy-client/src/queries/dsl.js:154](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L154)
 
 ***
 
@@ -286,7 +286,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:166](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L166)
+[packages/cozy-client/src/queries/dsl.js:181](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L181)
 
 ***
 
@@ -310,7 +310,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:179](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L179)
+[packages/cozy-client/src/queries/dsl.js:194](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L194)
 
 ***
 
@@ -335,7 +335,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:259](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L259)
+[packages/cozy-client/src/queries/dsl.js:274](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L274)
 
 ***
 
@@ -359,7 +359,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:215](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L215)
+[packages/cozy-client/src/queries/dsl.js:230](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L230)
 
 ***
 
@@ -383,7 +383,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:272](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L272)
+[packages/cozy-client/src/queries/dsl.js:287](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L287)
 
 ***
 
@@ -410,7 +410,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:289](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L289)
+[packages/cozy-client/src/queries/dsl.js:304](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L304)
 
 ***
 
@@ -437,7 +437,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:327](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L327)
+[packages/cozy-client/src/queries/dsl.js:342](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L342)
 
 ***
 
@@ -466,7 +466,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:309](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L309)
+[packages/cozy-client/src/queries/dsl.js:324](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L324)
 
 ***
 
@@ -492,7 +492,7 @@ You can find more information about partial indexes [here](https://docs.cozy.io/
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:229](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L229)
+[packages/cozy-client/src/queries/dsl.js:244](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L244)
 
 ***
 
@@ -516,7 +516,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:342](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L342)
+[packages/cozy-client/src/queries/dsl.js:357](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L357)
 
 ***
 
@@ -540,7 +540,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:203](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L203)
+[packages/cozy-client/src/queries/dsl.js:218](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L218)
 
 ***
 
@@ -564,7 +564,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:240](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L240)
+[packages/cozy-client/src/queries/dsl.js:255](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L255)
 
 ***
 
@@ -595,7 +595,7 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:346](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L346)
+[packages/cozy-client/src/queries/dsl.js:361](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L361)
 
 ***
 
@@ -620,4 +620,4 @@ The QueryDefinition object.
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:190](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L190)
+[packages/cozy-client/src/queries/dsl.js:205](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L205)

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -129,6 +129,21 @@ class QueryDefinition {
         Selector: ${JSON.stringify(selector)}`
       )
     }
+
+    const nestedArrayKey = findKey(selector, value => Array.isArray(value))
+    const hasNestedArrayWithoutOperator =
+      nestedArrayKey && !nestedArrayKey.startsWith('$')
+    if (hasNestedArrayWithoutOperator) {
+      throw new Error(
+        `You pass ${JSON.stringify(
+          selector
+        )}, this is a valid mango operation, \n
+        but sift doesn't support it so CozyClient can not evaluate \n
+        the request in memory. You must use a MongoDB operator \n
+        like $in or $or operator instead, preferably in a partial index, \n
+        to avoid costly full-scan`
+      )
+    }
   }
 
   /**

--- a/packages/cozy-client/src/queries/dsl.spec.js
+++ b/packages/cozy-client/src/queries/dsl.spec.js
@@ -108,7 +108,18 @@ describe('QueryDefinition', () => {
     Q('io.cozy.files').where({ _id: { $ne: 'io.cozy.root-id' } })
     expect(logger.info).toHaveBeenCalledTimes(1)
   })
-
+  it('should throw when using a selector with an array without an $operator', () => {
+    const query = () =>
+      Q('io.cozy.files').where({ worker: ['worker1', 'worker2'] })
+    expect(() => query()).toThrow()
+  })
+  it('should not throw an error when we make a selector on multiple value with a mango operator', () => {
+    const query = () =>
+      Q('io.cozy.files').where({
+        worker: { $in: ['konnector', 'client'] }
+      })
+    expect(() => query()).not.toThrow()
+  })
   it('should throw an error when there is a select without all the fields in selector', () => {
     const query = () =>
       Q('io.cozy.files')


### PR DESCRIPTION
This query is a valid mango query :
```
where({ worker: ['client', 'konnector']})
```

But the library [sift](https://github.com/crcn/sift.js) that we use to replay the query with the same doctype can't apply that selector because it requires MongoDB operators.

As a result, we have issues when some query where emptied and were breaking some feature

That is why we throw an error. I've chosen to have a deep check to avoid too many calculations at runtime.

BREAKING CHANGE: if you use a selector on multiple value without the `$and`  mango operator, you have to change that and use this `$and` operator.