### PR TITLE
fix(models/document): Rename "stranger" locale

### DIFF
--- a/packages/cozy-client/src/models/document/locales/en.json
+++ b/packages/cozy-client/src/models/document/locales/en.json
@@ -1,6 +1,6 @@
 {
   "country": {
-    "stranger": "Stranger"
+    "foreign": "Foreign"
   },
   "Scan": {
     "scan_a_doc": "Scan a doc",

--- a/packages/cozy-client/src/models/document/locales/fr.json
+++ b/packages/cozy-client/src/models/document/locales/fr.json
@@ -1,6 +1,6 @@
 {
   "country": {
-    "stranger": "Étranger"
+    "foreign": "Étranger"
   },
   "Scan": {
     "scan_a_doc": "Numériser un doc",

--- a/packages/cozy-client/src/models/document/locales/index.js
+++ b/packages/cozy-client/src/models/document/locales/index.js
@@ -29,8 +29,8 @@ const getBoundT = lang => {
     const country = opts?.country
 
     const emojiCountry =
-      country !== 'stranger' ? getEmojiByCountry(country) : null
-    const strangerLabel = country === 'stranger' ? t('country.stranger') : null
+      country !== 'foreign' ? getEmojiByCountry(country) : null
+    const strangerLabel = country === 'foreign' ? t('country.foreign') : null
 
     return emojiCountry || strangerLabel
       ? `${t(label, newOpts)} ${emojiCountry || strangerLabel}`

--- a/packages/cozy-client/src/models/document/locales/index.spec.js
+++ b/packages/cozy-client/src/models/document/locales/index.spec.js
@@ -20,16 +20,16 @@ describe('getBoundT', () => {
   })
 
   it.each`
-    translationKey                   | country       | smart_count  | lang    | expected
-    ${'Scan.items.national_id_card'} | ${undefined}  | ${undefined} | ${'en'} | ${'ID card'}
-    ${'Scan.items.national_id_card'} | ${'fr'}       | ${undefined} | ${'en'} | ${'ID card 🇫🇷'}
-    ${'Scan.items.national_id_card'} | ${'stranger'} | ${undefined} | ${'en'} | ${'ID card Stranger'}
-    ${'Scan.items.national_id_card'} | ${'be'}       | ${1}         | ${'en'} | ${'ID card 🇧🇪'}
-    ${'Scan.items.national_id_card'} | ${'be'}       | ${2}         | ${'en'} | ${'ID cards 🇧🇪'}
-    ${'Scan.items.national_id_card'} | ${'fr'}       | ${1}         | ${'en'} | ${'ID card 🇫🇷'}
-    ${'Scan.items.national_id_card'} | ${'fr'}       | ${2}         | ${'en'} | ${'ID cards 🇫🇷'}
-    ${'Scan.items.national_id_card'} | ${undefined}  | ${1}         | ${'en'} | ${'ID card'}
-    ${'Scan.items.national_id_card'} | ${undefined}  | ${2}         | ${'en'} | ${'ID cards'}
+    translationKey                   | country      | smart_count  | lang    | expected
+    ${'Scan.items.national_id_card'} | ${undefined} | ${undefined} | ${'en'} | ${'ID card'}
+    ${'Scan.items.national_id_card'} | ${'fr'}      | ${undefined} | ${'en'} | ${'ID card 🇫🇷'}
+    ${'Scan.items.national_id_card'} | ${'foreign'} | ${undefined} | ${'en'} | ${'ID card Foreign'}
+    ${'Scan.items.national_id_card'} | ${'be'}      | ${1}         | ${'en'} | ${'ID card 🇧🇪'}
+    ${'Scan.items.national_id_card'} | ${'be'}      | ${2}         | ${'en'} | ${'ID cards 🇧🇪'}
+    ${'Scan.items.national_id_card'} | ${'fr'}      | ${1}         | ${'en'} | ${'ID card 🇫🇷'}
+    ${'Scan.items.national_id_card'} | ${'fr'}      | ${2}         | ${'en'} | ${'ID cards 🇫🇷'}
+    ${'Scan.items.national_id_card'} | ${undefined} | ${1}         | ${'en'} | ${'ID card'}
+    ${'Scan.items.national_id_card'} | ${undefined} | ${2}         | ${'en'} | ${'ID cards'}
   `(
     'should test if the translation is suitable with the param country: $country and with the param smart_count: $smart_count',
     ({ translationKey, country, smart_count, lang, expected }) => {


### PR DESCRIPTION
This term had been replaced in the MyPapers app but was forgotten here.
As a result, we've lost the ''(Foreign)'' display on papers such as the foreign driver's license, and this generates a lot of error logs.