### PR TITLE
fix: Correctly handle document's store updates

### DIFF
--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@cozy/minilog": "1.0.0",
+    "@fastify/deepmerge": "^2.0.2",
     "@types/jest": "^26.0.20",
     "@types/lodash": "^4.14.170",
     "btoa": "^1.2.1",

--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -20,6 +20,7 @@
     "btoa": "^1.2.1",
     "cozy-stack-client": "^57.0.0",
     "date-fns": "2.29.3",
+    "fast-deep-equal": "^3.1.3",
     "json-stable-stringify": "^1.0.1",
     "lodash": "^4.17.13",
     "microee": "^0.0.6",

--- a/packages/cozy-client/src/store/documents.js
+++ b/packages/cozy-client/src/store/documents.js
@@ -1,13 +1,15 @@
 import get from 'lodash/get'
 import omit from 'lodash/omit'
-import merge from 'lodash/merge'
-import logger from '../logger'
 import fastEqual from 'fast-deep-equal'
+import deepmerge from '@fastify/deepmerge'
+import logger from '../logger'
 import { isReceivingData } from './queries'
 import { MutationTypes } from '../queries/dsl'
 import { isReceivingMutationResult } from './mutations'
 
 import { properId } from './helpers'
+
+const deepmergeFn = deepmerge()
 
 const storeDocument = (state, document) => {
   const type = document._type
@@ -235,7 +237,8 @@ export const extractAndMergeDocument = (newData, updatedStateWithIncluded) => {
       //  - some documents might change without a rev change: typically the thumbnails links
       //    in io.cozy.files, and the io.cozy.settings.instance doc, with additional
       //    fields added by the stack
-      mergedState[doctype][id] = merge({}, mergedState[doctype][id], newDoc)
+      //  - some documents don't have any revision
+      mergedState[doctype][id] = deepmergeFn(mergedState[doctype][id], newDoc)
       haveDocumentsChanged = true
     }
   })

--- a/packages/cozy-client/src/store/documents.spec.js
+++ b/packages/cozy-client/src/store/documents.spec.js
@@ -6,9 +6,7 @@ import {
 describe('extractAndMerge', () => {
   const data = [
     {
-      id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
       _id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
-      type: 'io.cozy.files',
       _type: 'io.cozy.files',
       blabla: 'new field',
       cozyMetadata: {
@@ -19,23 +17,19 @@ describe('extractAndMerge', () => {
       }
     },
     {
-      id: 'b6ff135b34e041ffb2d4a4865f3e235f',
-      type: 'io.cozy.files',
-      _type: 'io.cozy.files',
       _id: 'b6ff135b34e041ffb2d4a4865f3e235f',
+      _type: 'io.cozy.files',
       blibli: 'another new field'
     }
   ]
   const updatedStateWithIncluded = {
     'io.cozy.files': {
       b6ff135b34e041ffb2d4a4865f3e0a53: {
-        attributes: {
-          type: 'file',
-          name: 'IMG_0016.PNG',
-          dir_id: '7d2f9c24cd345ce3171bf71f401e80c6'
-        },
-        id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
         _id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
+        _type: 'io.cozy.files',
+        name: 'IMG_0016.PNG',
+        type: 'file',
+        dir_id: '7d2f9c24cd345ce3171bf71f401e80c6',
         links: { self: '/files/b6ff135b34e041ffb2d4a4865f3e0a53' },
         meta: { rev: '5-87840eceaab358e38aa8b6bb0d4577b1' },
         relationships: {
@@ -43,8 +37,6 @@ describe('extractAndMerge', () => {
             links: { related: '/files/7d2f9c24cd345ce3171bf71f401e80c6' }
           }
         },
-        type: 'io.cozy.files',
-        _type: 'io.cozy.files',
         cozyMetadata: {
           updated_at: '987654',
           updatedByApps: {
@@ -53,22 +45,18 @@ describe('extractAndMerge', () => {
         }
       },
       b6ff135b34e041ffb2d4a4865f3e235f: {
-        attributes: {
-          type: 'file',
-          name: 'IMG_0054.PNG',
-          dir_id: '7d2f9c24cd345ce3171bf71f401e80c6'
-        },
-        id: 'b6ff135b34e041ffb2d4a4865f3e235f',
         _id: 'b6ff135b34e041ffb2d4a4865f3e235f',
+        _type: 'io.cozy.files',
+        type: 'file',
+        name: 'IMG_0054.PNG',
+        dir_id: '7d2f9c24cd345ce3171bf71f401e80c6',
         links: { self: '/files/b6ff135b34e041ffb2d4a4865f3e235f' },
         meta: { rev: '5-ca91c0dc02dafb38eb56070c1d80d62c' },
         relationships: {
           parent: {
             links: { related: '/files/7d2f9c24cd345ce3171bf71f401e80c6' }
           }
-        },
-        type: 'io.cozy.files',
-        _type: 'io.cozy.files'
+        }
       }
     }
   }
@@ -84,11 +72,9 @@ describe('extractAndMerge', () => {
         b6ff135b34e041ffb2d4a4865f3e0a53: {
           _id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
           _type: 'io.cozy.files',
-          attributes: {
-            dir_id: '7d2f9c24cd345ce3171bf71f401e80c6',
-            name: 'IMG_0016.PNG',
-            type: 'file'
-          },
+          dir_id: '7d2f9c24cd345ce3171bf71f401e80c6',
+          name: 'IMG_0016.PNG',
+          type: 'file',
           blabla: 'new field',
           cozyMetadata: {
             created_at: '123456',
@@ -98,34 +84,28 @@ describe('extractAndMerge', () => {
               date: '2019-06-11T01:02:03Z'
             }
           },
-          id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
           links: { self: '/files/b6ff135b34e041ffb2d4a4865f3e0a53' },
           meta: { rev: '5-87840eceaab358e38aa8b6bb0d4577b1' },
           relationships: {
             parent: {
               links: { related: '/files/7d2f9c24cd345ce3171bf71f401e80c6' }
             }
-          },
-          type: 'io.cozy.files'
+          }
         },
         b6ff135b34e041ffb2d4a4865f3e235f: {
           _id: 'b6ff135b34e041ffb2d4a4865f3e235f',
           _type: 'io.cozy.files',
-          attributes: {
-            dir_id: '7d2f9c24cd345ce3171bf71f401e80c6',
-            name: 'IMG_0054.PNG',
-            type: 'file'
-          },
+          dir_id: '7d2f9c24cd345ce3171bf71f401e80c6',
+          name: 'IMG_0054.PNG',
+          type: 'file',
           blibli: 'another new field',
-          id: 'b6ff135b34e041ffb2d4a4865f3e235f',
           links: { self: '/files/b6ff135b34e041ffb2d4a4865f3e235f' },
           meta: { rev: '5-ca91c0dc02dafb38eb56070c1d80d62c' },
           relationships: {
             parent: {
               links: { related: '/files/7d2f9c24cd345ce3171bf71f401e80c6' }
             }
-          },
-          type: 'io.cozy.files'
+          }
         }
       }
     }
@@ -173,16 +153,12 @@ describe('extractAndMerge', () => {
     () => {
       const dataAlreadyIncludedInUpdatedStateWithIncluded = [
         {
-          id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
           _id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
-          type: 'io.cozy.files',
           _type: 'io.cozy.files'
         },
         {
-          id: 'b6ff135b34e041ffb2d4a4865f3e235f',
-          type: 'io.cozy.files',
-          _type: 'io.cozy.files',
-          _id: 'b6ff135b34e041ffb2d4a4865f3e235f'
+          _id: 'b6ff135b34e041ffb2d4a4865f3e235f',
+          _type: 'io.cozy.files'
         }
       ]
 
@@ -202,6 +178,44 @@ describe('extractAndMerge', () => {
       )
     }
   )
+  it('should keep state reference in case no document has changed', () => {
+    const newDoc = { ...data[0] }
+
+    const mergedState = extractAndMergeDocument(
+      [newDoc],
+      updatedStateWithIncluded
+    )
+    expect(mergedState === updatedStateWithIncluded)
+  })
+
+  it('should have different state reference if a new document is added', () => {
+    const newDoc = {
+      _id: '1234',
+      _type: 'io.cozy.files',
+      name: 'New doc'
+    }
+    const mergedState = extractAndMergeDocument(
+      [newDoc],
+      updatedStateWithIncluded
+    )
+    expect(mergedState !== updatedStateWithIncluded)
+  })
+
+  it('should have different state reference if an existing document have changed', () => {
+    const newDoc = {
+      ...data[0],
+      cozyMetadata: {
+        ...data[0].cozyMetadata,
+        updatedByApps: '2025-01-01'
+      }
+    }
+
+    const mergedState = extractAndMergeDocument(
+      [newDoc],
+      updatedStateWithIncluded
+    )
+    expect(mergedState !== updatedStateWithIncluded)
+  })
 })
 
 describe('mergeDocumentsWithRelationships', () => {

--- a/packages/cozy-client/src/store/documents.spec.js
+++ b/packages/cozy-client/src/store/documents.spec.js
@@ -4,8 +4,8 @@ import {
 } from './documents'
 
 describe('extractAndMerge', () => {
-  const data = {
-    0: {
+  const data = [
+    {
       id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
       _id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
       type: 'io.cozy.files',
@@ -18,14 +18,14 @@ describe('extractAndMerge', () => {
         }
       }
     },
-    1: {
+    {
       id: 'b6ff135b34e041ffb2d4a4865f3e235f',
       type: 'io.cozy.files',
       _type: 'io.cozy.files',
       _id: 'b6ff135b34e041ffb2d4a4865f3e235f',
       blibli: 'another new field'
     }
-  }
+  ]
   const updatedStateWithIncluded = {
     'io.cozy.files': {
       b6ff135b34e041ffb2d4a4865f3e0a53: {
@@ -171,20 +171,20 @@ describe('extractAndMerge', () => {
       'even if the mergedData is the same, because reselect createSelector update ' +
       'according to object reference, not only value',
     () => {
-      const dataAlreadyIncludedInUpdatedStateWithIncluded = {
-        0: {
+      const dataAlreadyIncludedInUpdatedStateWithIncluded = [
+        {
           id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
           _id: 'b6ff135b34e041ffb2d4a4865f3e0a53',
           type: 'io.cozy.files',
           _type: 'io.cozy.files'
         },
-        1: {
+        {
           id: 'b6ff135b34e041ffb2d4a4865f3e235f',
           type: 'io.cozy.files',
           _type: 'io.cozy.files',
           _id: 'b6ff135b34e041ffb2d4a4865f3e235f'
         }
-      }
+      ]
 
       const returnedDatas = extractAndMergeDocument(
         dataAlreadyIncludedInUpdatedStateWithIncluded,

--- a/packages/cozy-client/types/store/documents.d.ts
+++ b/packages/cozy-client/types/store/documents.d.ts
@@ -3,5 +3,5 @@ export default documents;
 export function getDocumentFromSlice(state: import('../types').DocumentsStateSlice, doctype: string, id: string): import('../types').CozyClientDocument;
 export function getDocumentsFromSlice(state: import('../types').DocumentsStateSlice, doctype: string, ids: Array<string>): Array<import('../types').CozyClientDocument>;
 export function getCollectionFromSlice(state: {}, doctype: any): any[];
-export function extractAndMergeDocument(data: any, updatedStateWithIncluded: any): any;
+export function extractAndMergeDocument(newData: Array<import('../types').CozyClientDocument>, updatedStateWithIncluded: import("../types").DocumentsStateSlice): import("../types").DocumentsStateSlice;
 declare function documents(state: {}, action: any): any;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3109,7 +3109,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@17.0.0", "@types/react@>=16.9.0", "@types/react@^17":
+"@types/react@*", "@types/react@>=16.9.0", "@types/react@^17":
   version "17.0.0"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
   integrity sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==
@@ -12504,16 +12504,7 @@ string-length@^2.0.0:
     astral-regex "^1.0.0"
     strip-ansi "^4.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -12645,7 +12636,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12672,13 +12663,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -13890,7 +13874,7 @@ wordwrapjs@^3.0.0:
     reduce-flatten "^1.0.1"
     typical "^2.6.1"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13912,15 +13896,6 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1235,6 +1235,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fastify/deepmerge@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@fastify/deepmerge/-/deepmerge-2.0.2.tgz#5dcbda2acb266e309b8a1ca92fa48b2125e65fc0"
+  integrity sha512-3wuLdX5iiiYeZWP6bQrjqhrcvBIf0NHbQH1Ur1WbHvoiuTYUEItgygea3zs8aHpiitn0lOB8gX20u1qO+FDm7Q==
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"


### PR DESCRIPTION
We used to create a new reference on the `documents` state for any query.
This is problematic because we do a referential comparison on the updated `documents` state to evaluate if there is any update on it, resulting on all store's queries re-evaluation.
So, basically, we were doing a full queries re-evaluation for *any* query execution, even if the same query is run several time with no change.
This is particularly problematic when there are a lot of queries and/or
queries with many documents returned, as their re-evaluation will be
costful. Moreover, the document merging itself is costful.

The comparison between old and new docs is crucial for performances, so
we did some performances measures: we took a worst case where we fill
the store with 25K docs with a query and run again the same query with
no document change.
What we measure here is the time taken in the `extractAndMergeDocument` method:

- **Before: 73892 ms**
- Compare with lodash isEqual: 47530 ms
- Compare with stringify + djb2 hash: 19785 ms
- **Compare with fast-deep-equal: 2404 ms (used solution)**
- Compare with JSON.stringify: 1899 ms
- Compare with rev (for the record): 123ms

ℹ️  The JSON.stringify comparison is faster, but it does not guarantee
key order: 2 documents with same value but different order will be seen
as different. For safety, we prefer fast-deep-equal, slighly slower, but
more reliable.

ℹ️  The rev measurement is here because it would be the ideal solution:
assume any document change implies a new revision, as it is made with
CouchDB / PouchDB. However, this is more complicated in practice:
- Some docs returned by the stack do not have revision
- Some docs returned by the stack might have changed, with the same
  revision: for instance the thumbnails links for files change over
time.
- If we have a partial doc query, i.e. a query with `.select(fields)`,
  and then another query returning a common doc, the content might be
different between the 2 queries, with the same doc revision.
As this is more complicated to deal with, we do not rely on revision
yet.

We also improved the document merging. For 1K docs to merge: 
- Before: 1626ms
- After: 278ms 