### PR TITLE
feat: Make PouchLink querying system compatible with new PouchDB version

### DIFF
--- a/docs/api/cozy-pouch-link/classes/PouchLink.md
+++ b/docs/api/cozy-pouch-link/classes/PouchLink.md
@@ -46,7 +46,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:136](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L136)
+[CozyPouchLink.js:137](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L137)
 
 ***
 
@@ -67,6 +67,16 @@ CozyLink.constructor
 *Defined in*
 
 [CozyPouchLink.js:94](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L94)
+
+***
+
+### ignoreWarmup
+
+• **ignoreWarmup**: `any`
+
+*Defined in*
+
+[CozyPouchLink.js:99](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L99)
 
 ***
 
@@ -96,7 +106,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:206](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L206)
+[CozyPouchLink.js:207](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L207)
 
 ***
 
@@ -106,7 +116,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:101](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L101)
+[CozyPouchLink.js:102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L102)
 
 ***
 
@@ -136,7 +146,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:607](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L607)
+[CozyPouchLink.js:666](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L666)
 
 ***
 
@@ -156,7 +166,33 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:568](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L568)
+[CozyPouchLink.js:627](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L627)
+
+***
+
+### createIndex
+
+▸ **createIndex**(`fields`, `indexOption?`): `Promise`<`PouchDbIndex`>
+
+Create the PouchDB index if not existing
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `fields` | `any`\[] | Fields to index |
+| `indexOption` | `Object` | Options for the index |
+| `indexOption.doctype` | `string` | - |
+| `indexOption.indexName` | `string` | - |
+| `indexOption.partialFilter` | `any` | - |
+
+*Returns*
+
+`Promise`<`PouchDbIndex`>
+
+*Defined in*
+
+[CozyPouchLink.js:464](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L464)
 
 ***
 
@@ -177,7 +213,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:611](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L611)
+[CozyPouchLink.js:670](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L670)
 
 ***
 
@@ -197,28 +233,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:596](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L596)
-
-***
-
-### ensureIndex
-
-▸ **ensureIndex**(`doctype`, `query`): `Promise`<`any`>
-
-*Parameters*
-
-| Name | Type |
-| :------ | :------ |
-| `doctype` | `any` |
-| `query` | `any` |
-
-*Returns*
-
-`Promise`<`any`>
-
-*Defined in*
-
-[CozyPouchLink.js:467](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L467)
+[CozyPouchLink.js:655](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L655)
 
 ***
 
@@ -240,7 +255,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:539](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L539)
+[CozyPouchLink.js:597](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L597)
 
 ***
 
@@ -260,7 +275,31 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:485](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L485)
+[CozyPouchLink.js:528](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L528)
+
+***
+
+### findExistingIndex
+
+▸ **findExistingIndex**(`doctype`, `options`, `indexName`): `PouchDbIndex`
+
+Retrieve the PouchDB index if exist, undefined otherwise
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `doctype` | `string` | The query's doctype |
+| `options` | `MangoQueryOptions` | The find options |
+| `indexName` | `string` | The index name |
+
+*Returns*
+
+`PouchDbIndex`
+
+*Defined in*
+
+[CozyPouchLink.js:488](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L488)
 
 ***
 
@@ -280,7 +319,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:323](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L323)
+[CozyPouchLink.js:324](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L324)
 
 ***
 
@@ -300,7 +339,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:116](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L116)
+[CozyPouchLink.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L117)
 
 ***
 
@@ -320,7 +359,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:319](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L319)
+[CozyPouchLink.js:320](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L320)
 
 ***
 
@@ -340,7 +379,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:260](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L260)
+[CozyPouchLink.js:261](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L261)
 
 ***
 
@@ -360,7 +399,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:255](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L255)
+[CozyPouchLink.js:256](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L256)
 
 ***
 
@@ -386,7 +425,7 @@ Emits an event (pouchlink:sync:end) when the sync (all doctypes) is done
 
 *Defined in*
 
-[CozyPouchLink.js:241](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L241)
+[CozyPouchLink.js:242](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L242)
 
 ***
 
@@ -406,28 +445,7 @@ Emits an event (pouchlink:sync:end) when the sync (all doctypes) is done
 
 *Defined in*
 
-[CozyPouchLink.js:449](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L449)
-
-***
-
-### mergePartialIndexInSelector
-
-▸ **mergePartialIndexInSelector**(`selector`, `partialFilter`): `any`
-
-*Parameters*
-
-| Name | Type |
-| :------ | :------ |
-| `selector` | `any` |
-| `partialFilter` | `any` |
-
-*Returns*
-
-`any`
-
-*Defined in*
-
-[CozyPouchLink.js:454](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L454)
+[CozyPouchLink.js:450](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L450)
 
 ***
 
@@ -457,7 +475,7 @@ Migrate the current adapter
 
 *Defined in*
 
-[CozyPouchLink.js:150](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L150)
+[CozyPouchLink.js:151](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L151)
 
 ***
 
@@ -482,7 +500,7 @@ the need to wait for the warmup
 
 *Defined in*
 
-[CozyPouchLink.js:435](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L435)
+[CozyPouchLink.js:436](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L436)
 
 ***
 
@@ -496,7 +514,7 @@ the need to wait for the warmup
 
 *Defined in*
 
-[CozyPouchLink.js:169](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L169)
+[CozyPouchLink.js:170](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L170)
 
 ***
 
@@ -516,7 +534,7 @@ the need to wait for the warmup
 
 *Defined in*
 
-[CozyPouchLink.js:299](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L299)
+[CozyPouchLink.js:300](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L300)
 
 ***
 
@@ -541,7 +559,7 @@ CozyLink.persistData
 
 *Defined in*
 
-[CozyPouchLink.js:390](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L390)
+[CozyPouchLink.js:391](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L391)
 
 ***
 
@@ -561,7 +579,7 @@ CozyLink.persistData
 
 *Defined in*
 
-[CozyPouchLink.js:135](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L135)
+[CozyPouchLink.js:136](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L136)
 
 ***
 
@@ -587,7 +605,7 @@ CozyLink.request
 
 *Defined in*
 
-[CozyPouchLink.js:342](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L342)
+[CozyPouchLink.js:343](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L343)
 
 ***
 
@@ -601,7 +619,7 @@ CozyLink.request
 
 *Defined in*
 
-[CozyPouchLink.js:225](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L225)
+[CozyPouchLink.js:226](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L226)
 
 ***
 
@@ -620,7 +638,7 @@ Emits pouchlink:sync:start event when the replication begins
 
 *Defined in*
 
-[CozyPouchLink.js:274](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L274)
+[CozyPouchLink.js:275](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L275)
 
 ***
 
@@ -639,7 +657,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:291](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L291)
+[CozyPouchLink.js:292](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L292)
 
 ***
 
@@ -659,7 +677,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:327](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L327)
+[CozyPouchLink.js:328](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L328)
 
 ***
 
@@ -673,7 +691,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:633](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L633)
+[CozyPouchLink.js:692](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L692)
 
 ***
 
@@ -693,7 +711,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:573](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L573)
+[CozyPouchLink.js:632](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L632)
 
 ***
 
@@ -713,7 +731,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:578](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L578)
+[CozyPouchLink.js:637](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L637)
 
 ***
 
@@ -738,4 +756,4 @@ The adapter name
 
 *Defined in*
 
-[CozyPouchLink.js:111](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L111)
+[CozyPouchLink.js:112](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L112)

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -85,11 +85,15 @@ Serves to dedupe equal queries requested at the same time</p>
 </dd>
 <dt><a href="#makeKeyFromPartialFilter">makeKeyFromPartialFilter</a> ⇒ <code>string</code></dt>
 <dd><p>Process a partial filter to generate a string key</p>
+<p>/!\ Warning: this method is similar to cozy-pouch-link mango.makeKeyFromPartialFilter()
+If you edit this method, please check if the change is also needed in mango file</p>
 </dd>
 <dt><a href="#getIndexNameFromFields">getIndexNameFromFields</a> ⇒ <code>string</code></dt>
 <dd><p>Name an index, based on its indexed fields and partial filter.</p>
 <p>It follows this naming convention:
 <code>by_{indexed_field1}_and_{indexed_field2}_filter_({partial_filter.key1}_{partial_filter.value1})_and_({partial_filter.key2}_{partial_filter.value2})</code></p>
+<p>/!\ Warning: this method is similar to cozy-pouch-link mango.getIndexNameFromFields()
+If you edit this method, please check if the change is also needed in mango file</p>
 </dd>
 <dt><a href="#transformSort">transformSort</a> ⇒ <code><a href="#MangoSort">MangoSort</a></code></dt>
 <dd><p>Transform sort into Array</p>
@@ -2175,6 +2179,9 @@ Get the list of illegal characters in the file name
 ## makeKeyFromPartialFilter ⇒ <code>string</code>
 Process a partial filter to generate a string key
 
+/!\ Warning: this method is similar to cozy-pouch-link mango.makeKeyFromPartialFilter()
+If you edit this method, please check if the change is also needed in mango file
+
 **Kind**: global constant  
 **Returns**: <code>string</code> - - The string key of the processed partial filter  
 
@@ -2189,6 +2196,9 @@ Name an index, based on its indexed fields and partial filter.
 
 It follows this naming convention:
 `by_{indexed_field1}_and_{indexed_field2}_filter_({partial_filter.key1}_{partial_filter.value1})_and_({partial_filter.key2}_{partial_filter.value2})`
+
+/!\ Warning: this method is similar to cozy-pouch-link mango.getIndexNameFromFields()
+If you edit this method, please check if the change is also needed in mango file
 
 **Kind**: global constant  
 **Returns**: <code>string</code> - The index name, built from the fields  

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -54,8 +54,8 @@ export const isExpiredTokenError = pouchError => {
   return expiredTokenError.test(pouchError.error)
 }
 
-const normalizeAll = (docs, doctype) => {
-  return docs.map(doc => jsonapi.normalizeDoc(doc, doctype))
+const normalizeAll = client => (docs, doctype) => {
+  return docs.map(doc => jsonapi.normalizeDoc(doc, doctype, client))
 }
 
 /**
@@ -239,7 +239,7 @@ class PouchLink extends CozyLink {
    * Emits an event (pouchlink:sync:end) when the sync (all doctypes) is done
    */
   handleOnSync(doctypeUpdates) {
-    const normalizedData = mapValues(doctypeUpdates, normalizeAll)
+    const normalizedData = mapValues(doctypeUpdates, normalizeAll(this.client))
     if (this.client) {
       this.client.setData(normalizedData)
     }
@@ -590,7 +590,7 @@ class PouchLink extends CozyLink {
       res.limit = limit
       withRows = true
     }
-    return jsonapi.fromPouchResult(res, withRows, doctype)
+    return jsonapi.fromPouchResult(res, withRows, doctype, this.client)
   }
 
   async executeMutation(mutation, result, forward) {
@@ -618,7 +618,8 @@ class PouchLink extends CozyLink {
     return jsonapi.fromPouchResult(
       pouchRes,
       false,
-      getDoctypeFromOperation(mutation)
+      getDoctypeFromOperation(mutation),
+      this.client
     )
   }
 

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -556,6 +556,15 @@ class PouchLink extends CozyLink {
       res = withoutDesignDocuments(res)
       withRows = true
     } else {
+      if (indexedFields) {
+        for (const indexedField of indexedFields) {
+          if (!Object.keys(selector).includes(indexedField)) {
+            selector[indexedField] = {
+              $gt: null
+            }
+          }
+        }
+      }
       const findOpts = {
         sort,
         selector,

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -506,15 +506,14 @@ class PouchLink extends CozyLink {
   async ensureIndex(doctype, options) {
     let { indexedFields, partialFilter } = options
 
-    let fields = indexedFields
     if (!indexedFields) {
-      fields = getIndexFields(options)
+      indexedFields = getIndexFields(options)
     }
     const partialFilterFields = partialFilter
       ? getIndexFields({ selector: {}, partialFilter })
       : null
 
-    const indexName = getIndexNameFromFields(fields, {
+    const indexName = getIndexNameFromFields(indexedFields, {
       partialFilterFields
     })
 

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -509,13 +509,8 @@ class PouchLink extends CozyLink {
     if (!indexedFields) {
       indexedFields = getIndexFields(options)
     }
-    const partialFilterFields = partialFilter
-      ? getIndexFields({ selector: {}, partialFilter })
-      : null
 
-    const indexName = getIndexNameFromFields(indexedFields, {
-      partialFilterFields
-    })
+    const indexName = getIndexNameFromFields(indexedFields, partialFilter)
 
     const existingIndex = this.findExistingIndex(doctype, options, indexName)
     if (!existingIndex) {

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -83,7 +83,7 @@ class PouchLink extends CozyLink {
   constructor(opts) {
     const options = defaults({}, opts, DEFAULT_OPTIONS)
     super(options)
-    const { doctypes, doctypesReplicationOptions } = options
+    const { doctypes, doctypesReplicationOptions, ignoreWarmup } = options
     this.options = options
     if (!doctypes) {
       throw new Error(
@@ -96,6 +96,7 @@ class PouchLink extends CozyLink {
     this.storage = new PouchLocalStorage(
       options.platform?.storage || platformWeb.storage
     )
+    this.ignoreWarmup = ignoreWarmup
 
     /** @type {Record<string, ReplicationStatus>} - Stores replication states per doctype */
     this.replicationStatus = this.replicationStatus || {}
@@ -361,7 +362,7 @@ class PouchLink extends CozyLink {
       return forward(operation)
     }
 
-    if (await this.needsToWaitWarmup(doctype)) {
+    if (!this.ignoreWarmup && (await this.needsToWaitWarmup(doctype))) {
       if (process.env.NODE_ENV !== 'production') {
         logger.info(
           `Tried to access local ${doctype} but not warmuped yet. Forwarding the operation to next link`

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -556,18 +556,28 @@ class PouchLink extends CozyLink {
       res = withoutDesignDocuments(res)
       withRows = true
     } else {
+      let findSelector = selector
+      const shouldAddId = !findSelector
+      if (shouldAddId) {
+        findSelector = {}
+      }
       if (indexedFields) {
         for (const indexedField of indexedFields) {
-          if (!Object.keys(selector).includes(indexedField)) {
-            selector[indexedField] = {
+          if (!Object.keys(findSelector).includes(indexedField)) {
+            findSelector[indexedField] = {
               $gt: null
             }
           }
         }
       }
+      if (shouldAddId) {
+        findSelector['_id'] = {
+          $gt: null
+        }
+      }
       const findOpts = {
         sort,
-        selector,
+        selector: findSelector,
         // same selector as Document Collection. We force _id.
         // Fix https://github.com/cozy/cozy-client/issues/985
         fields: fields ? [...fields, '_id', '_type', 'class'] : undefined,

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -454,7 +454,10 @@ describe('CozyPouchLink', () => {
             cozyFromPouch: true,
             done: false,
             id: '1',
-            label: 'Buy bread'
+            label: 'Buy bread',
+            relationships: {
+              referenced_by: undefined
+            }
           }
         ]
       })

--- a/packages/cozy-pouch-link/src/jsonapi.js
+++ b/packages/cozy-pouch-link/src/jsonapi.js
@@ -1,6 +1,8 @@
 export const normalizeDoc = (doc, doctype) => {
   const id = doc._id || doc.id
 
+  const { relationships, referenced_by } = doc
+
   // PouchDB sends back .rev attribute but we do not want to
   // keep it on the server. It is potentially higher than the
   // _rev.
@@ -11,7 +13,11 @@ export const normalizeDoc = (doc, doctype) => {
     _id: id,
     _rev,
     _type: doctype,
-    cozyFromPouch: true
+    cozyFromPouch: true,
+    relationships: {
+      ...relationships,
+      referenced_by
+    }
   }
   if (normalizedDoc.rev) {
     delete normalizedDoc.rev

--- a/packages/cozy-pouch-link/src/jsonapi.spec.js
+++ b/packages/cozy-pouch-link/src/jsonapi.spec.js
@@ -45,7 +45,10 @@ describe('doc normalization', () => {
       _type: 'io.cozy.contacts',
       cozyFromPouch: true,
       firstName: 'Bobba',
-      lastName: 'Fett'
+      lastName: 'Fett',
+      relationships: {
+        referenced_by: undefined
+      }
     })
   })
 })

--- a/packages/cozy-pouch-link/src/mango.js
+++ b/packages/cozy-pouch-link/src/mango.js
@@ -1,13 +1,60 @@
 import head from 'lodash/head'
 
-export const getIndexNameFromFields = (
-  fields,
-  { partialFilterFields } = {}
-) => {
+/**
+ * Process a partial filter to generate a string key
+ *
+ * /!\ Warning: this method is similar to cozy-stack-client mangoIndex.makeKeyFromPartialFilter()
+ * If you edit this method, please check if the change is also needed in mangoIndex file
+ *
+ * @param {object} condition - An object representing the partial filter or a sub-condition of the partial filter
+ * @returns {string} - The string key of the processed partial filter
+ */
+export const makeKeyFromPartialFilter = condition => {
+  if (typeof condition !== 'object' || condition === null) {
+    return String(condition)
+  }
+
+  const conditions = Object.entries(condition).map(([key, value]) => {
+    if (
+      Array.isArray(value) &&
+      value.every(subObj => typeof subObj === 'string')
+    ) {
+      return `${key}_(${value.join('_')})`
+    } else if (Array.isArray(value)) {
+      return `(${value
+        .map(subCondition => `${makeKeyFromPartialFilter(subCondition)}`)
+        .join(`)_${key}_(`)})`
+    } else if (typeof value === 'object') {
+      return `${key}_${makeKeyFromPartialFilter(value)}`
+    } else {
+      return `${key}_${value}`
+    }
+  })
+
+  return conditions.join(')_and_(')
+}
+
+/**
+ * Name an index, based on its indexed fields and partial filter.
+ *
+ * It follows this naming convention:
+ * `by_{indexed_field1}_and_{indexed_field2}_filter_({partial_filter.key1}_{partial_filter.value1})_and_({partial_filter.key2}_{partial_filter.value2})`
+ *
+ * /!\ Warning: this method is similar to cozy-stack-client mangoIndex.getIndexNameFromFields()
+ * If you edit this method, please check if the change is also needed in mangoIndex file
+ *
+ * @param {Array<string>} fields - The indexed fields
+ * @param {object} [partialFilter] - The partial filter
+ * @returns {string} The index name, built from the fields
+ */
+export const getIndexNameFromFields = (fields, partialFilter) => {
   const indexName = `by_${fields.join('_and_')}`
-  return partialFilterFields
-    ? `${indexName}_filter_${partialFilterFields.join('_and_')}`
-    : indexName
+
+  if (partialFilter) {
+    return `${indexName}_filter_(${makeKeyFromPartialFilter(partialFilter)})`
+  }
+
+  return indexName
 }
 
 /**

--- a/packages/cozy-pouch-link/src/mango.js
+++ b/packages/cozy-pouch-link/src/mango.js
@@ -16,15 +16,17 @@ export const getIndexNameFromFields = (
  * query to work
  *
  * @private
- * @param  {object} options - Mango query options
+ * @param  {import('./types').MangoQueryOptions} options - Mango query options
  * @returns {Array} - Fields to index
  */
 const defaultSelector = { _id: { $gt: null } }
-export const getIndexFields = ({
-  selector = defaultSelector,
-  sort = [],
-  partialFilter
-}) => {
+export const getIndexFields = (
+  /** @type {import('./types').MangoQueryOptions} */ {
+    selector = defaultSelector,
+    sort = [],
+    partialFilter
+  }
+) => {
   return Array.from(
     new Set([
       ...sort.map(sortOption => head(Object.keys(sortOption))),

--- a/packages/cozy-pouch-link/src/mango.spec.js
+++ b/packages/cozy-pouch-link/src/mango.spec.js
@@ -6,6 +6,6 @@ describe('mango utils', () => {
   it('should be able to get the fields from the selector', () => {
     const query = Q('io.cozy.rockets').sortBy([{ label: true }, { _id: true }])
     const fields = getIndexFields(query)
-    expect(fields).toEqual(['_id', 'label'])
+    expect(fields).toEqual(['label', '_id'])
   })
 })

--- a/packages/cozy-pouch-link/src/types.js
+++ b/packages/cozy-pouch-link/src/types.js
@@ -35,4 +35,39 @@
  * @property {function(): Promise<boolean>} isOnline Method that check if the app is connected to internet
  */
 
+/**
+ * @typedef {Object} MangoPartialFilter
+ */
+
+/**
+ * @typedef {object} MangoSelector
+ */
+
+/**
+ * @typedef {Array<object>} MangoSort
+ */
+
+/**
+ * @typedef {object} MangoQueryOptions
+ * @property {MangoSelector} [selector] Selector
+ * @property {MangoSort} [sort] The sorting parameters
+ * @property {Array<string>} [fields] The fields to return
+ * @property {Array<string>} [partialFilterFields] The partial filter fields
+ * @property {number|null} [limit] For pagination, the number of results to return
+ * @property {number|null} [skip] For skip-based pagination, the number of referenced files to skip
+ * @property {string|null} [indexId] The _id of the CouchDB index to use for this request
+ * @property {string|null} [bookmark] For bookmark-based pagination, the document _id to start from
+ * @property {Array<string>} [indexedFields]
+ * @property {string} [use_index] Name of the index to use
+ * @property {boolean} [execution_stats] If true, we request the stats from Couch
+ * @property {MangoPartialFilter|null} [partialFilter] An optional partial filter
+ */
+
+/**
+ * @typedef {object} PouchDbIndex
+ * @property {string} id - The ddoc's id
+ * @property {string} name - The ddoc's name
+ * @property {'exists'|'created'} result - If the index has been created or if it already exists
+ */
+
 export default {}

--- a/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
+++ b/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
@@ -49,6 +49,7 @@ declare class PouchLink extends CozyLink {
     doctypesReplicationOptions: any[];
     indexes: {};
     storage: PouchLocalStorage;
+    ignoreWarmup: any;
     /** @type {Record<string, ReplicationStatus>} - Stores replication states per doctype */
     replicationStatus: Record<string, ReplicationStatus>;
     getReplicationURL(doctype: any): string;
@@ -140,8 +141,45 @@ declare class PouchLink extends CozyLink {
      */
     needsToWaitWarmup(doctype: string): Promise<boolean>;
     hasIndex(name: any): boolean;
-    mergePartialIndexInSelector(selector: any, partialFilter: any): any;
-    ensureIndex(doctype: any, query: any): Promise<any>;
+    /**
+     * Create the PouchDB index if not existing
+     *
+     * @param {Array} fields - Fields to index
+     * @param {object} indexOption - Options for the index
+     * @param {object} [indexOption.partialFilter] - partialFilter
+     * @param {string} [indexOption.indexName] - indexName
+     * @param {string} [indexOption.doctype] - doctype
+     * @returns {Promise<import('./types').PouchDbIndex>}
+     */
+    createIndex(fields: any[], { partialFilter, indexName, doctype }?: {
+        partialFilter: object;
+        indexName: string;
+        doctype: string;
+    }): Promise<import('./types').PouchDbIndex>;
+    /**
+     * Retrieve the PouchDB index if exist, undefined otherwise
+     *
+     * @param {string} doctype - The query's doctype
+     * @param {import('./types').MangoQueryOptions} options - The find options
+     * @param {string} indexName - The index name
+     * @returns {import('./types').PouchDbIndex | undefined}
+     */
+    findExistingIndex(doctype: string, options: import('./types').MangoQueryOptions, indexName: string): import('./types').PouchDbIndex | undefined;
+    /**
+     * Handle index creation if it is missing.
+     *
+     * When an index is missing, we first check if there is one with a different
+     * name but the same definition. If there is none, we create the new index.
+     *
+     * /!\ Warning: this method is similar to DocumentCollection.handleMissingIndex()
+     * If you edit this method, please check if the change is also needed in DocumentCollection
+     *
+     * @param {string} doctype The mango selector
+     * @param {import('./types').MangoQueryOptions} options The find options
+     * @returns {Promise<import('./types').PouchDbIndex>} index
+     * @private
+     */
+    private ensureIndex;
     executeQuery({ doctype, selector, sort, fields, limit, id, ids, skip, indexedFields, partialFilter }: {
         doctype: any;
         selector: any;

--- a/packages/cozy-pouch-link/types/jsonapi.d.ts
+++ b/packages/cozy-pouch-link/types/jsonapi.d.ts
@@ -1,5 +1,5 @@
-export function normalizeDoc(doc: any, doctype: any): any;
-export function fromPouchResult(res: any, withRows: any, doctype: any): {
+export function normalizeDoc(doc: any, doctype: any, client: any): any;
+export function fromPouchResult(res: any, withRows: any, doctype: any, client: any): {
     data: any;
     meta?: undefined;
     skip?: undefined;

--- a/packages/cozy-pouch-link/types/mango.d.ts
+++ b/packages/cozy-pouch-link/types/mango.d.ts
@@ -1,9 +1,3 @@
-export function getIndexNameFromFields(fields: any): string;
-export function getIndexFields({ selector, sort }: {
-    selector?: {
-        _id: {
-            $gt: any;
-        };
-    };
-    sort?: {};
-}): string[];
+export function makeKeyFromPartialFilter(condition: object): string;
+export function getIndexNameFromFields(fields: Array<string>, partialFilter?: object): string;
+export function getIndexFields({ selector, sort, partialFilter }: import('./types').MangoQueryOptions): string[];

--- a/packages/cozy-pouch-link/types/types.d.ts
+++ b/packages/cozy-pouch-link/types/types.d.ts
@@ -38,3 +38,67 @@ export type LinkPlatform = {
      */
     isOnline: () => Promise<boolean>;
 };
+export type MangoPartialFilter = any;
+export type MangoSelector = any;
+export type MangoSort = any[];
+export type MangoQueryOptions = {
+    /**
+     * Selector
+     */
+    selector?: MangoSelector;
+    /**
+     * The sorting parameters
+     */
+    sort?: MangoSort;
+    /**
+     * The fields to return
+     */
+    fields?: Array<string>;
+    /**
+     * The partial filter fields
+     */
+    partialFilterFields?: Array<string>;
+    /**
+     * For pagination, the number of results to return
+     */
+    limit?: number | null;
+    /**
+     * For skip-based pagination, the number of referenced files to skip
+     */
+    skip?: number | null;
+    /**
+     * The _id of the CouchDB index to use for this request
+     */
+    indexId?: string | null;
+    /**
+     * For bookmark-based pagination, the document _id to start from
+     */
+    bookmark?: string | null;
+    indexedFields?: Array<string>;
+    /**
+     * Name of the index to use
+     */
+    use_index?: string;
+    /**
+     * If true, we request the stats from Couch
+     */
+    execution_stats?: boolean;
+    /**
+     * An optional partial filter
+     */
+    partialFilter?: MangoPartialFilter | null;
+};
+export type PouchDbIndex = {
+    /**
+     * - The ddoc's id
+     */
+    id: string;
+    /**
+     * - The ddoc's name
+     */
+    name: string;
+    /**
+     * - If the index has been created or if it already exists
+     */
+    result: 'exists' | 'created';
+};

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -227,6 +227,9 @@ class DocumentCollection {
    * name but the same definition. If yes, it means we found an old unamed
    * index, so we migrate it. If there is none, we create the new index.
    *
+   * /!\ Warning: this method is similar to CozyPouchLink.ensureIndex()
+   * If you edit this method, please check if the change is also needed in CozyPouchLink
+   *
    * @param {object} selector The mango selector
    * @param {MangoQueryOptions} options The find options
    * @private
@@ -238,10 +241,9 @@ class DocumentCollection {
       indexedFields = getIndexFields({ sort: options.sort, selector })
     }
 
-    const existingIndex = await this.findExistingIndex(selector, options)
-
     const indexName = getIndexNameFromFields(indexedFields, partialFilter)
 
+    const existingIndex = await this.findExistingIndex(selector, options)
     if (!existingIndex) {
       await this.createIndex(indexedFields, {
         partialFilter,

--- a/packages/cozy-stack-client/src/mangoIndex.js
+++ b/packages/cozy-stack-client/src/mangoIndex.js
@@ -50,6 +50,9 @@ export const normalizeDesignDoc = designDoc => {
 /**
  * Process a partial filter to generate a string key
  *
+ * /!\ Warning: this method is similar to cozy-pouch-link mango.makeKeyFromPartialFilter()
+ * If you edit this method, please check if the change is also needed in mango file
+ *
  * @param {object} condition - An object representing the partial filter or a sub-condition of the partial filter
  * @returns {string} - The string key of the processed partial filter
  */
@@ -83,6 +86,9 @@ export const makeKeyFromPartialFilter = condition => {
  *
  * It follows this naming convention:
  * `by_{indexed_field1}_and_{indexed_field2}_filter_({partial_filter.key1}_{partial_filter.value1})_and_({partial_filter.key2}_{partial_filter.value2})`
+ *
+ * /!\ Warning: this method is similar to cozy-pouch-link mango.getIndexNameFromFields()
+ * If you edit this method, please check if the change is also needed in mango file
  *
  * @param {Array<string>} fields - The indexed fields
  * @param {object} [partialFilter] - The partial filter


### PR DESCRIPTION
In previous PRs we modified cozy-client and cozy-pouch-link to make them compatible with the react-native Flagship app

Since we didn't use this link for a long time but also because we use a newer PouchDB version, some queries do not work anymore (i.e. incompatible indexes, bad selectors etc)

This PR improve PouchLink querying system to make our app ecosystem compatible with new PouchDB version