### PR TITLE
feat: Do not query /jobs/triggers with a partialFilter

### DIFF
--- a/packages/cozy-stack-client/src/TriggerCollection.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.js
@@ -122,7 +122,8 @@ class TriggerCollection extends DocumentCollection {
    */
   async find(selector = {}, options = {}) {
     const { worker, type, ...rest } = selector
-    const hasOnlyWorkerAndType = Object.keys(rest).length === 0
+    const hasOnlyWorkerAndType =
+      Object.keys(rest).length === 0 && !options.partialFilter
     if (hasOnlyWorkerAndType) {
       // @see https://github.com/cozy/cozy-stack/blob/master/docs/jobs.md#get-jobstriggers
       const url = `/jobs/triggers?${buildParamsUrl(worker, type)}`

--- a/packages/cozy-stack-client/src/TriggerCollection.spec.js
+++ b/packages/cozy-stack-client/src/TriggerCollection.spec.js
@@ -260,6 +260,20 @@ describe('TriggerCollection', () => {
         }
       )
     })
+
+    it('should call /data/io.cozy.triggers/_find route if partialFilter is passed', async () => {
+      stackClient.fetchJSON.mockReturnValue(FIND_RESPONSE_FIXTURES)
+      await collection.find({}, { partialFilter: { worker: 'konnector' } })
+      expect(stackClient.fetchJSON).toHaveBeenLastCalledWith(
+        'POST',
+        '/data/io.cozy.triggers/_find',
+        {
+          selector: { worker: 'konnector' },
+          skip: 0,
+          use_index: '_design/by__filter_(worker_konnector)'
+        }
+      )
+    })
   })
 
   describe('destroy', () => {


### PR DESCRIPTION
One might want to avoid querying the `/jobs/triggers` route and stick to the `/data` route, to avoid extra work from the stack, that can be costful.
We were using the existence of `worker` and `type` keys in selector, but a partialFilter existence should also force the use of the `/data` route.