### PR TITLE
fix: Remove realtimes.d.ts

### DIFF
--- a/packages/cozy-client/types/store/realtimes.d.ts
+++ b/packages/cozy-client/types/store/realtimes.d.ts
@@ -1,3 +1,0 @@
-export function dispatchCreate(client: object, doctype: import("../types").Doctype, couchDBDoc: import("../types").CouchDBDocument): void;
-export function dispatchUpdate(client: object, doctype: import("../types").Doctype, couchDBDoc: import("../types").CouchDBDocument): void;
-export function dispatchDelete(client: object, doctype: import("../types").Doctype, couchDBDoc: import("../types").CouchDBDocument): void;


### PR DESCRIPTION
`realtime.js` has been renamed to `realtime.js` but the old typing file has not been removed

Related commit: 4aa9ab0d091a111efebf963278ac7a8e208ded7e