### PR TITLE
chore: Improve `watch` script to output result

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "lint": "eslint 'packages/*/src/**/*.{js,jsx}' 'packages/*/examples/**/*.{js,jsx}'",
     "test": "jest",
-    "watch": "lerna run watch --parallel",
+    "watch": "lerna run watch --parallel --stream",
     "build": "lerna run build",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "clean": "rm -rf packages/*/dist",


### PR DESCRIPTION
Since we updated Lerna to V8, the task-runner implementation has been changed from `p-map/p-queue` to `nx`

The side effect is that we now have a very light output when running `yarn watch` with no feedback when the build fails

To fix this, we can add the `--stream` argument in addition to the `--parallel` one in order to get the build logs back

The Lerna's `--stream` argument is equivalent to the Nx's `--output-style=stream` one

More info:
- https://github.com/lerna/lerna/releases/tag/v6.0.0
- https://nx.dev/nx-api/nx/documents/run-many#outputstyle
- https://fig.io/manual/lerna/run