### PR TITLE
feat: Parallelize `loadInstanceOptionsFromStacks` queries

### DIFF
--- a/docs/api/cozy-client/classes/CozyClient.md
+++ b/docs/api/cozy-client/classes/CozyClient.md
@@ -73,7 +73,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1832](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1832)
+[packages/cozy-client/src/CozyClient.js:1834](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1834)
 
 ***
 
@@ -123,7 +123,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1830](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1830)
+[packages/cozy-client/src/CozyClient.js:1832](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1832)
 
 ***
 
@@ -955,7 +955,7 @@ extract the value corresponding to the given `key`
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1856](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1856)
+[packages/cozy-client/src/CozyClient.js:1858](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1858)
 
 ***
 
@@ -1594,7 +1594,7 @@ This method will reset the query state to its initial state and refetch it.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1885](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1885)
+[packages/cozy-client/src/CozyClient.js:1887](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1887)
 
 ***
 
@@ -1652,7 +1652,7 @@ save the new resulting settings into database
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1873](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1873)
+[packages/cozy-client/src/CozyClient.js:1875](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1875)
 
 ***
 
@@ -1701,7 +1701,7 @@ Saves multiple documents in one batch
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1815](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1815)
+[packages/cozy-client/src/CozyClient.js:1817](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1817)
 
 ***
 
@@ -1725,7 +1725,7 @@ set some data in the store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1788](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1788)
+[packages/cozy-client/src/CozyClient.js:1790](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1790)
 
 ***
 
@@ -1749,7 +1749,7 @@ we manually call the links onLogin methods
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1829](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1829)
+[packages/cozy-client/src/CozyClient.js:1831](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1831)
 
 ***
 
@@ -1773,7 +1773,7 @@ At any time put an error function
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1801](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1801)
+[packages/cozy-client/src/CozyClient.js:1803](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1803)
 
 ***
 
@@ -1849,7 +1849,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1808](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1808)
+[packages/cozy-client/src/CozyClient.js:1810](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1810)
 
 ***
 

--- a/docs/offline/updateDoc.md
+++ b/docs/offline/updateDoc.md
@@ -1,0 +1,124 @@
+
+```mermaid
+---
+title: Offline query from WebApp
+---
+sequenceDiagram
+    participant WebApp
+    participant CC_WebApp as CC WebApp
+    participant Proxy as HTTP Proxy
+    participant AA
+    participant CC_AA as CC AA
+    participant PouchDB
+
+    WebApp->>CC_WebApp: client.query
+    CC_WebApp->>CC_WebApp: check link
+    CC_WebApp->>Proxy: request /pouch
+    Proxy->>AA: requestPouch
+    AA->>CC_AA: client.query
+    CC_AA->>CC_AA: check link
+    CC_AA->>PouchDB: query
+    CC_AA->>CC_WebApp: data
+    CC_AA->>CC_AA: update store
+    CC_WebApp->>CC_WebApp: update store
+```
+
+```mermaid
+---
+title: Update / Create Doc offline from WebApp
+---
+sequenceDiagram
+    participant WebApp
+    participant CC_WebApp as CC WebApp
+    participant Proxy as HTTP Proxy
+    participant AA
+    participant CC_AA as CC AA
+    participant PouchDB
+
+    WebApp->>CC_WebApp: save doc
+    CC_WebApp->>CC_WebApp: check link
+    CC_WebApp->>Proxy: request /pouch
+    Proxy->>AA: requestPouch
+    AA->>CC_AA: client.save
+    CC_AA->>CC_AA: check link
+    CC_AA->>PouchDB: write
+    CC_AA->>CC_WebApp: ok
+    CC_AA->>CC_AA: update store
+    CC_WebApp->>CC_WebApp: update store
+```
+
+```mermaid
+---
+title: Update / Create Doc from AA
+---
+sequenceDiagram
+    participant WebAppOff as WebApp Offline
+    participant CC_WebApp as CC WebApp
+    participant Proxy as HTTP Proxy
+    participant AA
+    participant CC_AA as CC AA
+    participant PouchDB
+
+
+    AA->>CC_AA: save doc
+    CC_AA->>CC_AA: check link
+    CC_AA->>PouchDB: write
+    CC_AA->>Proxy: realtime event
+    CC_AA->>CC_AA: update store
+    Proxy->>CC_WebApp: realtime event
+    CC_WebApp->>CC_WebApp: udpate store
+
+
+```
+
+```mermaid
+---
+title: Reconciliate online/offline changes
+---
+sequenceDiagram
+    participant WebApp
+    participant CC_WebApp as CC WebApp
+    participant Proxy as HTTP Proxy
+    participant CC_AA as CC AA
+    participant PouchDB
+    participant Stack
+    participant CouchDB
+
+    CC_AA->>PouchDB: offline writes
+    Stack->>CouchDB: update doc
+    Stack->>Stack: update event
+    CC_AA->>CC_AA: turns online
+    CC_AA->>Stack: sync on _changes
+    Stack->>CouchDB: write changes
+    CC_AA->>PouchDB: Write changes
+    CC_AA->>Proxy: update event
+    CC_AA->>CC_AA: update store
+    Proxy->>CC_WebApp: update event
+    CC_WebApp->>CC_WebApp: udpate store
+
+```
+
+```mermaid
+---
+title: Online changes
+---
+sequenceDiagram
+    participant CC_WebApp as CC WebApp
+    participant Proxy as HTTP Proxy
+    participant CC_AA as CC AA
+    participant PouchDB
+    participant Stack
+    participant CouchDB
+
+    Stack->>CouchDB: update doc
+    Stack->>Proxy: update event
+    Proxy->>CC_WebApp: update event
+    Proxy->>CC_AA: update event
+    CC_AA->>CC_AA: update store
+    CC_WebApp->>CC_WebApp: update store
+
+    CC_AA->>Stack: sync on _changes
+    CC_AA->>PouchDB: Write changes
+    CC_AA->>CC_AA: update store
+
+```

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -1761,16 +1761,18 @@ instantiation of the client.`
    * @returns {Promise<void>}
    */
   async loadInstanceOptionsFromStack() {
-    const { data } = await this.query(
-      Q('io.cozy.settings').getById('io.cozy.settings.capabilities')
-    )
+    const results = await Promise.all([
+      this.query(
+        Q('io.cozy.settings').getById('io.cozy.settings.capabilities')
+      ),
+      this.query(Q('io.cozy.settings').getById('io.cozy.settings.instance'))
+    ])
 
-    const { data: instanceData } = await this.query(
-      Q('io.cozy.settings').getById('io.cozy.settings.instance')
-    )
+    const { data: capabilitiesData } = results[0]
+    const { data: instanceData } = results[1]
 
     this.instanceOptions = {
-      capabilities: data,
+      capabilities: capabilitiesData,
       locale: instanceData.locale,
       tracking: instanceData.tracking
     }


### PR DESCRIPTION
We want to optimize the flagship app's startup time and this method is in the critical path

By parallelizing those two queries we expect to redue this method's execution duration