### PR TITLE
docs: Fix types for CozyPouchLink and StackLink constructors

### DIFF
--- a/docs/api/cozy-client/classes/StackLink.md
+++ b/docs/api/cozy-client/classes/StackLink.md
@@ -20,10 +20,7 @@ Transfers queries and mutations to a remote stack
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `[options]` | `Object` | Options |
-| `[options].client` | `any` | - |
-| `[options].platform` | `any` | - |
-| `[options].stackClient` | `any` | - |
+| `[options]` | `StackLinkOptions` | Options |
 
 *Overrides*
 
@@ -31,7 +28,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:64](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L64)
+[packages/cozy-client/src/StackLink.js:68](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L68)
 
 ## Properties
 
@@ -41,7 +38,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:72](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L72)
+[packages/cozy-client/src/StackLink.js:76](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L76)
 
 ***
 
@@ -51,7 +48,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:71](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L71)
+[packages/cozy-client/src/StackLink.js:75](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L75)
 
 ## Methods
 
@@ -73,7 +70,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:132](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L132)
+[packages/cozy-client/src/StackLink.js:136](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L136)
 
 ***
 
@@ -93,7 +90,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:109](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L109)
+[packages/cozy-client/src/StackLink.js:113](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L113)
 
 ***
 
@@ -118,7 +115,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:101](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L101)
+[packages/cozy-client/src/StackLink.js:105](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L105)
 
 ***
 
@@ -138,7 +135,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:75](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L75)
+[packages/cozy-client/src/StackLink.js:79](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L79)
 
 ***
 
@@ -164,7 +161,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:83](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L83)
+[packages/cozy-client/src/StackLink.js:87](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L87)
 
 ***
 
@@ -178,4 +175,4 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/StackLink.js:79](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L79)
+[packages/cozy-client/src/StackLink.js:83](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/StackLink.js#L83)

--- a/docs/api/cozy-pouch-link/classes/PouchLink.md
+++ b/docs/api/cozy-pouch-link/classes/PouchLink.md
@@ -22,13 +22,9 @@ constructor - Initializes a new PouchLink
 
 *Parameters*
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `opts` | `Object` | - |
-| `opts.doctypes` | `string`\[] | Doctypes to replicate |
-| `opts.doctypesReplicationOptions` | `any`\[] | A mapping from doctypes to replication options. All pouch replication options can be used, as well as the "strategy" option that determines which way the replication is done (can be "sync", "fromRemote" or "toRemote") |
-| `opts.platform` | `LinkPlatform` | Platform specific adapters and methods |
-| `opts.replicationInterval` | `number` | - |
+| Name | Type |
+| :------ | :------ |
+| `opts` | `PouchLinkOptions` |
 
 *Overrides*
 
@@ -36,7 +32,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:83](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L83)
+[CozyPouchLink.js:87](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L87)
 
 ## Properties
 
@@ -46,7 +42,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:137](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L137)
+[CozyPouchLink.js:141](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L141)
 
 ***
 
@@ -56,17 +52,17 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:93](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L93)
+[CozyPouchLink.js:97](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L97)
 
 ***
 
 ### doctypesReplicationOptions
 
-• **doctypesReplicationOptions**: `any`\[]
+• **doctypesReplicationOptions**: `Record`<`string`, `any`>
 
 *Defined in*
 
-[CozyPouchLink.js:94](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L94)
+[CozyPouchLink.js:98](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L98)
 
 ***
 
@@ -76,7 +72,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:99](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L99)
+[CozyPouchLink.js:103](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L103)
 
 ***
 
@@ -86,17 +82,17 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:95](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L95)
+[CozyPouchLink.js:99](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L99)
 
 ***
 
 ### options
 
-• **options**: { `replicationInterval`: `number`  } & { `doctypes`: `string`\[] ; `doctypesReplicationOptions`: `any`\[] ; `platform`: `LinkPlatform` ; `replicationInterval`: `number`  }
+• **options**: { `replicationInterval`: `number`  } & `PouchLinkOptions`
 
 *Defined in*
 
-[CozyPouchLink.js:87](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L87)
+[CozyPouchLink.js:91](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L91)
 
 ***
 
@@ -106,7 +102,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:207](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L207)
+[CozyPouchLink.js:211](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L211)
 
 ***
 
@@ -116,7 +112,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L102)
+[CozyPouchLink.js:106](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L106)
 
 ***
 
@@ -126,7 +122,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:96](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L96)
+[CozyPouchLink.js:100](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L100)
 
 ## Methods
 
@@ -146,7 +142,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:666](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L666)
+[CozyPouchLink.js:670](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L670)
 
 ***
 
@@ -166,7 +162,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:627](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L627)
+[CozyPouchLink.js:631](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L631)
 
 ***
 
@@ -192,7 +188,7 @@ Create the PouchDB index if not existing
 
 *Defined in*
 
-[CozyPouchLink.js:464](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L464)
+[CozyPouchLink.js:468](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L468)
 
 ***
 
@@ -213,7 +209,7 @@ Create the PouchDB index if not existing
 
 *Defined in*
 
-[CozyPouchLink.js:670](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L670)
+[CozyPouchLink.js:674](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L674)
 
 ***
 
@@ -233,7 +229,7 @@ Create the PouchDB index if not existing
 
 *Defined in*
 
-[CozyPouchLink.js:655](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L655)
+[CozyPouchLink.js:659](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L659)
 
 ***
 
@@ -255,7 +251,7 @@ Create the PouchDB index if not existing
 
 *Defined in*
 
-[CozyPouchLink.js:597](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L597)
+[CozyPouchLink.js:601](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L601)
 
 ***
 
@@ -275,7 +271,7 @@ Create the PouchDB index if not existing
 
 *Defined in*
 
-[CozyPouchLink.js:528](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L528)
+[CozyPouchLink.js:532](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L532)
 
 ***
 
@@ -299,7 +295,7 @@ Retrieve the PouchDB index if exist, undefined otherwise
 
 *Defined in*
 
-[CozyPouchLink.js:488](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L488)
+[CozyPouchLink.js:492](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L492)
 
 ***
 
@@ -319,7 +315,7 @@ Retrieve the PouchDB index if exist, undefined otherwise
 
 *Defined in*
 
-[CozyPouchLink.js:324](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L324)
+[CozyPouchLink.js:328](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L328)
 
 ***
 
@@ -339,7 +335,7 @@ Retrieve the PouchDB index if exist, undefined otherwise
 
 *Defined in*
 
-[CozyPouchLink.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L117)
+[CozyPouchLink.js:121](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L121)
 
 ***
 
@@ -359,7 +355,7 @@ Retrieve the PouchDB index if exist, undefined otherwise
 
 *Defined in*
 
-[CozyPouchLink.js:320](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L320)
+[CozyPouchLink.js:324](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L324)
 
 ***
 
@@ -379,7 +375,7 @@ Retrieve the PouchDB index if exist, undefined otherwise
 
 *Defined in*
 
-[CozyPouchLink.js:261](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L261)
+[CozyPouchLink.js:265](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L265)
 
 ***
 
@@ -399,7 +395,7 @@ Retrieve the PouchDB index if exist, undefined otherwise
 
 *Defined in*
 
-[CozyPouchLink.js:256](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L256)
+[CozyPouchLink.js:260](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L260)
 
 ***
 
@@ -425,7 +421,7 @@ Emits an event (pouchlink:sync:end) when the sync (all doctypes) is done
 
 *Defined in*
 
-[CozyPouchLink.js:242](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L242)
+[CozyPouchLink.js:246](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L246)
 
 ***
 
@@ -445,7 +441,7 @@ Emits an event (pouchlink:sync:end) when the sync (all doctypes) is done
 
 *Defined in*
 
-[CozyPouchLink.js:450](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L450)
+[CozyPouchLink.js:454](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L454)
 
 ***
 
@@ -475,7 +471,7 @@ Migrate the current adapter
 
 *Defined in*
 
-[CozyPouchLink.js:151](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L151)
+[CozyPouchLink.js:155](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L155)
 
 ***
 
@@ -500,7 +496,7 @@ the need to wait for the warmup
 
 *Defined in*
 
-[CozyPouchLink.js:436](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L436)
+[CozyPouchLink.js:440](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L440)
 
 ***
 
@@ -514,7 +510,7 @@ the need to wait for the warmup
 
 *Defined in*
 
-[CozyPouchLink.js:170](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L170)
+[CozyPouchLink.js:174](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L174)
 
 ***
 
@@ -534,7 +530,7 @@ the need to wait for the warmup
 
 *Defined in*
 
-[CozyPouchLink.js:300](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L300)
+[CozyPouchLink.js:304](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L304)
 
 ***
 
@@ -559,7 +555,7 @@ CozyLink.persistData
 
 *Defined in*
 
-[CozyPouchLink.js:391](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L391)
+[CozyPouchLink.js:395](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L395)
 
 ***
 
@@ -579,7 +575,7 @@ CozyLink.persistData
 
 *Defined in*
 
-[CozyPouchLink.js:136](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L136)
+[CozyPouchLink.js:140](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L140)
 
 ***
 
@@ -605,7 +601,7 @@ CozyLink.request
 
 *Defined in*
 
-[CozyPouchLink.js:343](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L343)
+[CozyPouchLink.js:347](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L347)
 
 ***
 
@@ -619,7 +615,7 @@ CozyLink.request
 
 *Defined in*
 
-[CozyPouchLink.js:226](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L226)
+[CozyPouchLink.js:230](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L230)
 
 ***
 
@@ -638,7 +634,7 @@ Emits pouchlink:sync:start event when the replication begins
 
 *Defined in*
 
-[CozyPouchLink.js:275](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L275)
+[CozyPouchLink.js:279](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L279)
 
 ***
 
@@ -657,7 +653,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:292](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L292)
+[CozyPouchLink.js:296](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L296)
 
 ***
 
@@ -677,7 +673,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:328](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L328)
+[CozyPouchLink.js:332](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L332)
 
 ***
 
@@ -691,7 +687,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:692](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L692)
+[CozyPouchLink.js:696](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L696)
 
 ***
 
@@ -711,7 +707,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:632](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L632)
+[CozyPouchLink.js:636](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L636)
 
 ***
 
@@ -731,7 +727,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:637](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L637)
+[CozyPouchLink.js:641](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L641)
 
 ***
 
@@ -756,4 +752,4 @@ The adapter name
 
 *Defined in*
 
-[CozyPouchLink.js:112](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L112)
+[CozyPouchLink.js:116](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L116)

--- a/packages/cozy-client/src/StackLink.js
+++ b/packages/cozy-client/src/StackLink.js
@@ -52,14 +52,18 @@ export const transformBulkDocsResponse = (bulkResponse, originalDocuments) => {
 }
 
 /**
+ * @typedef {object} StackLinkOptions
+ * @property {object} [stackClient] - A StackClient
+ * @property {object} [client] - A StackClient (deprecated)
+ * @property {import('cozy-pouch-link/dist/types').LinkPlatform} [platform] - Platform specific adapters and methods
+ */
+
+/**
  * Transfers queries and mutations to a remote stack
  */
 export default class StackLink extends CozyLink {
   /**
-   * @param {object} [options] - Options
-   * @param  {object} [options.stackClient] - A StackClient
-   * @param  {object} [options.client] - A StackClient (deprecated)
-   * @param {import('cozy-pouch-link/dist/types').LinkPlatform} [options.platform] Platform specific adapters and methods
+   * @param {StackLinkOptions} [options] - Options
    */
   constructor({ client, stackClient, platform } = {}) {
     super()

--- a/packages/cozy-client/types/StackLink.d.ts
+++ b/packages/cozy-client/types/StackLink.d.ts
@@ -2,20 +2,19 @@ export function transformBulkDocsResponse(bulkResponse: import("./types").CouchD
     data: import("./types").CozyClientDocument[];
 };
 /**
+ * @typedef {object} StackLinkOptions
+ * @property {object} [stackClient] - A StackClient
+ * @property {object} [client] - A StackClient (deprecated)
+ * @property {import('cozy-pouch-link/dist/types').LinkPlatform} [platform] - Platform specific adapters and methods
+ */
+/**
  * Transfers queries and mutations to a remote stack
  */
 export default class StackLink extends CozyLink {
     /**
-     * @param {object} [options] - Options
-     * @param  {object} [options.stackClient] - A StackClient
-     * @param  {object} [options.client] - A StackClient (deprecated)
-     * @param {import('cozy-pouch-link/dist/types').LinkPlatform} [options.platform] Platform specific adapters and methods
+     * @param {StackLinkOptions} [options] - Options
      */
-    constructor({ client, stackClient, platform }?: {
-        stackClient: object;
-        client: object;
-        platform: import('cozy-pouch-link/dist/types').LinkPlatform;
-    });
+    constructor({ client, stackClient, platform }?: StackLinkOptions);
     stackClient: any;
     isOnline: any;
     registerClient(client: any): void;
@@ -28,5 +27,19 @@ export default class StackLink extends CozyLink {
     executeQuery(query: QueryDefinition): Promise<import("./types").ClientResponse>;
     executeMutation(mutation: any, result: any, forward: any): Promise<any>;
 }
+export type StackLinkOptions = {
+    /**
+     * - A StackClient
+     */
+    stackClient?: object;
+    /**
+     * - A StackClient (deprecated)
+     */
+    client?: object;
+    /**
+     * - Platform specific adapters and methods
+     */
+    platform?: any;
+};
 import CozyLink from "./CozyLink";
 import { QueryDefinition } from "./queries/dsl";

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -65,6 +65,14 @@ const normalizeAll = client => (docs, doctype) => {
  */
 
 /**
+ * @typedef {object} PouchLinkOptions
+ * @property {number} [replicationInterval] Milliseconds between replications
+ * @property {string[]} doctypes Doctypes to replicate
+ * @property {object[]} doctypesReplicationOptions A mapping from doctypes to replication options. All pouch replication options can be used, as well as the "strategy" option that determines which way the replication is done (can be "sync", "fromRemote" or "toRemote")
+ * @property {import('./types').LinkPlatform} platform Platform specific adapters and methods
+ */
+
+/**
  * Link to be passed to a `CozyClient` instance to support CouchDB. It instantiates
  * PouchDB collections for each doctype that it supports and knows how
  * to respond to queries and mutations.
@@ -73,11 +81,7 @@ class PouchLink extends CozyLink {
   /**
    * constructor - Initializes a new PouchLink
    *
-   * @param {object} [opts={}]
-   * @param {number} [opts.replicationInterval] Milliseconds between replications
-   * @param {string[]} opts.doctypes Doctypes to replicate
-   * @param {object[]} opts.doctypesReplicationOptions A mapping from doctypes to replication options. All pouch replication options can be used, as well as the "strategy" option that determines which way the replication is done (can be "sync", "fromRemote" or "toRemote")
-   * @param {import('./types').LinkPlatform} opts.platform Platform specific adapters and methods
+   * @param {PouchLinkOptions} [opts={}]
    */
 
   constructor(opts) {

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -68,7 +68,7 @@ const normalizeAll = client => (docs, doctype) => {
  * @typedef {object} PouchLinkOptions
  * @property {number} [replicationInterval] Milliseconds between replications
  * @property {string[]} doctypes Doctypes to replicate
- * @property {object[]} doctypesReplicationOptions A mapping from doctypes to replication options. All pouch replication options can be used, as well as the "strategy" option that determines which way the replication is done (can be "sync", "fromRemote" or "toRemote")
+ * @property {Record<string, object>} doctypesReplicationOptions A mapping from doctypes to replication options. All pouch replication options can be used, as well as the "strategy" option that determines which way the replication is done (can be "sync", "fromRemote" or "toRemote")
  * @property {import('./types').LinkPlatform} platform Platform specific adapters and methods
  */
 

--- a/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
+++ b/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
@@ -3,10 +3,35 @@ export function isExpiredTokenError(pouchError: any): boolean;
 export default PouchLink;
 export type CozyClientDocument = any;
 export type ReplicationStatus = "idle" | "replicating";
+export type PouchLinkOptions = {
+    /**
+     * Milliseconds between replications
+     */
+    replicationInterval?: number;
+    /**
+     * Doctypes to replicate
+     */
+    doctypes: string[];
+    /**
+     * A mapping from doctypes to replication options. All pouch replication options can be used, as well as the "strategy" option that determines which way the replication is done (can be "sync", "fromRemote" or "toRemote")
+     */
+    doctypesReplicationOptions: Record<string, object>;
+    /**
+     * Platform specific adapters and methods
+     */
+    platform: import('./types').LinkPlatform;
+};
 /**
  * @typedef {import('cozy-client/src/types').CozyClientDocument} CozyClientDocument
  *
  * @typedef {"idle"|"replicating"} ReplicationStatus
+ */
+/**
+ * @typedef {object} PouchLinkOptions
+ * @property {number} [replicationInterval] Milliseconds between replications
+ * @property {string[]} doctypes Doctypes to replicate
+ * @property {Record<string, object>} doctypesReplicationOptions A mapping from doctypes to replication options. All pouch replication options can be used, as well as the "strategy" option that determines which way the replication is done (can be "sync", "fromRemote" or "toRemote")
+ * @property {import('./types').LinkPlatform} platform Platform specific adapters and methods
  */
 /**
  * Link to be passed to a `CozyClient` instance to support CouchDB. It instantiates
@@ -25,28 +50,14 @@ declare class PouchLink extends CozyLink {
     /**
      * constructor - Initializes a new PouchLink
      *
-     * @param {object} [opts={}]
-     * @param {number} [opts.replicationInterval] Milliseconds between replications
-     * @param {string[]} opts.doctypes Doctypes to replicate
-     * @param {object[]} opts.doctypesReplicationOptions A mapping from doctypes to replication options. All pouch replication options can be used, as well as the "strategy" option that determines which way the replication is done (can be "sync", "fromRemote" or "toRemote")
-     * @param {import('./types').LinkPlatform} opts.platform Platform specific adapters and methods
+     * @param {PouchLinkOptions} [opts={}]
      */
-    constructor(opts?: {
-        replicationInterval: number;
-        doctypes: string[];
-        doctypesReplicationOptions: object[];
-        platform: import('./types').LinkPlatform;
-    });
+    constructor(opts?: PouchLinkOptions);
     options: {
         replicationInterval: number;
-    } & {
-        replicationInterval?: number;
-        doctypes: string[];
-        doctypesReplicationOptions: object[];
-        platform: import('./types').LinkPlatform;
-    };
+    } & PouchLinkOptions;
     doctypes: string[];
-    doctypesReplicationOptions: any[];
+    doctypesReplicationOptions: Record<string, any>;
     indexes: {};
     storage: PouchLocalStorage;
     ignoreWarmup: any;


### PR DESCRIPTION
Previous declaration would generate non-optional attributes for options in `.d.ts` files

Also `doctypesReplicationOptions` type was incorrect