### PR TITLE
feat: Make CozyPouchLink compatible with ReactNative

### DIFF
--- a/docs/api/cozy-pouch-link/classes/PouchLink.md
+++ b/docs/api/cozy-pouch-link/classes/PouchLink.md
@@ -27,6 +27,7 @@ constructor - Initializes a new PouchLink
 | `opts` | `Object` | - |
 | `opts.doctypes` | `string`\[] | Doctypes to replicate |
 | `opts.doctypesReplicationOptions` | `any`\[] | A mapping from doctypes to replication options. All pouch replication options can be used, as well as the "strategy" option that determines which way the replication is done (can be "sync", "fromRemote" or "toRemote") |
+| `opts.platform` | `LinkPlatform` | Platform specific adapters and methods |
 | `opts.replicationInterval` | `number` | - |
 
 *Overrides*
@@ -35,7 +36,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:84](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L84)
+[CozyPouchLink.js:81](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L81)
 
 ## Properties
 
@@ -45,7 +46,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:132](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L132)
+[CozyPouchLink.js:134](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L134)
 
 ***
 
@@ -55,7 +56,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:94](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L94)
+[CozyPouchLink.js:91](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L91)
 
 ***
 
@@ -65,7 +66,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:95](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L95)
+[CozyPouchLink.js:92](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L92)
 
 ***
 
@@ -75,17 +76,17 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:96](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L96)
+[CozyPouchLink.js:93](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L93)
 
 ***
 
 ### options
 
-• **options**: { `replicationInterval`: `number`  } & { `doctypes`: `string`\[] ; `doctypesReplicationOptions`: `any`\[] ; `replicationInterval`: `number`  }
+• **options**: { `replicationInterval`: `number`  } & { `doctypes`: `string`\[] ; `doctypesReplicationOptions`: `any`\[] ; `platform`: `LinkPlatform` ; `replicationInterval`: `number`  }
 
 *Defined in*
 
-[CozyPouchLink.js:88](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L88)
+[CozyPouchLink.js:85](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L85)
 
 ***
 
@@ -95,7 +96,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:202](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L202)
+[CozyPouchLink.js:204](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L204)
 
 ***
 
@@ -106,6 +107,16 @@ CozyLink.constructor
 *Defined in*
 
 [CozyPouchLink.js:99](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L99)
+
+***
+
+### storage
+
+• **storage**: `PouchLocalStorage`
+
+*Defined in*
+
+[CozyPouchLink.js:94](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L94)
 
 ## Methods
 
@@ -125,7 +136,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:563](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L563)
+[CozyPouchLink.js:567](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L567)
 
 ***
 
@@ -145,7 +156,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:524](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L524)
+[CozyPouchLink.js:528](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L528)
 
 ***
 
@@ -166,7 +177,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:567](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L567)
+[CozyPouchLink.js:571](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L571)
 
 ***
 
@@ -186,7 +197,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:552](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L552)
+[CozyPouchLink.js:556](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L556)
 
 ***
 
@@ -207,7 +218,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:423](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L423)
+[CozyPouchLink.js:427](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L427)
 
 ***
 
@@ -229,7 +240,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:495](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L495)
+[CozyPouchLink.js:499](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L499)
 
 ***
 
@@ -249,7 +260,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:441](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L441)
+[CozyPouchLink.js:445](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L445)
 
 ***
 
@@ -269,7 +280,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:317](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L317)
+[CozyPouchLink.js:321](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L321)
 
 ***
 
@@ -289,7 +300,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:112](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L112)
+[CozyPouchLink.js:114](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L114)
 
 ***
 
@@ -309,7 +320,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:313](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L313)
+[CozyPouchLink.js:317](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L317)
 
 ***
 
@@ -329,7 +340,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:254](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L254)
+[CozyPouchLink.js:258](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L258)
 
 ***
 
@@ -349,7 +360,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:249](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L249)
+[CozyPouchLink.js:253](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L253)
 
 ***
 
@@ -375,7 +386,7 @@ Emits an event (pouchlink:sync:end) when the sync (all doctypes) is done
 
 *Defined in*
 
-[CozyPouchLink.js:235](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L235)
+[CozyPouchLink.js:239](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L239)
 
 ***
 
@@ -395,7 +406,7 @@ Emits an event (pouchlink:sync:end) when the sync (all doctypes) is done
 
 *Defined in*
 
-[CozyPouchLink.js:405](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L405)
+[CozyPouchLink.js:409](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L409)
 
 ***
 
@@ -416,7 +427,7 @@ Emits an event (pouchlink:sync:end) when the sync (all doctypes) is done
 
 *Defined in*
 
-[CozyPouchLink.js:410](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L410)
+[CozyPouchLink.js:414](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L414)
 
 ***
 
@@ -446,13 +457,13 @@ Migrate the current adapter
 
 *Defined in*
 
-[CozyPouchLink.js:146](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L146)
+[CozyPouchLink.js:148](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L148)
 
 ***
 
 ### needsToWaitWarmup
 
-▸ **needsToWaitWarmup**(`doctype`): `boolean`
+▸ **needsToWaitWarmup**(`doctype`): `Promise`<`boolean`>
 
 Check if there is warmup queries for this doctype
 and return if those queries are already warmed up or not
@@ -465,13 +476,13 @@ and return if those queries are already warmed up or not
 
 *Returns*
 
-`boolean`
+`Promise`<`boolean`>
 
 the need to wait for the warmup
 
 *Defined in*
 
-[CozyPouchLink.js:391](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L391)
+[CozyPouchLink.js:395](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L395)
 
 ***
 
@@ -485,7 +496,7 @@ the need to wait for the warmup
 
 *Defined in*
 
-[CozyPouchLink.js:165](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L165)
+[CozyPouchLink.js:167](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L167)
 
 ***
 
@@ -505,7 +516,7 @@ the need to wait for the warmup
 
 *Defined in*
 
-[CozyPouchLink.js:293](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L293)
+[CozyPouchLink.js:297](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L297)
 
 ***
 
@@ -525,13 +536,13 @@ the need to wait for the warmup
 
 *Defined in*
 
-[CozyPouchLink.js:131](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L131)
+[CozyPouchLink.js:133](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L133)
 
 ***
 
 ### request
 
-▸ **request**(`operation`, `result?`, `forward?`): `void` | `Promise`<`any`>
+▸ **request**(`operation`, `result?`, `forward?`): `Promise`<`any`>
 
 *Parameters*
 
@@ -543,7 +554,7 @@ the need to wait for the warmup
 
 *Returns*
 
-`void` | `Promise`<`any`>
+`Promise`<`any`>
 
 *Overrides*
 
@@ -551,7 +562,7 @@ CozyLink.request
 
 *Defined in*
 
-[CozyPouchLink.js:336](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L336)
+[CozyPouchLink.js:340](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L340)
 
 ***
 
@@ -565,7 +576,7 @@ CozyLink.request
 
 *Defined in*
 
-[CozyPouchLink.js:219](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L219)
+[CozyPouchLink.js:223](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L223)
 
 ***
 
@@ -584,7 +595,7 @@ Emits pouchlink:sync:start event when the replication begins
 
 *Defined in*
 
-[CozyPouchLink.js:268](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L268)
+[CozyPouchLink.js:272](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L272)
 
 ***
 
@@ -603,7 +614,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:285](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L285)
+[CozyPouchLink.js:289](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L289)
 
 ***
 
@@ -623,7 +634,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:321](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L321)
+[CozyPouchLink.js:325](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L325)
 
 ***
 
@@ -637,7 +648,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:589](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L589)
+[CozyPouchLink.js:593](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L593)
 
 ***
 
@@ -657,7 +668,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:529](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L529)
+[CozyPouchLink.js:533](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L533)
 
 ***
 
@@ -677,23 +688,29 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:534](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L534)
+[CozyPouchLink.js:538](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L538)
 
 ***
 
 ### getPouchAdapterName
 
-▸ `Static` **getPouchAdapterName**(): `string`
+▸ `Static` **getPouchAdapterName**(`localStorage`): `Promise`<`string`>
 
 Return the PouchDB adapter name.
 Should be IndexedDB for newest adapters.
 
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `localStorage` | `LocalStorage` | Methods to access local storage |
+
 *Returns*
 
-`string`
+`Promise`<`string`>
 
 The adapter name
 
 *Defined in*
 
-[CozyPouchLink.js:108](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L108)
+[CozyPouchLink.js:109](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L109)

--- a/packages/cozy-pouch-link/examples/periodic-sync/index.js
+++ b/packages/cozy-pouch-link/examples/periodic-sync/index.js
@@ -62,8 +62,9 @@ class App extends React.Component {
   }
 
   componentDidMount() {
-    this.createManager()
-    this.displayDocs()
+    this.createManager().then(() => {
+      this.displayDocs()
+    })
   }
 
   componentWillUnmount() {
@@ -83,7 +84,7 @@ class App extends React.Component {
     })
   }
 
-  createManager() {
+  async createManager() {
     this.manager = new PouchManager([DOCTYPE], {
       replicationDelay: 2 * 1000,
       getReplicationURL: this.getReplicationURL,
@@ -101,6 +102,7 @@ class App extends React.Component {
         this.displayDocs()
       }
     })
+    await this.manager.init()
   }
 
   async displayDocs() {

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -1,4 +1,3 @@
-import PouchDB from 'pouchdb-browser'
 import fromPairs from 'lodash/fromPairs'
 import forEach from 'lodash/forEach'
 import get from 'lodash/get'
@@ -40,16 +39,21 @@ class PouchManager {
     this.storage = new PouchLocalStorage(
       options.platform?.storage || platformWeb.storage
     )
+    this.PouchDB = options.platform?.pouchAdapter || platformWeb.pouchAdapter
   }
 
   async init() {
     const pouchPlugins = get(this.options, 'pouch.plugins', [])
     const pouchOptions = get(this.options, 'pouch.options', {})
 
+    forEach(pouchPlugins, plugin => this.PouchDB.plugin(plugin))
     this.pouches = fromPairs(
       this.doctypes.map(doctype => [
         doctype,
-        new PouchDB(getDatabaseName(this.options.prefix, doctype), pouchOptions)
+        new this.PouchDB(
+          getDatabaseName(this.options.prefix, doctype),
+          pouchOptions
+        )
       ])
     )
     this.syncedDoctypes = await this.storage.getPersistedSyncedDoctypes()

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -40,6 +40,7 @@ class PouchManager {
       options.platform?.storage || platformWeb.storage
     )
     this.PouchDB = options.platform?.pouchAdapter || platformWeb.pouchAdapter
+    this.isOnline = options.platform?.isOnline || platformWeb.isOnline
   }
 
   async init() {
@@ -174,7 +175,7 @@ class PouchManager {
 
   /** Starts replication */
   async replicateOnce() {
-    if (!window.navigator.onLine) {
+    if (!(await this.isOnline())) {
       logger.info(
         'PouchManager: The device is offline so the replication has been skipped'
       )

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -41,6 +41,7 @@ class PouchManager {
     )
     this.PouchDB = options.platform?.pouchAdapter || platformWeb.pouchAdapter
     this.isOnline = options.platform?.isOnline || platformWeb.isOnline
+    this.events = options.platform?.events || platformWeb.events
   }
 
   async init() {
@@ -77,11 +78,11 @@ class PouchManager {
   addListeners() {
     if (!this.listenerLaunched) {
       if (isMobileApp()) {
-        document.addEventListener('pause', this.stopReplicationLoop)
-        document.addEventListener('resume', this.startReplicationLoop)
+        this.events.addEventListener('pause', this.stopReplicationLoop)
+        this.events.addEventListener('resume', this.startReplicationLoop)
       }
-      document.addEventListener('online', this.startReplicationLoop)
-      document.addEventListener('offline', this.stopReplicationLoop)
+      this.events.addEventListener('online', this.startReplicationLoop)
+      this.events.addEventListener('offline', this.stopReplicationLoop)
       this.listenerLaunched = true
     }
   }
@@ -89,11 +90,11 @@ class PouchManager {
   removeListeners() {
     if (this.listenerLaunched) {
       if (isMobileApp()) {
-        document.removeEventListener('pause', this.stopReplicationLoop)
-        document.removeEventListener('resume', this.startReplicationLoop)
+        this.events.removeEventListener('pause', this.stopReplicationLoop)
+        this.events.removeEventListener('resume', this.startReplicationLoop)
       }
-      document.removeEventListener('online', this.startReplicationLoop)
-      document.removeEventListener('offline', this.stopReplicationLoop)
+      this.events.removeEventListener('online', this.startReplicationLoop)
+      this.events.removeEventListener('offline', this.stopReplicationLoop)
       this.listenerLaunched = false
     }
   }

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -10,9 +10,9 @@ import { isMobileApp } from 'cozy-device-helper'
 import { PouchLocalStorage } from './localStorage'
 import Loop from './loop'
 import logger from './logger'
+import { platformWeb } from './platformWeb'
 import { fetchRemoteLastSequence } from './remote'
 import { startReplication } from './startReplication'
-import * as localStorage from './localStorage'
 import { getDatabaseName } from './utils'
 
 const DEFAULT_DELAY = 30 * 1000
@@ -37,7 +37,9 @@ class PouchManager {
     this.options = options
     this.doctypes = doctypes
 
-    this.storage = new PouchLocalStorage()
+    this.storage = new PouchLocalStorage(
+      options.platform?.storage || platformWeb.storage
+    )
   }
 
   async init() {

--- a/packages/cozy-pouch-link/src/PouchManager.spec.js
+++ b/packages/cozy-pouch-link/src/PouchManager.spec.js
@@ -24,10 +24,11 @@ import {
   LOCALSTORAGE_WARMUPEDQUERIES_KEY,
   PouchLocalStorage
 } from './localStorage'
+import { platformWeb } from './platformWeb'
 
 import { fetchRemoteLastSequence, fetchRemoteInstance } from './remote'
 
-const ls = new PouchLocalStorage()
+const ls = new PouchLocalStorage(platformWeb.storage)
 
 const sleep = delay => {
   return new Promise(resolve => {

--- a/packages/cozy-pouch-link/src/localStorage.js
+++ b/packages/cozy-pouch-link/src/localStorage.js
@@ -7,182 +7,212 @@ export const LOCALSTORAGE_LASTREPLICATEDDOCID_KEY =
   'cozy-client-pouch-link-lastreplicateddocid'
 export const LOCALSTORAGE_ADAPTERNAME = 'cozy-client-pouch-link-adaptername'
 
-/**
- * Persist the last replicated doc id for a doctype
- *
- * @param {string} doctype - The replicated doctype
- * @param {string} id - The docid
- */
-export const persistLastReplicatedDocID = (doctype, id) => {
-  const docids = getAllLastReplicatedDocID()
-  docids[doctype] = id
+export class PouchLocalStorage {
+  /**
+   * Persist the last replicated doc id for a doctype
+   *
+   * @param {string} doctype - The replicated doctype
+   * @param {string} id - The docid
+   *
+   * @returns {Promise<void>}
+   */
+  async persistLastReplicatedDocID(doctype, id) {
+    const docids = await this.getAllLastReplicatedDocID()
+    docids[doctype] = id
 
-  window.localStorage.setItem(
-    LOCALSTORAGE_LASTREPLICATEDDOCID_KEY,
-    JSON.stringify(docids)
-  )
-}
-
-export const getAllLastReplicatedDocID = () => {
-  const item = window.localStorage.getItem(LOCALSTORAGE_LASTREPLICATEDDOCID_KEY)
-  return item ? JSON.parse(item) : {}
-}
-
-/**
- * Get the last replicated doc id for a doctype
- *
- * @param {string} doctype - The doctype
- * @returns {string} The last replicated docid
- */
-export const getLastReplicatedDocID = doctype => {
-  const docids = getAllLastSequences()
-  return docids[doctype]
-}
-
-/**
- * Destroy all the replicated doc id
- */
-export const destroyAllLastReplicatedDocID = () => {
-  window.localStorage.removeItem(LOCALSTORAGE_LASTREPLICATEDDOCID_KEY)
-}
-
-/**
- * Persist the synchronized doctypes
- *
- * @typedef {object} SyncInfo
- * @property {string} Date
- *
- * @param {Record<string, SyncInfo>} syncedDoctypes - The sync doctypes
- */
-export const persistSyncedDoctypes = syncedDoctypes => {
-  window.localStorage.setItem(
-    LOCALSTORAGE_SYNCED_KEY,
-    JSON.stringify(syncedDoctypes)
-  )
-}
-
-/**
- * Get the persisted doctypes
- *
- * @returns {object} The synced doctypes
- */
-export const getPersistedSyncedDoctypes = () => {
-  const item = window.localStorage.getItem(LOCALSTORAGE_SYNCED_KEY)
-  const parsed = item ? JSON.parse(item) : {}
-  if (typeof parsed !== 'object') {
-    return {}
+    await window.localStorage.setItem(
+      LOCALSTORAGE_LASTREPLICATEDDOCID_KEY,
+      JSON.stringify(docids)
+    )
   }
-  return parsed
-}
 
-/**
- * Destroy the synced doctypes
- *
- */
-export const destroySyncedDoctypes = () => {
-  window.localStorage.removeItem(LOCALSTORAGE_SYNCED_KEY)
-}
-
-/**
- * Persist the last CouchDB sequence for a synced doctype
- *
- * @param {string} doctype - The synced doctype
- * @param {string} sequence - The sequence hash
- */
-export const persistDoctypeLastSequence = (doctype, sequence) => {
-  const seqs = getAllLastSequences()
-  seqs[doctype] = sequence
-
-  window.localStorage.setItem(
-    LOCALSTORAGE_LASTSEQUENCES_KEY,
-    JSON.stringify(seqs)
-  )
-}
-
-export const getAllLastSequences = () => {
-  const item = window.localStorage.getItem(LOCALSTORAGE_LASTSEQUENCES_KEY)
-  return item ? JSON.parse(item) : {}
-}
-
-/**
- * Get the last CouchDB sequence for a doctype
- *
- * @param {string} doctype - The doctype
- * @returns {string} the last sequence
- */
-export const getDoctypeLastSequence = doctype => {
-  const seqs = getAllLastSequences()
-  return seqs[doctype]
-}
-
-/**
- * Destroy all the last sequence
- */
-export const destroyAllDoctypeLastSequence = () => {
-  window.localStorage.removeItem(LOCALSTORAGE_LASTSEQUENCES_KEY)
-}
-
-/**
- * Destroy the last sequence for a doctype
- *
- * @param {string} doctype - The doctype
- */
-export const destroyDoctypeLastSequence = doctype => {
-  const seqs = getAllLastSequences()
-  delete seqs[doctype]
-  window.localStorage.setItem(
-    LOCALSTORAGE_LASTSEQUENCES_KEY,
-    JSON.stringify(seqs)
-  )
-}
-
-/**
- * Persist the warmed up queries
- *
- * @param {object} warmedUpQueries - The warmedup queries
- */
-export const persistWarmedUpQueries = warmedUpQueries => {
-  window.localStorage.setItem(
-    LOCALSTORAGE_WARMUPEDQUERIES_KEY,
-    JSON.stringify(warmedUpQueries)
-  )
-}
-
-/**
- * Get the warmed up queries
- *
- * @returns {object} the warmed up queries
- */
-export const getPersistedWarmedUpQueries = () => {
-  const item = window.localStorage.getItem(LOCALSTORAGE_WARMUPEDQUERIES_KEY)
-  if (!item) {
-    return {}
+  /**
+   * @returns {Promise<Record<string, string>>}
+   */
+  async getAllLastReplicatedDocID() {
+    const item = await window.localStorage.getItem(
+      LOCALSTORAGE_LASTREPLICATEDDOCID_KEY
+    )
+    return item ? JSON.parse(item) : {}
   }
-  return JSON.parse(item)
-}
 
-/**
- * Destroy the warmed queries
- *
- */
-export const destroyWarmedUpQueries = () => {
-  window.localStorage.removeItem(LOCALSTORAGE_WARMUPEDQUERIES_KEY)
-}
+  /**
+   * Get the last replicated doc id for a doctype
+   *
+   * @param {string} doctype - The doctype
+   * @returns {Promise<string>} The last replicated docid
+   */
+  async getLastReplicatedDocID(doctype) {
+    const docids = await this.getAllLastSequences()
+    return docids[doctype]
+  }
 
-/**
- * Get the adapter name
- *
- * @returns {string} The adapter name
- */
-export const getAdapterName = () => {
-  return window.localStorage.getItem(LOCALSTORAGE_ADAPTERNAME)
-}
+  /**
+   * Destroy all the replicated doc id
+   *
+   * @returns {Promise<void>}
+   */
+  async destroyAllLastReplicatedDocID() {
+    await window.localStorage.removeItem(LOCALSTORAGE_LASTREPLICATEDDOCID_KEY)
+  }
 
-/**
- * Persist the adapter name
- *
- * @param {string} adapter - The adapter name
- */
-export const persistAdapterName = adapter => {
-  window.localStorage.setItem(LOCALSTORAGE_ADAPTERNAME, adapter)
+  /**
+   * Persist the synchronized doctypes
+   *
+   * @param {Record<string, import("./types").SyncInfo>} syncedDoctypes - The sync doctypes
+   *
+   * @returns {Promise<void>}
+   */
+  async persistSyncedDoctypes(syncedDoctypes) {
+    await window.localStorage.setItem(
+      LOCALSTORAGE_SYNCED_KEY,
+      JSON.stringify(syncedDoctypes)
+    )
+  }
+
+  /**
+   * Get the persisted doctypes
+   *
+   * @returns {Promise<object>} The synced doctypes
+   */
+  async getPersistedSyncedDoctypes() {
+    const item = await window.localStorage.getItem(LOCALSTORAGE_SYNCED_KEY)
+    const parsed = item ? JSON.parse(item) : {}
+    if (typeof parsed !== 'object') {
+      return {}
+    }
+    return parsed
+  }
+
+  /**
+   * Destroy the synced doctypes
+   *
+   * @returns {Promise<void>}
+   */
+  async destroySyncedDoctypes() {
+    await window.localStorage.removeItem(LOCALSTORAGE_SYNCED_KEY)
+  }
+
+  /**
+   * Persist the last CouchDB sequence for a synced doctype
+   *
+   * @param {string} doctype - The synced doctype
+   * @param {string} sequence - The sequence hash
+   *
+   * @returns {Promise<void>}
+   */
+  async persistDoctypeLastSequence(doctype, sequence) {
+    const seqs = await this.getAllLastSequences()
+    seqs[doctype] = sequence
+
+    await window.localStorage.setItem(
+      LOCALSTORAGE_LASTSEQUENCES_KEY,
+      JSON.stringify(seqs)
+    )
+  }
+
+  /**
+   * @returns {Promise<object>}
+   */
+  async getAllLastSequences() {
+    const item = await window.localStorage.getItem(
+      LOCALSTORAGE_LASTSEQUENCES_KEY
+    )
+    return item ? JSON.parse(item) : {}
+  }
+
+  /**
+   * Get the last CouchDB sequence for a doctype
+   *
+   * @param {string} doctype - The doctype
+   *
+   * @returns {Promise<string>} the last sequence
+   */
+  async getDoctypeLastSequence(doctype) {
+    const seqs = await this.getAllLastSequences()
+    return seqs[doctype]
+  }
+
+  /**
+   * Destroy all the last sequence
+   *
+   * @returns {Promise<void>}
+   */
+  async destroyAllDoctypeLastSequence() {
+    await window.localStorage.removeItem(LOCALSTORAGE_LASTSEQUENCES_KEY)
+  }
+
+  /**
+   * Destroy the last sequence for a doctype
+   *
+   * @param {string} doctype - The doctype
+   *
+   * @returns {Promise<void>}
+   */
+  async destroyDoctypeLastSequence(doctype) {
+    const seqs = await this.getAllLastSequences()
+    delete seqs[doctype]
+    await window.localStorage.setItem(
+      LOCALSTORAGE_LASTSEQUENCES_KEY,
+      JSON.stringify(seqs)
+    )
+  }
+
+  /**
+   * Persist the warmed up queries
+   *
+   * @param {object} warmedUpQueries - The warmedup queries
+   *
+   * @returns {Promise<void>}
+   */
+  async persistWarmedUpQueries(warmedUpQueries) {
+    await window.localStorage.setItem(
+      LOCALSTORAGE_WARMUPEDQUERIES_KEY,
+      JSON.stringify(warmedUpQueries)
+    )
+  }
+
+  /**
+   * Get the warmed up queries
+   *
+   * @returns {Promise<object>} the warmed up queries
+   */
+  async getPersistedWarmedUpQueries() {
+    const item = await window.localStorage.getItem(
+      LOCALSTORAGE_WARMUPEDQUERIES_KEY
+    )
+    if (!item) {
+      return {}
+    }
+    return JSON.parse(item)
+  }
+
+  /**
+   * Destroy the warmed queries
+   *
+   * @returns {Promise<void>}
+   */
+  async destroyWarmedUpQueries() {
+    await window.localStorage.removeItem(LOCALSTORAGE_WARMUPEDQUERIES_KEY)
+  }
+
+  /**
+   * Get the adapter name
+   *
+   * @returns {Promise<string>} The adapter name
+   */
+  async getAdapterName() {
+    return await window.localStorage.getItem(LOCALSTORAGE_ADAPTERNAME)
+  }
+
+  /**
+   * Persist the adapter name
+   *
+   * @param {string} adapter - The adapter name
+   *
+   * @returns {Promise<void>}
+   */
+  async persistAdapterName(adapter) {
+    await window.localStorage.setItem(LOCALSTORAGE_ADAPTERNAME, adapter)
+  }
 }

--- a/packages/cozy-pouch-link/src/localStorage.js
+++ b/packages/cozy-pouch-link/src/localStorage.js
@@ -8,6 +8,10 @@ export const LOCALSTORAGE_LASTREPLICATEDDOCID_KEY =
 export const LOCALSTORAGE_ADAPTERNAME = 'cozy-client-pouch-link-adaptername'
 
 export class PouchLocalStorage {
+  constructor(storageEngine) {
+    this.storageEngine = storageEngine
+  }
+
   /**
    * Persist the last replicated doc id for a doctype
    *
@@ -20,7 +24,7 @@ export class PouchLocalStorage {
     const docids = await this.getAllLastReplicatedDocID()
     docids[doctype] = id
 
-    await window.localStorage.setItem(
+    await this.storageEngine.setItem(
       LOCALSTORAGE_LASTREPLICATEDDOCID_KEY,
       JSON.stringify(docids)
     )
@@ -30,7 +34,7 @@ export class PouchLocalStorage {
    * @returns {Promise<Record<string, string>>}
    */
   async getAllLastReplicatedDocID() {
-    const item = await window.localStorage.getItem(
+    const item = await this.storageEngine.getItem(
       LOCALSTORAGE_LASTREPLICATEDDOCID_KEY
     )
     return item ? JSON.parse(item) : {}
@@ -53,7 +57,7 @@ export class PouchLocalStorage {
    * @returns {Promise<void>}
    */
   async destroyAllLastReplicatedDocID() {
-    await window.localStorage.removeItem(LOCALSTORAGE_LASTREPLICATEDDOCID_KEY)
+    await this.storageEngine.removeItem(LOCALSTORAGE_LASTREPLICATEDDOCID_KEY)
   }
 
   /**
@@ -64,7 +68,7 @@ export class PouchLocalStorage {
    * @returns {Promise<void>}
    */
   async persistSyncedDoctypes(syncedDoctypes) {
-    await window.localStorage.setItem(
+    await this.storageEngine.setItem(
       LOCALSTORAGE_SYNCED_KEY,
       JSON.stringify(syncedDoctypes)
     )
@@ -76,7 +80,7 @@ export class PouchLocalStorage {
    * @returns {Promise<object>} The synced doctypes
    */
   async getPersistedSyncedDoctypes() {
-    const item = await window.localStorage.getItem(LOCALSTORAGE_SYNCED_KEY)
+    const item = await this.storageEngine.getItem(LOCALSTORAGE_SYNCED_KEY)
     const parsed = item ? JSON.parse(item) : {}
     if (typeof parsed !== 'object') {
       return {}
@@ -90,7 +94,7 @@ export class PouchLocalStorage {
    * @returns {Promise<void>}
    */
   async destroySyncedDoctypes() {
-    await window.localStorage.removeItem(LOCALSTORAGE_SYNCED_KEY)
+    await this.storageEngine.removeItem(LOCALSTORAGE_SYNCED_KEY)
   }
 
   /**
@@ -105,7 +109,7 @@ export class PouchLocalStorage {
     const seqs = await this.getAllLastSequences()
     seqs[doctype] = sequence
 
-    await window.localStorage.setItem(
+    await this.storageEngine.setItem(
       LOCALSTORAGE_LASTSEQUENCES_KEY,
       JSON.stringify(seqs)
     )
@@ -115,7 +119,7 @@ export class PouchLocalStorage {
    * @returns {Promise<object>}
    */
   async getAllLastSequences() {
-    const item = await window.localStorage.getItem(
+    const item = await this.storageEngine.getItem(
       LOCALSTORAGE_LASTSEQUENCES_KEY
     )
     return item ? JSON.parse(item) : {}
@@ -139,7 +143,7 @@ export class PouchLocalStorage {
    * @returns {Promise<void>}
    */
   async destroyAllDoctypeLastSequence() {
-    await window.localStorage.removeItem(LOCALSTORAGE_LASTSEQUENCES_KEY)
+    await this.storageEngine.removeItem(LOCALSTORAGE_LASTSEQUENCES_KEY)
   }
 
   /**
@@ -152,7 +156,7 @@ export class PouchLocalStorage {
   async destroyDoctypeLastSequence(doctype) {
     const seqs = await this.getAllLastSequences()
     delete seqs[doctype]
-    await window.localStorage.setItem(
+    await this.storageEngine.setItem(
       LOCALSTORAGE_LASTSEQUENCES_KEY,
       JSON.stringify(seqs)
     )
@@ -166,7 +170,7 @@ export class PouchLocalStorage {
    * @returns {Promise<void>}
    */
   async persistWarmedUpQueries(warmedUpQueries) {
-    await window.localStorage.setItem(
+    await this.storageEngine.setItem(
       LOCALSTORAGE_WARMUPEDQUERIES_KEY,
       JSON.stringify(warmedUpQueries)
     )
@@ -178,7 +182,7 @@ export class PouchLocalStorage {
    * @returns {Promise<object>} the warmed up queries
    */
   async getPersistedWarmedUpQueries() {
-    const item = await window.localStorage.getItem(
+    const item = await this.storageEngine.getItem(
       LOCALSTORAGE_WARMUPEDQUERIES_KEY
     )
     if (!item) {
@@ -193,7 +197,7 @@ export class PouchLocalStorage {
    * @returns {Promise<void>}
    */
   async destroyWarmedUpQueries() {
-    await window.localStorage.removeItem(LOCALSTORAGE_WARMUPEDQUERIES_KEY)
+    await this.storageEngine.removeItem(LOCALSTORAGE_WARMUPEDQUERIES_KEY)
   }
 
   /**
@@ -202,7 +206,7 @@ export class PouchLocalStorage {
    * @returns {Promise<string>} The adapter name
    */
   async getAdapterName() {
-    return await window.localStorage.getItem(LOCALSTORAGE_ADAPTERNAME)
+    return await this.storageEngine.getItem(LOCALSTORAGE_ADAPTERNAME)
   }
 
   /**
@@ -213,6 +217,6 @@ export class PouchLocalStorage {
    * @returns {Promise<void>}
    */
   async persistAdapterName(adapter) {
-    await window.localStorage.setItem(LOCALSTORAGE_ADAPTERNAME, adapter)
+    await this.storageEngine.setItem(LOCALSTORAGE_ADAPTERNAME, adapter)
   }
 }

--- a/packages/cozy-pouch-link/src/platformWeb.js
+++ b/packages/cozy-pouch-link/src/platformWeb.js
@@ -1,3 +1,5 @@
+import PouchDB from 'pouchdb-browser'
+
 const storage = {
   getItem: async key => {
     return window.localStorage.getItem(key)
@@ -11,5 +13,6 @@ const storage = {
 }
 
 export const platformWeb = {
-  storage
+  storage,
+  pouchAdapter: PouchDB
 }

--- a/packages/cozy-pouch-link/src/platformWeb.js
+++ b/packages/cozy-pouch-link/src/platformWeb.js
@@ -1,5 +1,14 @@
 import PouchDB from 'pouchdb-browser'
 
+const events = {
+  addEventListener: (eventName, handler) => {
+    document.addEventListener(eventName, handler)
+  },
+  removeEventListener: (eventName, handler) => {
+    document.removeEventListener(eventName, handler)
+  }
+}
+
 const storage = {
   getItem: async key => {
     return window.localStorage.getItem(key)
@@ -18,6 +27,7 @@ const isOnline = async () => {
 
 export const platformWeb = {
   storage,
+  events,
   pouchAdapter: PouchDB,
   isOnline
 }

--- a/packages/cozy-pouch-link/src/platformWeb.js
+++ b/packages/cozy-pouch-link/src/platformWeb.js
@@ -1,0 +1,15 @@
+const storage = {
+  getItem: async key => {
+    return window.localStorage.getItem(key)
+  },
+  setItem: async (key, value) => {
+    return window.localStorage.setItem(key, value)
+  },
+  removeItem: async key => {
+    return window.localStorage.removeItem(key)
+  }
+}
+
+export const platformWeb = {
+  storage
+}

--- a/packages/cozy-pouch-link/src/platformWeb.js
+++ b/packages/cozy-pouch-link/src/platformWeb.js
@@ -12,7 +12,12 @@ const storage = {
   }
 }
 
+const isOnline = async () => {
+  return window.navigator.onLine
+}
+
 export const platformWeb = {
   storage,
-  pouchAdapter: PouchDB
+  pouchAdapter: PouchDB,
+  isOnline
 }

--- a/packages/cozy-pouch-link/src/startReplication.spec.js
+++ b/packages/cozy-pouch-link/src/startReplication.spec.js
@@ -1,12 +1,6 @@
 import { fetchRemoteLastSequence, fetchRemoteInstance } from './remote'
-import { getLastReplicatedDocID } from './localStorage'
 
 import { replicateAllDocs } from './startReplication'
-
-jest.mock('./localStorage', () => ({
-  getLastReplicatedDocID: jest.fn(),
-  persistLastReplicatedDocID: jest.fn()
-}))
 
 jest.mock('./remote', () => ({
   fetchRemoteLastSequence: jest.fn(),
@@ -27,22 +21,27 @@ const generateDocs = nDocs => {
   return docs
 }
 
+const storage = {
+  getLastReplicatedDocID: jest.fn(),
+  persistLastReplicatedDocID: jest.fn()
+}
+
 describe('replication through _all_docs', () => {
   beforeEach(() => {
     fetchRemoteLastSequence.mockResolvedValue('10-xyz')
   })
   it('should replicate all docs', async () => {
-    getLastReplicatedDocID.mockReturnValue(null)
+    storage.getLastReplicatedDocID.mockReturnValue(null)
     const dummyDocs = generateDocs(2)
     fetchRemoteInstance.mockResolvedValue({ rows: dummyDocs })
 
-    const rep = await replicateAllDocs(null, url)
+    const rep = await replicateAllDocs(null, url, undefined, storage)
     const expectedDocs = dummyDocs.map(doc => doc.doc)
     expect(rep).toEqual(expectedDocs)
   })
 
   it('should replicate all docs when it gets more docs than the batch limit', async () => {
-    getLastReplicatedDocID.mockReturnValue(null)
+    storage.getLastReplicatedDocID.mockReturnValue(null)
     const dummyDocs = generateDocs(1002)
     fetchRemoteInstance.mockResolvedValueOnce({
       rows: dummyDocs.slice(0, 1001)
@@ -51,17 +50,17 @@ describe('replication through _all_docs', () => {
       rows: dummyDocs.slice(1000, 1002)
     })
 
-    const rep = await replicateAllDocs(null, url)
+    const rep = await replicateAllDocs(null, url, undefined, storage)
     const expectedDocs = dummyDocs.map(doc => doc.doc)
     expect(rep).toEqual(expectedDocs)
   })
 
   it('should replicate from the last saved doc id', async () => {
-    getLastReplicatedDocID.mockReturnValue('5')
+    storage.getLastReplicatedDocID.mockReturnValue('5')
     const dummyDocs = generateDocs(10)
     fetchRemoteInstance.mockResolvedValue({ rows: dummyDocs.slice(5, 11) })
 
-    const rep = await replicateAllDocs(null, url)
+    const rep = await replicateAllDocs(null, url, undefined, storage)
 
     const calledUrl = new URL(`${url}/_all_docs`)
     expect(fetchRemoteInstance).toHaveBeenCalledWith(calledUrl, {

--- a/packages/cozy-pouch-link/src/types.js
+++ b/packages/cozy-pouch-link/src/types.js
@@ -25,6 +25,7 @@
 /**
  * @typedef {object} LinkPlatform
  * @property {LocalStorage} storage Methods to access local storage
+ * @property {any} pouchAdapter PouchDB class (can be pouchdb-core or pouchdb-browser)
  */
 
 export default {}

--- a/packages/cozy-pouch-link/src/types.js
+++ b/packages/cozy-pouch-link/src/types.js
@@ -15,4 +15,16 @@
  * @property {string} Date
  */
 
+/**
+ * @typedef {object} LocalStorage
+ * @property {function(string): Promise<string | null>} getItem
+ * @property {function(string, string): Promise<void>} setItem
+ * @property {function(string): Promise<void>} removeItem
+ */
+
+/**
+ * @typedef {object} LinkPlatform
+ * @property {LocalStorage} storage Methods to access local storage
+ */
+
 export default {}

--- a/packages/cozy-pouch-link/src/types.js
+++ b/packages/cozy-pouch-link/src/types.js
@@ -11,4 +11,8 @@
  * @typedef {CancelablePromise[] & Cancelable} CancelablePromises
  */
 
+/** @typedef {object} SyncInfo
+ * @property {string} Date
+ */
+
 export default {}

--- a/packages/cozy-pouch-link/src/types.js
+++ b/packages/cozy-pouch-link/src/types.js
@@ -26,6 +26,7 @@
  * @typedef {object} LinkPlatform
  * @property {LocalStorage} storage Methods to access local storage
  * @property {any} pouchAdapter PouchDB class (can be pouchdb-core or pouchdb-browser)
+ * @property {function(): Promise<boolean>} isOnline Method that check if the app is connected to internet
  */
 
 export default {}

--- a/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
+++ b/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
@@ -15,9 +15,10 @@ declare class PouchLink extends CozyLink {
      * Return the PouchDB adapter name.
      * Should be IndexedDB for newest adapters.
      *
-     * @returns {string} The adapter name
+     * @param {import('./types').LocalStorage} localStorage Methods to access local storage
+     * @returns {Promise<string>} The adapter name
      */
-    static getPouchAdapterName: () => string;
+    static getPouchAdapterName: (localStorage: import('./types').LocalStorage) => Promise<string>;
     /**
      * constructor - Initializes a new PouchLink
      *
@@ -25,11 +26,13 @@ declare class PouchLink extends CozyLink {
      * @param {number} [opts.replicationInterval] Milliseconds between replications
      * @param {string[]} opts.doctypes Doctypes to replicate
      * @param {object[]} opts.doctypesReplicationOptions A mapping from doctypes to replication options. All pouch replication options can be used, as well as the "strategy" option that determines which way the replication is done (can be "sync", "fromRemote" or "toRemote")
+     * @param {import('./types').LinkPlatform} opts.platform Platform specific adapters and methods
      */
     constructor(opts?: {
         replicationInterval: number;
         doctypes: string[];
         doctypesReplicationOptions: object[];
+        platform: import('./types').LinkPlatform;
     });
     options: {
         replicationInterval: number;
@@ -37,10 +40,12 @@ declare class PouchLink extends CozyLink {
         replicationInterval?: number;
         doctypes: string[];
         doctypesReplicationOptions: object[];
+        platform: import('./types').LinkPlatform;
     };
     doctypes: string[];
     doctypesReplicationOptions: any[];
     indexes: {};
+    storage: PouchLocalStorage;
     /** @type {Record<string, SyncStatus>} - Stores replication states per doctype */
     replicationStatus: Record<string, SyncStatus>;
     getReplicationURL(doctype: any): string;
@@ -118,9 +123,9 @@ declare class PouchLink extends CozyLink {
      * and return if those queries are already warmed up or not
      *
      * @param {string} doctype - Doctype to check
-     * @returns {boolean} the need to wait for the warmup
+     * @returns {Promise<boolean>} the need to wait for the warmup
      */
-    needsToWaitWarmup(doctype: string): boolean;
+    needsToWaitWarmup(doctype: string): Promise<boolean>;
     hasIndex(name: any): boolean;
     mergePartialIndexInSelector(selector: any, partialFilter: any): any;
     ensureIndex(doctype: any, query: any): Promise<any>;
@@ -158,4 +163,5 @@ declare class PouchLink extends CozyLink {
     syncImmediately(): Promise<void>;
 }
 import { CozyLink } from "cozy-client";
+import { PouchLocalStorage } from "./localStorage";
 import PouchManager from "./PouchManager";

--- a/packages/cozy-pouch-link/types/PouchManager.d.ts
+++ b/packages/cozy-pouch-link/types/PouchManager.d.ts
@@ -8,6 +8,12 @@ export default PouchManager;
 declare class PouchManager {
     constructor(doctypes: any, options: any);
     options: any;
+    doctypes: any;
+    storage: PouchLocalStorage;
+    PouchDB: any;
+    isOnline: any;
+    events: any;
+    init(): Promise<void>;
     pouches: import("lodash").Dictionary<any>;
     syncedDoctypes: any;
     warmedUpQueries: any;
@@ -52,13 +58,14 @@ declare class PouchManager {
     cancelCurrentReplications(): void;
     waitForCurrentReplications(): Promise<void> | Promise<any[]>;
     getPouch(doctype: any): any;
-    updateSyncInfo(doctype: any): void;
+    updateSyncInfo(doctype: any): Promise<void>;
     getSyncInfo(doctype: any): any;
     isSynced(doctype: any): boolean;
-    clearSyncedDoctypes(): void;
+    clearSyncedDoctypes(): Promise<void>;
     warmupQueries(doctype: any, queries: any): Promise<void>;
     checkToWarmupDoctype(doctype: any, replicationOptions: any): void;
-    areQueriesWarmedUp(doctype: any, queries: any): any;
-    clearWarmedUpQueries(): void;
+    areQueriesWarmedUp(doctype: any, queries: any): Promise<any>;
+    clearWarmedUpQueries(): Promise<void>;
 }
+import { PouchLocalStorage } from "./localStorage";
 import Loop from "./loop";

--- a/packages/cozy-pouch-link/types/localStorage.d.ts
+++ b/packages/cozy-pouch-link/types/localStorage.d.ts
@@ -3,26 +3,122 @@ export const LOCALSTORAGE_WARMUPEDQUERIES_KEY: "cozy-client-pouch-link-warmupedq
 export const LOCALSTORAGE_LASTSEQUENCES_KEY: "cozy-client-pouch-link-lastreplicationsequence";
 export const LOCALSTORAGE_LASTREPLICATEDDOCID_KEY: "cozy-client-pouch-link-lastreplicateddocid";
 export const LOCALSTORAGE_ADAPTERNAME: "cozy-client-pouch-link-adaptername";
-export function persistLastReplicatedDocID(doctype: string, id: string): void;
-export function getAllLastReplicatedDocID(): any;
-export function getLastReplicatedDocID(doctype: string): string;
-export function destroyAllLastReplicatedDocID(): void;
-export function persistSyncedDoctypes(syncedDoctypes: Record<string, SyncInfo>): void;
-export function getPersistedSyncedDoctypes(): object;
-export function destroySyncedDoctypes(): void;
-export function persistDoctypeLastSequence(doctype: string, sequence: string): void;
-export function getAllLastSequences(): any;
-export function getDoctypeLastSequence(doctype: string): string;
-export function destroyAllDoctypeLastSequence(): void;
-export function destroyDoctypeLastSequence(doctype: string): void;
-export function persistWarmedUpQueries(warmedUpQueries: object): void;
-export function getPersistedWarmedUpQueries(): object;
-export function destroyWarmedUpQueries(): void;
-export function getAdapterName(): string;
-export function persistAdapterName(adapter: string): void;
-/**
- * Persist the synchronized doctypes
- */
-export type SyncInfo = {
-    Date: string;
-};
+export class PouchLocalStorage {
+    constructor(storageEngine: any);
+    storageEngine: any;
+    /**
+     * Persist the last replicated doc id for a doctype
+     *
+     * @param {string} doctype - The replicated doctype
+     * @param {string} id - The docid
+     *
+     * @returns {Promise<void>}
+     */
+    persistLastReplicatedDocID(doctype: string, id: string): Promise<void>;
+    /**
+     * @returns {Promise<Record<string, string>>}
+     */
+    getAllLastReplicatedDocID(): Promise<Record<string, string>>;
+    /**
+     * Get the last replicated doc id for a doctype
+     *
+     * @param {string} doctype - The doctype
+     * @returns {Promise<string>} The last replicated docid
+     */
+    getLastReplicatedDocID(doctype: string): Promise<string>;
+    /**
+     * Destroy all the replicated doc id
+     *
+     * @returns {Promise<void>}
+     */
+    destroyAllLastReplicatedDocID(): Promise<void>;
+    /**
+     * Persist the synchronized doctypes
+     *
+     * @param {Record<string, import("./types").SyncInfo>} syncedDoctypes - The sync doctypes
+     *
+     * @returns {Promise<void>}
+     */
+    persistSyncedDoctypes(syncedDoctypes: Record<string, import("./types").SyncInfo>): Promise<void>;
+    /**
+     * Get the persisted doctypes
+     *
+     * @returns {Promise<object>} The synced doctypes
+     */
+    getPersistedSyncedDoctypes(): Promise<object>;
+    /**
+     * Destroy the synced doctypes
+     *
+     * @returns {Promise<void>}
+     */
+    destroySyncedDoctypes(): Promise<void>;
+    /**
+     * Persist the last CouchDB sequence for a synced doctype
+     *
+     * @param {string} doctype - The synced doctype
+     * @param {string} sequence - The sequence hash
+     *
+     * @returns {Promise<void>}
+     */
+    persistDoctypeLastSequence(doctype: string, sequence: string): Promise<void>;
+    /**
+     * @returns {Promise<object>}
+     */
+    getAllLastSequences(): Promise<object>;
+    /**
+     * Get the last CouchDB sequence for a doctype
+     *
+     * @param {string} doctype - The doctype
+     *
+     * @returns {Promise<string>} the last sequence
+     */
+    getDoctypeLastSequence(doctype: string): Promise<string>;
+    /**
+     * Destroy all the last sequence
+     *
+     * @returns {Promise<void>}
+     */
+    destroyAllDoctypeLastSequence(): Promise<void>;
+    /**
+     * Destroy the last sequence for a doctype
+     *
+     * @param {string} doctype - The doctype
+     *
+     * @returns {Promise<void>}
+     */
+    destroyDoctypeLastSequence(doctype: string): Promise<void>;
+    /**
+     * Persist the warmed up queries
+     *
+     * @param {object} warmedUpQueries - The warmedup queries
+     *
+     * @returns {Promise<void>}
+     */
+    persistWarmedUpQueries(warmedUpQueries: object): Promise<void>;
+    /**
+     * Get the warmed up queries
+     *
+     * @returns {Promise<object>} the warmed up queries
+     */
+    getPersistedWarmedUpQueries(): Promise<object>;
+    /**
+     * Destroy the warmed queries
+     *
+     * @returns {Promise<void>}
+     */
+    destroyWarmedUpQueries(): Promise<void>;
+    /**
+     * Get the adapter name
+     *
+     * @returns {Promise<string>} The adapter name
+     */
+    getAdapterName(): Promise<string>;
+    /**
+     * Persist the adapter name
+     *
+     * @param {string} adapter - The adapter name
+     *
+     * @returns {Promise<void>}
+     */
+    persistAdapterName(adapter: string): Promise<void>;
+}

--- a/packages/cozy-pouch-link/types/platformWeb.d.ts
+++ b/packages/cozy-pouch-link/types/platformWeb.d.ts
@@ -1,0 +1,17 @@
+export namespace platformWeb {
+    export { storage };
+    export { events };
+    export { PouchDB as pouchAdapter };
+    export { isOnline };
+}
+declare namespace storage {
+    function getItem(key: any): Promise<string>;
+    function setItem(key: any, value: any): Promise<void>;
+    function removeItem(key: any): Promise<void>;
+}
+declare namespace events {
+    function addEventListener(eventName: any, handler: any): void;
+    function removeEventListener(eventName: any, handler: any): void;
+}
+declare function isOnline(): Promise<boolean>;
+export {};

--- a/packages/cozy-pouch-link/types/startReplication.d.ts
+++ b/packages/cozy-pouch-link/types/startReplication.d.ts
@@ -3,5 +3,5 @@ export function startReplication(pouch: object, replicationOptions: {
     initialReplication: boolean;
     doctype: string;
     warmupQueries: import('cozy-client/types/types').Query[];
-}, getReplicationURL: Function): import('./types').CancelablePromise;
-export function replicateAllDocs(db: object, baseUrl: string, doctype: string): Promise<any[]>;
+}, getReplicationURL: Function, storage: import('./localStorage').PouchLocalStorage): import('./types').CancelablePromise;
+export function replicateAllDocs(db: object, baseUrl: string, doctype: string, storage: import('./localStorage').PouchLocalStorage): Promise<any[]>;

--- a/packages/cozy-pouch-link/types/types.d.ts
+++ b/packages/cozy-pouch-link/types/types.d.ts
@@ -8,3 +8,25 @@ export type Cancelable = {
 };
 export type CancelablePromise = Promise<any> & Cancelable;
 export type CancelablePromises = CancelablePromise[] & Cancelable;
+export type SyncInfo = {
+    Date: string;
+};
+export type LocalStorage = {
+    getItem: (arg0: string) => Promise<string | null>;
+    setItem: (arg0: string, arg1: string) => Promise<void>;
+    removeItem: (arg0: string) => Promise<void>;
+};
+export type LinkPlatform = {
+    /**
+     * Methods to access local storage
+     */
+    storage: LocalStorage;
+    /**
+     * PouchDB class (can be pouchdb-core or pouchdb-browser)
+     */
+    pouchAdapter: any;
+    /**
+     * Method that check if the app is connected to internet
+     */
+    isOnline: () => Promise<boolean>;
+};


### PR DESCRIPTION
We want to reduce coupling between CozyPouchLink and the browser's
local storage

This PR adds a `platform` option into the PouchLink constructor in
order to allow injecting custom local storage API, PouchDB adapter, an
isOnline method and a custom event emitter for online/offline and
pause/resume events from the consuming app

This will allow to use CozyPouchLink from a react-native project where
a different PouchDB adapter is used and where none of
`window.localStorage`, `window.navigator.onLine`,
`document.addEventListener` and `document.removeEventListener` API are
available

If no custom `platform` is injected, then `platformWeb.js` will be used
by default

In order to inject a custom `platform`, create a new platform object
containing the same API as `platformWeb.js` and add it into the
PouchLink constructor's `platform` option

```js
import { default as PouchLink } from 'cozy-pouch-link'

// Class based on `platformWeb.js`
import { CustomPlaftorm } from './CustomPlaftorm'

const pouchLink = new PouchLink({
  platform: new CustomPlaftorm()
})
```

___

### Related PRs:
- #1483
- #1486
- cozy/cozy-flagship-app#1209