### PR TITLE
fix: Allow remote request on web environment

### DIFF
--- a/packages/cozy-pouch-link/src/remote.js
+++ b/packages/cozy-pouch-link/src/remote.js
@@ -31,7 +31,7 @@ export const fetchRemoteInstance = async (url, params = {}) => {
   headers.append('Accept', 'application/json')
   headers.append('Content-Type', 'application/json')
   headers.append('Authorization', access.toAuthHeader())
-  const resp = await fetch(fetchUrl, { headers })
+  const resp = await fetch(fetchUrl, { headers, credentials: 'include' })
   const data = await resp.json()
   if (resp.ok) {
     return data

--- a/packages/cozy-pouch-link/src/remote.spec.js
+++ b/packages/cozy-pouch-link/src/remote.spec.js
@@ -39,7 +39,8 @@ describe('remote', () => {
       expect(fetch).toHaveBeenCalledWith(
         'https://claude.mycozy.cloud/data/io.cozy.accounts/_changes',
         {
-          headers: expectedHeaders
+          headers: expectedHeaders,
+          credentials: 'include'
         }
       )
     })


### PR DESCRIPTION
When using PouchLink in a web environment, we need to pass the cookies through the fetch method in order to authenticate to the stack. Note we didn't have the issue before we were using PouchLink in a mobile environment, with OAuth authentication.

For more insights, see
```
https://reqbin.com/code/javascript/lcpj87js/
javascript-fetch-with-credentials
```