### PR TITLE
feat(SharingColl): Add `shortcut` option to getDiscoveryLink

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -1854,7 +1854,7 @@ Implements the `DocumentCollection` API along with specific methods for
     * [.get(id)](#SharingCollection+get) ⇒ [<code>Sharing</code>](#Sharing)
     * [.create(params)](#SharingCollection+create)
     * ~~[.share(document, recipients, sharingType, description, [previewPath])](#SharingCollection+share)~~
-    * [.getDiscoveryLink(sharingId, sharecode)](#SharingCollection+getDiscoveryLink) ⇒ <code>string</code>
+    * [.getDiscoveryLink(sharingId, sharecode, [options])](#SharingCollection+getDiscoveryLink) ⇒ <code>string</code>
     * [.addRecipients(options)](#SharingCollection+addRecipients)
     * [.revokeRecipient(sharing, recipientIndex)](#SharingCollection+revokeRecipient)
     * [.revokeGroup(sharing, groupIndex)](#SharingCollection+revokeGroup)
@@ -1909,7 +1909,7 @@ Creates a new Sharing. See https://docs.cozy.io/en/cozy-stack/sharing/#post-shar
 
 <a name="SharingCollection+getDiscoveryLink"></a>
 
-### sharingCollection.getDiscoveryLink(sharingId, sharecode) ⇒ <code>string</code>
+### sharingCollection.getDiscoveryLink(sharingId, sharecode, [options]) ⇒ <code>string</code>
 getDiscoveryLink - Returns the URL of the page that can be used to accept a sharing. See https://docs.cozy.io/en/cozy-stack/sharing/#get-sharingssharing-iddiscovery
 
 **Kind**: instance method of [<code>SharingCollection</code>](#SharingCollection)  
@@ -1918,6 +1918,8 @@ getDiscoveryLink - Returns the URL of the page that can be used to accept a shar
 | --- | --- | --- |
 | sharingId | <code>string</code> | Id of the sharing |
 | sharecode | <code>string</code> | Code of the sharing |
+| [options] | <code>object</code> | Options |
+| [options.shortcut] | <code>boolean</code> | If true, add a shortcut to the sharing in the user's cozy and skip the OAuth authorize page. |
 
 <a name="SharingCollection+addRecipients"></a>
 

--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -169,11 +169,18 @@ class SharingCollection extends DocumentCollection {
    *
    * @param  {string} sharingId - Id of the sharing
    * @param  {string} sharecode - Code of the sharing
+   * @param  {object} [options] - Options
+   * @param  {boolean} [options.shortcut] - If true, add a shortcut to the sharing in the user's cozy and skip the OAuth authorize page.
    * @returns {string}
    */
-  getDiscoveryLink(sharingId, sharecode) {
+  getDiscoveryLink(sharingId, sharecode, options) {
+    const { shortcut } = options || {}
+    const searchParams = new URLSearchParams()
+    searchParams.append('sharecode', sharecode)
+    if (shortcut) searchParams.append('shortcut', true)
+
     return this.stackClient.fullpath(
-      `/sharings/${sharingId}/discovery?sharecode=${sharecode}`
+      `/sharings/${sharingId}/discovery?${searchParams}`
     )
   }
 
@@ -287,8 +294,8 @@ export const getSharingRules = (document, sharingType) => {
     logger.warn(
       `sharingType is deprecated and will be removed. We now set this default rules: ${getSharingRulesWithoutWarning(
         document
-      )}} \n      
-      If this default rules do not fill your need, please set custom rules 
+      )}} \n
+      If this default rules do not fill your need, please set custom rules
       by using the 'rules' object of the SharingCollection.create() method`
     )
   }

--- a/packages/cozy-stack-client/src/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/SharingCollection.spec.js
@@ -538,4 +538,21 @@ describe('SharingCollection', () => {
       )
     })
   })
+
+  describe('getDiscoveryLink', () => {
+    it('should call the route without a shortcut param', () => {
+      client.fullpath.mockImplementation(path => path)
+      const result = collection.getDiscoveryLink('sharingID', 'abc123')
+      expect(result).toBe('/sharings/sharingID/discovery?sharecode=abc123')
+    })
+    it('should call the route with a shortcut param', () => {
+      client.fullpath.mockImplementation(path => path)
+      const result = collection.getDiscoveryLink('sharingID', 'abc123', {
+        shortcut: true
+      })
+      expect(result).toBe(
+        '/sharings/sharingID/discovery?sharecode=abc123&shortcut=true'
+      )
+    })
+  })
 })


### PR DESCRIPTION
This option allows you to directly redirect users to their Cozy with the share's Shortcut, without using OAuth.
See cozy/cozy-stack#4503