### PR TITLE
[VO-957] fix(move): Trash the conflicting file instead of the destination folder

### DIFF
--- a/docs/api/cozy-client/interfaces/models.file.FileUploadOptions.md
+++ b/docs/api/cozy-client/interfaces/models.file.FileUploadOptions.md
@@ -14,7 +14,7 @@ Conflict options
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:499](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L499)
+[packages/cozy-client/src/models/file.js:494](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L494)
 
 ***
 
@@ -26,7 +26,7 @@ Erase / rename
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:498](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L498)
+[packages/cozy-client/src/models/file.js:493](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L493)
 
 ***
 
@@ -38,7 +38,7 @@ The file Content-Type
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:497](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L497)
+[packages/cozy-client/src/models/file.js:492](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L492)
 
 ***
 
@@ -50,7 +50,7 @@ The dirId to upload the file to
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:495](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L495)
+[packages/cozy-client/src/models/file.js:490](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L490)
 
 ***
 
@@ -62,7 +62,7 @@ An object containing the metadata to attach
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:496](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L496)
+[packages/cozy-client/src/models/file.js:491](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L491)
 
 ***
 
@@ -74,4 +74,4 @@ The file name to upload
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:494](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L494)
+[packages/cozy-client/src/models/file.js:489](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L489)

--- a/docs/api/cozy-client/modules/models.file.md
+++ b/docs/api/cozy-client/modules/models.file.md
@@ -40,7 +40,7 @@ Upload a file on a mobile
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:604](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L604)
+[packages/cozy-client/src/models/file.js:599](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L599)
 
 ***
 
@@ -86,7 +86,7 @@ file object with path attribute
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:650](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L650)
+[packages/cozy-client/src/models/file.js:645](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L645)
 
 ***
 
@@ -135,7 +135,7 @@ Generate a file name for a revision
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:484](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L484)
+[packages/cozy-client/src/models/file.js:479](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L479)
 
 ***
 
@@ -160,7 +160,7 @@ A filename with the right suffix
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:454](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L454)
+[packages/cozy-client/src/models/file.js:449](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L449)
 
 ***
 
@@ -302,7 +302,7 @@ The mime-type of the target file, or an empty string is the target is not a file
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:630](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L630)
+[packages/cozy-client/src/models/file.js:625](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L625)
 
 ***
 
@@ -346,7 +346,7 @@ Whether the file's metadata attribute exists
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:622](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L622)
+[packages/cozy-client/src/models/file.js:617](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L617)
 
 ***
 
@@ -428,7 +428,7 @@ Whether the file is client-side encrypted
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:641](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L641)
+[packages/cozy-client/src/models/file.js:636](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L636)
 
 ***
 
@@ -493,7 +493,7 @@ Whether the file is supported by Only Office
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:614](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L614)
+[packages/cozy-client/src/models/file.js:609](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L609)
 
 ***
 
@@ -695,7 +695,7 @@ The overrided file
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:420](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L420)
+[packages/cozy-client/src/models/file.js:415](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L415)
 
 ***
 
@@ -717,7 +717,7 @@ Read a file on a mobile
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:557](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L557)
+[packages/cozy-client/src/models/file.js:552](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L552)
 
 ***
 
@@ -827,4 +827,4 @@ If there is a conflict, then we apply the conflict strategy : `erase` or `rename
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:517](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L517)
+[packages/cozy-client/src/models/file.js:512](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L512)

--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -377,16 +377,11 @@ export const move = async (
     }
   } catch (e) {
     if (e.status === 409 && force) {
-      let destinationPath
-      if (destination.path) {
-        destinationPath = destination.path
-      } else {
-        const { data: movedFile } = await client.query(
-          Q(DOCTYPE_FILES).getById(file._id)
-        )
-        const filename = movedFile.name
-        destinationPath = await getFullpath(client, destination._id, filename)
-      }
+      const destinationPath = await getFullpath(
+        client,
+        destination._id,
+        file.name
+      )
       const conflictResp = await client
         .collection(DOCTYPE_FILES)
         .statByPath(destinationPath)

--- a/packages/cozy-client/src/models/file.spec.js
+++ b/packages/cozy-client/src/models/file.spec.js
@@ -455,8 +455,11 @@ describe('File Model', () => {
       _id: 'dir-b1e1c256',
       _type: 'io.cozy.files',
       dir_id: 'io.cozy.files.root-dir',
-      path: '/'
+      type: 'directory',
+      name: 'Photos',
+      path: '/Photos'
     }
+
     const nextcloudFolder = {
       _id: 'folder-12435',
       _type: 'io.cozy.remote.nextcloud.files',
@@ -517,13 +520,6 @@ describe('File Model', () => {
         data: {
           id: cozyFile._id,
           dir_id: cozyFolder._id,
-          _type: 'io.cozy.files'
-        }
-      })
-      getSpy.mockResolvedValue({
-        data: {
-          id: cozyFile._id,
-          name: 'mydoc.odt',
           _type: 'io.cozy.files'
         }
       })


### PR DESCRIPTION
The issue comes from a previous [PR](https://github.com/cozy/cozy-client/pull/1488). Where, I changed the function header to pass an object like `io.cozy.files` instead of his attributes directly.

**Old:** 
```
move(client, fileId, destination, force = false)
``` 
**New:** 
```
move(client, file, destination, { force } = { force: false })
```

The old object `destination` could have a path property which was corresponding to the file path into destination (destination folder path + filename of the moved file). In the new one, as the object is an `io.cozy.files` folder always contains the path of himself only.

When there is a conflit and the destination is not a shared folder (`force`), we want to move into the trash the file that already exists inside destination folder so we could try to move again the file. 

**Problem:**
This [condition](https://github.com/cozy/cozy-client/blob/73a573aa72e2b1d5d2589ae5c0afeec349092c1e/packages/cozy-client/src/models/file.js#L381) was always true so it would not add the filename anymore to the path. So the path will correspond to the destination folder and it will be moved to the trash

**Answer:** 
We compute the destination path each time to retrieve the file already in the folder and move it to the trash