### PR TITLE
feat(FileCollection): Add getAll(), and so Q(`io.cozy.files`).getByIds

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -749,6 +749,7 @@ files associated to a specific document
 * [FileCollection](#FileCollection)
     * [.forceFileDownload](#FileCollection+forceFileDownload)
     * [.get(id)](#FileCollection+get) ⇒ <code>Object</code>
+    * [.getAll(ids)](#FileCollection+getAll) ⇒ <code>Promise.&lt;{data, meta, execution\_stats}&gt;</code>
     * [.find(selector, options)](#FileCollection+find) ⇒ <code>Promise.&lt;{data, meta, skip, next, bookmark, execution\_stats}&gt;</code>
     * [.findReferencedBy(document, options)](#FileCollection+findReferencedBy) ⇒ <code>Promise.&lt;{data, included, meta, skip, next}&gt;</code>
     * [.addReferencedBy(document, documents)](#FileCollection+addReferencedBy) ⇒ <code>Promise.&lt;{data, meta}&gt;</code>
@@ -803,6 +804,18 @@ Fetches the file's data
 | Param | Type | Description |
 | --- | --- | --- |
 | id | <code>string</code> | File id |
+
+<a name="FileCollection+getAll"></a>
+
+### fileCollection.getAll(ids) ⇒ <code>Promise.&lt;{data, meta, execution\_stats}&gt;</code>
+Get all files by their ids
+
+**Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
+**Returns**: <code>Promise.&lt;{data, meta, execution\_stats}&gt;</code> - JSON API response  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ids | <code>Array.&lt;string&gt;</code> | files ids |
 
 <a name="FileCollection+find"></a>
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "docs": "yarn cleanDocsApi && node scripts/docs.js && yarn docs:cozy-client && yarn docs:cozy-pouch-link",
     "docs:cozy-client": "yarn typedoc --readme none --hideInPageTOC --excludeExternals --excludePrivate --tsconfig packages/cozy-client/tsconfig.json packages/cozy-client/src/index.js --out docs/api/cozy-client --gitRevision master && yarn remark -o -u ./scripts/strip-typedoc-headings.mjs docs/api/cozy-client/",
     "docs:cozy-pouch-link": "yarn typedoc --readme none --hideInPageTOC --excludeExternals --excludePrivate --tsconfig packages/cozy-pouch-link/tsconfig.json packages/cozy-pouch-link/src/index.js --out docs/api/cozy-pouch-link --gitRevision master && yarn remark -o -u ./scripts/strip-typedoc-headings.mjs docs/api/cozy-pouch-link/",
+    "beforecommit": "yarn build && yarn docs && yarn types",
     "types": "yarn cleanTypes && cd packages/cozy-client && yarn typecheck && cd ../cozy-pouch-link && yarn typecheck"
   },
   "commitlint": {

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -209,6 +209,34 @@ class FileCollection extends DocumentCollection {
     return this.statById(id)
   }
 
+  /**
+   * Get all files by their ids
+   *
+   * @param {Array<string>} ids - files ids
+   * @returns {Promise<{data, meta, execution_stats}>} JSON API response
+   */
+  async getAll(ids) {
+    let resp
+    try {
+      resp = await this.stackClient.fetchJSON(
+        'POST',
+        uri`/files/_all_docs?include_docs=true`,
+        {
+          keys: ids
+        }
+      )
+    } catch (error) {
+      return dontThrowNotFoundError(error)
+    }
+    return {
+      data: resp.data.map(f => normalizeFile(f)),
+      meta: {
+        count: resp.data.length
+      },
+      execution_stats: resp.execution_stats
+    }
+  }
+
   async fetchFindFiles(selector, options) {
     return this.stackClient.fetchJSON(
       'POST',


### PR DESCRIPTION
need to deploy stack before merging...