### PR TITLE
feat: We make sure that the translation key matches to an alpha-2 code

### DIFF
--- a/packages/cozy-client/src/models/country/countries.js
+++ b/packages/cozy-client/src/models/country/countries.js
@@ -258,19 +258,55 @@ export const COUNTRIES_ISO = [
 ]
 
 /**
+ * Check if a country code translation is valid
+ *
+ * @param {string} lang - Language of country names and nationalities
+ * @param {string} val - Country code
+ * @returns {boolean} - True if the translation is valid, false otherwise
+ */
+export const isValidCountryCodeTranslation = (lang, val) => {
+  const { polyglot } = getLocalizer(lang)
+  return (
+    isCountryCodeAlpha2(val) &&
+    polyglot.has(`nationalities.${val}`) &&
+    polyglot.has(`countries.${val}`)
+  )
+}
+
+/**
+ * Check if a country code is an ISO 3166-1 alpha-3 code
+ *
+ * @param {string} code - The country code
+ * @returns {boolean} - True if the code is an ISO 3166-1 alpha-3 code, false otherwise
+ */
+export const isCountryCodeAlpha3 = code => {
+  if (!code) return false
+
+  const codeUpperCase = code.toUpperCase()
+  return COUNTRIES_ISO.some(c => c.code3 === codeUpperCase)
+}
+
+/**
+ * Check if a country code is an ISO 3166-1 alpha-2 code
+ *
+ * @param {string} code - The country code
+ * @returns {boolean} - True if the code is an ISO 3166-1 alpha-2 code, false otherwise
+ */
+export const isCountryCodeAlpha2 = code => {
+  if (!code) return false
+
+  const codeUpperCase = code.toUpperCase()
+  return COUNTRIES_ISO.some(c => c.code2 === codeUpperCase)
+}
+
+/**
  * Check if a country code is valid
  *
  * @param {string} code - The country code
  * @returns {boolean} - True if the code is valid, false otherwise
  */
 export const checkCountryCode = code => {
-  if (!code) return false
-  const codeUpperCase = code.toUpperCase()
-  const foundCountry = COUNTRIES_ISO.find(
-    country =>
-      country.code2 === codeUpperCase || country.code3 === codeUpperCase
-  )
-  return !!foundCountry
+  return isCountryCodeAlpha2(code) || isCountryCodeAlpha3(code)
 }
 
 /**
@@ -280,7 +316,7 @@ export const checkCountryCode = code => {
  * @returns {import('../../types').Country[]} - List of countries
  */
 export const getAllCountries = lang => {
-  const t = getLocalizer(lang)
+  const { t } = getLocalizer(lang)
 
   return COUNTRIES_ISO.map(country => ({
     code2: country.code2,

--- a/packages/cozy-client/src/models/country/countries.spec.js
+++ b/packages/cozy-client/src/models/country/countries.spec.js
@@ -4,7 +4,9 @@ import {
   getAllCountryNames,
   getAllNationalities,
   getCountryNameByCodeISO,
-  getEmojiByCountry
+  getEmojiByCountry,
+  isCountryCodeAlpha2,
+  isCountryCodeAlpha3
 } from './countries'
 import logger from '../../logger'
 
@@ -163,5 +165,39 @@ describe('getEmojiByCountry', () => {
 
     expect(logger.error).toHaveBeenCalledTimes(1)
     expect(res).toBe(null)
+  })
+})
+
+describe('isCountryCodeAlpha3', () => {
+  it('should return true for valid country codes', () => {
+    expect(isCountryCodeAlpha3('FRA')).toBe(true)
+    expect(isCountryCodeAlpha3('fra')).toBe(true)
+    expect(isCountryCodeAlpha3('USA')).toBe(true)
+    expect(isCountryCodeAlpha3('usa')).toBe(true)
+  })
+
+  it('should return false for invalid country codes', () => {
+    expect(isCountryCodeAlpha3(undefined)).toBe(false)
+    expect(isCountryCodeAlpha3(null)).toBe(false)
+    expect(isCountryCodeAlpha3('')).toBe(false)
+    expect(isCountryCodeAlpha3('AAA')).toBe(false)
+    expect(isCountryCodeAlpha3('FR')).toBe(false)
+  })
+})
+
+describe('isCountryCodeAlpha2', () => {
+  it('should return true for valid country codes', () => {
+    expect(isCountryCodeAlpha2('FR')).toBe(true)
+    expect(isCountryCodeAlpha2('fr')).toBe(true)
+    expect(isCountryCodeAlpha2('US')).toBe(true)
+    expect(isCountryCodeAlpha2('us')).toBe(true)
+  })
+
+  it('should return false for invalid country codes', () => {
+    expect(isCountryCodeAlpha2(undefined)).toBe(false)
+    expect(isCountryCodeAlpha2(null)).toBe(false)
+    expect(isCountryCodeAlpha2('')).toBe(false)
+    expect(isCountryCodeAlpha2('AA')).toBe(false)
+    expect(isCountryCodeAlpha2('FRA')).toBe(false)
   })
 })

--- a/packages/cozy-client/src/models/country/locales/index.js
+++ b/packages/cozy-client/src/models/country/locales/index.js
@@ -15,10 +15,10 @@ for (const lang of langs) {
 
 /**
  * @param {string} lang - fr, en, etc
- * @returns {Function} - localization function
+ * @returns {{ t: Function, polyglot: object, lang: string }}
  */
 export const getLocalizer = lang => {
   const polyglot = polyglots[lang] || polyglots['en']
   const t = polyglot.t.bind(polyglot)
-  return t
+  return { t, polyglot, lang }
 }

--- a/packages/cozy-client/src/models/paper.js
+++ b/packages/cozy-client/src/models/paper.js
@@ -6,7 +6,7 @@ import { getLocalizer as localizerDocument } from './document/locales'
 import { getLocalizer as localizerCountry } from './country/locales'
 import { getDisplayName } from './contact'
 import get from 'lodash/get'
-import { checkCountryCode } from './country/countries'
+import { isValidCountryCodeTranslation } from './country/countries'
 
 /**
  * @typedef {import("../types").IOCozyFile} IOCozyFile
@@ -366,7 +366,7 @@ export const formatInformationMetadataValue = (
   { lang, name, qualificationLabel }
 ) => {
   const tDoc = localizerDocument(lang)
-  const tCountry = localizerCountry(lang)
+  const { t: tCountry } = localizerCountry(lang)
 
   if (typeof value !== 'number' && !value) {
     return tDoc('Scan.qualification.noInfo')
@@ -388,7 +388,7 @@ export const formatInformationMetadataValue = (
     return `${value} €`
   }
 
-  if (name === 'country' && checkCountryCode(value)) {
+  if (name === 'country' && isValidCountryCodeTranslation(lang, value)) {
     return tCountry(`nationalities.${value}`)
   }
 

--- a/packages/cozy-client/types/models/country/countries.d.ts
+++ b/packages/cozy-client/types/models/country/countries.d.ts
@@ -5,6 +5,9 @@
  * @type {import('../../types').CountryISO[]}
  */
 export const COUNTRIES_ISO: import('../../types').CountryISO[];
+export function isValidCountryCodeTranslation(lang: string, val: string): boolean;
+export function isCountryCodeAlpha3(code: string): boolean;
+export function isCountryCodeAlpha2(code: string): boolean;
 export function checkCountryCode(code: string): boolean;
 export function getAllCountries(lang: string): import('../../types').Country[];
 export function getCountryNameByCodeISO(code: string | number, { lang }?: {

--- a/packages/cozy-client/types/models/country/locales/index.d.ts
+++ b/packages/cozy-client/types/models/country/locales/index.d.ts
@@ -1,1 +1,5 @@
-export function getLocalizer(lang: string): Function;
+export function getLocalizer(lang: string): {
+    t: Function;
+    polyglot: object;
+    lang: string;
+};


### PR DESCRIPTION
Via OCR, the value comes from a text field, and it can have values like "fra," "bob," "aa," etc.
These changes prevent any bad UI/UX behavior.