### PR TITLE
fix: Add missing fields on CozyMetadata for io.cozy.files

### DIFF
--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -420,6 +420,20 @@ import { QueryDefinition } from './queries/dsl'
  */
 
 /**
+ * @typedef {object} UploadedBy
+ * @property {string} slug - The slug of the application that has made the upload
+ * @property {string} version - The version number of this application
+ */
+
+/**
+ * @typedef {object} CozyMetadataFile - Extra fields inside cozyMetadata only for io.cozy.files documents
+ * @property {string} [createdOn] - The instance URL on which the file has created (useful if the file is shared between several cozy instances)
+ * @property {string} [uploadedAt] - The server date/time of the last upload (when the content was changed)
+ * @property {string} [uploadedOn] - The instance URL on which the file content was changed the last time
+ * @property {UploadedBy[]} [uploadedBy] - Information on which app has made the last upload
+ */
+
+/**
  * @typedef {object} CozyClientDocumentMeta - Meta object as specified by JSON-API (https://jsonapi.org/format/#document-meta)
  * @property {string} [rev] - Current revision of the document
  */
@@ -486,6 +500,7 @@ import { QueryDefinition } from './queries/dsl'
  * @property {string} updated_at - Last modification date of the file
  * @property {number} size - Size of the file, in bytes
  * @property {boolean} trashed - Whether the folder is in the trash
+ * @property {CozyMetadata & CozyMetadataFile} [cozyMetadata] - Cozy Metadata
  * @typedef {CozyClientDocument & FileDocument} IOCozyFile - An io.cozy.files document
  */
 

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -705,6 +705,37 @@ export type CozyMetadata = {
      */
     favorite?: boolean;
 };
+export type UploadedBy = {
+    /**
+     * - The slug of the application that has made the upload
+     */
+    slug: string;
+    /**
+     * - The version number of this application
+     */
+    version: string;
+};
+/**
+ * - Extra fields inside cozyMetadata only for io.cozy.files documents
+ */
+export type CozyMetadataFile = {
+    /**
+     * - The instance URL on which the file has created (useful if the file is shared between several cozy instances)
+     */
+    createdOn?: string;
+    /**
+     * - The server date/time of the last upload (when the content was changed)
+     */
+    uploadedAt?: string;
+    /**
+     * - The instance URL on which the file content was changed the last time
+     */
+    uploadedOn?: string;
+    /**
+     * - Information on which app has made the last upload
+     */
+    uploadedBy?: UploadedBy[];
+};
 /**
  * - Meta object as specified by JSON-API (https://jsonapi.org/format/#document-meta)
  */
@@ -894,6 +925,10 @@ export type FileDocument = {
      * - Whether the folder is in the trash
      */
     trashed: boolean;
+    /**
+     * - Cozy Metadata
+     */
+    cozyMetadata?: CozyMetadata & CozyMetadataFile;
 };
 /**
  * - An io.cozy.files document


### PR DESCRIPTION
By typing inside cozy-drive, I found out that `io.cozy.files` have extra fields inside their `cozyMetadata`. Their are documented inside cozy-doctype but not inside cozy-client ([doc](https://github.com/cozy/cozy-doctypes/blob/master/docs/io.cozy.files.md#cozymetadata)). This commit aims to correct this for future use