### PR TITLE
[VO-1125] feat: Spread attributes from JSON:API at document root

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -135,9 +135,6 @@ See <a href="https://docs.cozy.io/en/cozy-stack/sharing-design/#description-of-a
 <dt><a href="#getAccessToken">getAccessToken()</a> ⇒ <code>string</code></dt>
 <dd><p>Get the app token string</p>
 </dd>
-<dt><a href="#normalizeDoctypeJsonApi">normalizeDoctypeJsonApi(doctype)</a> ⇒ <code>function</code></dt>
-<dd><p>Normalizes a document in JSON API format for a specific doctype</p>
-</dd>
 <dt><a href="#getIconURL">getIconURL()</a></dt>
 <dd><p>Get Icon URL using blob mechanism if OAuth connected
 or using preloaded url when blob not needed</p>
@@ -151,6 +148,9 @@ CouchDB transforms $nor into $and with $ne operators</p>
 </dd>
 <dt><a href="#memoize">memoize()</a></dt>
 <dd><p>Memoize with maxDuration and custom key</p>
+</dd>
+<dt><a href="#normalizeDoctypeJsonApi">normalizeDoctypeJsonApi(doctype)</a> ⇒ <code>function</code></dt>
+<dd><p>Normalizes a document in JSON API format for a specific doctype</p>
 </dd>
 <dt><a href="#getSharingRulesForPhotosAlbum">getSharingRulesForPhotosAlbum(document, sharingType)</a> ⇒ <code><a href="#Rule">Array.&lt;Rule&gt;</a></code></dt>
 <dd><p>Compute the rules that define how to share a Photo Album. See <a href="https://docs.cozy.io/en/cozy-stack/sharing-design/#description-of-a-sharing">https://docs.cozy.io/en/cozy-stack/sharing-design/#description-of-a-sharing</a></p>
@@ -2352,18 +2352,6 @@ Get the app token string
 **Kind**: global function  
 **Returns**: <code>string</code> - token  
 **See**: CozyStackClient.getAccessToken  
-<a name="normalizeDoctypeJsonApi"></a>
-
-## normalizeDoctypeJsonApi(doctype) ⇒ <code>function</code>
-Normalizes a document in JSON API format for a specific doctype
-
-**Kind**: global function  
-**Returns**: <code>function</code> - A function that normalizes the document  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| doctype | <code>string</code> | The document type |
-
 <a name="getIconURL"></a>
 
 ## getIconURL()
@@ -2396,6 +2384,18 @@ Delete outdated results from cache
 Memoize with maxDuration and custom key
 
 **Kind**: global function  
+<a name="normalizeDoctypeJsonApi"></a>
+
+## normalizeDoctypeJsonApi(doctype) ⇒ <code>function</code>
+Normalizes a document in JSON API format for a specific doctype
+
+**Kind**: global function  
+**Returns**: <code>function</code> - A function that normalizes the document  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| doctype | <code>string</code> | The document type |
+
 <a name="getSharingRulesForPhotosAlbum"></a>
 
 ## getSharingRulesForPhotosAlbum(document, sharingType) ⇒ [<code>Array.&lt;Rule&gt;</code>](#Rule)

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -466,7 +466,6 @@ Abstracts a collection of documents of the same doctype, providing CRUD methods 
         * [.fetchChangesRaw(couchOptions)](#DocumentCollection+fetchChangesRaw)
     * _static_
         * [.normalizeDoctype(doctype)](#DocumentCollection.normalizeDoctype) ⇒ <code>function</code>
-        * [.normalizeDoctypeJsonApi(doctype)](#DocumentCollection.normalizeDoctypeJsonApi) ⇒ <code>function</code>
 
 <a name="DocumentCollection+all"></a>
 
@@ -719,19 +718,6 @@ No further treatment is done contrary to fetchchanges
 
 ### DocumentCollection.normalizeDoctype(doctype) ⇒ <code>function</code>
 Provides a callback for `Collection.get`
-
-**Kind**: static method of [<code>DocumentCollection</code>](#DocumentCollection)  
-**Returns**: <code>function</code> - (data, response) => normalizedDocument
-                                       using `normalizeDoc`  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| doctype | <code>string</code> | Document doctype |
-
-<a name="DocumentCollection.normalizeDoctypeJsonApi"></a>
-
-### DocumentCollection.normalizeDoctypeJsonApi(doctype) ⇒ <code>function</code>
-`normalizeDoctype` for api end points returning json api responses
 
 **Kind**: static method of [<code>DocumentCollection</code>](#DocumentCollection)  
 **Returns**: <code>function</code> - (data, response) => normalizedDocument

--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -135,6 +135,9 @@ See <a href="https://docs.cozy.io/en/cozy-stack/sharing-design/#description-of-a
 <dt><a href="#getAccessToken">getAccessToken()</a> ⇒ <code>string</code></dt>
 <dd><p>Get the app token string</p>
 </dd>
+<dt><a href="#normalizeDoctypeJsonApi">normalizeDoctypeJsonApi(doctype)</a> ⇒ <code>function</code></dt>
+<dd><p>Normalizes a document in JSON API format for a specific doctype</p>
+</dd>
 <dt><a href="#getIconURL">getIconURL()</a></dt>
 <dd><p>Get Icon URL using blob mechanism if OAuth connected
 or using preloaded url when blob not needed</p>
@@ -463,6 +466,7 @@ Abstracts a collection of documents of the same doctype, providing CRUD methods 
         * [.fetchChangesRaw(couchOptions)](#DocumentCollection+fetchChangesRaw)
     * _static_
         * [.normalizeDoctype(doctype)](#DocumentCollection.normalizeDoctype) ⇒ <code>function</code>
+        * [.normalizeDoctypeJsonApi(doctype)](#DocumentCollection.normalizeDoctypeJsonApi) ⇒ <code>function</code>
 
 <a name="DocumentCollection+all"></a>
 
@@ -715,6 +719,19 @@ No further treatment is done contrary to fetchchanges
 
 ### DocumentCollection.normalizeDoctype(doctype) ⇒ <code>function</code>
 Provides a callback for `Collection.get`
+
+**Kind**: static method of [<code>DocumentCollection</code>](#DocumentCollection)  
+**Returns**: <code>function</code> - (data, response) => normalizedDocument
+                                       using `normalizeDoc`  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| doctype | <code>string</code> | Document doctype |
+
+<a name="DocumentCollection.normalizeDoctypeJsonApi"></a>
+
+### DocumentCollection.normalizeDoctypeJsonApi(doctype) ⇒ <code>function</code>
+`normalizeDoctype` for api end points returning json api responses
 
 **Kind**: static method of [<code>DocumentCollection</code>](#DocumentCollection)  
 **Returns**: <code>function</code> - (data, response) => normalizedDocument
@@ -2335,6 +2352,18 @@ Get the app token string
 **Kind**: global function  
 **Returns**: <code>string</code> - token  
 **See**: CozyStackClient.getAccessToken  
+<a name="normalizeDoctypeJsonApi"></a>
+
+## normalizeDoctypeJsonApi(doctype) ⇒ <code>function</code>
+Normalizes a document in JSON API format for a specific doctype
+
+**Kind**: global function  
+**Returns**: <code>function</code> - A function that normalizes the document  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| doctype | <code>string</code> | The document type |
+
 <a name="getIconURL"></a>
 
 ## getIconURL()

--- a/packages/cozy-client/src/RealTimeQueries.jsx
+++ b/packages/cozy-client/src/RealTimeQueries.jsx
@@ -52,9 +52,9 @@ const RealTimeQueries = ({ doctype }) => {
     subscribe()
 
     return () => {
-      realtime.unsubscribe('created', doctype, dispatchCreate)
-      realtime.unsubscribe('updated', doctype, dispatchUpdate)
-      realtime.unsubscribe('deleted', doctype, dispatchDelete)
+      realtime.unsubscribe('created', doctype, handleCreated)
+      realtime.unsubscribe('updated', doctype, handleUpdated)
+      realtime.unsubscribe('deleted', doctype, handleDeleted)
     }
   }, [client, doctype])
 

--- a/packages/cozy-stack-client/src/AppCollection.js
+++ b/packages/cozy-stack-client/src/AppCollection.js
@@ -121,6 +121,6 @@ class AppCollection extends DocumentCollection {
   }
 }
 
-AppCollection.normalizeDoctype = DocumentCollection.normalizeDoctypeJsonApi
+AppCollection.normalizeDoctype = normalizeDoctypeJsonApi
 
 export default AppCollection

--- a/packages/cozy-stack-client/src/AppCollection.js
+++ b/packages/cozy-stack-client/src/AppCollection.js
@@ -5,17 +5,18 @@ import {
 } from 'cozy-client/dist/registry'
 
 import Collection from './Collection'
-import DocumentCollection, { normalizeDoc } from './DocumentCollection'
+import DocumentCollection, {
+  normalizeDoctypeJsonApi
+} from './DocumentCollection'
 import { FetchError } from './errors'
 import logger from './logger'
 
 export const APPS_DOCTYPE = 'io.cozy.apps'
 
 export const normalizeApp = (app, doctype) => {
+  const normalizedApp = normalizeDoctypeJsonApi(doctype)(app)
   return {
-    ...app.attributes,
-    ...app,
-    ...normalizeDoc(app, doctype),
+    ...normalizedApp,
     id: app.id // ignores any 'id' attribute in the manifest
   }
 }

--- a/packages/cozy-stack-client/src/AppCollection.js
+++ b/packages/cozy-stack-client/src/AppCollection.js
@@ -5,9 +5,8 @@ import {
 } from 'cozy-client/dist/registry'
 
 import Collection from './Collection'
-import DocumentCollection, {
-  normalizeDoctypeJsonApi
-} from './DocumentCollection'
+import DocumentCollection from './DocumentCollection'
+import { normalizeDoctypeJsonApi } from './normalize'
 import { FetchError } from './errors'
 import logger from './logger'
 

--- a/packages/cozy-stack-client/src/AppsRegistryCollection.js
+++ b/packages/cozy-stack-client/src/AppsRegistryCollection.js
@@ -1,4 +1,5 @@
-import DocumentCollection, { normalizeDoc } from './DocumentCollection'
+import DocumentCollection from './DocumentCollection'
+import { normalizeDoc } from './normalize'
 
 export const APPS_REGISTRY_DOCTYPE = 'io.cozy.apps_registry'
 

--- a/packages/cozy-stack-client/src/ContactsCollection.js
+++ b/packages/cozy-stack-client/src/ContactsCollection.js
@@ -1,12 +1,17 @@
-import DocumentCollection, { normalizeDoc } from './DocumentCollection'
+import DocumentCollection, {
+  normalizeDoctypeJsonApi
+} from './DocumentCollection'
 // @ts-ignore Need to import it to be used in jsdoc
 import { IOCozyContact } from 'cozy-client/dist/types'
 
-const normalizeMyselfResp = resp => {
+export const CONTACTS_DOCTYPE = 'io.cozy.contacts'
+
+const normalizeContactJsonApi = normalizeDoctypeJsonApi(CONTACTS_DOCTYPE)
+
+const normalizeMyself = contact => {
   return {
-    ...normalizeDoc(resp.data, CONTACTS_DOCTYPE),
-    ...resp.data.attributes,
-    _rev: resp.data.meta.rev
+    ...normalizeContactJsonApi(contact),
+    _rev: contact?.meta?.rev
   }
 }
 
@@ -26,7 +31,7 @@ class ContactsCollection extends DocumentCollection {
   async findMyself() {
     const resp = await this.stackClient.fetchJSON('POST', '/contacts/myself')
     const col = {
-      data: [normalizeMyselfResp(resp)],
+      data: [normalizeMyself(resp.data)],
       next: false,
       meta: null,
       bookmark: false
@@ -56,7 +61,5 @@ class ContactsCollection extends DocumentCollection {
     }
   }
 }
-
-export const CONTACTS_DOCTYPE = 'io.cozy.contacts'
 
 export default ContactsCollection

--- a/packages/cozy-stack-client/src/ContactsCollection.js
+++ b/packages/cozy-stack-client/src/ContactsCollection.js
@@ -1,6 +1,5 @@
-import DocumentCollection, {
-  normalizeDoctypeJsonApi
-} from './DocumentCollection'
+import DocumentCollection from './DocumentCollection'
+import { normalizeDoctypeJsonApi } from './normalize'
 // @ts-ignore Need to import it to be used in jsdoc
 import { IOCozyContact } from 'cozy-client/dist/types'
 

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -48,6 +48,26 @@ export function normalizeDoc(doc = {}, doctype) {
   return { id, _id: id, _type: doctype, ...doc }
 }
 
+/**
+ * Normalizes a document in JSON API format for a specific doctype
+ *
+ * @param {string} doctype - The document type
+ * @returns {Function} A function that normalizes the document
+ */
+export function normalizeDoctypeJsonApi(doctype) {
+  /**
+   * @param {object} data - The document from "data" property of the response in JSON API format
+   * @returns {object} The normalized document
+   */
+  return function(data) {
+    const normalizedDoc = normalizeDoc(data, doctype)
+    return {
+      ...normalizedDoc,
+      ...normalizedDoc.attributes
+    }
+  }
+}
+
 const prepareForDeletion = x =>
   Object.assign({}, omit(x, '_type'), { _deleted: true })
 
@@ -76,16 +96,12 @@ class DocumentCollection {
   /**
    * `normalizeDoctype` for api end points returning json api responses
    *
-   * @private
    * @param {string} doctype - Document doctype
    * @returns {Function} (data, response) => normalizedDocument
    *                                        using `normalizeDoc`
    */
   static normalizeDoctypeJsonApi(doctype) {
-    return function(data, response) {
-      // use the "data" attribute of the response
-      return normalizeDoc(data, doctype)
-    }
+    return normalizeDoctypeJsonApi(doctype)
   }
 
   /**

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -12,7 +12,7 @@ import {
   MangoPartialFilter,
   DesignDoc
 } from './mangoIndex'
-import { normalizeDoc, normalizeDoctypeJsonApi } from './normalize'
+import { normalizeDoc, normalizeDoctypeRawApi } from './normalize'
 
 import Collection, {
   dontThrowNotFoundError,
@@ -58,33 +58,7 @@ class DocumentCollection {
    *                                        using `normalizeDoc`
    */
   static normalizeDoctype(doctype) {
-    return this.normalizeDoctypeRawApi(doctype)
-  }
-
-  /**
-   * `normalizeDoctype` for api end points returning json api responses
-   *
-   * @param {string} doctype - Document doctype
-   * @returns {Function} (data, response) => normalizedDocument
-   *                                        using `normalizeDoc`
-   */
-  static normalizeDoctypeJsonApi(doctype) {
-    return normalizeDoctypeJsonApi(doctype)
-  }
-
-  /**
-   * `normalizeDoctype` for api end points returning raw documents
-   *
-   * @private
-   * @param {string} doctype - Document doctype
-   * @returns {Function} (data, response) => normalizedDocument
-   *                                        using `normalizeDoc`
-   */
-  static normalizeDoctypeRawApi(doctype) {
-    return function(data, response) {
-      // use the response directly
-      return normalizeDoc(response, doctype)
-    }
+    return normalizeDoctypeRawApi(doctype)
   }
 
   /**

--- a/packages/cozy-stack-client/src/DocumentCollection.js
+++ b/packages/cozy-stack-client/src/DocumentCollection.js
@@ -12,6 +12,7 @@ import {
   MangoPartialFilter,
   DesignDoc
 } from './mangoIndex'
+import { normalizeDoc, normalizeDoctypeJsonApi } from './normalize'
 
 import Collection, {
   dontThrowNotFoundError,
@@ -34,39 +35,6 @@ import { FetchError } from './errors'
 import logger from './logger'
 
 const DATABASE_DOES_NOT_EXIST = 'Database does not exist.'
-
-/**
- * Normalize a document, adding its doctype if needed
- *
- * @param {object} doc - Document to normalize
- * @param {string} doctype - Document doctype
- * @returns {object} normalized document
- * @private
- */
-export function normalizeDoc(doc = {}, doctype) {
-  const id = doc._id || doc.id
-  return { id, _id: id, _type: doctype, ...doc }
-}
-
-/**
- * Normalizes a document in JSON API format for a specific doctype
- *
- * @param {string} doctype - The document type
- * @returns {Function} A function that normalizes the document
- */
-export function normalizeDoctypeJsonApi(doctype) {
-  /**
-   * @param {object} data - The document from "data" property of the response in JSON API format
-   * @returns {object} The normalized document
-   */
-  return function(data) {
-    const normalizedDoc = normalizeDoc(data, doctype)
-    return {
-      ...normalizedDoc,
-      ...normalizedDoc.attributes
-    }
-  }
-}
 
 const prepareForDeletion = x =>
   Object.assign({}, omit(x, '_type'), { _deleted: true })
@@ -823,5 +791,3 @@ The returned documents are paginated by the stack.
 }
 
 export default DocumentCollection
-
-export const normalizeDoctype = DocumentCollection.normalizeDoctype

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -5,7 +5,9 @@ import omit from 'lodash/omit'
 import pick from 'lodash/pick'
 import { MangoQueryOptions } from './mangoIndex'
 
-import DocumentCollection, { normalizeDoc } from './DocumentCollection'
+import DocumentCollection, {
+  normalizeDoctypeJsonApi
+} from './DocumentCollection'
 import { uri, slugify, formatBytes, forceDownload } from './utils'
 import { FetchError } from './errors'
 import { dontThrowNotFoundError } from './Collection'
@@ -81,6 +83,8 @@ import logger from './logger'
 const ROOT_DIR_ID = 'io.cozy.files.root-dir'
 const CONTENT_TYPE_OCTET_STREAM = 'application/octet-stream'
 
+const normalizeFileJsonApi = normalizeDoctypeJsonApi('io.cozy.files')
+
 /**
  * Normalize a file, adding document's doctype if needed
  *
@@ -89,8 +93,7 @@ const CONTENT_TYPE_OCTET_STREAM = 'application/octet-stream'
  * @private
  */
 const normalizeFile = file => ({
-  ...normalizeDoc(file, 'io.cozy.files'),
-  ...file.attributes,
+  ...normalizeFileJsonApi(file),
   _rev: file?.meta?.rev // Beware of JSON-API
 })
 

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -5,9 +5,8 @@ import omit from 'lodash/omit'
 import pick from 'lodash/pick'
 import { MangoQueryOptions } from './mangoIndex'
 
-import DocumentCollection, {
-  normalizeDoctypeJsonApi
-} from './DocumentCollection'
+import DocumentCollection from './DocumentCollection'
+import { normalizeDoctypeJsonApi } from './normalize'
 import { uri, slugify, formatBytes, forceDownload } from './utils'
 import { FetchError } from './errors'
 import { dontThrowNotFoundError } from './Collection'

--- a/packages/cozy-stack-client/src/JobCollection.js
+++ b/packages/cozy-stack-client/src/JobCollection.js
@@ -1,8 +1,7 @@
 import Collection from './Collection'
-import DocumentCollection, {
-  normalizeDoctypeJsonApi
-} from './DocumentCollection'
+import DocumentCollection from './DocumentCollection'
 import { uri } from './utils'
+import { normalizeDoctypeJsonApi } from './normalize'
 
 export const JOBS_DOCTYPE = 'io.cozy.jobs'
 

--- a/packages/cozy-stack-client/src/JobCollection.js
+++ b/packages/cozy-stack-client/src/JobCollection.js
@@ -1,18 +1,14 @@
 import Collection from './Collection'
-import DocumentCollection, { normalizeDoc } from './DocumentCollection'
+import DocumentCollection, {
+  normalizeDoctypeJsonApi
+} from './DocumentCollection'
 import { uri } from './utils'
 
 export const JOBS_DOCTYPE = 'io.cozy.jobs'
 
 const sleep = delay => new Promise(resolve => setTimeout(resolve, delay))
 
-export const normalizeJob = job => {
-  return {
-    ...job,
-    ...normalizeDoc(job, JOBS_DOCTYPE),
-    ...job.attributes
-  }
-}
+export const normalizeJob = normalizeDoctypeJsonApi(JOBS_DOCTYPE)
 
 export const hasJobFinished = job => {
   return job.state === 'done' || job.state === 'errored'

--- a/packages/cozy-stack-client/src/KonnectorCollection.js
+++ b/packages/cozy-stack-client/src/KonnectorCollection.js
@@ -5,7 +5,7 @@ import TriggerCollection, {
   isForKonnector,
   isForAccount
 } from './TriggerCollection'
-import { normalizeDoc } from './DocumentCollection'
+import { normalizeDoc } from './normalize'
 
 export const KONNECTORS_DOCTYPE = 'io.cozy.konnectors'
 

--- a/packages/cozy-stack-client/src/NextcloudFilesCollection.js
+++ b/packages/cozy-stack-client/src/NextcloudFilesCollection.js
@@ -1,8 +1,7 @@
-import DocumentCollection, {
-  normalizeDoctypeJsonApi
-} from './DocumentCollection'
+import DocumentCollection from './DocumentCollection'
 import { forceDownload, joinPath, encodePath } from './utils'
 import { FetchError } from './errors'
+import { normalizeDoctypeJsonApi } from './normalize'
 
 const NEXTCLOUD_FILES_DOCTYPE = 'io.cozy.remote.nextcloud.files'
 

--- a/packages/cozy-stack-client/src/NextcloudFilesCollection.js
+++ b/packages/cozy-stack-client/src/NextcloudFilesCollection.js
@@ -1,10 +1,12 @@
-import DocumentCollection from './DocumentCollection'
+import DocumentCollection, {
+  normalizeDoctypeJsonApi
+} from './DocumentCollection'
 import { forceDownload, joinPath, encodePath } from './utils'
 import { FetchError } from './errors'
 
 const NEXTCLOUD_FILES_DOCTYPE = 'io.cozy.remote.nextcloud.files'
 
-const normalizeDoc = DocumentCollection.normalizeDoctypeJsonApi(
+const normalizeNextcloudFileJsonApi = normalizeDoctypeJsonApi(
   NEXTCLOUD_FILES_DOCTYPE
 )
 
@@ -13,21 +15,18 @@ const normalizeNextcloudFile = (
   parentPath,
   { fromTrash = false } = {}
 ) => file => {
-  const extendedAttributes = {
-    ...file.attributes,
-    parentPath,
-    path: fromTrash
-      ? file.attributes.path
-      : joinPath(parentPath, file.attributes.name),
-    cozyMetadata: {
-      ...file.attributes.cozyMetadata,
-      sourceAccount
-    }
-  }
+  const normalizedDoc = normalizeNextcloudFileJsonApi(file)
 
   return {
-    ...normalizeDoc(file, NEXTCLOUD_FILES_DOCTYPE),
-    ...extendedAttributes
+    ...normalizedDoc,
+    parentPath,
+    path: fromTrash
+      ? normalizedDoc.path
+      : joinPath(parentPath, normalizedDoc.name),
+    cozyMetadata: {
+      ...normalizedDoc.cozyMetadata,
+      sourceAccount
+    }
   }
 }
 

--- a/packages/cozy-stack-client/src/NotesCollection.js
+++ b/packages/cozy-stack-client/src/NotesCollection.js
@@ -1,6 +1,5 @@
-import DocumentCollection, {
-  normalizeDoctypeJsonApi
-} from './DocumentCollection'
+import DocumentCollection from './DocumentCollection'
+import { normalizeDoctypeJsonApi } from './normalize'
 import { uri } from './utils'
 import { getDefaultSchema as modelDefaultSchema } from './NotesSchema'
 export const NOTES_DOCTYPE = 'io.cozy.notes'

--- a/packages/cozy-stack-client/src/NotesCollection.js
+++ b/packages/cozy-stack-client/src/NotesCollection.js
@@ -1,19 +1,13 @@
-import DocumentCollection from './DocumentCollection'
+import DocumentCollection, {
+  normalizeDoctypeJsonApi
+} from './DocumentCollection'
 import { uri } from './utils'
 import { getDefaultSchema as modelDefaultSchema } from './NotesSchema'
 export const NOTES_DOCTYPE = 'io.cozy.notes'
 export const NOTES_URL_DOCTYPE = 'io.cozy.notes.url'
 
-const normalizeDoc = DocumentCollection.normalizeDoctypeJsonApi(NOTES_DOCTYPE)
-const normalizeNote = note => ({
-  ...normalizeDoc(note, NOTES_DOCTYPE),
-  ...note.attributes
-})
-
-const normalizeNoteUrl = noteUrl => ({
-  ...DocumentCollection.normalizeDoctypeJsonApi(NOTES_URL_DOCTYPE)(noteUrl),
-  ...noteUrl.attributes
-})
+const normalizeNote = normalizeDoctypeJsonApi(NOTES_DOCTYPE)
+const normalizeNoteUrl = normalizeDoctypeJsonApi(NOTES_URL_DOCTYPE)
 
 /**
  * Implements `DocumentCollection` API to interact with the /notes endpoint of the stack

--- a/packages/cozy-stack-client/src/NotesCollection.js
+++ b/packages/cozy-stack-client/src/NotesCollection.js
@@ -114,6 +114,6 @@ class NotesCollection extends DocumentCollection {
   }
 }
 
-NotesCollection.normalizeDoctype = DocumentCollection.normalizeDoctypeJsonApi
+NotesCollection.normalizeDoctype = normalizeDoctypeJsonApi
 
 export default NotesCollection

--- a/packages/cozy-stack-client/src/OAuthClientsCollection.js
+++ b/packages/cozy-stack-client/src/OAuthClientsCollection.js
@@ -112,7 +112,6 @@ class OAuthClientsCollection extends DocumentCollection {
   }
 }
 
-OAuthClientsCollection.normalizeDoctype =
-  DocumentCollection.normalizeDoctypeJsonApi
+OAuthClientsCollection.normalizeDoctype = normalizeDoctypeJsonApi
 
 export default OAuthClientsCollection

--- a/packages/cozy-stack-client/src/OAuthClientsCollection.js
+++ b/packages/cozy-stack-client/src/OAuthClientsCollection.js
@@ -1,6 +1,8 @@
 import get from 'lodash/get'
 
-import DocumentCollection from './DocumentCollection'
+import DocumentCollection, {
+  normalizeDoctypeJsonApi
+} from './DocumentCollection'
 import { uri } from './utils'
 import * as querystring from './querystring'
 import { dontThrowNotFoundError } from './Collection'
@@ -8,13 +10,7 @@ import { FetchError } from './errors'
 
 export const OAUTH_CLIENTS_DOCTYPE = 'io.cozy.oauth.clients'
 
-const normalizeDoc = DocumentCollection.normalizeDoctypeJsonApi(
-  OAUTH_CLIENTS_DOCTYPE
-)
-const normalizeOAuthClient = client => ({
-  ...normalizeDoc(client, OAUTH_CLIENTS_DOCTYPE),
-  ...client.attributes
-})
+const normalizeOAuthClient = normalizeDoctypeJsonApi(OAUTH_CLIENTS_DOCTYPE)
 
 /**
  * Implements `DocumentCollection` API to interact with the /settings/clients endpoint of the stack

--- a/packages/cozy-stack-client/src/OAuthClientsCollection.js
+++ b/packages/cozy-stack-client/src/OAuthClientsCollection.js
@@ -1,8 +1,7 @@
 import get from 'lodash/get'
 
-import DocumentCollection, {
-  normalizeDoctypeJsonApi
-} from './DocumentCollection'
+import DocumentCollection from './DocumentCollection'
+import { normalizeDoctypeJsonApi } from './normalize'
 import { uri } from './utils'
 import * as querystring from './querystring'
 import { dontThrowNotFoundError } from './Collection'

--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -280,9 +280,6 @@ export const getPermissionsFor = (
       }
 }
 
-PermissionCollection.normalizeDoctype =
-  DocumentCollection.normalizeDoctypeJsonApi
-
 const isPermissionRelatedTo = (perm, document) => {
   const { _id } = document
   return isFile(document)

--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -1,4 +1,5 @@
-import DocumentCollection, { normalizeDoc } from './DocumentCollection'
+import DocumentCollection from './DocumentCollection'
+import { normalizeDoc } from './normalize'
 import { isFile } from './FileCollection'
 import { uri } from './utils'
 import logger from './logger'

--- a/packages/cozy-stack-client/src/SettingsCollection.js
+++ b/packages/cozy-stack-client/src/SettingsCollection.js
@@ -89,6 +89,6 @@ class SettingsCollection extends DocumentCollection {
   }
 }
 
-SettingsCollection.normalizeDoctype = DocumentCollection.normalizeDoctypeJsonApi
+SettingsCollection.normalizeDoctype = normalizeDoctypeJsonApi
 
 export default SettingsCollection

--- a/packages/cozy-stack-client/src/SettingsCollection.js
+++ b/packages/cozy-stack-client/src/SettingsCollection.js
@@ -1,4 +1,6 @@
-import DocumentCollection, { normalizeDoc } from './DocumentCollection'
+import DocumentCollection, {
+  normalizeDoctypeJsonApi
+} from './DocumentCollection'
 import logger from './logger'
 import { uri } from './utils'
 
@@ -10,13 +12,7 @@ export const SETTINGS_DOCTYPE = 'io.cozy.settings'
  * @param {object} doc - Document to normalize
  * @returns {object} normalized document
  */
-export const normalizeSettings = doc => {
-  const normDoc = normalizeDoc(doc, SETTINGS_DOCTYPE)
-  return {
-    ...normDoc,
-    ...normDoc.attributes
-  }
-}
+export const normalizeSettings = normalizeDoctypeJsonApi(SETTINGS_DOCTYPE)
 
 /**
  * Implements `DocumentCollection` API to interact with the /settings endpoint of the stack
@@ -41,10 +37,7 @@ class SettingsCollection extends DocumentCollection {
         '/data/io.cozy.settings/io.cozy.settings.bitwarden'
       )
       return {
-        data: DocumentCollection.normalizeDoctypeJsonApi(SETTINGS_DOCTYPE)(
-          resp,
-          resp
-        )
+        data: normalizeSettings(resp)
       }
     }
 
@@ -64,7 +57,10 @@ class SettingsCollection extends DocumentCollection {
 
     const resp = await this.stackClient.fetchJSON('GET', `/settings/${path}`)
     return {
-      data: normalizeSettings({ id: `/settings/${path}`, ...resp.data })
+      data: normalizeSettings({
+        id: `/settings/${path}`,
+        ...resp.data
+      })
     }
   }
 

--- a/packages/cozy-stack-client/src/SettingsCollection.js
+++ b/packages/cozy-stack-client/src/SettingsCollection.js
@@ -1,8 +1,7 @@
-import DocumentCollection, {
-  normalizeDoctypeJsonApi
-} from './DocumentCollection'
+import DocumentCollection from './DocumentCollection'
 import logger from './logger'
 import { uri } from './utils'
+import { normalizeDoctypeJsonApi } from './normalize'
 
 export const SETTINGS_DOCTYPE = 'io.cozy.settings'
 

--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -259,7 +259,7 @@ class SharingCollection extends DocumentCollection {
   }
 }
 
-SharingCollection.normalizeDoctype = DocumentCollection.normalizeDoctypeJsonApi
+SharingCollection.normalizeDoctype = normalizeDoctypeJsonApi
 
 const getSharingRulesWithoutWarning = (document, sharingType) => {
   if (isFile(document)) {

--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -1,4 +1,6 @@
-import DocumentCollection, { normalizeDoc } from './DocumentCollection'
+import DocumentCollection, {
+  normalizeDoctypeJsonApi
+} from './DocumentCollection'
 import { isFile, isDirectory } from './FileCollection'
 import { uri } from './utils'
 import logger from './logger'
@@ -7,7 +9,7 @@ export const SHARING_DOCTYPE = 'io.cozy.sharings'
 export const BITWARDEN_ORGANIZATIONS_DOCTYPE = 'com.bitwarden.organizations'
 export const BITWARDEN_CIPHERS_DOCTYPE = 'com.bitwarden.ciphers'
 
-const normalizeSharing = sharing => normalizeDoc(sharing, SHARING_DOCTYPE)
+const normalizeSharing = normalizeDoctypeJsonApi(SHARING_DOCTYPE)
 
 /**
  * @typedef {object} Rule A sharing rule

--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -1,6 +1,5 @@
-import DocumentCollection, {
-  normalizeDoctypeJsonApi
-} from './DocumentCollection'
+import DocumentCollection from './DocumentCollection'
+import { normalizeDoctypeJsonApi } from './normalize'
 import { isFile, isDirectory } from './FileCollection'
 import { uri } from './utils'
 import logger from './logger'

--- a/packages/cozy-stack-client/src/ShortcutsCollection.js
+++ b/packages/cozy-stack-client/src/ShortcutsCollection.js
@@ -73,7 +73,6 @@ class ShortcutsCollection extends DocumentCollection {
   }
 }
 
-ShortcutsCollection.normalizeDoctype =
-  DocumentCollection.normalizeDoctypeJsonApi
+ShortcutsCollection.normalizeDoctype = normalizeDoctypeJsonApi
 
 export default ShortcutsCollection

--- a/packages/cozy-stack-client/src/ShortcutsCollection.js
+++ b/packages/cozy-stack-client/src/ShortcutsCollection.js
@@ -1,6 +1,5 @@
-import DocumentCollection, {
-  normalizeDoctypeJsonApi
-} from './DocumentCollection'
+import DocumentCollection from './DocumentCollection'
+import { normalizeDoctypeJsonApi } from './normalize'
 import { uri } from './utils'
 import { getIllegalCharacters } from './getIllegalCharacter'
 

--- a/packages/cozy-stack-client/src/ShortcutsCollection.js
+++ b/packages/cozy-stack-client/src/ShortcutsCollection.js
@@ -1,13 +1,25 @@
-import DocumentCollection from './DocumentCollection'
+import DocumentCollection, {
+  normalizeDoctypeJsonApi
+} from './DocumentCollection'
 import { uri } from './utils'
 import { getIllegalCharacters } from './getIllegalCharacter'
 
 export const SHORTCUTS_DOCTYPE = 'io.cozy.files.shortcuts'
 
+const normalizeShortcutsJsonApi = normalizeDoctypeJsonApi(SHORTCUTS_DOCTYPE)
+
+const normalizeShortcuts = doc => {
+  return {
+    ...normalizeShortcutsJsonApi(doc),
+    _id: doc._id // Ensures that the _id replaces by _id inside attributes
+  }
+}
+
 class ShortcutsCollection extends DocumentCollection {
   constructor(stackClient) {
     super(SHORTCUTS_DOCTYPE, stackClient)
   }
+
   /**
    * Create a shortcut
    *
@@ -49,10 +61,7 @@ class ShortcutsCollection extends DocumentCollection {
       }
     })
     return {
-      data: DocumentCollection.normalizeDoctypeJsonApi(SHORTCUTS_DOCTYPE)(
-        resp.data,
-        resp
-      )
+      data: normalizeShortcuts(resp.data)
     }
   }
 
@@ -60,10 +69,7 @@ class ShortcutsCollection extends DocumentCollection {
     const path = uri`/shortcuts/${id}`
     const resp = await this.stackClient.fetchJSON('GET', path)
     return {
-      data: DocumentCollection.normalizeDoctypeJsonApi(SHORTCUTS_DOCTYPE)(
-        resp.data,
-        resp
-      )
+      data: normalizeShortcuts(resp.data)
     }
   }
 }

--- a/packages/cozy-stack-client/src/TriggerCollection.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.js
@@ -209,6 +209,6 @@ class TriggerCollection extends DocumentCollection {
   }
 }
 
-TriggerCollection.normalizeDoctype = DocumentCollection.normalizeDoctypeJsonApi
+TriggerCollection.normalizeDoctype = normalizeDoctypeJsonApi
 
 export default TriggerCollection

--- a/packages/cozy-stack-client/src/TriggerCollection.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.js
@@ -1,5 +1,5 @@
 import Collection, { dontThrowNotFoundError } from './Collection'
-import { normalizeDoc } from './DocumentCollection'
+import { normalizeDoctypeJsonApi } from './DocumentCollection'
 import { normalizeJob } from './JobCollection'
 import { uri } from './utils'
 import DocumentCollection from './DocumentCollection'
@@ -8,13 +8,7 @@ import { FetchError } from './errors'
 export const JOBS_DOCTYPE = 'io.cozy.jobs'
 export const TRIGGERS_DOCTYPE = 'io.cozy.triggers'
 
-export const normalizeTrigger = trigger => {
-  return {
-    ...trigger,
-    ...normalizeDoc(trigger, TRIGGERS_DOCTYPE),
-    ...trigger.attributes
-  }
-}
+export const normalizeTrigger = normalizeDoctypeJsonApi(TRIGGERS_DOCTYPE)
 
 export const isForKonnector = (triggerAttrs, slug) => {
   return (
@@ -68,7 +62,7 @@ class TriggerCollection extends DocumentCollection {
       const resp = await this.stackClient.fetchJSON('GET', `/jobs/triggers`)
 
       return {
-        data: resp.data.map(row => normalizeTrigger(row, TRIGGERS_DOCTYPE)),
+        data: resp.data.map(row => normalizeTrigger(row)),
         meta: { count: resp.data.length },
         next: false,
         skip: 0
@@ -137,7 +131,7 @@ class TriggerCollection extends DocumentCollection {
         const resp = await this.stackClient.fetchJSON('GET', url)
 
         return {
-          data: resp.data.map(row => normalizeTrigger(row, TRIGGERS_DOCTYPE)),
+          data: resp.data.map(row => normalizeTrigger(row)),
           meta: { count: resp.data.length },
           next: false,
           skip: 0

--- a/packages/cozy-stack-client/src/TriggerCollection.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.js
@@ -1,5 +1,5 @@
 import Collection, { dontThrowNotFoundError } from './Collection'
-import { normalizeDoctypeJsonApi } from './DocumentCollection'
+import { normalizeDoctypeJsonApi } from './normalize'
 import { normalizeJob } from './JobCollection'
 import { uri } from './utils'
 import DocumentCollection from './DocumentCollection'

--- a/packages/cozy-stack-client/src/index.js
+++ b/packages/cozy-stack-client/src/index.js
@@ -1,4 +1,4 @@
 export { default } from './CozyStackClient'
 export { default as OAuthClient } from './OAuthClient'
 export { default as errors, FetchError } from './errors'
-export { normalizeDoc } from './DocumentCollection'
+export { normalizeDoc } from './normalize'

--- a/packages/cozy-stack-client/src/normalize.js
+++ b/packages/cozy-stack-client/src/normalize.js
@@ -20,13 +20,38 @@ export function normalizeDoc(doc = {}, doctype) {
 export function normalizeDoctypeJsonApi(doctype) {
   /**
    * @param {object} data - The document from "data" property of the response in JSON API format
+   * @param {object} response - The response from the API (not used in this function)
    * @returns {object} The normalized document
    */
-  return function(data) {
+  return function(data, response) {
+    // use the "data" attribute of the response
     const normalizedDoc = normalizeDoc(data, doctype)
     return {
       ...normalizedDoc,
-      ...normalizedDoc.attributes
+      ...(normalizedDoc.attributes || {})
+    }
+  }
+}
+
+/**
+ * `normalizeDoctype` for api end points returning raw documents
+ *
+ * @private
+ * @param {string} doctype - Document doctype
+ * @returns {Function} A function that normalizes the document
+ */
+export function normalizeDoctypeRawApi(doctype) {
+  /**
+   * @param {object} data - The data from the API response (not used in this function)
+   * @param {object} response - The raw response from the API
+   * @returns {object} The normalized document
+   */
+  return function(data, response) {
+    // use the response directly
+    const normalizedDoc = normalizeDoc(response, doctype)
+    return {
+      ...normalizedDoc,
+      ...(normalizedDoc.attributes || {})
     }
   }
 }

--- a/packages/cozy-stack-client/src/normalize.js
+++ b/packages/cozy-stack-client/src/normalize.js
@@ -1,0 +1,32 @@
+/**
+ * Normalize a document, adding its doctype if needed
+ *
+ * @param {object} doc - Document to normalize
+ * @param {string} doctype - Document doctype
+ * @returns {object} normalized document
+ * @private
+ */
+export function normalizeDoc(doc = {}, doctype) {
+  const id = doc._id || doc.id
+  return { id, _id: id, _type: doctype, ...doc }
+}
+
+/**
+ * Normalizes a document in JSON API format for a specific doctype
+ *
+ * @param {string} doctype - The document type
+ * @returns {Function} A function that normalizes the document
+ */
+export function normalizeDoctypeJsonApi(doctype) {
+  /**
+   * @param {object} data - The document from "data" property of the response in JSON API format
+   * @returns {object} The normalized document
+   */
+  return function(data) {
+    const normalizedDoc = normalizeDoc(data, doctype)
+    return {
+      ...normalizedDoc,
+      ...normalizedDoc.attributes
+    }
+  }
+}


### PR DESCRIPTION
This PR moves document properties from the 'attributes' sub-object to the document
root to avoid data inconsistencies between JSON and CouchDB formats.
This ensures compatibility with CouchDB documents, where properties are
at the root level. By spreading attributes directly to the root in the
JSON document, the structure now aligns with CouchDB's format, allowing
seamless interaction across different APIs, including real-time updates
and the data API. This prevents potential issues caused by schema
mismatches in data retrieval and synchronization processes.