### PR TITLE
fix: Always use response body as FetchError reason

### DIFF
--- a/packages/cozy-stack-client/src/CozyStackClient.js
+++ b/packages/cozy-stack-client/src/CozyStackClient.js
@@ -129,7 +129,9 @@ class CozyStackClient {
    * @throws {FetchError}
    */
   async fetch(method, path, body, opts = {}) {
-    const { throwFetchErrors, ...options } = { ...opts }
+    const { throwFetchErrors = this.options.throwFetchErrors, ...options } = {
+      ...opts
+    }
     options.method = method
     const headers = (options.headers = { ...opts.headers })
 


### PR DESCRIPTION
  BREAKING CHANGE: The `reason` attribute of non-JSON fetch errors is no
  longer a string composed of the server response status and status
  text.

  We used to have 2 different kinds of values for the `reason` attribute
  of `FetchError` built in `CozyStackClient`:
  - a string representation of the response body sent by the server (which may contain details about what when wrong, especially for 400 status responses) for JSON requests
  - a string composed of the server response status and status text for non-JSON requests

  In the non-JSON request situation, we lose information by not using
  the server response body as the reason of the `FetchError` which
  prevents users of `cozy-client` from reacting appropriately when
  receiving such an error to their request.
  Therefore we homogenize our `FetchError` instances by always using the
  server response body to build the error `reason`.

  We need to add a new `throwFetchErrors` option to
  `CozyStackClient.fetch` to determine when to throw the error rather
  than emitting it as JSON requests expect the error to be thrown but we
  can't keep reading the response body from the JSON request method to
  build a new error to throw as it's already been read to build the
  emitted error.
  Besides, by doing so, we build the error only once, making sure we get
  the same kind no matter what type of request we make.