### PR TITLE
[VO-874] feat: Improve index naming

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -83,10 +83,13 @@ Serves to dedupe equal queries requested at the same time</p>
 <dt><a href="#getIllegalCharacters">getIllegalCharacters</a> ⇒ <code>string</code></dt>
 <dd><p>Get the list of illegal characters in the file name</p>
 </dd>
+<dt><a href="#makeKeyFromPartialFilter">makeKeyFromPartialFilter</a> ⇒ <code>string</code></dt>
+<dd><p>Process a partial filter to generate a string key</p>
+</dd>
 <dt><a href="#getIndexNameFromFields">getIndexNameFromFields</a> ⇒ <code>string</code></dt>
 <dd><p>Name an index, based on its indexed fields and partial filter.</p>
 <p>It follows this naming convention:
-`by_{indexed_field1}<em>and</em>{indexed_field2}<em>filter</em>{partial_filter_field1}<em>and</em>{partial_filter_field2}</p>
+<code>by_{indexed_field1}_and_{indexed_field2}_filter_({partial_filter.key1}_{partial_filter.value1})_and_({partial_filter.key2}_{partial_filter.value2})</code></p>
 </dd>
 <dt><a href="#transformSort">transformSort</a> ⇒ <code><a href="#MangoSort">MangoSort</a></code></dt>
 <dd><p>Transform sort into Array</p>
@@ -2160,13 +2163,25 @@ Get the list of illegal characters in the file name
 | --- | --- | --- |
 | name | <code>string</code> | the file name |
 
+<a name="makeKeyFromPartialFilter"></a>
+
+## makeKeyFromPartialFilter ⇒ <code>string</code>
+Process a partial filter to generate a string key
+
+**Kind**: global constant  
+**Returns**: <code>string</code> - - The string key of the processed partial filter  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| condition | <code>object</code> | An object representing the partial filter or a sub-condition of the partial filter |
+
 <a name="getIndexNameFromFields"></a>
 
 ## getIndexNameFromFields ⇒ <code>string</code>
 Name an index, based on its indexed fields and partial filter.
 
 It follows this naming convention:
-`by_{indexed_field1}_and_{indexed_field2}_filter_{partial_filter_field1}_and_{partial_filter_field2}
+`by_{indexed_field1}_and_{indexed_field2}_filter_({partial_filter.key1}_{partial_filter.value1})_and_({partial_filter.key2}_{partial_filter.value2})`
 
 **Kind**: global constant  
 **Returns**: <code>string</code> - The index name, built from the fields  
@@ -2174,8 +2189,7 @@ It follows this naming convention:
 | Param | Type | Description |
 | --- | --- | --- |
 | fields | <code>Array.&lt;string&gt;</code> | The indexed fields |
-| params | <code>object</code> | The additional params |
-| [params.partialFilterFields] | <code>Array.&lt;string&gt;</code> | The partial filter fields |
+| [partialFilter] | <code>object</code> | The partial filter |
 
 <a name="transformSort"></a>
 

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -101,6 +101,9 @@ query to work</p>
 <dt><a href="#isMatchingIndex">isMatchingIndex</a> ⇒ <code>boolean</code></dt>
 <dd><p>Check if an index is matching the given fields</p>
 </dd>
+<dt><a href="#makeOperatorsExplicit">makeOperatorsExplicit</a> ⇒ <code>object</code></dt>
+<dd><p>Transform a query to make all operators explicit</p>
+</dd>
 <dt><a href="#getPermissionsFor">getPermissionsFor</a> ⇒ <code>object</code></dt>
 <dd><p>Build a permission set</p>
 </dd>
@@ -131,6 +134,10 @@ See <a href="https://docs.cozy.io/en/cozy-stack/sharing-design/#description-of-a
 <dt><a href="#getIconURL">getIconURL()</a></dt>
 <dd><p>Get Icon URL using blob mechanism if OAuth connected
 or using preloaded url when blob not needed</p>
+</dd>
+<dt><a href="#handleNorOperator">handleNorOperator(conditions)</a> ⇒ <code>Array</code></dt>
+<dd><p>Handle the $nor operator in a query
+CouchDB transforms $nor into $and with $ne operators</p>
 </dd>
 <dt><a href="#garbageCollect">garbageCollect()</a></dt>
 <dd><p>Delete outdated results from cache</p>
@@ -2224,6 +2231,19 @@ Check if an index is matching the given fields
 | fields | <code>Array</code> | The fields that the index must have |
 | partialFilter | <code>object</code> | An optional partial filter |
 
+<a name="makeOperatorsExplicit"></a>
+
+## makeOperatorsExplicit ⇒ <code>object</code>
+Transform a query to make all operators explicit
+
+**Kind**: global constant  
+**Returns**: <code>object</code> - - The transformed query with all operators explicit  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| query | <code>object</code> | The query to transform |
+| reverseEq | <code>boolean</code> | If true, $eq will be transformed to $ne (useful for manage $nor) |
+
 <a name="getPermissionsFor"></a>
 
 ## getPermissionsFor ⇒ <code>object</code>
@@ -2312,6 +2332,19 @@ Get Icon URL using blob mechanism if OAuth connected
 or using preloaded url when blob not needed
 
 **Kind**: global function  
+<a name="handleNorOperator"></a>
+
+## handleNorOperator(conditions) ⇒ <code>Array</code>
+Handle the $nor operator in a query
+CouchDB transforms $nor into $and with $ne operators
+
+**Kind**: global function  
+**Returns**: <code>Array</code> - - The reversed conditions  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| conditions | <code>Array</code> | The conditions inside the $nor operator |
+
 <a name="garbageCollect"></a>
 
 ## garbageCollect()

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -804,7 +804,7 @@ describe('DocumentCollection', () => {
         .mockResolvedValueOnce({ rows: [index] })
         .mockReturnValueOnce(
           Promise.resolve({
-            id: '_design/by_label_and_done_filter_trashed',
+            id: '_design/by_label_and_done_filter_(trashed_false)',
             ok: true,
             rev: '1-123'
           })
@@ -834,7 +834,7 @@ describe('DocumentCollection', () => {
         skip: 0,
         selector: { done: { $exists: true }, trashed: false },
         sort: [{ label: 'desc' }, { done: 'desc' }],
-        use_index: '_design/by_label_and_done_filter_trashed'
+        use_index: '_design/by_label_and_done_filter_(trashed_false)'
       }
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'POST',
@@ -851,7 +851,11 @@ describe('DocumentCollection', () => {
         'POST',
         '/data/io.cozy.todos/_design/123456/copy?rev=1-123',
         null,
-        { headers: { Destination: '_design/by_label_and_done_filter_trashed' } }
+        {
+          headers: {
+            Destination: '_design/by_label_and_done_filter_(trashed_false)'
+          }
+        }
       )
       expect(client.fetchJSON).toHaveBeenNthCalledWith(
         4,
@@ -1316,7 +1320,7 @@ describe('DocumentCollection', () => {
 
     beforeEach(() => {
       collection.findExistingIndex = jest.fn()
-      collection.migrateUnamedIndex = jest.fn()
+      collection.migrateIndex = jest.fn()
       collection.createIndex = jest.fn()
     })
 
@@ -1335,13 +1339,13 @@ describe('DocumentCollection', () => {
         _id: '123'
       }
       collection.findExistingIndex.mockResolvedValue(existingIndex)
-      collection.migrateUnamedIndex.mockResolvedValue({})
+      collection.migrateIndex.mockResolvedValue({})
 
       await collection.handleMissingIndex(selector, {
         indexedFields: undefined,
         sort: undefined
       })
-      expect(collection.migrateUnamedIndex).toHaveBeenCalledWith(
+      expect(collection.migrateIndex).toHaveBeenCalledWith(
         existingIndex,
         'by_message.account'
       )
@@ -1349,7 +1353,7 @@ describe('DocumentCollection', () => {
       await collection.handleMissingIndex(selector, {
         indexedFields: ['message.account']
       })
-      expect(collection.migrateUnamedIndex).toHaveBeenCalledWith(
+      expect(collection.migrateIndex).toHaveBeenCalledWith(
         existingIndex,
         'by_message.account'
       )
@@ -1470,7 +1474,9 @@ describe('DocumentCollection', () => {
         }
       }
       const opts = collection.toMangoOptions(selector, { partialFilter })
-      expect(opts.use_index).toEqual('_design/by_name_and_date_filter_trashed')
+      expect(opts.use_index).toEqual(
+        '_design/by_name_and_date_filter_(trashed_$ne_true)'
+      )
     })
 
     it('should merge selector and partialFilter', () => {


### PR DESCRIPTION
Index naming has two weaknesses: 
- it doesn't include partial index values

This can cause differences between the expected result and the result when modifying queries.

**An example of the new index name**: 

Query definition :
```js
Q('io.cozy.files')
  .where({
    type: 'file',
  })
  .partialIndex({
    class: {
      $or: ['image', 'pdf'] 
    }
    trashed: {
      $eq: false 
    }
  })
  .sortBy([
    { name: 'desc' }
  ])
```
Old index name : `_design/by_type_and_name_filter_class_and_trashed`
New index name : `_design/by_type_and_name_filter_(class_(image_$or_pdf))_and_(trashed_$eq_false)`