### PR TITLE
feat: Improve CozyLink typing and add `reset()` method

### DIFF
--- a/docs/api/cozy-client/classes/CozyLink.md
+++ b/docs/api/cozy-client/classes/CozyLink.md
@@ -31,41 +31,61 @@
 
 ### persistCozyData
 
-▸ **persistCozyData**(`data`, `forward`): `void`
+▸ **persistCozyData**(`data`, `forward`): `Promise`<`any`>
+
+Persist the given data into the links storage
 
 *Parameters*
 
-| Name | Type |
-| :------ | :------ |
-| `data` | `any` |
-| `forward` | `any` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `data` | `any` | The document to persist |
+| `forward` | `any` | The next persistCozyData of the chain |
 
 *Returns*
 
-`void`
+`Promise`<`any`>
 
 *Defined in*
 
-[packages/cozy-client/src/CozyLink.js:16](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyLink.js#L16)
+[packages/cozy-client/src/CozyLink.js:31](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyLink.js#L31)
 
 ***
 
 ### request
 
-▸ **request**(`operation`, `result`, `forward`): `void`
+▸ **request**(`operation`, `result`, `forward`): `Promise`<`any`>
+
+Request the given operation from the link
 
 *Parameters*
 
-| Name | Type |
-| :------ | :------ |
-| `operation` | `any` |
-| `result` | `any` |
-| `forward` | `any` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `operation` | `any` | The operation to request |
+| `result` | `any` | The result from the previous request of the chain |
+| `forward` | `any` | The next request of the chain |
 
 *Returns*
 
-`void`
+`Promise`<`any`>
 
 *Defined in*
 
-[packages/cozy-client/src/CozyLink.js:12](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyLink.js#L12)
+[packages/cozy-client/src/CozyLink.js:20](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyLink.js#L20)
+
+***
+
+### reset
+
+▸ **reset**(): `Promise`<`any`>
+
+Reset the link data
+
+*Returns*
+
+`Promise`<`any`>
+
+*Defined in*
+
+[packages/cozy-client/src/CozyLink.js:40](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyLink.js#L40)

--- a/docs/api/cozy-client/classes/FlagshipLink.md
+++ b/docs/api/cozy-client/classes/FlagshipLink.md
@@ -45,6 +45,8 @@
 
 ▸ **persistCozyData**(`data`, `forward`): `Promise`<`void`>
 
+Persist the given data into the links storage
+
 *Parameters*
 
 | Name | Type |
@@ -90,6 +92,8 @@
 
 ▸ **request**(`operation`, `result`, `forward`): `Promise`<`boolean`>
 
+Request the given operation from the link
+
 *Parameters*
 
 | Name | Type |
@@ -114,11 +118,17 @@
 
 ### reset
 
-▸ **reset**(): `void`
+▸ **reset**(): `Promise`<`void`>
+
+Reset the link data
 
 *Returns*
 
-`void`
+`Promise`<`void`>
+
+*Overrides*
+
+[CozyLink](CozyLink.md).[reset](CozyLink.md#reset)
 
 *Defined in*
 

--- a/docs/api/cozy-client/classes/StackLink.md
+++ b/docs/api/cozy-client/classes/StackLink.md
@@ -98,6 +98,8 @@ Transfers queries and mutations to a remote stack
 
 ▸ **persistCozyData**(`data`, `forward`): `Promise`<`any`>
 
+Persist the given data into the links storage
+
 *Parameters*
 
 | Name | Type |
@@ -143,6 +145,8 @@ Transfers queries and mutations to a remote stack
 
 ▸ **request**(`operation`, `result`, `forward`): `Promise`<`any`>
 
+Request the given operation from the link
+
 *Parameters*
 
 | Name | Type |
@@ -167,11 +171,17 @@ Transfers queries and mutations to a remote stack
 
 ### reset
 
-▸ **reset**(): `void`
+▸ **reset**(): `Promise`<`void`>
+
+Reset the link data
 
 *Returns*
 
-`void`
+`Promise`<`void`>
+
+*Overrides*
+
+[CozyLink](CozyLink.md).[reset](CozyLink.md#reset)
 
 *Defined in*
 

--- a/docs/api/cozy-pouch-link/classes/PouchLink.md
+++ b/docs/api/cozy-pouch-link/classes/PouchLink.md
@@ -603,6 +603,10 @@ CozyLink.request
 
 `Promise`<`void`>
 
+*Overrides*
+
+CozyLink.reset
+
 *Defined in*
 
 [CozyPouchLink.js:229](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L229)

--- a/packages/cozy-client/src/CozyLink.js
+++ b/packages/cozy-client/src/CozyLink.js
@@ -9,12 +9,36 @@ export default class CozyLink {
     }
   }
 
-  request(operation, result, forward) {
+  /**
+   * Request the given operation from the link
+   *
+   * @param {any} operation - The operation to request
+   * @param {any} result - The result from the previous request of the chain
+   * @param {any} forward - The next request of the chain
+   * @returns {Promise<any>}
+   */
+  async request(operation, result, forward) {
     throw new Error('request is not implemented')
   }
 
-  persistCozyData(data, forward) {
+  /**
+   * Persist the given data into the links storage
+   *
+   * @param {any} data - The document to persist
+   * @param {any} forward - The next persistCozyData of the chain
+   * @returns {Promise<any>}
+   */
+  async persistCozyData(data, forward) {
     throw new Error('persistCozyData is not implemented')
+  }
+
+  /**
+   * Reset the link data
+   *
+   * @returns {Promise<any>}
+   */
+  async reset() {
+    throw new Error('reset is not implemented')
   }
 }
 

--- a/packages/cozy-client/src/FlagshipLink.js
+++ b/packages/cozy-client/src/FlagshipLink.js
@@ -14,7 +14,7 @@ export default class FlagshipLink extends CozyLink {
     // does nothing, we don't need any client for this kind of link
   }
 
-  reset() {
+  async reset() {
     // does nothing, we don't need any client for this kind of link
   }
 

--- a/packages/cozy-client/src/StackLink.js
+++ b/packages/cozy-client/src/StackLink.js
@@ -80,7 +80,7 @@ export default class StackLink extends CozyLink {
     this.stackClient = client.stackClient || client.client
   }
 
-  reset() {
+  async reset() {
     this.stackClient = null
   }
 

--- a/packages/cozy-client/types/CozyLink.d.ts
+++ b/packages/cozy-client/types/CozyLink.d.ts
@@ -1,6 +1,27 @@
 export default class CozyLink {
     constructor(requestHandler: any, persistHandler: any);
-    request(operation: any, result: any, forward: any): void;
-    persistCozyData(data: any, forward: any): void;
+    /**
+     * Request the given operation from the link
+     *
+     * @param {any} operation - The operation to request
+     * @param {any} result - The result from the previous request of the chain
+     * @param {any} forward - The next request of the chain
+     * @returns {Promise<any>}
+     */
+    request(operation: any, result: any, forward: any): Promise<any>;
+    /**
+     * Persist the given data into the links storage
+     *
+     * @param {any} data - The document to persist
+     * @param {any} forward - The next persistCozyData of the chain
+     * @returns {Promise<any>}
+     */
+    persistCozyData(data: any, forward: any): Promise<any>;
+    /**
+     * Reset the link data
+     *
+     * @returns {Promise<any>}
+     */
+    reset(): Promise<any>;
 }
 export function chain(links: any): any;

--- a/packages/cozy-client/types/FlagshipLink.d.ts
+++ b/packages/cozy-client/types/FlagshipLink.d.ts
@@ -8,6 +8,5 @@ export default class FlagshipLink extends CozyLink {
     });
     webviewIntent: import("cozy-intent").WebviewService;
     registerClient(client: any): void;
-    reset(): void;
 }
 import CozyLink from "./CozyLink";

--- a/packages/cozy-client/types/StackLink.d.ts
+++ b/packages/cozy-client/types/StackLink.d.ts
@@ -18,7 +18,6 @@ export default class StackLink extends CozyLink {
     stackClient: any;
     isOnline: any;
     registerClient(client: any): void;
-    reset(): void;
     /**
      *
      * @param {QueryDefinition} query - Query to execute

--- a/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
+++ b/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
@@ -96,7 +96,6 @@ declare class PouchLink extends CozyLink {
     }): Promise<void>;
     onLogin(): Promise<void>;
     pouches: PouchManager;
-    reset(): Promise<void>;
     /**
      * Receives PouchDB updates (documents grouped by doctype).
      * Normalizes the data (.id -> ._id, .rev -> _rev).


### PR DESCRIPTION
In the Flagship app, we want to be able to reset the local PouchDB files in order to prevent beta testers to be blocked by an erroneous Pouch replication

To make this possible we want to expose a public method that resets all the cozy-client's links