### PR TITLE
[VO-740] feat: Add restore_path to NextcloudFile type

### DIFF
--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -479,6 +479,7 @@ import { QueryDefinition } from './queries/dsl'
  * @property {string} name - Name of the file
  * @property {string} path - Path to the file
  * @property {string} parentPath - Path to the folder containing the file
+ * @property {string} [restore_path] - Old path when the file is in the trash
  * @property {'file'|'directory'} type - Type of the file
  * @property {object} cozyMetadata - Mime of the file
  * @property {string} cozyMetadata.sourceAccount - Id of the io.cozy.account associated to the Nextcloud

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -903,6 +903,10 @@ export type NextcloudFile = {
      */
     parentPath: string;
     /**
+     * - Old path when the file is in the trash
+     */
+    restore_path?: string;
+    /**
      * - Type of the file
      */
     type: 'file' | 'directory';


### PR DESCRIPTION
This new property has been added to be able to reload destination folder query after a restore action.

**Related PRs :**
- https://github.com/cozy/cozy-stack/pull/4447