### PR TITLE
fix: Revert some updates to file metadata types

### DIFF
--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -451,6 +451,7 @@ import { QueryDefinition } from './queries/dsl'
  * @property {object} [content] - The Note's content. See https://prosemirror.net/docs/ref/#model for more informations
  * @property {object} [schema] - the schema used by prosemirror (with notes and marks serialized as arrays to preserve the order).
  * @property {string} [title] - the initial title of the note (that will also be used for the file name)
+ * @property {string} [description] - A brief description of the file
  * @property {number} [version] - Number of a note
  * @property {Qualification} [qualification] - Qualification of the file
  * @property {string} [country] - Country of the paper
@@ -461,7 +462,6 @@ import { QueryDefinition } from './queries/dsl'
  * @property {string} [instanceName] - Name of the instance
  * @property {object} [target] - Information of the target of the shortcut
  * @property {string} [target.title] - The title of the application to which the shortcut redirects
- * @property {string} [target.description] - A brief description of the application
  * @property {string} [target.category] - The category of the application
  * @property {object} [externalDataSource] - Additional information to maintain link with external data source
  * @property {string} [externalDataSource.source] - The space to which the application belongs

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -776,6 +776,10 @@ export type FileMetadata = {
      */
     title?: string;
     /**
+     * - A brief description of the file
+     */
+    description?: string;
+    /**
      * - Number of a note
      */
     version?: number;
@@ -812,7 +816,6 @@ export type FileMetadata = {
      */
     target?: {
         title: string;
-        description: string;
         category: string;
     };
     /**


### PR DESCRIPTION
This reverts some part of the commit fb1bbf0.
There are existing shortcuts that rely on `metadata.description`. Therefore, we revert this change.