### PR TITLE
feat: Add translation for MesPapiers app

### DIFF
--- a/packages/cozy-client/src/models/document/locales/en.json
+++ b/packages/cozy-client/src/models/document/locales/en.json
@@ -134,6 +134,14 @@
         "alternate": "Alternate",
         "internship": "Internship",
         "other": "Other"
+      },
+      "noticePeriod": {
+        "oneWeek": "1 week before",
+        "oneMonth": "1 month before",
+        "threeMonth": "3 months before",
+        "oneYear": "1 year before",
+        "custom": "Custom",
+        "noAlert": "Do not be alerted"
       }
     },
     "themes": {

--- a/packages/cozy-client/src/models/document/locales/fr.json
+++ b/packages/cozy-client/src/models/document/locales/fr.json
@@ -134,6 +134,14 @@
         "alternate": "Alternance",
         "internship": "Stage",
         "other": "Autre"
+      },
+      "noticePeriod": {
+        "oneWeek": "1 semaine avant",
+        "oneMonth": "1 mois avant",
+        "threeMonth": "3 mois avant",
+        "oneYear": "1 an avant",
+        "custom": "Personnalisé",
+        "noAlert": "Ne pas être alerté"
       }
     },
     "themes": {


### PR DESCRIPTION
When creating a paper, the UI of the step to define a "notice period" before being alerted of the expiration of its document changes.
Its translations were carried by the app, but with the new reworked UI coming from "contract types", the new translations make more sense here.