### PR TITLE
[VO-740] feat: Improve type of NextcloudFile

### DIFF
--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -482,6 +482,7 @@ import { QueryDefinition } from './queries/dsl'
  * @property {'file'|'directory'} type - Type of the file
  * @property {object} cozyMetadata - Mime of the file
  * @property {string} cozyMetadata.sourceAccount - Id of the io.cozy.account associated to the Nextcloud
+ * @property {{self: string}} links - Links to the file into nextcloud server
  */
 
 /**

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -912,6 +912,12 @@ export type NextcloudFile = {
     cozyMetadata: {
         sourceAccount: string;
     };
+    /**
+     * - Links to the file into nextcloud server
+     */
+    links: {
+        self: string;
+    };
 };
 /**
  * - An io.cozy.oauth.clients document


### PR DESCRIPTION
I chose not to use CozyClientDocument with NextcloudFile because the document is a bit special as it is a proxy to Nextcloud and therefore does not have all the fields filled.