### PR TITLE
fix: Remove attributes and meta attributes before persisting docs

### DIFF
--- a/docs/api/cozy-client/interfaces/models.instance.DiskInfos.md
+++ b/docs/api/cozy-client/interfaces/models.instance.DiskInfos.md
@@ -14,7 +14,7 @@ Space used in GB rounded
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:121](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L121)
+[packages/cozy-client/src/models/instance.js:113](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L113)
 
 ***
 
@@ -26,7 +26,7 @@ Maximum space available in GB rounded
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:122](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L122)
+[packages/cozy-client/src/models/instance.js:114](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L114)
 
 ***
 
@@ -38,4 +38,4 @@ Usage percent of the disk rounded
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:123](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L123)
+[packages/cozy-client/src/models/instance.js:115](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L115)

--- a/docs/api/cozy-client/interfaces/models.instance.DiskInfosRaw.md
+++ b/docs/api/cozy-client/interfaces/models.instance.DiskInfosRaw.md
@@ -14,7 +14,7 @@ Space used in GB
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:114](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L114)
+[packages/cozy-client/src/models/instance.js:106](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L106)
 
 ***
 
@@ -26,7 +26,7 @@ Maximum space available in GB
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:115](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L115)
+[packages/cozy-client/src/models/instance.js:107](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L107)
 
 ***
 
@@ -38,4 +38,4 @@ Usage percent of the disk
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:116](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L116)
+[packages/cozy-client/src/models/instance.js:108](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L108)

--- a/docs/api/cozy-client/modules/models.applications.md
+++ b/docs/api/cozy-client/modules/models.applications.md
@@ -27,7 +27,7 @@ Name of the app suitable for display
 
 *Defined in*
 
-[packages/cozy-client/src/models/applications.js:73](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/applications.js#L73)
+[packages/cozy-client/src/models/applications.js:71](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/applications.js#L71)
 
 ***
 
@@ -99,7 +99,7 @@ url to the app
 
 *Defined in*
 
-[packages/cozy-client/src/models/applications.js:61](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/applications.js#L61)
+[packages/cozy-client/src/models/applications.js:59](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/applications.js#L59)
 
 ***
 

--- a/docs/api/cozy-client/modules/models.instance.md
+++ b/docs/api/cozy-client/modules/models.instance.md
@@ -80,7 +80,7 @@ Returns the link to the Premium page on the Cozy's Manager
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:72](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L72)
+[packages/cozy-client/src/models/instance.js:70](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L70)
 
 ***
 
@@ -100,7 +100,7 @@ Returns the link to the Premium page on the Cozy's Manager
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:34](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L34)
+[packages/cozy-client/src/models/instance.js:32](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L32)
 
 ***
 
@@ -124,7 +124,7 @@ Does the cozy have offers
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:58](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L58)
+[packages/cozy-client/src/models/instance.js:56](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L56)
 
 ***
 
@@ -148,7 +148,7 @@ Checks the value of the password_defined attribute
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:92](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L92)
+[packages/cozy-client/src/models/instance.js:86](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L86)
 
 ***
 
@@ -168,7 +168,7 @@ Checks the value of the password_defined attribute
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:30](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L30)
+[packages/cozy-client/src/models/instance.js:28](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L28)
 
 ***
 
@@ -219,7 +219,7 @@ Make human readable information from disk information (usage, quota)
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:164](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L164)
+[packages/cozy-client/src/models/instance.js:156](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L156)
 
 ***
 
@@ -243,4 +243,4 @@ Should we display offers
 
 *Defined in*
 
-[packages/cozy-client/src/models/instance.js:44](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L44)
+[packages/cozy-client/src/models/instance.js:42](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/instance.js#L42)

--- a/docs/api/cozy-pouch-link/classes/PouchLink.md
+++ b/docs/api/cozy-pouch-link/classes/PouchLink.md
@@ -32,7 +32,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:87](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L87)
+[CozyPouchLink.js:87](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L87)
 
 ## Properties
 
@@ -42,7 +42,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:140](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L140)
+[CozyPouchLink.js:140](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L140)
 
 ***
 
@@ -52,7 +52,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:97](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L97)
+[CozyPouchLink.js:97](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L97)
 
 ***
 
@@ -62,7 +62,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:98](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L98)
+[CozyPouchLink.js:98](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L98)
 
 ***
 
@@ -72,7 +72,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:99](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L99)
+[CozyPouchLink.js:99](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L99)
 
 ***
 
@@ -82,7 +82,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:91](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L91)
+[CozyPouchLink.js:91](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L91)
 
 ***
 
@@ -92,7 +92,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:210](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L210)
+[CozyPouchLink.js:210](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L210)
 
 ***
 
@@ -102,7 +102,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:105](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L105)
+[CozyPouchLink.js:105](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L105)
 
 ***
 
@@ -112,7 +112,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:100](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L100)
+[CozyPouchLink.js:100](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L100)
 
 ## Methods
 
@@ -132,7 +132,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:661](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L661)
+[CozyPouchLink.js:688](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L688)
 
 ***
 
@@ -152,7 +152,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:622](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L622)
+[CozyPouchLink.js:649](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L649)
 
 ***
 
@@ -178,7 +178,7 @@ Create the PouchDB index if not existing
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:467](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L467)
+[CozyPouchLink.js:494](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L494)
 
 ***
 
@@ -199,7 +199,7 @@ Create the PouchDB index if not existing
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:665](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L665)
+[CozyPouchLink.js:692](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L692)
 
 ***
 
@@ -219,7 +219,7 @@ Create the PouchDB index if not existing
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:650](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L650)
+[CozyPouchLink.js:677](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L677)
 
 ***
 
@@ -241,7 +241,7 @@ Create the PouchDB index if not existing
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:592](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L592)
+[CozyPouchLink.js:619](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L619)
 
 ***
 
@@ -261,7 +261,7 @@ Create the PouchDB index if not existing
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:531](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L531)
+[CozyPouchLink.js:558](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L558)
 
 ***
 
@@ -285,7 +285,7 @@ Retrieve the PouchDB index if exist, undefined otherwise
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:491](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L491)
+[CozyPouchLink.js:518](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L518)
 
 ***
 
@@ -305,7 +305,7 @@ Retrieve the PouchDB index if exist, undefined otherwise
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:327](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L327)
+[CozyPouchLink.js:327](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L327)
 
 ***
 
@@ -325,7 +325,7 @@ Retrieve the PouchDB index if exist, undefined otherwise
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:120](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L120)
+[CozyPouchLink.js:120](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L120)
 
 ***
 
@@ -345,7 +345,7 @@ Retrieve the PouchDB index if exist, undefined otherwise
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:323](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L323)
+[CozyPouchLink.js:323](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L323)
 
 ***
 
@@ -365,7 +365,7 @@ Retrieve the PouchDB index if exist, undefined otherwise
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:264](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L264)
+[CozyPouchLink.js:264](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L264)
 
 ***
 
@@ -385,7 +385,7 @@ Retrieve the PouchDB index if exist, undefined otherwise
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:259](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L259)
+[CozyPouchLink.js:259](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L259)
 
 ***
 
@@ -411,7 +411,7 @@ Emits an event (pouchlink:sync:end) when the sync (all doctypes) is done
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:245](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L245)
+[CozyPouchLink.js:245](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L245)
 
 ***
 
@@ -431,7 +431,7 @@ Emits an event (pouchlink:sync:end) when the sync (all doctypes) is done
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:453](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L453)
+[CozyPouchLink.js:480](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L480)
 
 ***
 
@@ -461,7 +461,7 @@ Migrate the current adapter
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:154](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L154)
+[CozyPouchLink.js:154](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L154)
 
 ***
 
@@ -486,7 +486,7 @@ the need to wait for the warmup
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:439](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L439)
+[CozyPouchLink.js:466](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L466)
 
 ***
 
@@ -500,7 +500,7 @@ the need to wait for the warmup
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:173](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L173)
+[CozyPouchLink.js:173](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L173)
 
 ***
 
@@ -520,38 +520,13 @@ the need to wait for the warmup
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:303](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L303)
+[CozyPouchLink.js:303](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L303)
 
 ***
 
 ### persistCozyData
 
-▸ **persistCozyData**(`data`, `forward`): `void`
-
-*Parameters*
-
-| Name | Type |
-| :------ | :------ |
-| `data` | `any` |
-| `forward` | `any` |
-
-*Returns*
-
-`void`
-
-*Inherited from*
-
-CozyLink.persistCozyData
-
-*Defined in*
-
-[cozy-client/types/CozyLink.d.ts:4](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/types/CozyLink.d.ts#L4)
-
-***
-
-### persistData
-
-▸ **persistData**(`data`, `forward?`): `Promise`<`void`>
+▸ **persistCozyData**(`data`, `forward?`): `Promise`<`void`>
 
 *Parameters*
 
@@ -564,9 +539,13 @@ CozyLink.persistCozyData
 
 `Promise`<`void`>
 
+*Overrides*
+
+CozyLink.persistCozyData
+
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:394](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L394)
+[CozyPouchLink.js:421](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L421)
 
 ***
 
@@ -586,7 +565,7 @@ CozyLink.persistCozyData
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L139)
+[CozyPouchLink.js:139](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L139)
 
 ***
 
@@ -612,7 +591,7 @@ CozyLink.request
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:346](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L346)
+[CozyPouchLink.js:346](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L346)
 
 ***
 
@@ -626,7 +605,27 @@ CozyLink.request
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:229](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L229)
+[CozyPouchLink.js:229](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L229)
+
+***
+
+### sanitizeJsonApi
+
+▸ **sanitizeJsonApi**(`data`): `Omit`<`Pick`<`any`, `string` | `number` | `symbol`>, `"attributes"` | `"meta"`>
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `any` |
+
+*Returns*
+
+`Omit`<`Pick`<`any`, `string` | `number` | `symbol`>, `"attributes"` | `"meta"`>
+
+*Defined in*
+
+[CozyPouchLink.js:394](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L394)
 
 ***
 
@@ -645,7 +644,7 @@ Emits pouchlink:sync:start event when the replication begins
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:278](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L278)
+[CozyPouchLink.js:278](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L278)
 
 ***
 
@@ -664,7 +663,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:295](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L295)
+[CozyPouchLink.js:295](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L295)
 
 ***
 
@@ -684,7 +683,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:331](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L331)
+[CozyPouchLink.js:331](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L331)
 
 ***
 
@@ -698,7 +697,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:687](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L687)
+[CozyPouchLink.js:714](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L714)
 
 ***
 
@@ -718,7 +717,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:627](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L627)
+[CozyPouchLink.js:654](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L654)
 
 ***
 
@@ -738,7 +737,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:632](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L632)
+[CozyPouchLink.js:659](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L659)
 
 ***
 
@@ -763,4 +762,4 @@ The adapter name
 
 *Defined in*
 
-[cozy-pouch-link/src/CozyPouchLink.js:115](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L115)
+[CozyPouchLink.js:115](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L115)

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -1774,9 +1774,9 @@ instantiation of the client.`
     )
 
     this.instanceOptions = {
-      capabilities: data.attributes,
-      locale: instanceData.attributes?.locale,
-      tracking: instanceData.attributes?.tracking
+      capabilities: data,
+      locale: instanceData.locale,
+      tracking: instanceData.tracking
     }
 
     this.capabilities = this.instanceOptions.capabilities || null

--- a/packages/cozy-client/src/associations/HasManyFiles.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.js
@@ -57,7 +57,7 @@ export default class HasManyFiles extends HasMany {
         lastRelationship._type,
         lastRelationship._id
       )
-      const lastDatetime = getFileDatetime(lastRelDoc.attributes)
+      const lastDatetime = getFileDatetime(lastRelDoc)
       // cursor-based pagination
       const cursor = newCursor(
         [this.target._type, this.target._id, lastDatetime],

--- a/packages/cozy-client/src/hooks/useAppLinkWithStoreFallback.spec.jsx
+++ b/packages/cozy-client/src/hooks/useAppLinkWithStoreFallback.spec.jsx
@@ -30,9 +30,7 @@ describe('useAppLinkWithStoreFallback', () => {
     mockClient.query.mockResolvedValue({
       data: [
         {
-          attributes: {
-            slug: testAppSlug
-          },
+          slug: testAppSlug,
           links: { related: 'http://testapp.cozy.io' }
         }
       ]
@@ -52,9 +50,7 @@ describe('useAppLinkWithStoreFallback', () => {
     mockClient.query.mockResolvedValue({
       data: [
         {
-          attributes: {
-            slug: 'store'
-          },
+          slug: 'store',
           links: { related: 'http://store.cozy.io' }
         }
       ]

--- a/packages/cozy-client/src/hooks/useCapabilities.jsx
+++ b/packages/cozy-client/src/hooks/useCapabilities.jsx
@@ -13,7 +13,7 @@ const useCapabilities = client => {
           Q('io.cozy.settings').getById('io.cozy.settings.capabilities')
         )
 
-        setCapabilities(get(capabilitiesResult, 'data.attributes', {}))
+        setCapabilities(get(capabilitiesResult, 'data', {}))
         setFetchStatus('loaded')
       } catch (e) {
         setFetchStatus('failed')

--- a/packages/cozy-client/src/hooks/useCapabilities.spec.jsx
+++ b/packages/cozy-client/src/hooks/useCapabilities.spec.jsx
@@ -33,7 +33,8 @@ describe('useCapabilities', () => {
       data: {
         type: 'io.cozy.settings',
         id: 'io.cozy.settings.capabilities',
-        attributes: { file_versioning: true, flat_subdomains: true },
+        file_versioning: true,
+        flat_subdomains: true,
         meta: {},
         links: { self: '/settings/capabilities' }
       }
@@ -44,8 +45,12 @@ describe('useCapabilities', () => {
 
     await waitForNextUpdate()
     expect(result.current.capabilities).toEqual({
+      type: 'io.cozy.settings',
+      id: 'io.cozy.settings.capabilities',
       file_versioning: true,
-      flat_subdomains: true
+      flat_subdomains: true,
+      meta: {},
+      links: { self: '/settings/capabilities' }
     })
   })
 

--- a/packages/cozy-client/src/hooks/useFetchShortcut.jsx
+++ b/packages/cozy-client/src/hooks/useFetchShortcut.jsx
@@ -24,8 +24,7 @@ const useFetchShortcut = (client, id) => {
           }
         })
 
-        const targetApp =
-          shortcutInfosResult?.data?.attributes?.metadata?.target?.app
+        const targetApp = shortcutInfosResult?.data?.metadata?.target?.app
         if (targetApp) {
           const targetAppIconUrl = await client.getStackClient().getIconURL({
             type: 'app',
@@ -34,9 +33,7 @@ const useFetchShortcut = (client, id) => {
           })
           setShortcutImg(targetAppIconUrl)
         } else {
-          const shortcutRemoteUrl = new URL(
-            shortcutInfosResult.data.attributes.url
-          )
+          const shortcutRemoteUrl = new URL(shortcutInfosResult.data.url)
 
           const imgUrl = `${client.getStackClient().uri}/bitwarden/icons/${
             shortcutRemoteUrl.host

--- a/packages/cozy-client/src/hooks/useFetchShortcut.spec.jsx
+++ b/packages/cozy-client/src/hooks/useFetchShortcut.spec.jsx
@@ -16,13 +16,11 @@ describe('useFetchShortcut', () => {
           {
             type: 'io.cozy.files.shortcuts',
             id: 'b7470059d40c88e4bd30031d5e0109d3',
-            attributes: {
-              _id: '',
-              name: 'cozy.url',
-              dir_id: '8034db0016d0548ded99b9627e003270',
-              url: 'https://cozy.io',
-              metadata: { extractor_version: 2 }
-            },
+            _id: 'b7470059d40c88e4bd30031d5e0109d3',
+            name: 'cozy.url',
+            dir_id: '8034db0016d0548ded99b9627e003270',
+            url: 'https://cozy.io',
+            metadata: { extractor_version: 2 },
             meta: { rev: '1-60e1359e63fa7fa9fa000a2726d5d4c7' }
           }
         ]
@@ -37,16 +35,14 @@ describe('useFetchShortcut', () => {
           {
             type: 'io.cozy.files.shortcuts',
             id: 'linkToCozyApp',
-            attributes: {
-              _id: '',
-              name: 'cozy.url',
-              dir_id: '8034db0016d0548ded99b9627e003270',
-              url: 'https://cozy.io',
-              metadata: {
-                extractor_version: 2,
-                target: {
-                  app: 'notes'
-                }
+            _id: '',
+            name: 'cozy.url',
+            dir_id: '8034db0016d0548ded99b9627e003270',
+            url: 'https://cozy.io',
+            metadata: {
+              extractor_version: 2,
+              target: {
+                app: 'notes'
               }
             },
             meta: { rev: '1-60e1359e63fa7fa9fa000a2726d5d4c7' }
@@ -93,15 +89,12 @@ describe('useFetchShortcut', () => {
       data: {
         _id: 'b7470059d40c88e4bd30031d5e0109d3',
         _type: 'io.cozy.files.shortcuts',
-        type: 'io.cozy.files.shortcuts',
         id: 'b7470059d40c88e4bd30031d5e0109d3',
-        attributes: {
-          _id: '',
-          name: 'cozy.url',
-          dir_id: '8034db0016d0548ded99b9627e003270',
-          url: 'https://cozy.io',
-          metadata: { extractor_version: 2 }
-        },
+        type: 'io.cozy.files.shortcuts',
+        name: 'cozy.url',
+        dir_id: '8034db0016d0548ded99b9627e003270',
+        url: 'https://cozy.io',
+        metadata: { extractor_version: 2 },
         meta: { rev: '1-60e1359e63fa7fa9fa000a2726d5d4c7' }
       }
     })

--- a/packages/cozy-client/src/models/applications.js
+++ b/packages/cozy-client/src/models/applications.js
@@ -48,9 +48,7 @@ export const getStoreInstallationURL = (appData = [], app = {}) => {
  * @returns {object} The io.cozy.app is installed or undefined if not
  */
 export const isInstalled = (apps = [], wantedApp = {}) => {
-  return apps.find(
-    app => app.attributes && app.attributes.slug === wantedApp.slug
-  )
+  return apps.find(app => app.slug === wantedApp.slug)
 }
 
 /**

--- a/packages/cozy-client/src/models/applications.spec.js
+++ b/packages/cozy-client/src/models/applications.spec.js
@@ -94,9 +94,7 @@ describe('applications model', () => {
     describe('when the store app is installed', () => {
       it('should return the store url for the given app', () => {
         const storeApp = {
-          attributes: {
-            slug: 'store'
-          },
+          slug: 'store',
           links: {
             related: 'http://store.cozy.tools:8080/'
           }
@@ -120,9 +118,7 @@ describe('applications model', () => {
     describe('when the store app is installed', () => {
       it('should return the store installation url for the given app', () => {
         const storeApp = {
-          attributes: {
-            slug: 'store'
-          },
+          slug: 'store',
           links: {
             related: 'http://store.cozy.tools:8080/'
           }

--- a/packages/cozy-client/src/models/instance.js
+++ b/packages/cozy-client/src/models/instance.js
@@ -20,19 +20,17 @@ const PREMIUM_QUOTA = 50 * GB
 
 // If manager URL is present, then the instance is not self-hosted
 export const isSelfHosted = instanceInfo => {
-  return get(instanceInfo, 'context.data.attributes.manager_url') ? false : true
+  return get(instanceInfo, 'context.data.manager_url') ? false : true
 }
 export const arePremiumLinksEnabled = instanceInfo => {
-  return get(instanceInfo, 'context.data.attributes.enable_premium_links')
-    ? true
-    : false
+  return get(instanceInfo, 'context.data.enable_premium_links') ? true : false
 }
 export const isFreemiumUser = instanceInfo => {
-  const quota = get(instanceInfo, 'diskUsage.data.attributes.quota', false)
+  const quota = get(instanceInfo, 'diskUsage.data.quota', false)
   return parseInt(quota) <= PREMIUM_QUOTA
 }
 export const getUuid = instanceInfo => {
-  return get(instanceInfo, 'instance.data.attributes.uuid')
+  return get(instanceInfo, 'instance.data.uuid')
 }
 
 /**
@@ -70,11 +68,7 @@ export const hasAnOffer = data => {
  * @param {InstanceInfo} instanceInfo - Instance information
  */
 export const buildPremiumLink = instanceInfo => {
-  const managerUrl = get(
-    instanceInfo,
-    'context.data.attributes.manager_url',
-    false
-  )
+  const managerUrl = get(instanceInfo, 'context.data.manager_url', false)
   const uuid = getUuid(instanceInfo)
   if (managerUrl && uuid) {
     return `${managerUrl}/cozy/instances/${uuid}/premium`
@@ -92,9 +86,7 @@ export const buildPremiumLink = instanceInfo => {
 export const hasPasswordDefinedAttribute = async client => {
   try {
     const {
-      data: {
-        attributes: { password_defined }
-      }
+      data: { password_defined }
     } = await client.fetchQueryAndGetFromState({
       definition: Q('io.cozy.settings').getById('io.cozy.settings.instance'),
       options: {

--- a/packages/cozy-client/src/models/instance.spec.js
+++ b/packages/cozy-client/src/models/instance.spec.js
@@ -3,39 +3,29 @@ import { instance } from './'
 const noSelfHostedInstance = {
   context: {
     data: {
-      attributes: {
-        manager_url: 'https://manager.cozy.cc',
-        enable_premium_links: true
-      }
+      manager_url: 'https://manager.cozy.cc',
+      enable_premium_links: true
     }
   },
   instance: {
     data: {
-      attributes: {
-        uuid: '1234'
-      }
+      uuid: '1234'
     }
   },
   diskUsage: {
     data: {
-      attributes: {
-        quota: '400000000'
-      }
+      quota: '400000000'
     }
   }
 }
 
 const selftHostedInstance = {
   context: {
-    data: {
-      attributes: {}
-    }
+    data: {}
   },
   diskUsage: {
     data: {
-      attributes: {
-        quota: '6000000000000'
-      }
+      quota: '6000000000000'
     }
   }
 }
@@ -43,24 +33,18 @@ const selftHostedInstance = {
 const hadAnOfferInstance = {
   context: {
     data: {
-      attributes: {
-        manager_url: 'https://manager.cozy.cc',
-        enable_premium_links: true
-      }
+      manager_url: 'https://manager.cozy.cc',
+      enable_premium_links: true
     }
   },
   instance: {
     data: {
-      attributes: {
-        uuid: '1234'
-      }
+      uuid: '1234'
     }
   },
   diskUsage: {
     data: {
-      attributes: {
-        quota: '60000000000'
-      }
+      quota: '60000000000'
     }
   }
 }
@@ -163,17 +147,17 @@ describe('instance', () => {
     })
 
     it('should return false if attribute password_defined is undefined', async () => {
-      const res = await setup({ attributes: { password_defined: undefined } })
+      const res = await setup({ password_defined: undefined })
       expect(res).toBe(false)
     })
 
     it('should return false if attribute password_defined is false', async () => {
-      const res = await setup({ attributes: { password_defined: false } })
+      const res = await setup({ password_defined: false })
       expect(res).toBe(false)
     })
 
     it('should return true if attribute password_defined is true', async () => {
-      const res = await setup({ attributes: { password_defined: true } })
+      const res = await setup({ password_defined: true })
       expect(res).toBe(true)
     })
   })

--- a/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
+++ b/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
@@ -131,7 +131,7 @@ declare class PouchLink extends CozyLink {
     getSyncInfo(doctype: any): import("./types").SyncInfo;
     getPouch(doctype: any): any;
     supportsOperation(operation: any): boolean;
-    persistData(data: any, forward?: (operation: any, result?: any) => void): Promise<void>;
+    sanitizeJsonApi(data: any): Pick<Pick<any, string | number | symbol>, string | number | symbol>;
     /**
      * Retrieve the existing document from Pouch
      *


### PR DESCRIPTION
Those doc's attributes are specific to the JSON API and should not be inserted into the Pouch database

This implies that we will have a difference on documents regarding if they are served through the cozy-stack or through a local PouchDB, the first one may include those fields in their result, but not the second one

So from now we should avoid, as much as possible, to relies on the `attributes` member to prevent bugs on Offline mode. Multiple commits to fix usages of `attributes` in cozy-client will be done after this one

Usage of `attributes` and `meta` members on cozy-app will also have to be fixed. This will be a requirement to implement Offline mode on cozy-apps

___

Related PRs:
- #1507