### PR TITLE
fix: Metadata present but whose value is not specified must be returned in order to be modified in the Viewer

### DIFF
--- a/docs/api/cozy-client/modules/models.paper.md
+++ b/docs/api/cozy-client/modules/models.paper.md
@@ -22,7 +22,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:269](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L269)
+[packages/cozy-client/src/models/paper.js:271](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L271)
 
 ## Variables
 
@@ -146,7 +146,7 @@ Formatted and translated value of an array of contact
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:431](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L431)
+[packages/cozy-client/src/models/paper.js:433](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L433)
 
 ***
 
@@ -171,7 +171,7 @@ Formatted and translated value for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:315](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L315)
+[packages/cozy-client/src/models/paper.js:317](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L317)
 
 ***
 
@@ -197,7 +197,7 @@ Formatted and translated value for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:358](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L358)
+[packages/cozy-client/src/models/paper.js:360](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L360)
 
 ***
 
@@ -221,7 +221,7 @@ Formatted and translated value for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:238](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L238)
+[packages/cozy-client/src/models/paper.js:240](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L240)
 
 ***
 
@@ -246,7 +246,7 @@ Formatted and translated value for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:406](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L406)
+[packages/cozy-client/src/models/paper.js:408](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L408)
 
 ***
 
@@ -270,7 +270,7 @@ The type of the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:277](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L277)
+[packages/cozy-client/src/models/paper.js:279](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L279)
 
 ***
 
@@ -293,7 +293,7 @@ Translated name for contact
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:421](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L421)
+[packages/cozy-client/src/models/paper.js:423](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L423)
 
 ***
 
@@ -317,7 +317,7 @@ Translated name for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:302](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L302)
+[packages/cozy-client/src/models/paper.js:304](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L304)
 
 ***
 
@@ -342,7 +342,7 @@ Translated name for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:335](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L335)
+[packages/cozy-client/src/models/paper.js:337](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L337)
 
 ***
 
@@ -366,7 +366,7 @@ Translated name for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:393](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L393)
+[packages/cozy-client/src/models/paper.js:395](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L395)
 
 ***
 

--- a/packages/cozy-client/src/models/paper.js
+++ b/packages/cozy-client/src/models/paper.js
@@ -212,17 +212,19 @@ export const isExpiringSoon = file => {
 /**
  * @param {Object} params -
  * @param {Object} params.metadata - An io.cozy.files metadata object
- * @param {string} params.knownMetadataName - Name of the metadata
+ * @param {string} params.knownMetadataPath - Path of the metadata
  * @param {string | null} [params.value] - Value of the metadata
  * @returns {{ name: string, value: string | null }} displayable metadata
  */
-const makeMetadataQualification = ({ metadata, knownMetadataName, value }) => {
-  const _value = value || get(metadata, knownMetadataName, null)
-  const shouldReturnThisMetadata = !!_value
+const makeMetadataQualification = ({ metadata, knownMetadataPath, value }) => {
+  const _value = value || get(metadata, knownMetadataPath, null) || null
+  const shouldReturnThisMetadata = Object.keys(metadata).some(val =>
+    knownMetadataPath.startsWith(val)
+  )
 
-  if (shouldReturnThisMetadata || knownMetadataName === 'contact') {
+  if (shouldReturnThisMetadata || knownMetadataPath === 'contact') {
     return {
-      name: knownMetadataName,
+      name: knownMetadataPath,
       value: _value
     }
   }
@@ -237,7 +239,7 @@ const makeMetadataQualification = ({ metadata, knownMetadataName, value }) => {
  */
 export const formatMetadataQualification = metadata => {
   const dates = KNOWN_DATE_METADATA_NAMES.map(dateName =>
-    makeMetadataQualification({ metadata, knownMetadataName: dateName })
+    makeMetadataQualification({ metadata, knownMetadataPath: dateName })
   )
     .filter(Boolean)
     .filter((data, _, arr) => {
@@ -246,7 +248,7 @@ export const formatMetadataQualification = metadata => {
     })
 
   const informations = KNOWN_INFORMATION_METADATA_NAMES.map(infoName =>
-    makeMetadataQualification({ metadata, knownMetadataName: infoName })
+    makeMetadataQualification({ metadata, knownMetadataPath: infoName })
   ).filter(Boolean)
 
   const others = KNOWN_OTHER_METADATA_NAMES.map(otherName => {
@@ -257,7 +259,7 @@ export const formatMetadataQualification = metadata => {
 
     return makeMetadataQualification({
       metadata,
-      knownMetadataName: otherName,
+      knownMetadataPath: otherName,
       value
     })
   }).filter(Boolean)

--- a/packages/cozy-client/src/models/paper.spec.js
+++ b/packages/cozy-client/src/models/paper.spec.js
@@ -196,7 +196,8 @@ describe('Expiration', () => {
         datetime: '2029-12-10T23:00:00.000Z',
         qualification: { label: 'fake_label' },
         page: 'front',
-        contact: 'Alice Durand'
+        contact: 'Alice Durand',
+        noticePeriod: ''
       }
 
       const computedMetadata = [
@@ -210,6 +211,7 @@ describe('Expiration', () => {
         { name: 'shootingDate', value: '2029-12-08T23:00:00.000Z' },
         { name: 'date', value: '2029-12-09T23:00:00.000Z' },
         { name: 'number', value: '111111' },
+        { name: 'noticePeriod', value: null },
         { name: 'contact', value: 'Alice Durand' },
         { name: 'page', value: 'front' },
         { name: 'qualification', value: 'fake_label' }


### PR DESCRIPTION
related: c4c1545

A l'origine nous souhaitons que `makeMetadataQualification` retourne `null` si la clé de la metadata n'est pas connue (modulo autre check).
Les derniers changements, pour prendre en compte des attributs profonds, on changés ce comportement en retournant `null` si la valeur de cette metadata est "falsy"

Cette PR conserve le dernier besoin implémenté mais corrige la régression apportée.