### PR TITLE
feat: We don't want to concatenate `additionalName` in the `displayName`

### DIFF
--- a/docs/api/cozy-client/modules/models.contact.md
+++ b/docs/api/cozy-client/modules/models.contact.md
@@ -4,6 +4,16 @@
 
 [models](models.md).contact
 
+## Type aliases
+
+### FullnameAttributes
+
+Ƭ **FullnameAttributes**<>: `"namePrefix"` | `"givenName"` | `"additionalName"` | `"familyName"` | `"nameSuffix"`
+
+*Defined in*
+
+[packages/cozy-client/src/models/contact.js:9](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L9)
+
 ## Variables
 
 ### CONTACTS_DOCTYPE
@@ -36,7 +46,7 @@ Returns 'byFamilyNameGivenNameEmailCozyUrl' index of a contact
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:201](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L201)
+[packages/cozy-client/src/models/contact.js:214](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L214)
 
 ***
 
@@ -60,7 +70,7 @@ Returns a display name for the contact
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:163](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L163)
+[packages/cozy-client/src/models/contact.js:176](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L176)
 
 ***
 
@@ -84,7 +94,7 @@ Returns the contact's fullname
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:125](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L125)
+[packages/cozy-client/src/models/contact.js:137](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L137)
 
 ***
 
@@ -110,7 +120,7 @@ Returns 'byFamilyNameGivenNameEmailCozyUrl' index of a contact
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:222](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L222)
+[packages/cozy-client/src/models/contact.js:235](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L235)
 
 ***
 
@@ -134,7 +144,7 @@ Returns the initials of the contact.
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:19](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L19)
+[packages/cozy-client/src/models/contact.js:23](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L23)
 
 ***
 
@@ -158,7 +168,7 @@ Returns the contact's main address
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:92](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L92)
+[packages/cozy-client/src/models/contact.js:96](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L96)
 
 ***
 
@@ -182,7 +192,7 @@ Returns the contact's main cozy
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:57](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L57)
+[packages/cozy-client/src/models/contact.js:61](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L61)
 
 ***
 
@@ -206,7 +216,7 @@ Returns the contact's main cozy url without protocol
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:68](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L68)
+[packages/cozy-client/src/models/contact.js:72](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L72)
 
 ***
 
@@ -230,7 +240,7 @@ Returns the contact's main email
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:46](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L46)
+[packages/cozy-client/src/models/contact.js:50](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L50)
 
 ***
 
@@ -262,7 +272,7 @@ Returns the contact's main email
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:8](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L8)
+[packages/cozy-client/src/models/contact.js:12](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L12)
 
 ***
 
@@ -286,7 +296,7 @@ Returns the contact's main phone number
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:83](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L83)
+[packages/cozy-client/src/models/contact.js:87](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L87)
 
 ***
 
@@ -308,7 +318,7 @@ Whether the document is a contact
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:236](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L236)
+[packages/cozy-client/src/models/contact.js:249](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L249)
 
 ***
 
@@ -332,13 +342,13 @@ Makes 'byFamilyNameGivenNameEmailCozyUrl' index of a contact
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:177](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L177)
+[packages/cozy-client/src/models/contact.js:190](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L190)
 
 ***
 
 ### makeDisplayName
 
-▸ **makeDisplayName**(`contact`): `string`
+▸ **makeDisplayName**(`contact`, `opts`): `string`
 
 Makes displayName from contact data
 
@@ -347,6 +357,8 @@ Makes displayName from contact data
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `contact` | `any` | A contact |
+| `opts` | `Object` | - |
+| `opts.attributesFullname` | [`FullnameAttributes`](models.contact.md#fullnameattributes)\[] | - |
 
 *Returns*
 
@@ -356,13 +368,13 @@ Makes displayName from contact data
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L139)
+[packages/cozy-client/src/models/contact.js:152](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L152)
 
 ***
 
 ### makeFullname
 
-▸ **makeFullname**(`contact`): `string`
+▸ **makeFullname**(`contact`, `opts`): `string`
 
 Makes fullname from contact name
 
@@ -371,6 +383,8 @@ Makes fullname from contact name
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `contact` | `any` | A contact |
+| `opts` | `Object` | - |
+| `opts.attributesFullname` | [`FullnameAttributes`](models.contact.md#fullnameattributes)\[] | - |
 
 *Returns*
 
@@ -380,4 +394,4 @@ Makes fullname from contact name
 
 *Defined in*
 
-[packages/cozy-client/src/models/contact.js:101](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L101)
+[packages/cozy-client/src/models/contact.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L117)

--- a/packages/cozy-client/src/models/contact.js
+++ b/packages/cozy-client/src/models/contact.js
@@ -5,6 +5,10 @@ import logger from '../logger'
 
 export const CONTACTS_DOCTYPE = 'io.cozy.contacts'
 
+/**
+ * @typedef {'namePrefix'|'givenName'|'additionalName'|'familyName'|'nameSuffix'} FullnameAttributes
+ */
+
 export const getPrimaryOrFirst = property => obj =>
   !obj[property] || obj[property].length === 0
     ? ''
@@ -93,20 +97,28 @@ export const getPrimaryAddress = contact =>
   getPrimaryOrFirst('address')(contact).formattedAddress || ''
 
 /**
+ * @type {FullnameAttributes[]}
+ */
+const defaultFullnameAttributes = [
+  'namePrefix',
+  'givenName',
+  'additionalName',
+  'familyName',
+  'nameSuffix'
+]
+
+/**
  * Makes fullname from contact name
  *
- * @param {*} contact - A contact
+ * @param {object} contact - A contact
+ * @param {{ attributesFullname: FullnameAttributes[] }} [opts] - Options
  * @returns {string} - The contact's fullname
  */
-export const makeFullname = contact => {
+export const makeFullname = (contact, opts) => {
+  const fullnameAttributes =
+    opts?.attributesFullname || defaultFullnameAttributes
   if (contact.name) {
-    return [
-      'namePrefix',
-      'givenName',
-      'additionalName',
-      'familyName',
-      'nameSuffix'
-    ]
+    return fullnameAttributes
       .map(part => contact.name[part])
       .filter(part => part !== undefined)
       .join(' ')
@@ -134,10 +146,11 @@ export const getFullname = contact => {
  * Makes displayName from contact data
  *
  * @param {*} contact - A contact
+ * @param {{ attributesFullname: FullnameAttributes[] }} [opts] - Options
  * @returns {string} - The contact's displayName
  */
-export const makeDisplayName = contact => {
-  const fullname = makeFullname(contact)
+export const makeDisplayName = (contact, opts) => {
+  const fullname = makeFullname(contact, opts)
   const primaryEmail = getPrimaryEmail(contact)
   const primaryCozyDomain = getPrimaryCozyDomain(contact)
 

--- a/packages/cozy-client/src/models/contact.spec.js
+++ b/packages/cozy-client/src/models/contact.spec.js
@@ -247,6 +247,22 @@ describe('makeFullname', () => {
     )
   })
 
+  it('should combine all name parts passed as options', () => {
+    const contact = {
+      name: {
+        namePrefix: 'The Mother of Dragons',
+        givenName: 'Daenerys',
+        additionalName: 'The Unburnt',
+        familyName: 'Targaryen',
+        nameSuffix: 'Breaker of Chains'
+      }
+    }
+    const result = makeFullname(contact, {
+      attributesFullname: ['givenName', 'additionalName', 'familyName']
+    })
+    expect(result).toEqual('Daenerys The Unburnt Targaryen')
+  })
+
   it("should return contact's givenName if no familyName", () => {
     const contact = {
       name: {

--- a/packages/cozy-client/types/models/contact.d.ts
+++ b/packages/cozy-client/types/models/contact.d.ts
@@ -6,11 +6,16 @@ export function getPrimaryCozy(contact: object): string;
 export function getPrimaryCozyDomain(contact: object): string;
 export function getPrimaryPhone(contact: object): string;
 export function getPrimaryAddress(contact: object): string;
-export function makeFullname(contact: any): string;
+export function makeFullname(contact: object, opts?: {
+    attributesFullname: FullnameAttributes[];
+}): string;
 export function getFullname(contact: object): string;
-export function makeDisplayName(contact: any): string;
+export function makeDisplayName(contact: any, opts?: {
+    attributesFullname: FullnameAttributes[];
+}): string;
 export function getDisplayName(contact: object): string;
 export function makeDefaultSortIndexValue(contact: object): string;
 export function getDefaultSortIndexValue(contact: object): string;
 export function getIndexByFamilyNameGivenNameEmailCozyUrl(contact: object): string;
 export function isContact(doc: object): boolean;
+export type FullnameAttributes = "namePrefix" | "givenName" | "additionalName" | "familyName" | "nameSuffix";


### PR DESCRIPTION
This attribute will be used within cozy-contacts.

In this case, we do not want to concatenate in the `displayName` attribute the `additionalName` attribute.

A simple solution is to offer the possibility to `makeFullname` to construct the `displayName` in a personalized way (within the limits of the attributes existing in `name`)