### PR TITLE
fix: Contact getInitials should  return initials even if name attributes are empty strings

### DIFF
--- a/docs/api/cozy-client/modules/models.contact.md
+++ b/docs/api/cozy-client/modules/models.contact.md
@@ -134,7 +134,7 @@ Returns the initials of the contact.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `contact` | `any` | A contact |
+| `contact` | `IOCozyContact` | A contact |
 
 *Returns*
 

--- a/packages/cozy-client/src/models/contact.js
+++ b/packages/cozy-client/src/models/contact.js
@@ -17,11 +17,11 @@ export const getPrimaryOrFirst = property => obj =>
 /**
  * Returns the initials of the contact.
  *
- * @param {object} contact - A contact
+ * @param {import('../types').IOCozyContact} contact - A contact
  * @returns {string} - the contact's initials
  */
 export const getInitials = contact => {
-  if (contact.name && !isEmpty(contact.name)) {
+  if (contact?.name?.givenName || contact?.name?.familyName) {
     return ['givenName', 'familyName']
       .map(part => get(contact, ['name', part, 0], ''))
       .join('')

--- a/packages/cozy-client/src/models/contact.spec.js
+++ b/packages/cozy-client/src/models/contact.spec.js
@@ -98,6 +98,23 @@ describe('getInitials', () => {
     expect(result).toEqual('A')
   })
 
+  it('should return the first letter of the primary email if contact has empty familyName and givenName', () => {
+    const contact = {
+      name: {
+        familyName: '',
+        givenName: ''
+      },
+      email: [
+        {
+          address: 'arya.stark@thenorth.westeros',
+          primary: true
+        }
+      ]
+    }
+    const result = getInitials(contact)
+    expect(result).toEqual('A')
+  })
+
   it('should return the first letter of the cozy domain if contact has empty name, an empty email but has a cozy url', () => {
     const contact = {
       name: {},

--- a/packages/cozy-client/types/models/contact.d.ts
+++ b/packages/cozy-client/types/models/contact.d.ts
@@ -1,6 +1,6 @@
 export const CONTACTS_DOCTYPE: "io.cozy.contacts";
 export function getPrimaryOrFirst(property: any): (obj: any) => any;
-export function getInitials(contact: object): string;
+export function getInitials(contact: import('../types').IOCozyContact): string;
 export function getPrimaryEmail(contact: object): string;
 export function getPrimaryCozy(contact: object): string;
 export function getPrimaryCozyDomain(contact: object): string;


### PR DESCRIPTION
When we create a new contact with only the email, it creates a contact object with `name: { familyName: '', givenName: '' }`.

So in this case getInitials was always returning an empty string whereas we want to return the first letter of the primary email.

@JF-Cozy @Merkur39 should we use maybe `displayName` to calculate initials ?