### PR TITLE
fix: Allow disabling file name sanitization

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -756,14 +756,14 @@ files associated to a specific document
     * [.removeReferencedBy(document, documents)](#FileCollection+removeReferencedBy) ⇒ <code>Promise.&lt;{data, meta}&gt;</code>
     * [.addReferencesTo(document, documents)](#FileCollection+addReferencesTo)
     * [.removeReferencesTo(document, documents)](#FileCollection+removeReferencesTo)
-    * [.destroy(file)](#FileCollection+destroy) ⇒ <code>Promise</code>
+    * [.destroy(file, [options])](#FileCollection+destroy) ⇒ <code>Promise</code>
     * [.emptyTrash()](#FileCollection+emptyTrash)
     * [.restore(id)](#FileCollection+restore) ⇒ <code>Promise</code>
-    * [.copy(id, [name], [dirId])](#FileCollection+copy) ⇒ <code>Promise.&lt;object&gt;</code>
+    * [.copy(id, [name], [dirId], [options])](#FileCollection+copy) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.deleteFilePermanently(id)](#FileCollection+deleteFilePermanently) ⇒ <code>Promise.&lt;object&gt;</code>
-    * [.upload(data, dirPath)](#FileCollection+upload) ⇒ <code>Promise.&lt;object&gt;</code>
-    * [.create(attributes)](#FileCollection+create)
-    * [.updateFile(data, params)](#FileCollection+updateFile) ⇒ <code>object</code>
+    * [.upload(data, dirPath, [options])](#FileCollection+upload) ⇒ <code>Promise.&lt;object&gt;</code>
+    * [.create(attributes, [options])](#FileCollection+create)
+    * [.updateFile(data, params, options)](#FileCollection+updateFile) ⇒ [<code>Promise.&lt;FileAttributes&gt;</code>](#FileAttributes)
     * [.download(file, versionId, filename)](#FileCollection+download)
     * [.fetchFileContentById(id)](#FileCollection+fetchFileContentById)
     * [.getBeautifulSize(file, decimal)](#FileCollection+getBeautifulSize)
@@ -772,7 +772,7 @@ files associated to a specific document
     * [.createArchiveLinkByIds(params)](#FileCollection+createArchiveLinkByIds) ⇒ <code>Promise.&lt;string&gt;</code>
     * [.isChildOf(child, parent)](#FileCollection+isChildOf) ⇒ <code>boolean</code>
     * [.statById(id, options)](#FileCollection+statById) ⇒ <code>object</code>
-    * [.createDirectoryByPath(path)](#FileCollection+createDirectoryByPath) ⇒ <code>object</code>
+    * [.createDirectoryByPath(path, [options])](#FileCollection+createDirectoryByPath) ⇒ <code>object</code>
     * [.createFileMetadata(attributes)](#FileCollection+createFileMetadata) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.updateMetadataAttribute(id, metadata)](#FileCollection+updateMetadataAttribute) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.getFileTypeFromName(name)](#FileCollection+getFileTypeFromName) ⇒ <code>string</code>
@@ -924,7 +924,7 @@ Remove files references to a document — see https://docs.cozy.io/en/cozy-stack
 
 <a name="FileCollection+destroy"></a>
 
-### fileCollection.destroy(file) ⇒ <code>Promise</code>
+### fileCollection.destroy(file, [options]) ⇒ <code>Promise</code>
 Sends file to trash and removes references to it
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
@@ -934,6 +934,7 @@ and file has been sent to trash
 | Param | Type | Description |
 | --- | --- | --- |
 | file | [<code>FileDocument</code>](#FileDocument) | File that will be sent to trash |
+| [options] | <code>object</code> | Optionnal request options |
 
 <a name="FileCollection+emptyTrash"></a>
 
@@ -959,7 +960,7 @@ Restores a trashed file.
 
 <a name="FileCollection+copy"></a>
 
-### fileCollection.copy(id, [name], [dirId]) ⇒ <code>Promise.&lt;object&gt;</code>
+### fileCollection.copy(id, [name], [dirId], [options]) ⇒ <code>Promise.&lt;object&gt;</code>
 Copy a file.
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
@@ -974,6 +975,7 @@ Copy a file.
 | id | <code>string</code> | The file's id |
 | [name] | <code>string</code> | The file copy name |
 | [dirId] | <code>string</code> | The destination directory id |
+| [options] | <code>object</code> | Optionnal request options |
 
 <a name="FileCollection+deleteFilePermanently"></a>
 
@@ -989,7 +991,7 @@ async deleteFilePermanently - Definitely delete a file
 
 <a name="FileCollection+upload"></a>
 
-### fileCollection.upload(data, dirPath) ⇒ <code>Promise.&lt;object&gt;</code>
+### fileCollection.upload(data, dirPath, [options]) ⇒ <code>Promise.&lt;object&gt;</code>
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
 **Returns**: <code>Promise.&lt;object&gt;</code> - Created io.cozy.files  
 
@@ -997,10 +999,11 @@ async deleteFilePermanently - Definitely delete a file
 | --- | --- | --- |
 | data | <code>File</code> \| <code>Blob</code> \| [<code>Stream</code>](#Stream) \| <code>string</code> \| <code>ArrayBuffer</code> | file to be uploaded |
 | dirPath | <code>string</code> | Path to upload the file to. ie : /Administative/XXX/ |
+| [options] | <code>object</code> | Optionnal request options |
 
 <a name="FileCollection+create"></a>
 
-### fileCollection.create(attributes)
+### fileCollection.create(attributes, [options])
 Creates directory or file.
 - Used by StackLink to support CozyClient.create('io.cozy.files', options)
 
@@ -1014,14 +1017,15 @@ Creates directory or file.
 | --- | --- | --- |
 | attributes | [<code>FileAttributes</code>](#FileAttributes) \| [<code>DirectoryAttributes</code>](#DirectoryAttributes) | Attributes of the created file/directory |
 | attributes.data | <code>File</code> \| <code>Blob</code> \| <code>string</code> \| <code>ArrayBuffer</code> | Will be used as content of the created file |
+| [options] | <code>object</code> | Optionnal request options |
 
 <a name="FileCollection+updateFile"></a>
 
-### fileCollection.updateFile(data, params) ⇒ <code>object</code>
+### fileCollection.updateFile(data, params, options) ⇒ [<code>Promise.&lt;FileAttributes&gt;</code>](#FileAttributes)
 updateFile - Updates a file's data
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
-**Returns**: <code>object</code> - Updated document  
+**Returns**: [<code>Promise.&lt;FileAttributes&gt;</code>](#FileAttributes) - Updated document  
 **Throws**:
 
 - <code>Error</code> - explaining reason why update failed
@@ -1030,8 +1034,8 @@ updateFile - Updates a file's data
 | Param | Type | Description |
 | --- | --- | --- |
 | data | <code>File</code> \| <code>Blob</code> \| [<code>Stream</code>](#Stream) \| <code>string</code> \| <code>ArrayBuffer</code> | file to be uploaded |
-| params | [<code>FileAttributes</code>](#FileAttributes) | Additional parameters |
-| params.options | <code>object</code> | Options to pass to doUpload method (additional headers) |
+| params | [<code>FileAttributes</code>](#FileAttributes) | File attributes to update and doUpload options (additional headers) |
+| options | <code>object</code> | Request Options |
 
 <a name="FileCollection+download"></a>
 
@@ -1141,7 +1145,7 @@ statById - Fetches the metadata about a document. For folders, the results inclu
 
 <a name="FileCollection+createDirectoryByPath"></a>
 
-### fileCollection.createDirectoryByPath(path) ⇒ <code>object</code>
+### fileCollection.createDirectoryByPath(path, [options]) ⇒ <code>object</code>
 async createDirectoryByPath - Creates one or more folders until the given path exists
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
@@ -1150,6 +1154,7 @@ async createDirectoryByPath - Creates one or more folders until the given path e
 | Param | Type | Description |
 | --- | --- | --- |
 | path | <code>string</code> | Path of the created directory |
+| [options] | <code>object</code> | Optionnal request options |
 
 <a name="FileCollection+createFileMetadata"></a>
 

--- a/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
+++ b/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
@@ -1,5 +1,137 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`FileCollection create directory - should not sanitize the filename if asked not to 1`] = `
+Array [
+  "POST",
+  "/files/undefined?Name=Name%20&Type=directory&MetadataID=",
+  undefined,
+  Object {
+    "headers": Object {
+      "Date": "",
+    },
+  },
+]
+`;
+
+exports[`FileCollection create directory - should sanitize the filename 1`] = `
+Array [
+  "POST",
+  "/files/undefined?Name=Name&Type=directory&MetadataID=",
+  undefined,
+  Object {
+    "headers": Object {
+      "Date": "",
+    },
+  },
+]
+`;
+
+exports[`FileCollection create file - should not sanitize the filename if asked not to 1`] = `
+Array [
+  "POST",
+  "/files/?Name=Name%20&Type=file&Executable=false&Encrypted=false&MetadataID=&Size=&SourceAccount=&SourceAccountIdentifier=",
+  "content",
+  Object {
+    "headers": Object {
+      "Content-Type": "text/plain",
+    },
+    "onUploadProgress": undefined,
+  },
+]
+`;
+
+exports[`FileCollection create file - should sanitize the filename 1`] = `
+Array [
+  "POST",
+  "/files/?Name=Name&Type=file&Executable=false&Encrypted=false&MetadataID=&Size=&SourceAccount=&SourceAccountIdentifier=",
+  "content",
+  Object {
+    "headers": Object {
+      "Content-Type": "text/plain",
+    },
+    "onUploadProgress": undefined,
+  },
+]
+`;
+
+exports[`FileCollection createDirectory should not sanitize the filename if asked not to 1`] = `
+Array [
+  "POST",
+  "/files/12345?Name=Name%20&Type=directory&MetadataID=",
+  undefined,
+  Object {
+    "headers": Object {
+      "Date": "Wed, 01 Feb 2017 10:24:42 GMT",
+    },
+  },
+]
+`;
+
+exports[`FileCollection createDirectory should sanitize the filename 1`] = `
+Array [
+  "POST",
+  "/files/12345?Name=Name&Type=directory&MetadataID=",
+  undefined,
+  Object {
+    "headers": Object {
+      "Date": "Wed, 01 Feb 2017 10:24:42 GMT",
+    },
+  },
+]
+`;
+
+exports[`FileCollection createDirectoryByPath should not sanitize the filename if asked not to 1`] = `
+Array [
+  Object {
+    "dirId": "7c217f9bf5e7118a34627f1ab800243b",
+    "name": " baz ",
+  },
+  Object {
+    "sanitizeName": false,
+  },
+]
+`;
+
+exports[`FileCollection createDirectoryByPath should sanitize the filename 1`] = `
+Array [
+  Object {
+    "dirId": "9c217f9bf5e7118a34627f1ab800243b",
+    "name": "baz",
+  },
+  Object {
+    "sanitizeName": true,
+  },
+]
+`;
+
+exports[`FileCollection createFile should not sanitize the filename if asked not to 1`] = `
+Array [
+  "POST",
+  "/files/41686c35-9d8e?Name=%20mydoc%20.epub&Type=file&Executable=false&Encrypted=false&MetadataID=&Size=&SourceAccount=&SourceAccountIdentifier=&UpdatedAt=2021-01-01T00:00:00.000Z&CreatedAt=2021-01-01T00:00:00.000Z",
+  File {},
+  Object {
+    "headers": Object {
+      "Content-Type": "application/epub+zip",
+    },
+    "onUploadProgress": undefined,
+  },
+]
+`;
+
+exports[`FileCollection createFile should sanitize the filename 1`] = `
+Array [
+  "POST",
+  "/files/41686c35-9d8e?Name=mydoc%20.epub&Type=file&Executable=false&Encrypted=false&MetadataID=&Size=&SourceAccount=&SourceAccountIdentifier=&UpdatedAt=2021-01-01T00:00:00.000Z&CreatedAt=2021-01-01T00:00:00.000Z",
+  File {},
+  Object {
+    "headers": Object {
+      "Content-Type": "application/epub+zip",
+    },
+    "onUploadProgress": undefined,
+  },
+]
+`;
+
 exports[`FileCollection createFileMetadata should call the right route 1`] = `
 Array [
   "POST",
@@ -199,6 +331,62 @@ exports[`FileCollection synchronization directories exclusions should remove a d
 }
 `;
 
+exports[`FileCollection update should not sanitize the filename if asked not to 1`] = `
+Array [
+  Blob {},
+  Object {
+    "fileId": undefined,
+    "name": " thoughts .txt",
+    "type": "file",
+  },
+  Object {
+    "sanitizeName": false,
+  },
+]
+`;
+
+exports[`FileCollection update should not sanitize the filename if asked not to 2`] = `
+Array [
+  undefined,
+  Object {
+    "fileId": "123",
+    "name": " thoughts .txt",
+    "type": "file",
+  },
+  Object {
+    "sanitizeName": false,
+  },
+]
+`;
+
+exports[`FileCollection update should sanitize the filename 1`] = `
+Array [
+  Blob {},
+  Object {
+    "fileId": undefined,
+    "name": " thoughts .txt",
+    "type": "file",
+  },
+  Object {
+    "sanitizeName": true,
+  },
+]
+`;
+
+exports[`FileCollection update should sanitize the filename 2`] = `
+Array [
+  undefined,
+  Object {
+    "fileId": "123",
+    "name": " thoughts .txt",
+    "type": "file",
+  },
+  Object {
+    "sanitizeName": true,
+  },
+]
+`;
+
 exports[`FileCollection updateAttributes should call the right route 1`] = `
 Array [
   "PATCH",
@@ -208,6 +396,23 @@ Array [
       "attributes": Object {
         "dir_id": "123",
         "name": "correct-name",
+      },
+      "id": "42",
+      "type": "io.cozy.files",
+    },
+  },
+]
+`;
+
+exports[`FileCollection updateAttributes should not sanitize the filename if asked not to 1`] = `
+Array [
+  "PATCH",
+  "/files/42",
+  Object {
+    "data": Object {
+      "attributes": Object {
+        "dir_id": "123",
+        "name": "Name ",
       },
       "id": "42",
       "type": "io.cozy.files",
@@ -229,6 +434,38 @@ Array [
       "id": "42",
       "type": "io.cozy.files",
     },
+  },
+]
+`;
+
+exports[`FileCollection updateFile should not sanitize the filename if asked not to 1`] = `
+Array [
+  "PUT",
+  "/files/59140416-b95f?Name=%20mydoc%20.epub&Type=file&Executable=false&Encrypted=false&Size=1234&UpdatedAt=2021-01-01T00:00:00.000Z&CreatedAt=2021-01-01T00:00:00.000Z",
+  File {},
+  Object {
+    "headers": Object {
+      "Content-Length": "1234",
+      "Content-MD5": "a6dabd99832b270468e254814df2ed20",
+      "Content-Type": "application/epub+zip",
+    },
+    "onUploadProgress": undefined,
+  },
+]
+`;
+
+exports[`FileCollection updateFile should sanitize the filename 1`] = `
+Array [
+  "PUT",
+  "/files/59140416-b95f?Name=mydoc%20.epub&Type=file&Executable=false&Encrypted=false&Size=1234&UpdatedAt=2021-01-01T00:00:00.000Z&CreatedAt=2021-01-01T00:00:00.000Z",
+  File {},
+  Object {
+    "headers": Object {
+      "Content-Length": "1234",
+      "Content-MD5": "a6dabd99832b270468e254814df2ed20",
+      "Content-Type": "application/epub+zip",
+    },
+    "onUploadProgress": undefined,
   },
 ]
 `;


### PR DESCRIPTION
Some clients, like Cozy Desktop, do their own file name sanitization
and don't expect `cozy-client` to do it for them. In fact, this
sanitization would lead to issues down the road.

To prevent these, we add a `sanitizeName` option to `FileCollection`'s
methods to disable `cozy-client`'s sanitization.
The option's value will be `true` by default so other clients don't
have anything to do.