### PR TITLE
feat: Force _rev for queries with .select fields

### DIFF
--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -532,8 +532,8 @@ The returned documents are paginated by the stack.
     return {
       selector: mergedSelector,
       use_index: indexName,
-      // TODO: type and class should not be necessary, it's just a temp fix for a stack bug
-      fields: fields ? [...fields, '_id', '_type', 'class'] : undefined,
+      // _id is necessary for the store, and _rev is required for offline. See https://github.com/cozy/cozy-client/blob/95978d39546023920b0c01d689fed5dd41577a02/packages/cozy-client/src/CozyClient.js#L1153
+      fields: fields ? [...fields, '_id', '_rev'] : undefined,
       limit,
       skip,
       bookmark: options.bookmark || bookmark,

--- a/packages/cozy-stack-client/src/DocumentCollection.spec.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.spec.js
@@ -1527,13 +1527,21 @@ describe('DocumentCollection', () => {
       })
       expect(opts.sort).toEqual([{ name: 'asc' }, { date: 'asc' }])
     })
+
     it('should raise warning when there is a selector and no indexFields', () => {
       collection.toMangoOptions({ name: 'toto' }, {})
       expect(warnSpy).toHaveBeenCalled()
     })
+
     it('should not raise warning when there is a selector and indexFields', () => {
       collection.toMangoOptions({ name: 'toto' }, { indexedFields: ['name'] })
       expect(warnSpy).not.toHaveBeenCalled()
+    })
+
+    it('should add mandatory attributes when specifying fields', () => {
+      const fields = ['date']
+      const opts = collection.toMangoOptions({}, { fields })
+      expect(opts.fields).toEqual(['date', '_id', '_rev'])
     })
   })
 })


### PR DESCRIPTION
When specifying fields in a query, e.g.
`Q('io.cozy.todos').where({done: true}).select(['date'])`, the revision was missing if not explicitly given. This is now problematic because we rely on the revision existence to identify "virtual" documents, i.e. not persisted in CouchDB, that never have any revision. See https://github.com/cozy/cozy-client/pull/1486 for more insights.