### PR TITLE
feat: Rename FlagshipLink to WebFlagshipLink

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -16,7 +16,6 @@ cozy-client
 *   [CozyClient](classes/CozyClient.md)
 *   [CozyLink](classes/CozyLink.md)
 *   [CozyProvider](classes/CozyProvider.md)
-*   [FlagshipLink](classes/FlagshipLink.md)
 *   [HasMany](classes/HasMany.md)
 *   [HasManyInPlace](classes/HasManyInPlace.md)
 *   [HasManyTriggers](classes/HasManyTriggers.md)
@@ -29,6 +28,7 @@ cozy-client
 *   [QueryDefinition](classes/QueryDefinition.md)
 *   [Registry](classes/Registry.md)
 *   [StackLink](classes/StackLink.md)
+*   [WebFlagshipLink](classes/WebFlagshipLink.md)
 
 ## Properties
 

--- a/docs/api/cozy-client/classes/CozyLink.md
+++ b/docs/api/cozy-client/classes/CozyLink.md
@@ -8,7 +8,7 @@
 
     ↳ [`StackLink`](StackLink.md)
 
-    ↳ [`FlagshipLink`](FlagshipLink.md)
+    ↳ [`WebFlagshipLink`](WebFlagshipLink.md)
 
 ## Constructors
 

--- a/docs/api/cozy-client/classes/WebFlagshipLink.md
+++ b/docs/api/cozy-client/classes/WebFlagshipLink.md
@@ -1,18 +1,18 @@
-[cozy-client](../README.md) / FlagshipLink
+[cozy-client](../README.md) / WebFlagshipLink
 
-# Class: FlagshipLink
+# Class: WebFlagshipLink
 
 ## Hierarchy
 
 *   [`CozyLink`](CozyLink.md)
 
-    ↳ **`FlagshipLink`**
+    ↳ **`WebFlagshipLink`**
 
 ## Constructors
 
 ### constructor
 
-• **new FlagshipLink**(`[options]?`)
+• **new WebFlagshipLink**(`[options]?`)
 
 *Parameters*
 
@@ -27,7 +27,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/FlagshipLink.js:8](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/FlagshipLink.js#L8)
+[packages/cozy-client/src/WebFlagshipLink.js:8](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/WebFlagshipLink.js#L8)
 
 ## Properties
 
@@ -37,7 +37,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/FlagshipLink.js:10](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/FlagshipLink.js#L10)
+[packages/cozy-client/src/WebFlagshipLink.js:10](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/WebFlagshipLink.js#L10)
 
 ## Methods
 
@@ -64,7 +64,7 @@ Persist the given data into the links storage
 
 *Defined in*
 
-[packages/cozy-client/src/FlagshipLink.js:25](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/FlagshipLink.js#L25)
+[packages/cozy-client/src/WebFlagshipLink.js:25](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/WebFlagshipLink.js#L25)
 
 ***
 
@@ -84,7 +84,7 @@ Persist the given data into the links storage
 
 *Defined in*
 
-[packages/cozy-client/src/FlagshipLink.js:13](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/FlagshipLink.js#L13)
+[packages/cozy-client/src/WebFlagshipLink.js:13](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/WebFlagshipLink.js#L13)
 
 ***
 
@@ -112,7 +112,7 @@ Request the given operation from the link
 
 *Defined in*
 
-[packages/cozy-client/src/FlagshipLink.js:21](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/FlagshipLink.js#L21)
+[packages/cozy-client/src/WebFlagshipLink.js:21](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/WebFlagshipLink.js#L21)
 
 ***
 
@@ -132,4 +132,4 @@ Reset the link data
 
 *Defined in*
 
-[packages/cozy-client/src/FlagshipLink.js:17](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/FlagshipLink.js#L17)
+[packages/cozy-client/src/WebFlagshipLink.js:17](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/WebFlagshipLink.js#L17)

--- a/packages/cozy-client/src/WebFlagshipLink.js
+++ b/packages/cozy-client/src/WebFlagshipLink.js
@@ -1,6 +1,6 @@
 import CozyLink from './CozyLink'
 
-export default class FlagshipLink extends CozyLink {
+export default class WebFlagshipLink extends CozyLink {
   /**
    * @param {object} [options] - Options
    * @param  {import('cozy-intent').WebviewService} [options.webviewIntent] - The webview's intent reference

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -1,7 +1,7 @@
 export { default } from './CozyClient'
 export { default as CozyLink } from './CozyLink'
 export { default as StackLink } from './StackLink'
-export { default as FlagshipLink } from './FlagshipLink'
+export { default as WebFlagshipLink } from './WebFlagshipLink'
 export { default as compose } from 'lodash/flow'
 export {
   QueryDefinition,

--- a/packages/cozy-client/types/WebFlagshipLink.d.ts
+++ b/packages/cozy-client/types/WebFlagshipLink.d.ts
@@ -1,4 +1,4 @@
-export default class FlagshipLink extends CozyLink {
+export default class WebFlagshipLink extends CozyLink {
     /**
      * @param {object} [options] - Options
      * @param  {import('cozy-intent').WebviewService} [options.webviewIntent] - The webview's intent reference

--- a/packages/cozy-client/types/index.d.ts
+++ b/packages/cozy-client/types/index.d.ts
@@ -1,7 +1,7 @@
 export { default } from "./CozyClient";
 export { default as CozyLink } from "./CozyLink";
 export { default as StackLink } from "./StackLink";
-export { default as FlagshipLink } from "./FlagshipLink";
+export { default as WebFlagshipLink } from "./WebFlagshipLink";
 export { default as compose } from "lodash/flow";
 export { default as Registry } from "./registry";
 export { default as RealTimeQueries } from "./RealTimeQueries";


### PR DESCRIPTION
This should clarify that this link should be run on the web side and not on the Flagship app side