### PR TITLE
feat: Make Pouch replication work with react-native

### DIFF
--- a/docs/api/cozy-pouch-link/classes/PouchLink.md
+++ b/docs/api/cozy-pouch-link/classes/PouchLink.md
@@ -102,7 +102,7 @@ CozyLink.constructor
 
 ### replicationStatus
 
-• **replicationStatus**: `Record`<`string`, `SyncStatus`>
+• **replicationStatus**: `Record`<`string`, `ReplicationStatus`>
 
 *Defined in*
 

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -61,7 +61,7 @@ const normalizeAll = (docs, doctype) => {
 /**
  * @typedef {import('cozy-client/src/types').CozyClientDocument} CozyClientDocument
  *
- * @typedef {"idle"|"replicating"} SyncStatus
+ * @typedef {"idle"|"replicating"} ReplicationStatus
  */
 
 /**
@@ -97,7 +97,7 @@ class PouchLink extends CozyLink {
       options.platform?.storage || platformWeb.storage
     )
 
-    /** @type {Record<string, SyncStatus>} - Stores replication states per doctype */
+    /** @type {Record<string, ReplicationStatus>} - Stores replication states per doctype */
     this.replicationStatus = this.replicationStatus || {}
   }
 
@@ -352,7 +352,7 @@ class PouchLink extends CozyLink {
       return forward(operation)
     }
 
-    if (!this.pouches.isSynced(doctype)) {
+    if (this.pouches.getSyncStatus(doctype) === 'not_synced') {
       if (process.env.NODE_ENV !== 'production') {
         logger.info(
           `Tried to access local ${doctype} but Cozy Pouch is not synced yet. Forwarding the operation to next link`

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -120,7 +120,7 @@ describe('CozyPouchLink', () => {
           'io.cozy.files': { warmupQueries: [query1(), query2()] }
         }
       })
-      link.pouches.isSynced = jest.fn().mockReturnValue(true)
+      link.pouches.getSyncStatus = jest.fn().mockReturnValue('synced')
 
       const query = Q(TODO_DOCTYPE)
       expect.assertions(0)
@@ -174,7 +174,7 @@ describe('CozyPouchLink', () => {
           'io.cozy.todos': { strategy: 'fromRemote' }
         }
       })
-      link.pouches.isSynced = jest.fn().mockReturnValue(true)
+      link.pouches.getSyncStatus = jest.fn().mockReturnValue('synced')
       await link.request(
         {
           doctype: TODO_DOCTYPE,
@@ -194,7 +194,7 @@ describe('CozyPouchLink', () => {
           'io.cozy.todos': { strategy: 'fromRemote' }
         }
       })
-      link.pouches.isSynced = jest.fn().mockReturnValue(true)
+      link.pouches.getSyncStatus = jest.fn().mockReturnValue('synced')
       const mock = jest.fn()
       await link.request(Q(TODO_DOCTYPE), null, mock)
       expect(mock).not.toHaveBeenCalled()
@@ -210,7 +210,7 @@ describe('CozyPouchLink', () => {
     const docs = [TODO_1, TODO_2, TODO_3, TODO_4]
     it('should be able to execute a query', async () => {
       await setup()
-      link.pouches.isSynced = jest.fn().mockReturnValue(true)
+      link.pouches.getSyncStatus = jest.fn().mockReturnValue('synced')
       const db = link.getPouch(TODO_DOCTYPE)
       db.post({
         label: 'Make PouchDB link work',
@@ -223,7 +223,7 @@ describe('CozyPouchLink', () => {
 
     it('should be possible to query only one doc', async () => {
       await setup()
-      link.pouches.isSynced = jest.fn().mockReturnValue(true)
+      link.pouches.getSyncStatus = jest.fn().mockReturnValue('synced')
       const db = link.getPouch(TODO_DOCTYPE)
       db.post({
         _id: 'deadbeef',
@@ -238,7 +238,7 @@ describe('CozyPouchLink', () => {
     it('should be possible to explicitly index fields', async () => {
       find.mockReturnValue({ docs: [TODO_3, TODO_4] })
       await setup()
-      link.pouches.isSynced = jest.fn().mockReturnValue(true)
+      link.pouches.getSyncStatus = jest.fn().mockReturnValue('synced')
       const db = link.getPouch(TODO_DOCTYPE)
       await db.bulkDocs(docs.map(x => omit(x, '_type')))
       const query = Q(TODO_DOCTYPE)
@@ -253,7 +253,7 @@ describe('CozyPouchLink', () => {
     it('should be possible to query multiple docs', async () => {
       withoutDesignDocuments.mockReturnValue({ docs: [TODO_1, TODO_3] })
       await setup()
-      link.pouches.isSynced = jest.fn().mockReturnValue(true)
+      link.pouches.getSyncStatus = jest.fn().mockReturnValue('synced')
       const db = link.getPouch(TODO_DOCTYPE)
       await db.bulkDocs(docs.map(x => omit(x, '_type')))
       const ids = [TODO_1._id, TODO_3._id]
@@ -268,7 +268,7 @@ describe('CozyPouchLink', () => {
     it('should be possible to select', async () => {
       find.mockReturnValue({ docs: [TODO_3, TODO_4] })
       await setup()
-      link.pouches.isSynced = jest.fn().mockReturnValue(true)
+      link.pouches.getSyncStatus = jest.fn().mockReturnValue('synced')
       const db = link.getPouch(TODO_DOCTYPE)
       await db.bulkDocs(docs.map(x => omit(x, '_type')))
       const query = Q(TODO_DOCTYPE)
@@ -321,7 +321,7 @@ describe('CozyPouchLink', () => {
     it("should add _id in the selected fields since CozyClient' store needs it", async () => {
       find.mockReturnValue({ docs: [TODO_3, TODO_4] })
       await setup()
-      link.pouches.isSynced = jest.fn().mockReturnValue(true)
+      link.pouches.getSyncStatus = jest.fn().mockReturnValue('synced')
       const db = link.getPouch(TODO_DOCTYPE)
       await db.bulkDocs(docs.map(x => omit(x, '_type')))
       const query = Q(TODO_DOCTYPE)
@@ -342,7 +342,7 @@ describe('CozyPouchLink', () => {
   describe('mutations', () => {
     it('should be possible to save a new document', async () => {
       await setup()
-      link.pouches.isSynced = jest.fn().mockReturnValue(true)
+      link.pouches.getSyncStatus = jest.fn().mockReturnValue('synced')
       const { _id, ...NEW_TODO } = TODO_3
       const mutation = client.getDocumentSavePlan(NEW_TODO)
       const res = await link.request(mutation)
@@ -360,7 +360,7 @@ describe('CozyPouchLink', () => {
 
     it('should be possible to save multiple documents', async () => {
       await setup()
-      link.pouches.isSynced = jest.fn().mockReturnValue(true)
+      link.pouches.getSyncStatus = jest.fn().mockReturnValue('synced')
       const { _id, ...NEW_TODO } = TODO_3
       const res = await client.saveAll([TODO_3, TODO_4, NEW_TODO])
       expect(link.executeMutation).toHaveBeenCalled()
@@ -394,7 +394,7 @@ describe('CozyPouchLink', () => {
           { ok: true, id: '3', rev: '1-cffeebabe' }
         ]
       }
-      link.pouches.isSynced = jest.fn().mockReturnValue(true)
+      link.pouches.getSyncStatus = jest.fn().mockReturnValue('synced')
       const { _id, ...NEW_TODO } = TODO_3
       let err
       try {
@@ -412,7 +412,7 @@ describe('CozyPouchLink', () => {
 
     it('should be possible to update a document', async () => {
       await setup()
-      link.pouches.isSynced = jest.fn().mockReturnValue(true)
+      link.pouches.getSyncStatus = jest.fn().mockReturnValue('synced')
       const { _id, ...NEW_TODO } = TODO_3
       const saveMutation = client.getDocumentSavePlan(NEW_TODO)
       const saved = (await link.request(saveMutation)).data
@@ -584,7 +584,7 @@ describe('CozyPouchLink', () => {
     it('uses the default index, the one from the sort', async () => {
       spy = jest.spyOn(PouchDB.prototype, 'createIndex')
       await setup()
-      link.pouches.isSynced = jest.fn().mockReturnValue(true)
+      link.pouches.getSyncStatus = jest.fn().mockReturnValue('synced')
       const query = Q(TODO_DOCTYPE)
         .where({})
         .sortBy([{ name: 'asc' }])

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -8,7 +8,7 @@ import Loop from './loop'
 import logger from './logger'
 import { platformWeb } from './platformWeb'
 import { replicateOnce } from './replicateOnce'
-import { getDatabaseName } from './utils'
+import { formatAggregatedError, getDatabaseName } from './utils'
 
 const DEFAULT_DELAY = 30 * 1000
 
@@ -179,7 +179,15 @@ class PouchManager {
   }
 
   handleReplicationError(err) {
-    logger.warn('PouchManager: Error during replication', err)
+    let aggregatedMessage = ''
+    // @ts-ignore
+    // eslint-disable-next-line no-undef
+    if (err instanceof AggregateError) {
+      aggregatedMessage = formatAggregatedError(err)
+    }
+    logger.warn(
+      `PouchManager: Error during replication - ${err.message}${aggregatedMessage}`
+    )
     // On error, replication stops, it needs to be started
     // again manually by the owner of PouchManager
     this.stopReplicationLoop()

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -54,6 +54,7 @@ class PouchManager {
         )
       ])
     )
+    /** @type {Record<string, import('./types').SyncInfo>} - Stores synchronization info per doctype */
     this.syncedDoctypes = await this.storage.getPersistedSyncedDoctypes()
     this.warmedUpQueries = await this.storage.getPersistedWarmedUpQueries()
     this.getReplicationURL = this.options.getReplicationURL
@@ -217,18 +218,36 @@ class PouchManager {
     return this.pouches[doctype]
   }
 
-  async updateSyncInfo(doctype) {
-    this.syncedDoctypes[doctype] = { date: new Date().toISOString() }
+  /**
+   * Update the Sync info for the specifed doctype
+   *
+   * @param {string} doctype - The doctype to update
+   * @param {import('./types').SyncStatus} status - The new Sync status for the doctype
+   */
+  async updateSyncInfo(doctype, status = 'synced') {
+    this.syncedDoctypes[doctype] = { date: new Date().toISOString(), status }
     await this.storage.persistSyncedDoctypes(this.syncedDoctypes)
   }
 
+  /**
+   * Get the Sync info for the specified doctype
+   *
+   * @param {string} doctype - The doctype to check
+   * @returns {import('./types').SyncInfo}
+   */
   getSyncInfo(doctype) {
     return this.syncedDoctypes && this.syncedDoctypes[doctype]
   }
 
-  isSynced(doctype) {
+  /**
+   * Get the Sync status for the specified doctype
+   *
+   * @param {string} doctype - The doctype to check
+   * @returns {import('./types').SyncStatus}
+   */
+  getSyncStatus(doctype) {
     const info = this.getSyncInfo(doctype)
-    return info ? !!info.date : false
+    return info?.status || 'not_synced'
   }
 
   async clearSyncedDoctypes() {

--- a/packages/cozy-pouch-link/src/PouchManager.spec.js
+++ b/packages/cozy-pouch-link/src/PouchManager.spec.js
@@ -320,13 +320,16 @@ describe('PouchManager', () => {
       await manager.updateSyncInfo('io.cozy.todos')
       expect(localStorage.__STORE__[LOCALSTORAGE_SYNCED_KEY]).toEqual(
         JSON.stringify({
-          'io.cozy.todos': { date: '2021-08-01T00:00:00.000Z' }
+          'io.cozy.todos': {
+            date: '2021-08-01T00:00:00.000Z',
+            status: 'synced'
+          }
         })
       )
     })
   })
 
-  describe('isSynced', () => {
+  describe('getSyncStatus', () => {
     let manager
 
     beforeEach(async () => {
@@ -334,13 +337,18 @@ describe('PouchManager', () => {
       await manager.init()
     })
 
-    it('should return true if the doctype is synced', async () => {
+    it(`should return 'synced' if the doctype is synced`, async () => {
       await manager.updateSyncInfo('io.cozy.todos')
-      expect(manager.isSynced('io.cozy.todos')).toBe(true)
+      expect(manager.getSyncStatus('io.cozy.todos')).toBe('synced')
     })
 
-    it('should return false if the doctype is not synced', () => {
-      expect(manager.isSynced('io.cozy.todos')).toBe(false)
+    it(`should return 'not_synced' if the doctype is not synced`, () => {
+      expect(manager.getSyncStatus('io.cozy.todos')).toBe('not_synced')
+    })
+
+    it('should return status if updateSyncInfo was called with custom status', async () => {
+      await manager.updateSyncInfo('io.cozy.todos', 'not_complete')
+      expect(manager.getSyncStatus('io.cozy.todos')).toBe('not_complete')
     })
   })
 

--- a/packages/cozy-pouch-link/src/PouchManager.spec.js
+++ b/packages/cozy-pouch-link/src/PouchManager.spec.js
@@ -172,6 +172,9 @@ describe('PouchManager', () => {
     const writeOnlyPouch = manager.getPouch('io.cozy.writeonly')
     writeOnlyPouch.replicate = {}
     writeOnlyPouch.replicate.to = jest.fn()
+    manager.updateSyncInfo('io.cozy.todos')
+    manager.updateSyncInfo('io.cozy.readonly')
+    manager.updateSyncInfo('io.cozy.writeonly')
     manager.startReplicationLoop()
     await sleep(1000)
     expect(readOnlyPouch.replicate.from).toHaveBeenCalled()
@@ -224,6 +227,7 @@ describe('PouchManager', () => {
   it('should call on sync with doctype updates', async () => {
     jest.spyOn(manager, 'replicateOnce')
     onSync.mockReset()
+    manager.updateSyncInfo('io.cozy.todos')
     await manager.replicateOnce()
     expect(onSync).toHaveBeenCalledWith({
       'io.cozy.todos': [

--- a/packages/cozy-pouch-link/src/localStorage.js
+++ b/packages/cozy-pouch-link/src/localStorage.js
@@ -47,7 +47,7 @@ export class PouchLocalStorage {
    * @returns {Promise<string>} The last replicated docid
    */
   async getLastReplicatedDocID(doctype) {
-    const docids = await this.getAllLastSequences()
+    const docids = await this.getAllLastReplicatedDocID()
     return docids[doctype]
   }
 

--- a/packages/cozy-pouch-link/src/remote.js
+++ b/packages/cozy-pouch-link/src/remote.js
@@ -1,11 +1,15 @@
 import AccessToken from './AccessToken'
 
 export const DATABASE_NOT_FOUND_ERROR = 'Database does not exist'
+export const DATABASE_RESERVED_DOCTYPE_ERROR = 'Reserved doctype'
 
 export const isDatabaseNotFoundError = error => {
   return error.message === DATABASE_NOT_FOUND_ERROR
 }
 
+export const isDatabaseUnradableError = error => {
+  return error.message === DATABASE_RESERVED_DOCTYPE_ERROR
+}
 
 /**
  * Fetch remote instance
@@ -35,6 +39,10 @@ export const fetchRemoteInstance = async (url, params = {}) => {
 
   if (resp.status === 404) {
     throw new Error(DATABASE_NOT_FOUND_ERROR)
+  }
+
+  if (resp.status === 403 && data.error.includes('message=reserved doctype')) {
+    throw new Error(DATABASE_RESERVED_DOCTYPE_ERROR)
   }
 
   throw new Error(

--- a/packages/cozy-pouch-link/src/remote.js
+++ b/packages/cozy-pouch-link/src/remote.js
@@ -1,5 +1,12 @@
 import AccessToken from './AccessToken'
 
+export const DATABASE_NOT_FOUND_ERROR = 'Database does not exist'
+
+export const isDatabaseNotFoundError = error => {
+  return error.message === DATABASE_NOT_FOUND_ERROR
+}
+
+
 /**
  * Fetch remote instance
  *
@@ -25,7 +32,16 @@ export const fetchRemoteInstance = async (url, params = {}) => {
   if (resp.ok) {
     return data
   }
-  return null
+
+  if (resp.status === 404) {
+    throw new Error(DATABASE_NOT_FOUND_ERROR)
+  }
+
+  throw new Error(
+    `Error (${resp.status}) while fetching remote instance: ${JSON.stringify(
+      data
+    )}`
+  )
 }
 
 /**

--- a/packages/cozy-pouch-link/src/remote.spec.js
+++ b/packages/cozy-pouch-link/src/remote.spec.js
@@ -2,6 +2,7 @@ import { enableFetchMocks, disableFetchMocks } from 'jest-fetch-mock'
 
 import {
   DATABASE_NOT_FOUND_ERROR,
+  DATABASE_RESERVED_DOCTYPE_ERROR,
   fetchRemoteInstance,
   fetchRemoteLastSequence
 } from './remote'
@@ -141,6 +142,17 @@ describe('remote', () => {
       )
     })
 
+    it('Shoud throw dedicated error when Reserved Doctype error', async () => {
+      const remoteUrl =
+        'https://user:SOME_TOKEN@claude.mycozy.cloud/data/io.cozy.accounts'
+      mockDatabaseReservedDoctypeOn(
+        'https://claude.mycozy.cloud/data/io.cozy.accounts/_changes?limit=1&descending=true'
+      )
+
+      await expect(fetchRemoteLastSequence(remoteUrl)).rejects.toThrow(
+        DATABASE_RESERVED_DOCTYPE_ERROR
+      )
+    })
   })
 })
 
@@ -151,6 +163,19 @@ const mockDatabaseNotFoundOn = url => {
     reason: 'Database does not exist.',
     status: 404
   })
+}
+
+const mockDatabaseReservedDoctypeOn = url => {
+  fetch.mockOnceIf(
+    url,
+    JSON.stringify({
+      error: 'code=403, message=reserved doctype io.cozy.sharings unreadable'
+    }),
+    {
+      ok: false,
+      status: 403
+    }
+  )
 }
 
 const mockUnknownErrorOn = url => {

--- a/packages/cozy-pouch-link/src/remote.spec.js
+++ b/packages/cozy-pouch-link/src/remote.spec.js
@@ -1,0 +1,160 @@
+import { enableFetchMocks, disableFetchMocks } from 'jest-fetch-mock'
+
+import {
+  fetchRemoteInstance,
+  fetchRemoteLastSequence
+} from './remote'
+
+describe('remote', () => {
+  beforeAll(() => {
+    enableFetchMocks()
+  })
+
+  beforeEach(() => {
+    fetch.resetMocks()
+  })
+
+  afterAll(() => {
+    disableFetchMocks()
+  })
+
+  describe('fetchRemoteInstance', () => {
+    it(`Should add Authorization header based on URL's password`, async () => {
+      const remoteUrl =
+        'https://user:SOME_TOKEN@claude.mycozy.cloud/data/io.cozy.accounts/_changes'
+
+      mockDatabaseOn(
+        'https://claude.mycozy.cloud/data/io.cozy.accounts/_changes'
+      )
+
+      await fetchRemoteInstance(new URL(remoteUrl))
+
+      const expectedHeaders = new Headers()
+      expectedHeaders.append('Accept', 'application/json')
+      expectedHeaders.append('Content-Type', 'application/json')
+      expectedHeaders.append('Authorization', 'Bearer SOME_TOKEN')
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://claude.mycozy.cloud/data/io.cozy.accounts/_changes',
+        {
+          headers: expectedHeaders
+        }
+      )
+    })
+
+    it('Should return data when found', async () => {
+      const remoteUrl =
+        'https://user:SOME_TOKEN@claude.mycozy.cloud/data/io.cozy.accounts/_changes?limit=1&descending=true'
+      mockDatabaseOn(
+        'https://claude.mycozy.cloud/data/io.cozy.accounts/_changes?limit=1&descending=true'
+      )
+
+      const result = await fetchRemoteInstance(new URL(remoteUrl))
+
+      expect(result).toStrictEqual({
+        last_seq: '97-SOME_SEQ_VALUE',
+        pending: -1,
+        results: [
+          {
+            id: 'SOME_ID',
+            seq: '97-SOME_SEQ_VALUE',
+            doc: null,
+            changes: [{ rev: '3-SOME_REV' }]
+          }
+        ]
+      })
+    })
+
+    it('Should add parameters when given', async () => {
+      const remoteUrl =
+        'https://user:SOME_TOKEN@claude.mycozy.cloud/data/io.cozy.accounts/_changes'
+
+      mockDatabaseOn(
+        'https://claude.mycozy.cloud/data/io.cozy.accounts/_changes?limit=1&descending=true'
+      )
+
+      await fetchRemoteInstance(new URL(remoteUrl), {
+        limit: 1,
+        descending: true
+      })
+
+      const expectedHeaders = new Headers()
+      expectedHeaders.append('Accept', 'application/json')
+      expectedHeaders.append('Content-Type', 'application/json')
+      expectedHeaders.append('Authorization', 'Bearer SOME_TOKEN')
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://claude.mycozy.cloud/data/io.cozy.accounts/_changes?limit=1&descending=true',
+        expect.anything()
+      )
+    })
+
+    it('Should return null when 404 error', async () => {
+      const remoteUrl =
+        'https://user:SOME_TOKEN@claude.mycozy.cloud/data/io.cozy.accounts/_changes?limit=1&descending=true'
+
+      mockDatabaseNotFoundOn(
+        'https://claude.mycozy.cloud/data/io.cozy.accounts/_changes?limit=1&descending=true'
+      )
+
+      const result = await fetchRemoteInstance(new URL(remoteUrl))
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('fetchRemoteLastSequence', () => {
+    it('Should return data when found', async () => {
+      const remoteUrl =
+        'https://user:SOME_TOKEN@claude.mycozy.cloud/data/io.cozy.accounts'
+      mockDatabaseOn(
+        'https://claude.mycozy.cloud/data/io.cozy.accounts/_changes?limit=1&descending=true'
+      )
+
+      const result = await fetchRemoteLastSequence(remoteUrl)
+
+      expect(result).toBe('97-SOME_SEQ_VALUE')
+    })
+
+    it('Shoud throw when 404 error', async () => {
+      const remoteUrl =
+        'https://user:SOME_TOKEN@claude.mycozy.cloud/data/io.cozy.accounts'
+      mockDatabaseNotFoundOn(
+        'https://claude.mycozy.cloud/data/io.cozy.accounts/_changes?limit=1&descending=true'
+      )
+
+      await expect(fetchRemoteLastSequence(remoteUrl)).rejects.toThrow()
+    })
+  })
+})
+
+const mockDatabaseNotFoundOn = url => {
+  fetch.mockOnceIf(url, JSON.stringify({}), {
+    error: 'not_found',
+    ok: false,
+    reason: 'Database does not exist.',
+    status: 404
+  })
+}
+
+const mockDatabaseOn = url => {
+  fetch.mockOnceIf(
+    url,
+    JSON.stringify({
+      last_seq: '97-SOME_SEQ_VALUE',
+      pending: -1,
+      results: [
+        {
+          id: 'SOME_ID',
+          seq: '97-SOME_SEQ_VALUE',
+          doc: null,
+          changes: [{ rev: '3-SOME_REV' }]
+        }
+      ]
+    }),
+    {
+      ok: true,
+      status: 200
+    }
+  )
+}

--- a/packages/cozy-pouch-link/src/replicateOnce.js
+++ b/packages/cozy-pouch-link/src/replicateOnce.js
@@ -1,0 +1,105 @@
+import fromPairs from 'lodash/fromPairs'
+import get from 'lodash/get'
+import map from 'lodash/map'
+import startsWith from 'lodash/startsWith'
+import zip from 'lodash/zip'
+
+import logger from './logger'
+import { fetchRemoteLastSequence } from './remote'
+import { startReplication } from './startReplication'
+
+/**
+ * Process replication once for given PouchManager
+ *
+ * @param {import('./PouchManager').default} pouchManager - PouchManager that handle the replication
+ * @returns {Promise<any>} res
+ */
+export const replicateOnce = async pouchManager => {
+  if (!(await pouchManager.isOnline())) {
+    logger.info(
+      'PouchManager: The device is offline so the replication has been skipped'
+    )
+    return Promise.resolve()
+  }
+
+  logger.info('PouchManager: Starting replication iteration')
+
+  // Creating each replication
+  pouchManager.replications = map(
+    pouchManager.pouches,
+    async (pouch, doctype) => {
+      logger.info('PouchManager: Starting replication for ' + doctype)
+
+      const getReplicationURL = () => pouchManager.getReplicationURL(doctype)
+
+      const initialReplication = !pouchManager.isSynced(doctype)
+      const replicationFilter = doc => {
+        return !startsWith(doc._id, '_design')
+      }
+      let seq = ''
+      if (initialReplication) {
+        // Before the first replication, get the last remote sequence,
+        // which will be used as a checkpoint for the next replication
+        const lastSeq = await fetchRemoteLastSequence(getReplicationURL())
+        await pouchManager.storage.persistDoctypeLastSequence(doctype, lastSeq)
+      } else {
+        seq = await pouchManager.storage.getDoctypeLastSequence(doctype)
+      }
+
+      const replicationOptions = get(
+        pouchManager.doctypesReplicationOptions,
+        doctype,
+        {}
+      )
+      replicationOptions.initialReplication = initialReplication
+      replicationOptions.filter = replicationFilter
+      replicationOptions.since = seq
+      replicationOptions.doctype = doctype
+
+      if (pouchManager.options.onDoctypeSyncStart) {
+        pouchManager.options.onDoctypeSyncStart(doctype)
+      }
+      const res = await startReplication(
+        pouch,
+        replicationOptions,
+        getReplicationURL,
+        pouchManager.storage
+      )
+      if (seq) {
+        // We only need the sequence for the second replication, as PouchDB
+        // will use a local checkpoint for the next runs.
+        await pouchManager.storage.destroyDoctypeLastSequence(doctype)
+      }
+
+      await pouchManager.updateSyncInfo(doctype)
+      pouchManager.checkToWarmupDoctype(doctype, replicationOptions)
+      if (pouchManager.options.onDoctypeSyncEnd) {
+        pouchManager.options.onDoctypeSyncEnd(doctype)
+      }
+      return res
+    }
+  )
+
+  // Waiting on each replication
+  const doctypes = Object.keys(pouchManager.pouches)
+  const promises = Object.values(pouchManager.replications)
+  try {
+    const res = await Promise.all(promises)
+
+    if (process.env.NODE_ENV !== 'production') {
+      logger.info('PouchManager: Replication ended')
+    }
+
+    if (pouchManager.options.onSync) {
+      const doctypeUpdates = fromPairs(zip(doctypes, res))
+      pouchManager.options.onSync(doctypeUpdates)
+    }
+
+    // @ts-ignore
+    res.cancel = pouchManager.cancelCurrentReplications
+
+    return res
+  } catch (err) {
+    pouchManager.handleReplicationError(err)
+  }
+}

--- a/packages/cozy-pouch-link/src/replicateOnce.js
+++ b/packages/cozy-pouch-link/src/replicateOnce.js
@@ -5,7 +5,11 @@ import startsWith from 'lodash/startsWith'
 import zip from 'lodash/zip'
 
 import logger from './logger'
-import { fetchRemoteLastSequence, isDatabaseNotFoundError } from './remote'
+import {
+  fetchRemoteLastSequence,
+  isDatabaseNotFoundError,
+  isDatabaseUnradableError
+} from './remote'
 import { startReplication } from './startReplication'
 
 /**
@@ -104,7 +108,10 @@ export const replicateOnce = async pouchManager => {
         })
 
       const blockingErrors = res.filter(
-        r => r.status === 'rejected' && !isDatabaseNotFoundError(r.reason)
+        r =>
+          r.status === 'rejected' &&
+          !isDatabaseNotFoundError(r.reason) &&
+          !isDatabaseUnradableError(r.reason)
       )
 
       if (blockingErrors.length > 0) {

--- a/packages/cozy-pouch-link/src/startReplication.js
+++ b/packages/cozy-pouch-link/src/startReplication.js
@@ -69,7 +69,7 @@ export const startReplication = (
         }
       }
     }
-    let replication
+
     if (initialReplication && strategy !== 'toRemote') {
       ;(async () => {
         // For the first remote->local replication, we manually replicate all docs

--- a/packages/cozy-pouch-link/src/startReplication.js
+++ b/packages/cozy-pouch-link/src/startReplication.js
@@ -86,6 +86,7 @@ export const startReplication = (
         }
         return resolve(docs)
       })()
+      return
     }
     if (strategy === 'fromRemote') {
       replication = pouch.replicate.from(url, options)

--- a/packages/cozy-pouch-link/src/startReplication.spec.js
+++ b/packages/cozy-pouch-link/src/startReplication.spec.js
@@ -1,6 +1,7 @@
 import { fetchRemoteLastSequence, fetchRemoteInstance } from './remote'
 
 import { replicateAllDocs } from './startReplication'
+import { insertBulkDocs } from './helpers'
 
 jest.mock('./remote', () => ({
   fetchRemoteLastSequence: jest.fn(),
@@ -28,6 +29,7 @@ const storage = {
 
 describe('startReplication', () => {
   beforeEach(() => {
+    jest.resetAllMocks()
     fetchRemoteLastSequence.mockResolvedValue('10-xyz')
   })
 
@@ -40,6 +42,8 @@ describe('startReplication', () => {
       const rep = await replicateAllDocs(null, url, undefined, storage)
       const expectedDocs = dummyDocs.map(doc => doc.doc)
       expect(rep).toEqual(expectedDocs)
+      expect(fetchRemoteInstance).toHaveBeenCalledTimes(1)
+      expect(insertBulkDocs).toHaveBeenCalledTimes(1)
     })
 
     it('should replicate all docs when it gets more docs than the batch limit', async () => {
@@ -55,6 +59,8 @@ describe('startReplication', () => {
       const rep = await replicateAllDocs(null, url, undefined, storage)
       const expectedDocs = dummyDocs.map(doc => doc.doc)
       expect(rep).toEqual(expectedDocs)
+      expect(fetchRemoteInstance).toHaveBeenCalledTimes(2)
+      expect(insertBulkDocs).toHaveBeenCalledTimes(2)
     })
 
     it('should replicate from the last saved doc id', async () => {
@@ -70,6 +76,8 @@ describe('startReplication', () => {
         limit: 1000,
         startkey_docid: '5'
       })
+      expect(fetchRemoteInstance).toHaveBeenCalledTimes(1)
+      expect(insertBulkDocs).toHaveBeenCalledTimes(1)
       const expectedDocs = dummyDocs.map(doc => doc.doc).slice(6, 11)
       expect(rep).toEqual(expectedDocs)
     })

--- a/packages/cozy-pouch-link/src/startReplication.spec.js
+++ b/packages/cozy-pouch-link/src/startReplication.spec.js
@@ -327,6 +327,48 @@ describe('startReplication', () => {
         }
       ])
     })
+
+    it(`should allow to cancel promise when Pouch replication`, async () => {
+      const replicationOptions = getReplicationOptionsMock()
+      replicationOptions.initialReplication = false
+
+      const getReplicationURL = () =>
+        'https://user:SOME_TOKEN@claude.mycozy.cloud/data/io.cozy.files'
+
+      const pouch = getPouchMock()
+
+      const promise = startReplication(
+        pouch,
+        replicationOptions,
+        getReplicationURL,
+        storage
+      )
+
+      expect(promise.cancel).toBeDefined()
+
+      promise.cancel()
+
+      // this change should be ignored
+      mockReplicationOn.emit('change', {
+        change: {
+          docs: [
+            {
+              _id: 'SOME_DOCUMENT_ID_1',
+              some_property: 'some_value'
+            },
+            {
+              _id: 'SOME_DOCUMENT_ID_2',
+              some_property: 'some_value',
+              _deleted: true
+            }
+          ]
+        }
+      })
+
+      const result = await promise
+
+      expect(result).toStrictEqual([])
+    })
   })
 })
 

--- a/packages/cozy-pouch-link/src/startReplication.spec.js
+++ b/packages/cozy-pouch-link/src/startReplication.spec.js
@@ -26,49 +26,52 @@ const storage = {
   persistLastReplicatedDocID: jest.fn()
 }
 
-describe('replication through _all_docs', () => {
+describe('startReplication', () => {
   beforeEach(() => {
     fetchRemoteLastSequence.mockResolvedValue('10-xyz')
   })
-  it('should replicate all docs', async () => {
-    storage.getLastReplicatedDocID.mockReturnValue(null)
-    const dummyDocs = generateDocs(2)
-    fetchRemoteInstance.mockResolvedValue({ rows: dummyDocs })
 
-    const rep = await replicateAllDocs(null, url, undefined, storage)
-    const expectedDocs = dummyDocs.map(doc => doc.doc)
-    expect(rep).toEqual(expectedDocs)
-  })
+  describe('replication through _all_docs', () => {
+    it('should replicate all docs', async () => {
+      storage.getLastReplicatedDocID.mockReturnValue(null)
+      const dummyDocs = generateDocs(2)
+      fetchRemoteInstance.mockResolvedValue({ rows: dummyDocs })
 
-  it('should replicate all docs when it gets more docs than the batch limit', async () => {
-    storage.getLastReplicatedDocID.mockReturnValue(null)
-    const dummyDocs = generateDocs(1002)
-    fetchRemoteInstance.mockResolvedValueOnce({
-      rows: dummyDocs.slice(0, 1001)
-    })
-    fetchRemoteInstance.mockResolvedValueOnce({
-      rows: dummyDocs.slice(1000, 1002)
+      const rep = await replicateAllDocs(null, url, undefined, storage)
+      const expectedDocs = dummyDocs.map(doc => doc.doc)
+      expect(rep).toEqual(expectedDocs)
     })
 
-    const rep = await replicateAllDocs(null, url, undefined, storage)
-    const expectedDocs = dummyDocs.map(doc => doc.doc)
-    expect(rep).toEqual(expectedDocs)
-  })
+    it('should replicate all docs when it gets more docs than the batch limit', async () => {
+      storage.getLastReplicatedDocID.mockReturnValue(null)
+      const dummyDocs = generateDocs(1002)
+      fetchRemoteInstance.mockResolvedValueOnce({
+        rows: dummyDocs.slice(0, 1001)
+      })
+      fetchRemoteInstance.mockResolvedValueOnce({
+        rows: dummyDocs.slice(1000, 1002)
+      })
 
-  it('should replicate from the last saved doc id', async () => {
-    storage.getLastReplicatedDocID.mockReturnValue('5')
-    const dummyDocs = generateDocs(10)
-    fetchRemoteInstance.mockResolvedValue({ rows: dummyDocs.slice(5, 11) })
-
-    const rep = await replicateAllDocs(null, url, undefined, storage)
-
-    const calledUrl = new URL(`${url}/_all_docs`)
-    expect(fetchRemoteInstance).toHaveBeenCalledWith(calledUrl, {
-      include_docs: true,
-      limit: 1000,
-      startkey_docid: '5'
+      const rep = await replicateAllDocs(null, url, undefined, storage)
+      const expectedDocs = dummyDocs.map(doc => doc.doc)
+      expect(rep).toEqual(expectedDocs)
     })
-    const expectedDocs = dummyDocs.map(doc => doc.doc).slice(6, 11)
-    expect(rep).toEqual(expectedDocs)
+
+    it('should replicate from the last saved doc id', async () => {
+      storage.getLastReplicatedDocID.mockReturnValue('5')
+      const dummyDocs = generateDocs(10)
+      fetchRemoteInstance.mockResolvedValue({ rows: dummyDocs.slice(5, 11) })
+
+      const rep = await replicateAllDocs(null, url, undefined, storage)
+
+      const calledUrl = new URL(`${url}/_all_docs`)
+      expect(fetchRemoteInstance).toHaveBeenCalledWith(calledUrl, {
+        include_docs: true,
+        limit: 1000,
+        startkey_docid: '5'
+      })
+      const expectedDocs = dummyDocs.map(doc => doc.doc).slice(6, 11)
+      expect(rep).toEqual(expectedDocs)
+    })
   })
 })

--- a/packages/cozy-pouch-link/src/types.js
+++ b/packages/cozy-pouch-link/src/types.js
@@ -11,8 +11,14 @@
  * @typedef {CancelablePromise[] & Cancelable} CancelablePromises
  */
 
-/** @typedef {object} SyncInfo
- * @property {string} Date
+/**
+ * @typedef {"synced"|"not_synced"|"not_complete"} SyncStatus
+ */
+
+/**
+ * @typedef {object} SyncInfo
+ * @property {string} date - The date of the last synchronization
+ * @property {SyncStatus} status - The current synchronization status
  */
 
 /**

--- a/packages/cozy-pouch-link/src/utils.js
+++ b/packages/cozy-pouch-link/src/utils.js
@@ -19,3 +19,11 @@ export const getDatabaseName = (prefix, doctype) => {
 export const getPrefix = uri => {
   return uri.replace(/^https?:\/\//, '')
 }
+
+export const formatAggregatedError = aggregatedError => {
+  const strings = aggregatedError.errors.map((e, index) => {
+    return '\n[' + index + ']: ' + e.message + '\n' + e.stack
+  })
+
+  return strings.join('\n')
+}

--- a/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
+++ b/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
@@ -2,11 +2,11 @@ export function getReplicationURL(uri: any, token: any, doctype: any): string;
 export function isExpiredTokenError(pouchError: any): boolean;
 export default PouchLink;
 export type CozyClientDocument = any;
-export type SyncStatus = "idle" | "replicating";
+export type ReplicationStatus = "idle" | "replicating";
 /**
  * @typedef {import('cozy-client/src/types').CozyClientDocument} CozyClientDocument
  *
- * @typedef {"idle"|"replicating"} SyncStatus
+ * @typedef {"idle"|"replicating"} ReplicationStatus
  */
 /**
  * Link to be passed to a `CozyClient` instance to support CouchDB. It instantiates
@@ -49,8 +49,8 @@ declare class PouchLink extends CozyLink {
     doctypesReplicationOptions: any[];
     indexes: {};
     storage: PouchLocalStorage;
-    /** @type {Record<string, SyncStatus>} - Stores replication states per doctype */
-    replicationStatus: Record<string, SyncStatus>;
+    /** @type {Record<string, ReplicationStatus>} - Stores replication states per doctype */
+    replicationStatus: Record<string, ReplicationStatus>;
     getReplicationURL(doctype: any): string;
     registerClient(client: any): Promise<void>;
     client: any;
@@ -117,7 +117,7 @@ declare class PouchLink extends CozyLink {
      */
     public stopReplication(): void;
     onSyncError(error: any): Promise<void>;
-    getSyncInfo(doctype: any): any;
+    getSyncInfo(doctype: any): import("./types").SyncInfo;
     getPouch(doctype: any): any;
     supportsOperation(operation: any): boolean;
     /**

--- a/packages/cozy-pouch-link/types/PouchManager.d.ts
+++ b/packages/cozy-pouch-link/types/PouchManager.d.ts
@@ -15,7 +15,8 @@ declare class PouchManager {
     events: any;
     init(): Promise<void>;
     pouches: import("lodash").Dictionary<any>;
-    syncedDoctypes: any;
+    /** @type {Record<string, import('./types').SyncInfo>} - Stores synchronization info per doctype */
+    syncedDoctypes: Record<string, import('./types').SyncInfo>;
     warmedUpQueries: any;
     getReplicationURL: any;
     doctypesReplicationOptions: any;
@@ -30,8 +31,10 @@ declare class PouchManager {
     /** Stop periodic syncing of the pouches */
     stopReplicationLoop(): void;
     /** Starts replication */
-    replicateOnce(): Promise<void | import("./types").CancelablePromises>;
+    replicateOnce(): Promise<any>;
     executeQuery: any;
+    /** @type {import('./types').CancelablePromise[]} - Stores replication promises */
+    replications: import('./types').CancelablePromise[];
     addListeners(): void;
     removeListeners(): void;
     destroy(): Promise<any[]>;
@@ -48,19 +51,31 @@ declare class PouchManager {
      * immediately
      */
     syncImmediately(): void;
-    /**
-     * Creating each replication
-     *
-     * @type {import('./types').CancelablePromises}
-     */
-    replications: import('./types').CancelablePromises;
     handleReplicationError(err: any): void;
     cancelCurrentReplications(): void;
     waitForCurrentReplications(): Promise<void> | Promise<any[]>;
     getPouch(doctype: any): any;
-    updateSyncInfo(doctype: any): Promise<void>;
-    getSyncInfo(doctype: any): any;
-    isSynced(doctype: any): boolean;
+    /**
+     * Update the Sync info for the specifed doctype
+     *
+     * @param {string} doctype - The doctype to update
+     * @param {import('./types').SyncStatus} status - The new Sync status for the doctype
+     */
+    updateSyncInfo(doctype: string, status?: import('./types').SyncStatus): Promise<void>;
+    /**
+     * Get the Sync info for the specified doctype
+     *
+     * @param {string} doctype - The doctype to check
+     * @returns {import('./types').SyncInfo}
+     */
+    getSyncInfo(doctype: string): import('./types').SyncInfo;
+    /**
+     * Get the Sync status for the specified doctype
+     *
+     * @param {string} doctype - The doctype to check
+     * @returns {import('./types').SyncStatus}
+     */
+    getSyncStatus(doctype: string): import('./types').SyncStatus;
     clearSyncedDoctypes(): Promise<void>;
     warmupQueries(doctype: any, queries: any): Promise<void>;
     checkToWarmupDoctype(doctype: any, replicationOptions: any): void;

--- a/packages/cozy-pouch-link/types/remote.d.ts
+++ b/packages/cozy-pouch-link/types/remote.d.ts
@@ -1,2 +1,6 @@
+export const DATABASE_NOT_FOUND_ERROR: "Database does not exist";
+export const DATABASE_RESERVED_DOCTYPE_ERROR: "Reserved doctype";
+export function isDatabaseNotFoundError(error: any): boolean;
+export function isDatabaseUnradableError(error: any): boolean;
 export function fetchRemoteInstance(url: URL, params?: object): Promise<object>;
 export function fetchRemoteLastSequence(baseUrl: string): Promise<string>;

--- a/packages/cozy-pouch-link/types/replicateOnce.d.ts
+++ b/packages/cozy-pouch-link/types/replicateOnce.d.ts
@@ -1,0 +1,29 @@
+export function replicateOnce(pouchManager: import('./PouchManager').default): Promise<any>;
+export type FulfilledPromise = {
+    /**
+     * - The status of the promise
+     */
+    status: 'fulfilled';
+    /**
+     * - The Error rejected by the promise (undefined when fulfilled)
+     */
+    reason: undefined;
+    /**
+     * - The resolved value of the promise
+     */
+    value: any;
+};
+export type RejectedPromise = {
+    /**
+     * - The status of the promise
+     */
+    status: 'rejected';
+    /**
+     * - The Error rejected by the promise
+     */
+    reason: Error;
+    /**
+     * - The resolved value of the promise (undefined when rejected)
+     */
+    value: undefined;
+};

--- a/packages/cozy-pouch-link/types/types.d.ts
+++ b/packages/cozy-pouch-link/types/types.d.ts
@@ -8,8 +8,16 @@ export type Cancelable = {
 };
 export type CancelablePromise = Promise<any> & Cancelable;
 export type CancelablePromises = CancelablePromise[] & Cancelable;
+export type SyncStatus = "synced" | "not_synced" | "not_complete";
 export type SyncInfo = {
-    Date: string;
+    /**
+     * - The date of the last synchronization
+     */
+    date: string;
+    /**
+     * - The current synchronization status
+     */
+    status: SyncStatus;
 };
 export type LocalStorage = {
     getItem: (arg0: string) => Promise<string | null>;

--- a/packages/cozy-pouch-link/types/utils.d.ts
+++ b/packages/cozy-pouch-link/types/utils.d.ts
@@ -1,2 +1,3 @@
 export function getDatabaseName(prefix: string, doctype: string): string;
 export function getPrefix(uri: string): string;
+export function formatAggregatedError(aggregatedError: any): any;


### PR DESCRIPTION
In previous PRs we implemented react-native support for CozyPouchLink

Some of the doctypes we want to replicate may not always exist in remote database. This is the case for `io.cozy.accounts` that do not exist until the first konnector is configured. When this happens we want the replication process to be resilient and the react-native app to still serve data when offline

Some other doctypes are protected by the remote cozy-stack. When this is the case we still want to have a local Pouch to store cozy-stack answers and make them available offline. This is not a real replication but is considered as is in the code.

This PR adapts the Pouch replication process to those new needs and also make it more robust by fixing some historic bugs