### PR TITLE
Add an helper to delete a contact

### DIFF
--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -425,6 +425,103 @@ import { QueryDefinition } from './queries/dsl'
  */
 
 /**
+ * @typedef {object} ContactName
+ * @property {string} [familyName] - The family name (example: "House")
+ * @property {string} [givenName] - The given name (example: "Gregory")
+ * @property {string} [additionalName] - The additional name (example: "J.")
+ * @property {string} [namePrefix] - The name prefix (example: "Dr.")
+ * @property {string} [nameSuffix] - The name suffix (example: "III")
+ */
+
+/**
+ * @typedef {object} ContactEmail
+ * @property {string} address - Email address
+ * @property {string} [type] - A user-provided localized type of email address (example: "Work", "Home", "Other")
+ * @property {boolean} [primary] - Indicates a preferred-use address
+ */
+
+/**
+ * @typedef {object} ContactExtendedAddress
+ * @property {string} [locality] - Locality name
+ * @property {string} [building] - Building number
+ * @property {string} [stairs] - Stairs number
+ * @property {string} [floor] - Apartment floor
+ * @property {string} [apartment] - Apartment number
+ * @property {string} [entrycode] - Entry code
+ */
+
+/**
+ * @typedef {object} ContactGeo
+ * @property {Array<number>} [geo] - Coordinates of the address, must be [long, lat]
+ * @property {"home"|"work"} [cozyCategory] - The category of the address type
+ */
+
+/**
+ * @typedef {object} ContactAddress
+ * @property {string} [id] - Id of the address
+ * @property {string} [street] - Street name
+ * @property {string} [pobox] - P.O Box number
+ * @property {string} [city] - City name
+ * @property {string} [region] - Region name
+ * @property {string} [number] - Lane number
+ * @property {string} [code] - Postal code
+ * @property {string} [country] - Country name
+ * @property {string} [type] - A user-provided localized type of address (example: "Work", "Home", "Other")
+ * @property {boolean} [primary] - Indicates a preferred-use address
+ * @property {ContactExtendedAddress} [extendedAddress]
+ * @property {string} [formattedAddress] - Unstructured version of the address
+ * @property {ContactGeo} [geo]
+ */
+
+/**
+ * @typedef {object} ContactPhone
+ * @property {string} number - Phone number
+ * @property {string} [type] - A user-provided localized type of phone number (example: "Work", "Home", "Other")
+ * @property {boolean} [primary] - Indicates a preferred-use number
+ *
+ */
+
+/**
+ * @typedef {object} ContactCozy
+ * @property {string} url
+ * @property {string} [label] - A user-provided localized type of instance
+ * @property {boolean} [primary] - Indicates a preferred-use instance
+ *
+ */
+
+/**
+ * @typedef {object} ContactMetadata
+ * @property {boolean} cozy - Whether the contact has been created by cozy
+ * @property {object} google - Google metadata
+ * @property {number} version - Used for migrations. Current version is 1
+ *
+ */
+
+/**
+ * @typedef {object} ContactDocument
+ * @property {object} indexes - Used to sort contacts in different ways
+ * @property {string} indexes.byFamilyNameGivenNameEmailCozyUrl - Index for sorting
+ * @property {string} displayName - Displayed name in cozy applications
+ * @property {string} [fullname] - Unstructured representation of the name (example: "Dr. Gregory House, M.D.")
+ * @property {ContactName} [name] - Structured representation of the name
+ * @property {string} [birthday] - Birthday (example: "1959-05-15")
+ * @property {string} [note] - Note
+ * @property {Array<ContactEmail>} [email] - Email addresses
+ * @property {Array<ContactAddress>} [address] - Addresses
+ * @property {Array<ContactPhone>} [phone] - Phone numbers
+ * @property {Array<ContactCozy>} [cozy] - Cozy instances
+ * @property {string} company - Company
+ * @property {string} jobTitle - Job title
+ * @property {boolean} [trashed] - true if the contact is marked for removal and will be deleted soon (e.g. after remote deletion is confirmed)
+ * @property {boolean} me - Whether the contact matches the cozy owner (defaults to false)
+ * @property {Array<string>} [nationalities] - 2-letter iso3166 country codes (can be set in io.cozy.identities for legal reasons in Banks)
+ * @property {string} [birthcity] - City of birth of a contact (can be set in io.cozy.identities for legal reasons in Banks)
+ * @property {string} [birthcountry] - Country of birth of a contact (can be set in io.cozy.identities for legal reasons in Banks)
+ * @property {ContactMetadata} metadata - Previous metadata information
+ * @typedef {CozyClientDocument & ContactDocument} IOCozyContact - An io.cozy.contacts document
+ */
+
+/**
  * @typedef {object} ClientError
  * @property {string} [status]
  */

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -801,6 +801,245 @@ export type OAuthClientDocument = {
  * - An io.cozy.oauth.clients document
  */
 export type IOCozyOAuthClient = CozyClientDocument & OAuthClientDocument;
+export type ContactName = {
+    /**
+     * - The family name (example: "House")
+     */
+    familyName?: string;
+    /**
+     * - The given name (example: "Gregory")
+     */
+    givenName?: string;
+    /**
+     * - The additional name (example: "J.")
+     */
+    additionalName?: string;
+    /**
+     * - The name prefix (example: "Dr.")
+     */
+    namePrefix?: string;
+    /**
+     * - The name suffix (example: "III")
+     */
+    nameSuffix?: string;
+};
+export type ContactEmail = {
+    /**
+     * - Email address
+     */
+    address: string;
+    /**
+     * - A user-provided localized type of email address (example: "Work", "Home", "Other")
+     */
+    type?: string;
+    /**
+     * - Indicates a preferred-use address
+     */
+    primary?: boolean;
+};
+export type ContactExtendedAddress = {
+    /**
+     * - Locality name
+     */
+    locality?: string;
+    /**
+     * - Building number
+     */
+    building?: string;
+    /**
+     * - Stairs number
+     */
+    stairs?: string;
+    /**
+     * - Apartment floor
+     */
+    floor?: string;
+    /**
+     * - Apartment number
+     */
+    apartment?: string;
+    /**
+     * - Entry code
+     */
+    entrycode?: string;
+};
+export type ContactGeo = {
+    /**
+     * - Coordinates of the address, must be [long, lat]
+     */
+    geo?: Array<number>;
+    /**
+     * - The category of the address type
+     */
+    cozyCategory?: "home" | "work";
+};
+export type ContactAddress = {
+    /**
+     * - Id of the address
+     */
+    id?: string;
+    /**
+     * - Street name
+     */
+    street?: string;
+    /**
+     * - P.O Box number
+     */
+    pobox?: string;
+    /**
+     * - City name
+     */
+    city?: string;
+    /**
+     * - Region name
+     */
+    region?: string;
+    /**
+     * - Lane number
+     */
+    number?: string;
+    /**
+     * - Postal code
+     */
+    code?: string;
+    /**
+     * - Country name
+     */
+    country?: string;
+    /**
+     * - A user-provided localized type of address (example: "Work", "Home", "Other")
+     */
+    type?: string;
+    /**
+     * - Indicates a preferred-use address
+     */
+    primary?: boolean;
+    extendedAddress?: ContactExtendedAddress;
+    /**
+     * - Unstructured version of the address
+     */
+    formattedAddress?: string;
+    geo?: ContactGeo;
+};
+export type ContactPhone = {
+    /**
+     * - Phone number
+     */
+    number: string;
+    /**
+     * - A user-provided localized type of phone number (example: "Work", "Home", "Other")
+     */
+    type?: string;
+    /**
+     * - Indicates a preferred-use number
+     */
+    primary?: boolean;
+};
+export type ContactCozy = {
+    url: string;
+    /**
+     * - A user-provided localized type of instance
+     */
+    label?: string;
+    /**
+     * - Indicates a preferred-use instance
+     */
+    primary?: boolean;
+};
+export type ContactMetadata = {
+    /**
+     * - Whether the contact has been created by cozy
+     */
+    cozy: boolean;
+    /**
+     * - Google metadata
+     */
+    google: object;
+    /**
+     * - Used for migrations. Current version is 1
+     */
+    version: number;
+};
+export type ContactDocument = {
+    /**
+     * - Used to sort contacts in different ways
+     */
+    indexes: {
+        byFamilyNameGivenNameEmailCozyUrl: string;
+    };
+    /**
+     * - Displayed name in cozy applications
+     */
+    displayName: string;
+    /**
+     * - Unstructured representation of the name (example: "Dr. Gregory House, M.D.")
+     */
+    fullname?: string;
+    /**
+     * - Structured representation of the name
+     */
+    name?: ContactName;
+    /**
+     * - Birthday (example: "1959-05-15")
+     */
+    birthday?: string;
+    /**
+     * - Note
+     */
+    note?: string;
+    /**
+     * - Email addresses
+     */
+    email?: Array<ContactEmail>;
+    /**
+     * - Addresses
+     */
+    address?: Array<ContactAddress>;
+    /**
+     * - Phone numbers
+     */
+    phone?: Array<ContactPhone>;
+    /**
+     * - Cozy instances
+     */
+    cozy?: Array<ContactCozy>;
+    /**
+     * - Company
+     */
+    company: string;
+    /**
+     * - Job title
+     */
+    jobTitle: string;
+    /**
+     * - true if the contact is marked for removal and will be deleted soon (e.g. after remote deletion is confirmed)
+     */
+    trashed?: boolean;
+    /**
+     * - Whether the contact matches the cozy owner (defaults to false)
+     */
+    me: boolean;
+    /**
+     * - 2-letter iso3166 country codes (can be set in io.cozy.identities for legal reasons in Banks)
+     */
+    nationalities?: Array<string>;
+    /**
+     * - City of birth of a contact (can be set in io.cozy.identities for legal reasons in Banks)
+     */
+    birthcity?: string;
+    /**
+     * - Country of birth of a contact (can be set in io.cozy.identities for legal reasons in Banks)
+     */
+    birthcountry?: string;
+    /**
+     * - Previous metadata information
+     */
+    metadata: ContactMetadata;
+};
+/**
+ * - An io.cozy.contacts document
+ */
+export type IOCozyContact = CozyClientDocument & ContactDocument;
 export type ClientError = {
     status?: string;
 };

--- a/packages/cozy-stack-client/src/ContactsCollection.js
+++ b/packages/cozy-stack-client/src/ContactsCollection.js
@@ -31,6 +31,28 @@ class ContactsCollection extends DocumentCollection {
     }
     return col
   }
+
+  /**
+   * Destroys a contact
+   *
+   * If the contact is linked to accounts, it will be trashed instead of being
+   * destroyed.
+   *
+   * @param  {object} contact - Contact to destroy. IT MUST BE THE FULL CONTACT OBJECT
+   * @returns {Promise} - Resolves when contact has been destroyed
+   */
+  async destroy(contact) {
+    const syncData = contact?.cozyMetadata?.sync || {}
+    const isLinkedToAccounts = Object.keys(syncData).length > 0
+    if (isLinkedToAccounts) {
+      return super.update({
+        ...contact,
+        trashed: true
+      })
+    } else {
+      return super.destroy(contact)
+    }
+  }
 }
 
 export const CONTACTS_DOCTYPE = 'io.cozy.contacts'

--- a/packages/cozy-stack-client/src/ContactsCollection.js
+++ b/packages/cozy-stack-client/src/ContactsCollection.js
@@ -1,4 +1,6 @@
 import DocumentCollection, { normalizeDoc } from './DocumentCollection'
+// @ts-ignore Need to import it to be used in jsdoc
+import { IOCozyContact } from 'cozy-client/dist/types'
 
 const normalizeMyselfResp = resp => {
   return {
@@ -38,8 +40,8 @@ class ContactsCollection extends DocumentCollection {
    * If the contact is linked to accounts, it will be trashed instead of being
    * destroyed.
    *
-   * @param  {object} contact - Contact to destroy. IT MUST BE THE FULL CONTACT OBJECT
-   * @returns {Promise} - Resolves when contact has been destroyed
+   * @param  {IOCozyContact} contact - Contact to destroy. IT MUST BE THE FULL CONTACT OBJECT
+   * @returns {Promise<{ data: IOCozyContact }>} - Resolves when contact has been destroyed
    */
   async destroy(contact) {
     const syncData = contact?.cozyMetadata?.sync || {}

--- a/packages/cozy-stack-client/src/ContactsCollection.spec.js
+++ b/packages/cozy-stack-client/src/ContactsCollection.spec.js
@@ -16,63 +16,66 @@ const stackMyselfResponse = {
 }
 
 describe('ContactsCollection', () => {
-  const setup = () => {
-    const stackClient = new CozyStackClient({})
-    stackClient.fetchJSON = jest
-      .fn()
-      .mockImplementation(async (method, route) => {
-        if (method === 'POST' && route === '/contacts/myself') {
-          return stackMyselfResponse
-        } else if (route.includes('_index')) {
-          return { result: 'exists' }
-        } else {
-          return { docs: [] }
-        }
-      })
-    const col = new ContactsCollection('io.cozy.contacts', stackClient)
-    return { stackClient, col }
-  }
-  beforeEach(() => {
-    jest.spyOn(console, 'warn').mockImplementation(() => {})
-  })
+  describe('find', () => {
+    const setup = () => {
+      const stackClient = new CozyStackClient({})
+      stackClient.fetchJSON = jest
+        .fn()
+        .mockImplementation(async (method, route) => {
+          if (method === 'POST' && route === '/contacts/myself') {
+            return stackMyselfResponse
+          } else if (route.includes('_index')) {
+            return { result: 'exists' }
+          } else {
+            return { docs: [] }
+          }
+        })
+      const col = new ContactsCollection('io.cozy.contacts', stackClient)
+      return { stackClient, col }
+    }
 
-  it('call find route if there is no selector', async () => {
-    const { col, stackClient } = setup()
-    await col.find()
-    expect(stackClient.fetchJSON).toHaveBeenCalledWith(
-      'POST',
-      '/data/io.cozy.contacts/_find',
-      expect.any(Object)
-    )
-  })
-
-  it('should use a special route for the myself contact', async () => {
-    const { col, stackClient } = setup()
-    const resp = await col.find({
-      me: true
+    beforeEach(() => {
+      jest.spyOn(console, 'warn').mockImplementation(() => {})
     })
-    expect(stackClient.fetchJSON).toHaveBeenCalledWith(
-      'POST',
-      '/contacts/myself'
-    )
-    expect(resp.data).toEqual([
-      expect.objectContaining({
-        _id: 'bf91cce0-ef48-0137-2638-543d7eb8149c',
-        id: 'bf91cce0-ef48-0137-2638-543d7eb8149c',
-        fullname: 'Alice'
-      })
-    ])
-  })
 
-  it('should not use a special route for other types of find', async () => {
-    const { col, stackClient } = setup()
-    await col.find({
-      name: 'Alice'
+    it('call find route if there is no selector', async () => {
+      const { col, stackClient } = setup()
+      await col.find()
+      expect(stackClient.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        '/data/io.cozy.contacts/_find',
+        expect.any(Object)
+      )
     })
-    expect(stackClient.fetchJSON).toHaveBeenCalledWith(
-      'POST',
-      '/data/io.cozy.contacts/_find',
-      expect.objectContaining({ selector: { name: 'Alice' } })
-    )
+
+    it('should use a special route for the myself contact', async () => {
+      const { col, stackClient } = setup()
+      const resp = await col.find({
+        me: true
+      })
+      expect(stackClient.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        '/contacts/myself'
+      )
+      expect(resp.data).toEqual([
+        expect.objectContaining({
+          _id: 'bf91cce0-ef48-0137-2638-543d7eb8149c',
+          id: 'bf91cce0-ef48-0137-2638-543d7eb8149c',
+          fullname: 'Alice'
+        })
+      ])
+    })
+
+    it('should not use a special route for other types of find', async () => {
+      const { col, stackClient } = setup()
+      await col.find({
+        name: 'Alice'
+      })
+      expect(stackClient.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        '/data/io.cozy.contacts/_find',
+        expect.objectContaining({ selector: { name: 'Alice' } })
+      )
+    })
   })
 })


### PR DESCRIPTION
Depending if a contact has been imported by a konnector or not, there is logic to delete a contact.

We need to delete a contact at least in :
- cozy-contacts
- cozy-keys-browser

So let's centralize this logic.

Original function : https://github.com/cozy/cozy-contacts/blob/5c5df4606b53133fd3b0b2bfffc9fdda48e5052c/src/connections/allContacts.js#L77