### PR TITLE
Remove deprecated Linking.removeEventListener

### DIFF
--- a/packages/cozy-client/src/authentication/mobile.native.js
+++ b/packages/cozy-client/src/authentication/mobile.native.js
@@ -24,6 +24,8 @@ const USER_CANCELED = 'USER_CANCELED'
 
 export const authenticateWithReactNativeInAppBrowser = async url => {
   return new Promise((resolve, reject) => {
+    let linkingSubscription = null
+
     InAppBrowser.open(url, {
       // iOS Properties
       readerMode: false,
@@ -53,9 +55,6 @@ export const authenticateWithReactNativeInAppBrowser = async url => {
         reject(USER_CANCELED)
       }
     })
-    const removeListener = () => {
-      Linking.removeEventListener('url', linkListener)
-    }
 
     const linkListener = ({ url }) => {
       let sanitizedUrl = url
@@ -79,14 +78,14 @@ export const authenticateWithReactNativeInAppBrowser = async url => {
           }
         }
         resolve(sanitizedUrl)
-        removeListener()
+        linkingSubscription.remove()
         InAppBrowser.close()
       } else if (closeSignal) {
         reject(USER_CANCELED)
       }
     }
 
-    Linking.addEventListener('url', linkListener)
+    linkingSubscription = Linking.addEventListener('url', linkListener)
   })
 }
 


### PR DESCRIPTION
_Road to RN0.72 on cozy-flagship-app_

Linking.removeEventListener has been removed from react-native 0.71. We need to call remove() on the subcription returned by Linking.addEventListener().

Still compatible with react-native 0.66.