### PR TITLE
feat(models/paper): Add translation of "country" metadata

### DIFF
--- a/docs/api/cozy-client/modules/models.paper.md
+++ b/docs/api/cozy-client/modules/models.paper.md
@@ -12,7 +12,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:10](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L10)
+[packages/cozy-client/src/models/paper.js:11](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L11)
 
 ***
 
@@ -22,7 +22,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:273](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L273)
+[packages/cozy-client/src/models/paper.js:274](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L274)
 
 ## Variables
 
@@ -32,7 +32,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:23](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L23)
+[packages/cozy-client/src/models/paper.js:24](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L24)
 
 ***
 
@@ -42,7 +42,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:36](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L36)
+[packages/cozy-client/src/models/paper.js:37](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L37)
 
 ***
 
@@ -52,7 +52,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:48](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L48)
+[packages/cozy-client/src/models/paper.js:49](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L49)
 
 ## Functions
 
@@ -76,7 +76,7 @@ Expiration date
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:123](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L123)
+[packages/cozy-client/src/models/paper.js:124](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L124)
 
 ***
 
@@ -100,7 +100,7 @@ Expiration notice date
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:159](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L159)
+[packages/cozy-client/src/models/paper.js:160](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L160)
 
 ***
 
@@ -124,7 +124,7 @@ Expiration notice link
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:178](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L178)
+[packages/cozy-client/src/models/paper.js:179](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L179)
 
 ***
 
@@ -146,7 +146,7 @@ Formatted and translated value of an array of contact
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:435](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L435)
+[packages/cozy-client/src/models/paper.js:441](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L441)
 
 ***
 
@@ -171,7 +171,7 @@ Formatted and translated value for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:319](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L319)
+[packages/cozy-client/src/models/paper.js:320](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L320)
 
 ***
 
@@ -197,7 +197,7 @@ Formatted and translated value for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:362](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L362)
+[packages/cozy-client/src/models/paper.js:363](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L363)
 
 ***
 
@@ -221,7 +221,7 @@ Formatted and translated value for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:242](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L242)
+[packages/cozy-client/src/models/paper.js:243](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L243)
 
 ***
 
@@ -246,7 +246,7 @@ Formatted and translated value for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:410](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L410)
+[packages/cozy-client/src/models/paper.js:416](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L416)
 
 ***
 
@@ -270,7 +270,7 @@ The type of the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:281](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L281)
+[packages/cozy-client/src/models/paper.js:282](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L282)
 
 ***
 
@@ -293,7 +293,7 @@ Translated name for contact
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:425](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L425)
+[packages/cozy-client/src/models/paper.js:431](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L431)
 
 ***
 
@@ -317,7 +317,7 @@ Translated name for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:306](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L306)
+[packages/cozy-client/src/models/paper.js:307](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L307)
 
 ***
 
@@ -342,7 +342,7 @@ Translated name for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:339](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L339)
+[packages/cozy-client/src/models/paper.js:340](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L340)
 
 ***
 
@@ -366,7 +366,7 @@ Translated name for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:397](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L397)
+[packages/cozy-client/src/models/paper.js:403](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L403)
 
 ***
 
@@ -388,7 +388,7 @@ Translated name for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:190](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L190)
+[packages/cozy-client/src/models/paper.js:191](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L191)
 
 ***
 
@@ -410,7 +410,7 @@ Translated name for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:105](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L105)
+[packages/cozy-client/src/models/paper.js:106](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L106)
 
 ***
 
@@ -432,7 +432,7 @@ Translated name for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:202](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L202)
+[packages/cozy-client/src/models/paper.js:203](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L203)
 
 ***
 
@@ -454,7 +454,7 @@ Translated name for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:474](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L474)
+[packages/cozy-client/src/models/paper.js:480](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L480)
 
 ***
 
@@ -475,7 +475,7 @@ Translated name for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:446](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L446)
+[packages/cozy-client/src/models/paper.js:452](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L452)
 
 ***
 
@@ -497,4 +497,4 @@ Translated name for the metadata
 
 *Defined in*
 
-[packages/cozy-client/src/models/paper.js:458](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L458)
+[packages/cozy-client/src/models/paper.js:464](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/paper.js#L464)

--- a/packages/cozy-client/src/models/paper.js
+++ b/packages/cozy-client/src/models/paper.js
@@ -2,7 +2,8 @@ import add from 'date-fns/add'
 import sub from 'date-fns/sub'
 import formatDistanceToNowStrict from 'date-fns/formatDistanceToNowStrict'
 import fr from 'date-fns/locale/fr'
-import { getLocalizer } from './document/locales'
+import { getLocalizer as localizerDocument } from './document/locales'
+import { getLocalizer as localizerCountry } from './country/locales'
 import { getDisplayName } from './contact'
 import get from 'lodash/get'
 
@@ -304,7 +305,7 @@ export const getMetadataQualificationType = metadataName => {
  * @returns {string} Translated name for the metadata
  */
 export const getTranslatedNameForDateMetadata = (name, { lang }) => {
-  const t = getLocalizer(lang)
+  const t = localizerDocument(lang)
 
   return t(`Scan.qualification.date.title.${name}`)
 }
@@ -317,7 +318,7 @@ export const getTranslatedNameForDateMetadata = (name, { lang }) => {
  * @returns {string} Formatted and translated value for the metadata
  */
 export const formatDateMetadataValue = (value, { lang, f }) => {
-  const t = getLocalizer(lang)
+  const t = localizerDocument(lang)
 
   if (value) {
     if (lang === 'en') {
@@ -340,7 +341,7 @@ export const getTranslatedNameForInformationMetadata = (
   name,
   { lang, qualificationLabel }
 ) => {
-  const t = getLocalizer(lang)
+  const t = localizerDocument(lang)
 
   if (name === 'number') {
     return t(
@@ -363,19 +364,20 @@ export const formatInformationMetadataValue = (
   value,
   { lang, name, qualificationLabel }
 ) => {
-  const t = getLocalizer(lang)
+  const tDoc = localizerDocument(lang)
+  const tCountry = localizerCountry(lang)
 
   if (typeof value !== 'number' && !value) {
-    return t('Scan.qualification.noInfo')
+    return tDoc('Scan.qualification.noInfo')
   }
 
   if (name === 'noticePeriod') {
-    return `${value} ${t('Scan.qualification.information.day', {
+    return `${value} ${tDoc('Scan.qualification.information.day', {
       smart_count: value
     })}`
   }
   if (name === 'contractType') {
-    return t(`Scan.attributes.contractType.${value}`, { _: value })
+    return tDoc(`Scan.attributes.contractType.${value}`, { _: value })
   }
   if (
     name === 'refTaxIncome' ||
@@ -383,6 +385,10 @@ export const formatInformationMetadataValue = (
     (name === 'number' && qualificationLabel === 'pay_sheet')
   ) {
     return `${value} €`
+  }
+
+  if (name === 'country') {
+    return tCountry(`nationalities.${value}`)
   }
 
   return value
@@ -395,7 +401,7 @@ export const formatInformationMetadataValue = (
  * @returns {string} Translated name for the metadata
  */
 export const getTranslatedNameForOtherMetadata = (name, { lang }) => {
-  const t = getLocalizer(lang)
+  const t = localizerDocument(lang)
 
   return t(`Scan.qualification.${name}`)
 }
@@ -408,7 +414,7 @@ export const getTranslatedNameForOtherMetadata = (name, { lang }) => {
  * @returns {string} Formatted and translated value for the metadata
  */
 export const formatOtherMetadataValue = (value, { lang, name }) => {
-  const t = getLocalizer(lang)
+  const t = localizerDocument(lang)
 
   if (name === 'qualification') {
     return t(`Scan.items.${value}`, { smart_count: 1 })
@@ -423,7 +429,7 @@ export const formatOtherMetadataValue = (value, { lang, name }) => {
  * @returns {string} Translated name for contact
  */
 export const getTranslatedNameForContact = ({ lang }) => {
-  const t = getLocalizer(lang)
+  const t = localizerDocument(lang)
 
   return t('Scan.qualification.contact')
 }
@@ -444,7 +450,7 @@ export const formatContactValue = contacts => {
  * @returns {string}
  */
 export const makeExpiredMessage = ({ lang }) => {
-  const t = getLocalizer(lang)
+  const t = localizerDocument(lang)
 
   return t('Scan.expiration.expired')
 }
@@ -456,7 +462,7 @@ export const makeExpiredMessage = ({ lang }) => {
  * @returns {string}
  */
 export const makeExpiresInMessage = (expirationDate, { lang }) => {
-  const t = getLocalizer(lang)
+  const t = localizerDocument(lang)
 
   const distance = formatDistanceToNowStrict(new Date(expirationDate), {
     locale: lang === 'fr' ? fr : undefined // fallbacks to english if undefined
@@ -472,7 +478,7 @@ export const makeExpiresInMessage = (expirationDate, { lang }) => {
  * @returns {string}
  */
 export const makeExpirationDescription = (expirationDate, { lang }) => {
-  const t = getLocalizer(lang)
+  const t = localizerDocument(lang)
 
   const distance = formatDistanceToNowStrict(new Date(expirationDate), {
     locale: lang === 'fr' ? fr : undefined // fallbacks to english if undefined

--- a/packages/cozy-client/src/models/paper.spec.js
+++ b/packages/cozy-client/src/models/paper.spec.js
@@ -249,5 +249,14 @@ describe('Expiration', () => {
 
       expect(res).toEqual('metadataValue')
     })
+
+    it('should return nationality', () => {
+      const res = paperModel.formatInformationMetadataValue('FR', {
+        name: 'country',
+        lang: 'en'
+      })
+
+      expect(res).toEqual('French')
+    })
   })
 })


### PR DESCRIPTION
In order to return a more comprehensible value than the ISO 3166-1 alpha-2 code in the viewer information, among other things.