### PR TITLE
feat: Improve store query performance for id queries

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -521,7 +521,7 @@ Generated URL
 
 *Defined in*
 
-[packages/cozy-client/src/store/stateHelpers.js:15](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/store/stateHelpers.js#L15)
+[packages/cozy-client/src/store/stateHelpers.js:22](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/store/stateHelpers.js#L22)
 
 ***
 

--- a/packages/cozy-client/src/associations/HasManyFiles.js
+++ b/packages/cozy-client/src/associations/HasManyFiles.js
@@ -57,6 +57,7 @@ export default class HasManyFiles extends HasMany {
         lastRelationship._type,
         lastRelationship._id
       )
+      // @ts-ignore
       const lastDatetime = getFileDatetime(lastRelDoc)
       // cursor-based pagination
       const cursor = newCursor(

--- a/packages/cozy-client/src/store/documents.js
+++ b/packages/cozy-client/src/store/documents.js
@@ -99,7 +99,14 @@ const documents = (state = {}, action) => {
 
 export default documents
 
-// selector
+/**
+ * Get document from state, by its id
+ *
+ * @param {import('../types').DocumentsStateSlice} state The documents' slice
+ * @param {string} doctype The doctype to target
+ * @param {string} id The document id to get
+ * @returns {import('../types').CozyClientDocument} the document found by its id
+ */
 export const getDocumentFromSlice = (state = {}, doctype, id) => {
   if (!doctype) {
     throw new Error(
@@ -129,6 +136,37 @@ export const getDocumentFromSlice = (state = {}, doctype, id) => {
     return null
   }
   return state[doctype][id]
+}
+
+/**
+ * Get documents from state, by their ids
+ *
+ * @param {import('../types').DocumentsStateSlice} state The documents' slice
+ * @param {string} doctype The doctype to target
+ * @param {Array<string>} ids The list of document ids to get
+ * @returns {Array<import('../types').CozyClientDocument>} the list of documents found by their ids
+ */
+export const getDocumentsFromSlice = (state = {}, doctype, ids) => {
+  if (!doctype) {
+    throw new Error(
+      'getDocumentsFromSlice: Cannot retrieve documents with undefined doctype'
+    )
+  }
+  if (!ids || ids.length < 1) {
+    throw new Error(
+      'getDocumentsFromSlice: Cannot retrieve documents with undefined ids'
+    )
+  }
+  if (!state[doctype]) {
+    if (process.env.NODE_ENV !== 'production') {
+      logger.info(
+        `getDocumentsFromSlice: ${doctype} is absent from the store's documents. State is`,
+        state
+      )
+    }
+    return []
+  }
+  return ids.map(id => state[doctype][id]).filter(Boolean)
 }
 
 export const getCollectionFromSlice = (state = {}, doctype) => {

--- a/packages/cozy-client/src/store/queries.spec.js
+++ b/packages/cozy-client/src/store/queries.spec.js
@@ -779,6 +779,13 @@ describe('execute query from state', () => {
     }
     const res3 = executeQueryFromState(state, query3)
     expect(res3.data).toEqual(null)
+
+    const query4 = {
+      doctype: 'io.cozy.files',
+      ids: ['-1', '123']
+    }
+    const res4 = executeQueryFromState(state, query4)
+    expect(res4.data[0]).toEqual(docState['io.cozy.files']['123'])
   })
 
   it('should get all the docs from state for the doctype when no filter', () => {

--- a/packages/cozy-client/src/store/stateHelpers.js
+++ b/packages/cozy-client/src/store/stateHelpers.js
@@ -1,4 +1,8 @@
-import { getCollectionFromSlice, getDocumentFromSlice } from './documents'
+import {
+  getCollectionFromSlice,
+  getDocumentFromSlice,
+  getDocumentsFromSlice
+} from './documents'
 import { getQueryFromSlice } from './queries'
 
 export const getStateRoot = state => state.cozy || {}
@@ -8,6 +12,9 @@ export const getCollectionFromState = (state, doctype) =>
 
 export const getDocumentFromState = (state, doctype, id) =>
   getDocumentFromSlice(getStateRoot(state).documents, doctype, id)
+
+export const getDocumentsFromState = (state, doctype, ids) =>
+  getDocumentsFromSlice(getStateRoot(state).documents, doctype, ids)
 
 export const getQueryFromStore = (store, queryId) =>
   getQueryFromState(store.getState(), queryId)

--- a/packages/cozy-client/types/store/documents.d.ts
+++ b/packages/cozy-client/types/store/documents.d.ts
@@ -1,6 +1,7 @@
 export function mergeDocumentsWithRelationships(prevDocument?: {}, nextDocument?: {}): import("../types").CozyClientDocument;
 export default documents;
-export function getDocumentFromSlice(state: {}, doctype: any, id: any): any;
+export function getDocumentFromSlice(state: import('../types').DocumentsStateSlice, doctype: string, id: string): import('../types').CozyClientDocument;
+export function getDocumentsFromSlice(state: import('../types').DocumentsStateSlice, doctype: string, ids: Array<string>): Array<import('../types').CozyClientDocument>;
 export function getCollectionFromSlice(state: {}, doctype: any): any[];
 export function extractAndMergeDocument(data: any, updatedStateWithIncluded: any): any;
 declare function documents(state: {}, action: any): any;

--- a/packages/cozy-client/types/store/stateHelpers.d.ts
+++ b/packages/cozy-client/types/store/stateHelpers.d.ts
@@ -1,6 +1,7 @@
 export function getStateRoot(state: any): any;
 export function getCollectionFromState(state: any, doctype: any): any[];
-export function getDocumentFromState(state: any, doctype: any, id: any): any;
+export function getDocumentFromState(state: any, doctype: any, id: any): import("../types").CozyClientDocument;
+export function getDocumentsFromState(state: any, doctype: any, ids: any): import("../types").CozyClientDocument[];
 export function getQueryFromStore(store: any, queryId: any): any;
 export function getQueryFromState(state: any, queryId: any): any;
 export function getRawQueryFromState(state: any, queryId: any): any;


### PR DESCRIPTION
See https://github.com/cozy/cozy-client/issues/1591
For a query returning 352 docs by ids from a store containing 25K docs, we measure 49ms, against +1000ms before, thanks to k * O(1) evaluation vs O(n)

This is notably useful for search use-case: all the docs are loaded in store, and we need each query to be as fast as possible