### PR TITLE
feat: Implement FlagshipLink

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -16,6 +16,7 @@ cozy-client
 *   [CozyClient](classes/CozyClient.md)
 *   [CozyLink](classes/CozyLink.md)
 *   [CozyProvider](classes/CozyProvider.md)
+*   [FlagshipLink](classes/FlagshipLink.md)
 *   [HasMany](classes/HasMany.md)
 *   [HasManyInPlace](classes/HasManyInPlace.md)
 *   [HasManyTriggers](classes/HasManyTriggers.md)

--- a/docs/api/cozy-client/classes/CozyLink.md
+++ b/docs/api/cozy-client/classes/CozyLink.md
@@ -8,6 +8,8 @@
 
     ↳ [`StackLink`](StackLink.md)
 
+    ↳ [`FlagshipLink`](FlagshipLink.md)
+
 ## Constructors
 
 ### constructor

--- a/docs/api/cozy-client/classes/FlagshipLink.md
+++ b/docs/api/cozy-client/classes/FlagshipLink.md
@@ -1,0 +1,137 @@
+[cozy-client](../README.md) / FlagshipLink
+
+# Class: FlagshipLink
+
+## Hierarchy
+
+*   [`CozyLink`](CozyLink.md)
+
+    ↳ **`FlagshipLink`**
+
+## Constructors
+
+### constructor
+
+• **new FlagshipLink**(`[options]?`)
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `[options]` | `Object` | Options |
+| `[options].client` | `any` | - |
+| `[options].stackClient` | `any` | - |
+| `[options].webviewIntent` | `WebviewService` | - |
+
+*Overrides*
+
+[CozyLink](CozyLink.md).[constructor](CozyLink.md#constructor)
+
+*Defined in*
+
+[packages/cozy-client/src/FlagshipLink.js:11](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/FlagshipLink.js#L11)
+
+## Properties
+
+### stackClient
+
+• **stackClient**: `any`
+
+*Defined in*
+
+[packages/cozy-client/src/FlagshipLink.js:18](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/FlagshipLink.js#L18)
+
+***
+
+### webviewIntent
+
+• **webviewIntent**: `WebviewService`
+
+*Defined in*
+
+[packages/cozy-client/src/FlagshipLink.js:19](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/FlagshipLink.js#L19)
+
+## Methods
+
+### persistData
+
+▸ **persistData**(`data`, `forward`): `Promise`<`void`>
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `any` |
+| `forward` | `any` |
+
+*Returns*
+
+`Promise`<`void`>
+
+*Overrides*
+
+[CozyLink](CozyLink.md).[persistData](CozyLink.md#persistdata)
+
+*Defined in*
+
+[packages/cozy-client/src/FlagshipLink.js:34](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/FlagshipLink.js#L34)
+
+***
+
+### registerClient
+
+▸ **registerClient**(`client`): `void`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `client` | `any` |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/FlagshipLink.js:22](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/FlagshipLink.js#L22)
+
+***
+
+### request
+
+▸ **request**(`operation`, `result`, `forward`): `Promise`<`boolean`>
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `operation` | `any` |
+| `result` | `any` |
+| `forward` | `any` |
+
+*Returns*
+
+`Promise`<`boolean`>
+
+*Overrides*
+
+[CozyLink](CozyLink.md).[request](CozyLink.md#request)
+
+*Defined in*
+
+[packages/cozy-client/src/FlagshipLink.js:30](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/FlagshipLink.js#L30)
+
+***
+
+### reset
+
+▸ **reset**(): `void`
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/FlagshipLink.js:26](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/FlagshipLink.js#L26)

--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -50,7 +50,7 @@
     "btoa": "1.2.1",
     "cozy-device-helper": "2.7.0",
     "cozy-flags": "2.10.2",
-    "cozy-intent": "1.17.3",
+    "cozy-intent": "2.23.0",
     "cozy-logger": "1.7.0",
     "cozy-ui": "93.1.1",
     "jsdoc-plugin-intersection": "1.0.4",
@@ -65,7 +65,7 @@
   "peerDependencies": {
     "cozy-device-helper": ">=2.1.0",
     "cozy-flags": ">2.8.6",
-    "cozy-intent": ">=1.3.0",
+    "cozy-intent": ">=2.23.0",
     "cozy-logger": ">1.7.0",
     "cozy-ui": ">=93.1.1",
     "react": "^16.7.0",

--- a/packages/cozy-client/src/FlagshipLink.js
+++ b/packages/cozy-client/src/FlagshipLink.js
@@ -1,0 +1,38 @@
+import CozyLink from './CozyLink'
+import logger from './logger'
+
+export default class FlagshipLink extends CozyLink {
+  /**
+   * @param {object} [options] - Options
+   * @param  {object} [options.stackClient] - A StackClient
+   * @param  {object} [options.client] - A StackClient (deprecated)
+   * @param  {import('cozy-intent').WebviewService} [options.webviewIntent] - The webview's intent reference
+   */
+  constructor({ client, stackClient, webviewIntent } = {}) {
+    super()
+    if (client) {
+      logger.warn(
+        'Using options.client is deprecated, prefer options.stackClient'
+      )
+    }
+    this.stackClient = stackClient || client
+    this.webviewIntent = webviewIntent
+  }
+
+  registerClient(client) {
+    this.stackClient = client.stackClient || client.client
+  }
+
+  reset() {
+    this.stackClient = null
+  }
+
+  async request(operation, result, forward) {
+    return this.webviewIntent.call('flagshipLinkRequest', operation)
+  }
+
+  async persistData(data, forward) {
+    // Persist data should do nothing here as data is already persisted on Flagship side
+    return
+  }
+}

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -1,6 +1,7 @@
 export { default } from './CozyClient'
 export { default as CozyLink } from './CozyLink'
 export { default as StackLink } from './StackLink'
+export { default as FlagshipLink } from './FlagshipLink'
 export { default as compose } from 'lodash/flow'
 export {
   QueryDefinition,

--- a/packages/cozy-client/types/FlagshipLink.d.ts
+++ b/packages/cozy-client/types/FlagshipLink.d.ts
@@ -1,0 +1,18 @@
+export default class FlagshipLink extends CozyLink {
+    /**
+     * @param {object} [options] - Options
+     * @param  {object} [options.stackClient] - A StackClient
+     * @param  {object} [options.client] - A StackClient (deprecated)
+     * @param  {import('cozy-intent').WebviewService} [options.webviewIntent] - The webview's intent reference
+     */
+    constructor({ client, stackClient, webviewIntent }?: {
+        stackClient: object;
+        client: object;
+        webviewIntent: import('cozy-intent').WebviewService;
+    });
+    stackClient: any;
+    webviewIntent: import("cozy-intent").WebviewService;
+    registerClient(client: any): void;
+    reset(): void;
+}
+import CozyLink from "./CozyLink";

--- a/packages/cozy-client/types/index.d.ts
+++ b/packages/cozy-client/types/index.d.ts
@@ -1,6 +1,7 @@
 export { default } from "./CozyClient";
 export { default as CozyLink } from "./CozyLink";
 export { default as StackLink } from "./StackLink";
+export { default as FlagshipLink } from "./FlagshipLink";
 export { default as compose } from "lodash/flow";
 export { getQueryFromState } from "./store";
 export { default as Registry } from "./registry";

--- a/yarn.lock
+++ b/yarn.lock
@@ -5037,11 +5037,12 @@ cozy-flags@2.10.2:
   dependencies:
     microee "^0.0.6"
 
-cozy-intent@1.17.3:
-  version "1.17.3"
-  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-1.17.3.tgz#dcf8085a9c561ce56ab0c7afc69474243e4f9e9c"
-  integrity sha512-Qko/tUJlXWh5wYLfw+CknbIm+KeAW4F3lAk/n1CA+uKwcseua+LCoNIypC/04ttm9g6ntbEogb/u4h6d5+H6lg==
+cozy-intent@2.23.0:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-2.23.0.tgz#b6f3a407413df05c108e848b9dcb074b8780824b"
+  integrity sha512-DFn0ny4B4HpOE+3PYuZTTa074gRnFHqID+XaJ3gY2OrPL2xUQKEZmmFLp2bPVWThi5FvgvsU3EQeWPHZNQPbaQ==
   dependencies:
+    cozy-minilog "^3.3.1"
     post-me "0.4.5"
 
 cozy-interapp@^0.5.4:
@@ -5056,6 +5057,13 @@ cozy-logger@1.7.0:
   dependencies:
     chalk "^2.4.2"
     json-stringify-safe "5.0.1"
+
+cozy-minilog@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/cozy-minilog/-/cozy-minilog-3.3.1.tgz#472dccf4a9391c479120a83d26b435cf9d609c72"
+  integrity sha512-NLQNQ1Q/bvJrqNv9w5bLjfAxYKv+pESobJgUKXondxP616kx7k0mpiRrCZBaJRbEbpKryT/eJ0JJwLdVaIP5NA==
+  dependencies:
+    microee "0.0.6"
 
 cozy-ui@93.1.1:
   version "93.1.1"


### PR DESCRIPTION
When hosted in the Flagship app, we want the cozy-apps to be able to forward their queries to the native code

This will allow the native code to have control on the data lifecycle and chose between the cozy-stack or a local Pouch database as the source for executing the query

For now we use cozy-intent in order to communicate through post messages as it is the fastest implementation possible but this may change in the future if we encounter performances issues (i.e. using a local HTTP server)

___

### TODO:

- Upgrade cozy-intent after cozy/cozy-libs#2562 being merged (current commit has incorrect version)
___

### Related PRs:
- cozy/cozy-libs#2562