### PR TITLE
feat: Add ifMatch option to FileCollection methods

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -765,7 +765,7 @@ files associated to a specific document
     * [.emptyTrash()](#FileCollection+emptyTrash)
     * [.restore(id)](#FileCollection+restore) ⇒ <code>Promise</code>
     * [.copy(id, [name], [dirId], [options])](#FileCollection+copy) ⇒ <code>Promise.&lt;object&gt;</code>
-    * [.deleteFilePermanently(id)](#FileCollection+deleteFilePermanently) ⇒ <code>Promise.&lt;object&gt;</code>
+    * [.deleteFilePermanently(id, [options])](#FileCollection+deleteFilePermanently) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.upload(data, dirPath, [options])](#FileCollection+upload) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.create(attributes, [options])](#FileCollection+create)
     * [.updateFile(data, params, options)](#FileCollection+updateFile) ⇒ [<code>Promise.&lt;FileAttributes&gt;</code>](#FileAttributes)
@@ -781,7 +781,7 @@ files associated to a specific document
     * [.createFileMetadata(attributes)](#FileCollection+createFileMetadata) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.updateMetadataAttribute(id, metadata)](#FileCollection+updateMetadataAttribute) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.getFileTypeFromName(name)](#FileCollection+getFileTypeFromName) ⇒ <code>string</code>
-    * [.doUpload(dataArg, path, options, method)](#FileCollection+doUpload)
+    * [.doUpload(dataArg, path, options, [method])](#FileCollection+doUpload)
     * [.findNotSynchronizedDirectories(oauthClient, options)](#FileCollection+findNotSynchronizedDirectories) ⇒ <code>Array.&lt;(object\|IOCozyFolder)&gt;</code>
     * [.addNotSynchronizedDirectories(oauthClient, directories)](#FileCollection+addNotSynchronizedDirectories)
     * [.removeNotSynchronizedDirectories(oauthClient, directories)](#FileCollection+removeNotSynchronizedDirectories)
@@ -985,7 +985,7 @@ Copy a file.
 
 <a name="FileCollection+deleteFilePermanently"></a>
 
-### fileCollection.deleteFilePermanently(id) ⇒ <code>Promise.&lt;object&gt;</code>
+### fileCollection.deleteFilePermanently(id, [options]) ⇒ <code>Promise.&lt;object&gt;</code>
 async deleteFilePermanently - Definitely delete a file
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
@@ -994,6 +994,7 @@ async deleteFilePermanently - Definitely delete a file
 | Param | Type | Description |
 | --- | --- | --- |
 | id | <code>string</code> | The id of the file to delete |
+| [options] | <code>object</code> | Optionnal request options |
 
 <a name="FileCollection+upload"></a>
 
@@ -1208,7 +1209,7 @@ Get the file mime-type based on its name
 
 <a name="FileCollection+doUpload"></a>
 
-### fileCollection.doUpload(dataArg, path, options, method)
+### fileCollection.doUpload(dataArg, path, options, [method])
 This method should not be called directly to upload a file.
 You should use `createFile`
 
@@ -1219,7 +1220,7 @@ You should use `createFile`
 | dataArg | <code>File</code> \| <code>Blob</code> \| [<code>Stream</code>](#Stream) \| <code>string</code> \| <code>ArrayBuffer</code> |  | file to be uploaded |
 | path | <code>string</code> |  | Uri to call the stack from. Something like `/files/${dirId}?Name=${name}&Type=file&Executable=${executable}&MetadataID=${metadataId}` |
 | options | <code>object</code> |  | Additional headers |
-| method | <code>string</code> | <code>&quot;POST&quot;</code> | POST / PUT / PATCH |
+| [method] | <code>string</code> | <code>&quot;POST&quot;</code> | POST / PUT / PATCH |
 
 <a name="FileCollection+findNotSynchronizedDirectories"></a>
 

--- a/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
+++ b/packages/cozy-stack-client/src/__snapshots__/FileCollection.spec.js.snap
@@ -340,6 +340,7 @@ Array [
     "type": "file",
   },
   Object {
+    "ifMatch": "",
     "sanitizeName": false,
   },
 ]
@@ -354,6 +355,7 @@ Array [
     "type": "file",
   },
   Object {
+    "ifMatch": "",
     "sanitizeName": false,
   },
 ]
@@ -368,6 +370,7 @@ Array [
     "type": "file",
   },
   Object {
+    "ifMatch": "",
     "sanitizeName": true,
   },
 ]
@@ -382,6 +385,7 @@ Array [
     "type": "file",
   },
   Object {
+    "ifMatch": "",
     "sanitizeName": true,
   },
 ]
@@ -401,6 +405,11 @@ Array [
       "type": "io.cozy.files",
     },
   },
+  Object {
+    "headers": Object {
+      "If-Match": "",
+    },
+  },
 ]
 `;
 
@@ -418,6 +427,11 @@ Array [
       "type": "io.cozy.files",
     },
   },
+  Object {
+    "headers": Object {
+      "If-Match": "",
+    },
+  },
 ]
 `;
 
@@ -433,6 +447,33 @@ Array [
       },
       "id": "42",
       "type": "io.cozy.files",
+    },
+  },
+  Object {
+    "headers": Object {
+      "If-Match": "",
+    },
+  },
+]
+`;
+
+exports[`FileCollection updateAttributes should send any given If-Match revision 1`] = `
+Array [
+  "PATCH",
+  "/files/42",
+  Object {
+    "data": Object {
+      "attributes": Object {
+        "dir_id": "123",
+        "name": "Name",
+      },
+      "id": "42",
+      "type": "io.cozy.files",
+    },
+  },
+  Object {
+    "headers": Object {
+      "If-Match": "1-456",
     },
   },
 ]
@@ -464,6 +505,23 @@ Array [
       "Content-Length": "1234",
       "Content-MD5": "a6dabd99832b270468e254814df2ed20",
       "Content-Type": "application/epub+zip",
+    },
+    "onUploadProgress": undefined,
+  },
+]
+`;
+
+exports[`FileCollection updateFile should send any given If-Match revision 1`] = `
+Array [
+  "PUT",
+  "/files/59140416-b95f?Name=mydoc.epub&Type=file&Executable=false&Encrypted=false&Size=1234&UpdatedAt=2021-01-01T00:00:00.000Z&CreatedAt=2021-01-01T00:00:00.000Z",
+  File {},
+  Object {
+    "headers": Object {
+      "Content-Length": "1234",
+      "Content-MD5": "a6dabd99832b270468e254814df2ed20",
+      "Content-Type": "application/epub+zip",
+      "If-Match": "1-456",
     },
     "onUploadProgress": undefined,
   },


### PR DESCRIPTION
Some `cozy-stack` `io.cozy.files` routes will look for a `If-Match`
header and compare its value with the modified document's revision and
reject the request if they don't match.

This header was set in a few of `FileCollection`'s methods via an
`ifMatch` parameter but not all that make requests supporting this
mechanism.

We've made sure to add the mechanism to all the methods that should
send this header if necessary.