### PR TITLE
feat: Allow to enforce Stack link on request chain

### DIFF
--- a/docs/api/cozy-client/classes/CozyClient.md
+++ b/docs/api/cozy-client/classes/CozyClient.md
@@ -1564,13 +1564,14 @@ Contains the fetched token and the client information.
 
 ### requestMutation
 
-▸ **requestMutation**(`definition`): `any`
+▸ **requestMutation**(`definition`, `options`): `any`
 
 *Parameters*
 
 | Name | Type |
 | :------ | :------ |
 | `definition` | `any` |
+| `options` | `any` |
 
 *Returns*
 

--- a/docs/api/cozy-client/classes/CozyLink.md
+++ b/docs/api/cozy-client/classes/CozyLink.md
@@ -48,13 +48,13 @@ Persist the given data into the links storage
 
 *Defined in*
 
-[packages/cozy-client/src/CozyLink.js:31](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyLink.js#L31)
+[packages/cozy-client/src/CozyLink.js:32](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyLink.js#L32)
 
 ***
 
 ### request
 
-▸ **request**(`operation`, `result`, `forward`): `Promise`<`any`>
+▸ **request**(`operation`, `options`, `result`, `forward`): `Promise`<`any`>
 
 Request the given operation from the link
 
@@ -63,6 +63,7 @@ Request the given operation from the link
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `operation` | `any` | The operation to request |
+| `options` | `any` | The request options |
 | `result` | `any` | The result from the previous request of the chain |
 | `forward` | `any` | The next request of the chain |
 
@@ -72,7 +73,7 @@ Request the given operation from the link
 
 *Defined in*
 
-[packages/cozy-client/src/CozyLink.js:20](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyLink.js#L20)
+[packages/cozy-client/src/CozyLink.js:21](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyLink.js#L21)
 
 ***
 
@@ -88,4 +89,4 @@ Reset the link data
 
 *Defined in*
 
-[packages/cozy-client/src/CozyLink.js:40](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyLink.js#L40)
+[packages/cozy-client/src/CozyLink.js:41](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyLink.js#L41)

--- a/docs/api/cozy-client/classes/StackLink.md
+++ b/docs/api/cozy-client/classes/StackLink.md
@@ -64,13 +64,14 @@ Transfers queries and mutations to a remote stack
 
 ### executeMutation
 
-▸ **executeMutation**(`mutation`, `result`, `forward`): `Promise`<`any`>
+▸ **executeMutation**(`mutation`, `options`, `result`, `forward`): `Promise`<`any`>
 
 *Parameters*
 
 | Name | Type |
 | :------ | :------ |
 | `mutation` | `any` |
+| `options` | `any` |
 | `result` | `any` |
 | `forward` | `any` |
 
@@ -153,7 +154,7 @@ Persist the given data into the links storage
 
 ### request
 
-▸ **request**(`operation`, `result`, `forward`): `Promise`<`any`>
+▸ **request**(`operation`, `options`, `result`, `forward`): `Promise`<`any`>
 
 Request the given operation from the link
 
@@ -162,6 +163,7 @@ Request the given operation from the link
 | Name | Type |
 | :------ | :------ |
 | `operation` | `any` |
+| `options` | `any` |
 | `result` | `any` |
 | `forward` | `any` |
 

--- a/docs/api/cozy-client/classes/WebFlagshipLink.md
+++ b/docs/api/cozy-client/classes/WebFlagshipLink.md
@@ -90,7 +90,7 @@ Persist the given data into the links storage
 
 ### request
 
-▸ **request**(`operation`, `result`, `forward`): `Promise`<`boolean`>
+▸ **request**(`operation`, `options`, `result`, `forward`): `Promise`<`boolean`>
 
 Request the given operation from the link
 
@@ -99,6 +99,7 @@ Request the given operation from the link
 | Name | Type |
 | :------ | :------ |
 | `operation` | `any` |
+| `options` | `any` |
 | `result` | `any` |
 | `forward` | `any` |
 

--- a/docs/api/cozy-pouch-link/classes/PouchLink.md
+++ b/docs/api/cozy-pouch-link/classes/PouchLink.md
@@ -162,7 +162,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:833](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L833)
+[CozyPouchLink.js:837](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L837)
 
 ***
 
@@ -182,7 +182,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:794](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L794)
+[CozyPouchLink.js:798](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L798)
 
 ***
 
@@ -208,7 +208,7 @@ Create the PouchDB index if not existing
 
 *Defined in*
 
-[CozyPouchLink.js:599](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L599)
+[CozyPouchLink.js:603](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L603)
 
 ***
 
@@ -229,7 +229,7 @@ Create the PouchDB index if not existing
 
 *Defined in*
 
-[CozyPouchLink.js:837](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L837)
+[CozyPouchLink.js:841](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L841)
 
 ***
 
@@ -249,19 +249,20 @@ Create the PouchDB index if not existing
 
 *Defined in*
 
-[CozyPouchLink.js:822](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L822)
+[CozyPouchLink.js:826](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L826)
 
 ***
 
 ### executeMutation
 
-▸ **executeMutation**(`mutation`, `result`, `forward`): `Promise`<`any`>
+▸ **executeMutation**(`mutation`, `options`, `result`, `forward`): `Promise`<`any`>
 
 *Parameters*
 
 | Name | Type |
 | :------ | :------ |
 | `mutation` | `any` |
+| `options` | `any` |
 | `result` | `any` |
 | `forward` | `any` |
 
@@ -271,7 +272,7 @@ Create the PouchDB index if not existing
 
 *Defined in*
 
-[CozyPouchLink.js:756](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L756)
+[CozyPouchLink.js:760](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L760)
 
 ***
 
@@ -291,7 +292,7 @@ Create the PouchDB index if not existing
 
 *Defined in*
 
-[CozyPouchLink.js:676](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L676)
+[CozyPouchLink.js:680](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L680)
 
 ***
 
@@ -315,7 +316,7 @@ Retrieve the PouchDB index if exist, undefined otherwise
 
 *Defined in*
 
-[CozyPouchLink.js:623](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L623)
+[CozyPouchLink.js:627](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L627)
 
 ***
 
@@ -341,7 +342,7 @@ The changes
 
 *Defined in*
 
-[CozyPouchLink.js:469](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L469)
+[CozyPouchLink.js:473](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L473)
 
 ***
 
@@ -366,7 +367,7 @@ The db info
 
 *Defined in*
 
-[CozyPouchLink.js:484](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L484)
+[CozyPouchLink.js:488](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L488)
 
 ***
 
@@ -512,7 +513,7 @@ Emits an event (pouchlink:sync:end) when the sync (all doctypes) is done
 
 *Defined in*
 
-[CozyPouchLink.js:585](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L585)
+[CozyPouchLink.js:589](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L589)
 
 ***
 
@@ -567,7 +568,7 @@ the need to wait for the warmup
 
 *Defined in*
 
-[CozyPouchLink.js:571](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L571)
+[CozyPouchLink.js:575](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L575)
 
 ***
 
@@ -626,7 +627,7 @@ CozyLink.persistCozyData
 
 *Defined in*
 
-[CozyPouchLink.js:519](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L519)
+[CozyPouchLink.js:523](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L523)
 
 ***
 
@@ -652,13 +653,14 @@ CozyLink.persistCozyData
 
 ### request
 
-▸ **request**(`operation`, `result?`, `forward?`): `Promise`<`any`>
+▸ **request**(`operation`, `options`, `result?`, `forward?`): `Promise`<`any`>
 
 *Parameters*
 
 | Name | Type | Default value |
 | :------ | :------ | :------ |
 | `operation` | `any` | `undefined` |
+| `options` | `any` | `undefined` |
 | `result` | `any` | `null` |
 | `forward` | (`operation`: `any`, `result`: `any`) => `void` | `doNothing` |
 
@@ -710,7 +712,7 @@ CozyLink.reset
 
 *Defined in*
 
-[CozyPouchLink.js:492](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L492)
+[CozyPouchLink.js:496](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L496)
 
 ***
 
@@ -800,7 +802,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:867](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L867)
+[CozyPouchLink.js:871](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L871)
 
 ***
 
@@ -820,7 +822,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:799](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L799)
+[CozyPouchLink.js:803](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L803)
 
 ***
 
@@ -840,7 +842,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:804](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L804)
+[CozyPouchLink.js:808](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L808)
 
 ***
 

--- a/docs/link-authoring.md
+++ b/docs/link-authoring.md
@@ -20,9 +20,9 @@ In the chain example pictured above, the Dedup link would avoid re-fetching the 
 There are two ways of creating a new link. First, you can instantiate a `CozyLink` and pass a request handling function to its constructor:
 
 ```js
-const logLink = new CozyLink((operation, result, forward) => {
+const logLink = new CozyLink((operation, options, result, forward) => {
   console.log(JSON.stringify(operation))
-  return forward(operation, result)
+  return forward(operation, options, result)
 })
 ```
 
@@ -30,9 +30,9 @@ Or you can subclass `CozyLink`:
 
 ```js
 class LogLink extends CozyLink {
-  request(operation, result, forward) {
+  request(operation, options, result, forward) {
     console.log(JSON.stringify(operation))
-    return forward(operation, result)
+    return forward(operation, options, result)
   }
 }
 ```

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -974,7 +974,7 @@ client.query(Q('io.cozy.bills'))`)
             Promise.resolve(
               executeQueryFromState(this.store.getState(), queryDefinition)
             )
-        : () => this.requestQuery(queryDefinition)
+        : () => this.requestQuery(queryDefinition, options)
       const response = await this._promiseCache.exec(requestFn, () =>
         stringify(queryDefinition)
       )
@@ -1083,7 +1083,7 @@ client.query(Q('io.cozy.bills'))`)
       options.as || this.queryIdGenerator.generateId(mutationDefinition)
     this.dispatch(initMutation(mutationId, mutationDefinition))
     try {
-      const response = await this.requestMutation(mutationDefinition)
+      const response = await this.requestMutation(mutationDefinition, options)
       this.dispatch(
         receiveMutationResult(
           mutationId,
@@ -1109,8 +1109,8 @@ client.query(Q('io.cozy.bills'))`)
    * @param  {QueryDefinition} definition QueryDefinition to be executed
    * @returns {Promise<import("./types").ClientResponse>}
    */
-  async requestQuery(definition) {
-    const mainResponse = await this.chain.request(definition)
+  async requestQuery(definition, options) {
+    const mainResponse = await this.chain.request(definition, options)
 
     await this.persistVirtualDocuments(definition, mainResponse.data)
 
@@ -1260,7 +1260,7 @@ client.query(Q('io.cozy.bills'))`)
     }
   }
 
-  async requestMutation(definition) {
+  async requestMutation(definition, options) {
     if (Array.isArray(definition)) {
       const [first, ...rest] = definition
       const firstResponse = await this.requestMutation(first)
@@ -1273,7 +1273,7 @@ client.query(Q('io.cozy.bills'))`)
       )
       return firstResponse
     }
-    return this.chain.request(definition)
+    return this.chain.request(definition, options)
   }
 
   getIncludesRelationships(queryDefinition) {

--- a/packages/cozy-client/src/CozyClient.spec.js
+++ b/packages/cozy-client/src/CozyClient.spec.js
@@ -64,13 +64,13 @@ describe('CozyClient initialization', () => {
 
   beforeEach(() => {
     links = [
-      new CozyLink((operation, result = '', forward) => {
-        return forward(operation, result + 'foo')
+      new CozyLink((operation, options, result = '', forward) => {
+        return forward(operation, options, result + 'foo')
       }),
-      new CozyLink((operation, result, forward) => {
-        return forward(operation, result + 'bar')
+      new CozyLink((operation, options, result, forward) => {
+        return forward(operation, options, result + 'bar')
       }),
-      (operation, result) => {
+      (operation, options, result) => {
         return result + 'baz'
       }
     ]
@@ -475,13 +475,13 @@ describe('CozyClient logout', () => {
 
   beforeEach(() => {
     links = [
-      new CozyLink((operation, result = '', forward) => {
-        return forward(operation, result + 'foo')
+      new CozyLink((operation, options, result = '', forward) => {
+        return forward(operation, options, result + 'foo')
       }),
-      new CozyLink((operation, result, forward) => {
-        return forward(operation, result + 'bar')
+      new CozyLink((operation, options, result, forward) => {
+        return forward(operation, options, result + 'bar')
       }),
-      (operation, result) => {
+      (operation, options, result) => {
         return result + 'baz'
       }
     ]
@@ -632,13 +632,13 @@ describe('CozyClient login', () => {
 
   beforeEach(() => {
     links = [
-      new CozyLink((operation, result = '', forward) => {
-        return forward(operation, result + 'foo')
+      new CozyLink((operation, options, result = '', forward) => {
+        return forward(operation, options, result + 'foo')
       }),
-      new CozyLink((operation, result, forward) => {
-        return forward(operation, result + 'bar')
+      new CozyLink((operation, options, result, forward) => {
+        return forward(operation, options, result + 'bar')
       }),
-      (operation, result) => {
+      (operation, options, result) => {
         return result + 'baz'
       }
     ]

--- a/packages/cozy-client/src/CozyLink.js
+++ b/packages/cozy-client/src/CozyLink.js
@@ -13,11 +13,12 @@ export default class CozyLink {
    * Request the given operation from the link
    *
    * @param {any} operation - The operation to request
+   * @param {any} options - The request options
    * @param {any} result - The result from the previous request of the chain
    * @param {any} forward - The next request of the chain
    * @returns {Promise<any>}
    */
-  async request(operation, result, forward) {
+  async request(operation, options, result, forward) {
     throw new Error('request is not implemented')
   }
 
@@ -45,7 +46,7 @@ export default class CozyLink {
 const toLink = handler =>
   typeof handler === 'function' ? new CozyLink(handler) : handler
 
-const defaultLinkRequestHandler = (operation, result) => {
+const defaultLinkRequestHandler = (operation, options, result) => {
   if (result) return result
   else if (operation.execute) return operation.execute()
   else
@@ -67,11 +68,11 @@ export const chain = links =>
   [...links, defaultLinkHandler].map(toLink).reduce(concat)
 
 const concat = (firstLink, nextLink) => {
-  const requestHandler = (operation, result, forward) => {
-    const nextForward = (op, res) => {
-      return nextLink.request(op, res, forward)
+  const requestHandler = (operation, options, result, forward) => {
+    const nextForward = (op, opts, res) => {
+      return nextLink.request(op, opts, res, forward)
     }
-    return firstLink.request(operation, result, nextForward)
+    return firstLink.request(operation, options, result, nextForward)
   }
 
   const persistHandler = (data, forward) => {

--- a/packages/cozy-client/src/CozyLink.spec.js
+++ b/packages/cozy-client/src/CozyLink.spec.js
@@ -3,13 +3,13 @@ import CozyLink, { chain } from './CozyLink'
 describe('CozyLink', () => {
   it('should be chainable', () => {
     const link = chain([
-      new CozyLink((operation, result = '', forward) => {
-        return forward(operation, result + 'foo')
+      new CozyLink((operation, options, result = '', forward) => {
+        return forward(operation, options, result + 'foo')
       }),
-      new CozyLink((operation, result, forward) => {
-        return forward(operation, result + 'bar')
+      new CozyLink((operation, options, result, forward) => {
+        return forward(operation, options, result + 'bar')
       }),
-      (operation, result) => {
+      (operation, options, result) => {
         return result + 'baz'
       }
     ])
@@ -19,8 +19,8 @@ describe('CozyLink', () => {
   describe('default last link', () => {
     it('should throw an error when called without result', () => {
       const link = chain([
-        new CozyLink((operation, result = '', forward) => {
-          return forward(operation)
+        new CozyLink((operation, options, result = '', forward) => {
+          return forward(operation, options)
         })
       ])
       expect(() =>
@@ -28,10 +28,10 @@ describe('CozyLink', () => {
       ).toThrowErrorMatchingSnapshot()
     })
 
-    it('should return the final result if tehre is one', () => {
+    it('should return the final result if there is one', () => {
       const link = chain([
-        new CozyLink((operation, result, forward) => {
-          return forward(operation, 'foo')
+        new CozyLink((operation, options, result, forward) => {
+          return forward(operation, options, 'foo')
         })
       ])
 
@@ -40,8 +40,8 @@ describe('CozyLink', () => {
 
     it('should call the custom execution function', () => {
       const link = chain([
-        new CozyLink((operation, result = '', forward) => {
-          return forward(operation)
+        new CozyLink((operation, options, result = '', forward) => {
+          return forward(operation, options)
         })
       ])
       const spyFn = jest.fn(() => 'bar')

--- a/packages/cozy-client/src/StackLink.js
+++ b/packages/cozy-client/src/StackLink.js
@@ -89,19 +89,19 @@ export default class StackLink extends CozyLink {
     this.stackClient = null
   }
 
-  async request(operation, result, forward) {
-    if (this.isOnline && !(await this.isOnline())) {
-      return forward(operation)
+  async request(operation, options, result, forward) {
+    if (!options?.forceStack && this.isOnline && !(await this.isOnline())) {
+      return forward(operation, options)
     }
 
     try {
       if (operation.mutationType) {
-        return await this.executeMutation(operation, result, forward)
+        return await this.executeMutation(operation, options, result, forward)
       }
       return await this.executeQuery(operation)
     } catch (err) {
-      if (isReactNativeOfflineError(err)) {
-        return forward(operation)
+      if (!options?.forceStack && isReactNativeOfflineError(err)) {
+        return forward(operation, options)
       }
       throw err
     }
@@ -138,7 +138,7 @@ export default class StackLink extends CozyLink {
     }
   }
 
-  async executeMutation(mutation, result, forward) {
+  async executeMutation(mutation, options, result, forward) {
     const { mutationType, document: doc, documents: docs, ...props } = mutation
     switch (mutationType) {
       case MutationTypes.CREATE_DOCUMENT:
@@ -182,7 +182,7 @@ export default class StackLink extends CozyLink {
           .collection(DOCTYPE_FILES)
           .upload(props.file, props.dirPath)
       default:
-        return forward(mutation, result)
+        return forward(mutation, options, result)
     }
   }
 }

--- a/packages/cozy-client/src/WebFlagshipLink.js
+++ b/packages/cozy-client/src/WebFlagshipLink.js
@@ -18,8 +18,8 @@ export default class WebFlagshipLink extends CozyLink {
     // does nothing, we don't need any client for this kind of link
   }
 
-  async request(operation, result, forward) {
-    return this.webviewIntent.call('flagshipLinkRequest', operation)
+  async request(operation, options, result, forward) {
+    return this.webviewIntent.call('flagshipLinkRequest', operation, options)
   }
 
   async persistCozyData(data, forward) {

--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -302,6 +302,7 @@ import { QueryDefinition } from './queries/dsl'
  * a single doc instead of an array for single doc queries. Defaults to false for backward
  * compatibility but will be set to true in the future.
  * @property {boolean} [executeFromStore=false] - If set to true, the query will be run directly on the current store's state
+ * @property {boolean} [forceStack] - If set to true, the query will be executed through StackLink only even if there are other links available
  */
 
 /**

--- a/packages/cozy-client/types/CozyClient.d.ts
+++ b/packages/cozy-client/types/CozyClient.d.ts
@@ -535,7 +535,7 @@ declare class CozyClient {
      * @private
      */
     private fetchRelationships;
-    requestMutation(definition: any): any;
+    requestMutation(definition: any, options: any): any;
     getIncludesRelationships(queryDefinition: any): import("lodash").Dictionary<any>;
     /**
      * Returns documents with their relationships resolved according to their schema.

--- a/packages/cozy-client/types/CozyLink.d.ts
+++ b/packages/cozy-client/types/CozyLink.d.ts
@@ -4,11 +4,12 @@ export default class CozyLink {
      * Request the given operation from the link
      *
      * @param {any} operation - The operation to request
+     * @param {any} options - The request options
      * @param {any} result - The result from the previous request of the chain
      * @param {any} forward - The next request of the chain
      * @returns {Promise<any>}
      */
-    request(operation: any, result: any, forward: any): Promise<any>;
+    request(operation: any, options: any, result: any, forward: any): Promise<any>;
     /**
      * Persist the given data into the links storage
      *

--- a/packages/cozy-client/types/StackLink.d.ts
+++ b/packages/cozy-client/types/StackLink.d.ts
@@ -27,7 +27,7 @@ export default class StackLink extends CozyLink {
      * @returns {Promise<import("./types").ClientResponse>}
      */
     executeQuery(query: QueryDefinition): Promise<import("./types").ClientResponse>;
-    executeMutation(mutation: any, result: any, forward: any): Promise<any>;
+    executeMutation(mutation: any, options: any, result: any, forward: any): Promise<any>;
 }
 export type StackLinkOptions = {
     /**

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -553,6 +553,10 @@ export type QueryOptions = {
      * - If set to true, the query will be run directly on the current store's state
      */
     executeFromStore?: boolean;
+    /**
+     * - If set to true, the query will be executed through StackLink only even if there are other links available
+     */
+    forceStack?: boolean;
 };
 export type Query = {
     definition: QueryDefinition;

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -98,7 +98,7 @@ describe('CozyPouchLink', () => {
       await setup()
       const query = Q(TODO_DOCTYPE)
       expect.assertions(1)
-      await link.request(query, null, () => {
+      await link.request(query, null, null, () => {
         expect(true).toBe(true)
       })
     })
@@ -111,7 +111,7 @@ describe('CozyPouchLink', () => {
       })
       const query = Q(TODO_DOCTYPE)
       expect.assertions(1)
-      await link.request(query, null, () => {
+      await link.request(query, null, null, () => {
         expect(true).toBe(true)
       })
     })

--- a/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
+++ b/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
@@ -275,7 +275,7 @@ declare class PouchLink extends CozyLink {
         skip: any;
         next: boolean;
     }>;
-    executeMutation(mutation: any, result: any, forward: any): Promise<any>;
+    executeMutation(mutation: any, options: any, result: any, forward: any): Promise<any>;
     createDocument(mutation: any): Promise<any>;
     updateDocument(mutation: any): Promise<any>;
     updateDocuments(mutation: any): Promise<any[]>;


### PR DESCRIPTION
In previous commits we implemented supports for offline mode through CozyPouchLink and FlagshipLink

Since this feature, the StackLink is able to check for internet reachability by using the `isOnline()` method. When no internet is detected, then the request is forwarded to the next link (i.e. the CozyPouchLink)

In some scenario we may want to prevent that behavior. This is the case when we are working on a feature that cannot work without internet access, or when the query's result is expected to contain data that is injected by the cozy-stack (and so that is not available in the local Pouch database)

To make this possible we introduce the `forceStack` parameter that can be set in the query options

When set to `true` then the StackLink will not attempt to forward the request when offline, instead it will still attempt to do the request and throw

We chose to attempt the request instead of directly throwing an error in order to prevent hypothetical scenario where `isOnline()` method returns false even if internet is reachable


BREAKING CHANGE: CozyLink's request methods now takes an additional `options` argument that can be used to enforce usage of Stack link. Although `.request()` is meant to be an internal API, if your code calls it, you'll want to introduce a new argument for `options`. This is also the case if you instanciate a new CozyLink with a handler argument for `request`

Before:
```js
// Initialization
new CozyLink((operation, result = '', forward) => {
  return forward(operation, result + 'foo')
})

// Call
link.request(operation)

// Call with result and forward
link.request(operation, null, () => { /* do stuff */ })
```

After:
```js
// Initialization
new CozyLink((operation, options, result = '', forward) => {
  return forward(operation, options, result + 'foo')
})

// Call
link.request(operation, options)

// Call with result and forward
link.request(operation, options, null, () => { /* do stuff */ })
```

Related PR: cozy/cozy-flagship-app#1269