### PR TITLE
Improve performances on queries

### DIFF
--- a/docs/api/cozy-client/classes/CozyClient.md
+++ b/docs/api/cozy-client/classes/CozyClient.md
@@ -43,7 +43,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:157](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L157)
+[packages/cozy-client/src/CozyClient.js:158](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L158)
 
 ## Properties
 
@@ -53,7 +53,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:174](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L174)
+[packages/cozy-client/src/CozyClient.js:175](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L175)
 
 ***
 
@@ -63,7 +63,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:202](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L202)
+[packages/cozy-client/src/CozyClient.js:203](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L203)
 
 ***
 
@@ -73,7 +73,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1858](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1858)
+[packages/cozy-client/src/CozyClient.js:1870](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1870)
 
 ***
 
@@ -83,7 +83,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1718](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1718)
+[packages/cozy-client/src/CozyClient.js:1730](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1730)
 
 ***
 
@@ -93,7 +93,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:182](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L182)
+[packages/cozy-client/src/CozyClient.js:183](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L183)
 
 ***
 
@@ -103,7 +103,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:181](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L181)
+[packages/cozy-client/src/CozyClient.js:182](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L182)
 
 ***
 
@@ -113,7 +113,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:496](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L496)
+[packages/cozy-client/src/CozyClient.js:497](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L497)
 
 ***
 
@@ -123,7 +123,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1854](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1854)
+[packages/cozy-client/src/CozyClient.js:1866](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1866)
 
 ***
 
@@ -133,7 +133,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:175](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L175)
+[packages/cozy-client/src/CozyClient.js:176](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L176)
 
 ***
 
@@ -159,7 +159,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:178](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L178)
+[packages/cozy-client/src/CozyClient.js:179](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L179)
 
 ***
 
@@ -169,7 +169,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:172](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L172)
+[packages/cozy-client/src/CozyClient.js:173](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L173)
 
 ***
 
@@ -179,7 +179,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:205](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L205)
+[packages/cozy-client/src/CozyClient.js:206](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L206)
 
 ***
 
@@ -189,7 +189,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:180](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L180)
+[packages/cozy-client/src/CozyClient.js:181](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L181)
 
 ***
 
@@ -199,7 +199,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:197](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L197)
+[packages/cozy-client/src/CozyClient.js:198](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L198)
 
 ***
 
@@ -209,7 +209,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1693](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1693)
+[packages/cozy-client/src/CozyClient.js:1705](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1705)
 
 ***
 
@@ -219,7 +219,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1623](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1623)
+[packages/cozy-client/src/CozyClient.js:1635](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1635)
 
 ***
 
@@ -229,7 +229,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:230](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L230)
+[packages/cozy-client/src/CozyClient.js:231](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L231)
 
 ***
 
@@ -249,7 +249,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1377](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1377)
+[packages/cozy-client/src/CozyClient.js:1389](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1389)
 
 ***
 
@@ -294,7 +294,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:475](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L475)
+[packages/cozy-client/src/CozyClient.js:476](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L476)
 
 ***
 
@@ -314,7 +314,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:431](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L431)
+[packages/cozy-client/src/CozyClient.js:432](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L432)
 
 ***
 
@@ -334,7 +334,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:576](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L576)
+[packages/cozy-client/src/CozyClient.js:577](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L577)
 
 ***
 
@@ -363,7 +363,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1539](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1539)
+[packages/cozy-client/src/CozyClient.js:1551](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1551)
 
 ***
 
@@ -381,7 +381,7 @@ This mechanism is described in https://github.com/cozy/cozy-client/blob/master/p
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1520](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1520)
+[packages/cozy-client/src/CozyClient.js:1532](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1532)
 
 ***
 
@@ -397,7 +397,7 @@ Returns whether the client has been revoked on the server
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1635](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1635)
+[packages/cozy-client/src/CozyClient.js:1647](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1647)
 
 ***
 
@@ -422,7 +422,7 @@ Collection corresponding to the doctype
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:568](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L568)
+[packages/cozy-client/src/CozyClient.js:569](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L569)
 
 ***
 
@@ -460,7 +460,7 @@ await client.create('io.cozy.todos', {
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:623](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L623)
+[packages/cozy-client/src/CozyClient.js:624](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L624)
 
 ***
 
@@ -481,7 +481,7 @@ If `oauth` options are passed, stackClient is an OAuthStackClient.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1673](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1673)
+[packages/cozy-client/src/CozyClient.js:1685](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1685)
 
 ***
 
@@ -506,7 +506,7 @@ The document that has been deleted
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:879](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L879)
+[packages/cozy-client/src/CozyClient.js:880](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L880)
 
 ***
 
@@ -526,7 +526,7 @@ The document that has been deleted
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1744](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1744)
+[packages/cozy-client/src/CozyClient.js:1756](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1756)
 
 ***
 
@@ -552,7 +552,7 @@ a method from cozy-client
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:244](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L244)
+[packages/cozy-client/src/CozyClient.js:245](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L245)
 
 ***
 
@@ -574,7 +574,7 @@ a method from cozy-client
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:693](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L693)
+[packages/cozy-client/src/CozyClient.js:694](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L694)
 
 ***
 
@@ -598,7 +598,7 @@ Makes sure that the query exists in the store
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:900](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L900)
+[packages/cozy-client/src/CozyClient.js:901](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L901)
 
 ***
 
@@ -612,7 +612,7 @@ Makes sure that the query exists in the store
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1626](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1626)
+[packages/cozy-client/src/CozyClient.js:1638](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1638)
 
 ***
 
@@ -635,7 +635,7 @@ Makes sure that the query exists in the store
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:572](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L572)
+[packages/cozy-client/src/CozyClient.js:573](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L573)
 
 ***
 
@@ -664,7 +664,7 @@ Query state
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1474](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1474)
+[packages/cozy-client/src/CozyClient.js:1486](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1486)
 
 ***
 
@@ -685,7 +685,7 @@ Query state
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:585](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L585)
+[packages/cozy-client/src/CozyClient.js:586](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L586)
 
 ***
 
@@ -699,7 +699,7 @@ Query state
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1352](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1352)
+[packages/cozy-client/src/CozyClient.js:1364](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1364)
 
 ***
 
@@ -720,7 +720,7 @@ Query state
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:592](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L592)
+[packages/cozy-client/src/CozyClient.js:593](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L593)
 
 ***
 
@@ -743,7 +743,7 @@ Creates an association that is linked to the store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1359](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1359)
+[packages/cozy-client/src/CozyClient.js:1371](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1371)
 
 ***
 
@@ -757,7 +757,7 @@ Creates an association that is linked to the store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1726](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1726)
+[packages/cozy-client/src/CozyClient.js:1738](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1738)
 
 ***
 
@@ -781,7 +781,7 @@ Array of documents or null if the collection does not exist.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1395](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1395)
+[packages/cozy-client/src/CozyClient.js:1407](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1407)
 
 ***
 
@@ -806,7 +806,7 @@ Document or null if the object does not exist.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1412](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1412)
+[packages/cozy-client/src/CozyClient.js:1424](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1424)
 
 ***
 
@@ -841,7 +841,7 @@ One or more mutation to execute
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:792](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L792)
+[packages/cozy-client/src/CozyClient.js:793](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L793)
 
 ***
 
@@ -861,7 +861,7 @@ One or more mutation to execute
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1279](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1279)
+[packages/cozy-client/src/CozyClient.js:1291](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1291)
 
 ***
 
@@ -877,7 +877,7 @@ getInstanceOptions - Returns current instance options, such as domain or app slu
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1753](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1753)
+[packages/cozy-client/src/CozyClient.js:1765](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1765)
 
 ***
 
@@ -904,7 +904,7 @@ Get a query from the internal store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1433](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1433)
+[packages/cozy-client/src/CozyClient.js:1445](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1445)
 
 ***
 
@@ -933,7 +933,7 @@ the store up, which in turn will update the `<Query>`s and re-render the data.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1375](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1375)
+[packages/cozy-client/src/CozyClient.js:1387](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1387)
 
 ***
 
@@ -965,7 +965,7 @@ extract the value corresponding to the given `key`
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1882](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1882)
+[packages/cozy-client/src/CozyClient.js:1894](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1894)
 
 ***
 
@@ -979,7 +979,7 @@ extract the value corresponding to the given `key`
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1733](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1733)
+[packages/cozy-client/src/CozyClient.js:1745](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1745)
 
 ***
 
@@ -1001,7 +1001,7 @@ Sets public attribute and emits event related to revocation
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1644](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1644)
+[packages/cozy-client/src/CozyClient.js:1656](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1656)
 
 ***
 
@@ -1023,7 +1023,7 @@ Emits event when token is refreshed
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1655](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1655)
+[packages/cozy-client/src/CozyClient.js:1667](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1667)
 
 ***
 
@@ -1049,7 +1049,7 @@ the relationship
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1322](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1322)
+[packages/cozy-client/src/CozyClient.js:1334](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1334)
 
 ***
 
@@ -1074,7 +1074,7 @@ Instead, the relationships will have null documents.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1299](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1299)
+[packages/cozy-client/src/CozyClient.js:1311](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1311)
 
 ***
 
@@ -1095,7 +1095,7 @@ Instead, the relationships will have null documents.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1333](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1333)
+[packages/cozy-client/src/CozyClient.js:1345](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1345)
 
 ***
 
@@ -1109,7 +1109,7 @@ Instead, the relationships will have null documents.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1496](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1496)
+[packages/cozy-client/src/CozyClient.js:1508](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1508)
 
 ***
 
@@ -1131,7 +1131,7 @@ loadInstanceOptionsFromDOM - Loads the dataset injected by the Stack in web page
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1764](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1764)
+[packages/cozy-client/src/CozyClient.js:1776](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1776)
 
 ***
 
@@ -1149,7 +1149,7 @@ This method is not iso with loadInstanceOptionsFromDOM for now.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1785](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1785)
+[packages/cozy-client/src/CozyClient.js:1797](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1797)
 
 ***
 
@@ -1183,7 +1183,7 @@ Emits
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:464](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L464)
+[packages/cozy-client/src/CozyClient.js:465](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L465)
 
 ***
 
@@ -1206,7 +1206,7 @@ Emits
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:515](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L515)
+[packages/cozy-client/src/CozyClient.js:516](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L516)
 
 ***
 
@@ -1230,7 +1230,7 @@ and working.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1345](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1345)
+[packages/cozy-client/src/CozyClient.js:1357](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1357)
 
 ***
 
@@ -1251,7 +1251,7 @@ and working.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1062](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1062)
+[packages/cozy-client/src/CozyClient.js:1063](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1063)
 
 ***
 
@@ -1277,7 +1277,7 @@ Mutate a document
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1080](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1080)
+[packages/cozy-client/src/CozyClient.js:1081](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1081)
 
 ***
 
@@ -1297,7 +1297,7 @@ Mutate a document
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:245](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L245)
+[packages/cozy-client/src/CozyClient.js:246](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L246)
 
 ***
 
@@ -1319,7 +1319,7 @@ Dehydrates and adds metadata before saving a document
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:763](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L763)
+[packages/cozy-client/src/CozyClient.js:764](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L764)
 
 ***
 
@@ -1350,7 +1350,7 @@ please use `fetchQueryAndGetFromState` instead
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:927](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L927)
+[packages/cozy-client/src/CozyClient.js:928](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L928)
 
 ***
 
@@ -1377,7 +1377,7 @@ All documents matching the query
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1022](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1022)
+[packages/cozy-client/src/CozyClient.js:1023](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1023)
 
 ***
 
@@ -1411,7 +1411,7 @@ All documents matching the query
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1740](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1740)
+[packages/cozy-client/src/CozyClient.js:1752](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1752)
 
 ***
 
@@ -1436,7 +1436,7 @@ Contains the fetched token and the client information.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1490](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1490)
+[packages/cozy-client/src/CozyClient.js:1502](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1502)
 
 ***
 
@@ -1450,7 +1450,7 @@ Contains the fetched token and the client information.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:435](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L435)
+[packages/cozy-client/src/CozyClient.js:436](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L436)
 
 ***
 
@@ -1518,7 +1518,7 @@ client.plugins.alerts
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:295](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L295)
+[packages/cozy-client/src/CozyClient.js:296](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L296)
 
 ***
 
@@ -1538,7 +1538,7 @@ client.plugins.alerts
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:246](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L246)
+[packages/cozy-client/src/CozyClient.js:247](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L247)
 
 ***
 
@@ -1557,7 +1557,7 @@ Contains the fetched token and the client information.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1585](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1585)
+[packages/cozy-client/src/CozyClient.js:1597](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1597)
 
 ***
 
@@ -1578,7 +1578,7 @@ Contains the fetched token and the client information.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1263](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1263)
+[packages/cozy-client/src/CozyClient.js:1275](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1275)
 
 ***
 
@@ -1604,7 +1604,7 @@ This method will reset the query state to its initial state and refetch it.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1911](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1911)
+[packages/cozy-client/src/CozyClient.js:1923](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1923)
 
 ***
 
@@ -1627,7 +1627,7 @@ Create or update a document on the server
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:645](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L645)
+[packages/cozy-client/src/CozyClient.js:646](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L646)
 
 ***
 
@@ -1662,7 +1662,7 @@ save the new resulting settings into database
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1899](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1899)
+[packages/cozy-client/src/CozyClient.js:1911](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1911)
 
 ***
 
@@ -1691,7 +1691,7 @@ Saves multiple documents in one batch
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:666](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L666)
+[packages/cozy-client/src/CozyClient.js:667](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L667)
 
 ***
 
@@ -1711,7 +1711,7 @@ Saves multiple documents in one batch
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1839](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1839)
+[packages/cozy-client/src/CozyClient.js:1851](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1851)
 
 ***
 
@@ -1735,7 +1735,7 @@ set some data in the store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1812](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1812)
+[packages/cozy-client/src/CozyClient.js:1824](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1824)
 
 ***
 
@@ -1759,7 +1759,7 @@ we manually call the links onLogin methods
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1853](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1853)
+[packages/cozy-client/src/CozyClient.js:1865](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1865)
 
 ***
 
@@ -1783,7 +1783,7 @@ At any time put an error function
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1825](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1825)
+[packages/cozy-client/src/CozyClient.js:1837](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1837)
 
 ***
 
@@ -1821,7 +1821,7 @@ use options.force = true.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1611](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1611)
+[packages/cozy-client/src/CozyClient.js:1623](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1623)
 
 ***
 
@@ -1845,7 +1845,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1506](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1506)
+[packages/cozy-client/src/CozyClient.js:1518](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1518)
 
 ***
 
@@ -1859,7 +1859,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1832](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1832)
+[packages/cozy-client/src/CozyClient.js:1844](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1844)
 
 ***
 
@@ -1880,7 +1880,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:864](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L864)
+[packages/cozy-client/src/CozyClient.js:865](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L865)
 
 ***
 
@@ -1902,7 +1902,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:889](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L889)
+[packages/cozy-client/src/CozyClient.js:890](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L890)
 
 ***
 
@@ -1922,7 +1922,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:634](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L634)
+[packages/cozy-client/src/CozyClient.js:635](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L635)
 
 ***
 
@@ -1942,7 +1942,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1055](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1055)
+[packages/cozy-client/src/CozyClient.js:1056](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1056)
 
 ***
 
@@ -1968,7 +1968,7 @@ the DOM.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:398](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L398)
+[packages/cozy-client/src/CozyClient.js:399](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L399)
 
 ***
 
@@ -1992,7 +1992,7 @@ environment variables
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:369](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L369)
+[packages/cozy-client/src/CozyClient.js:370](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L370)
 
 ***
 
@@ -2016,7 +2016,7 @@ a client with a cookie-based instance of cozy-client-js.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:319](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L319)
+[packages/cozy-client/src/CozyClient.js:320](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L320)
 
 ***
 
@@ -2044,7 +2044,7 @@ An instance of a client, configured from the old client
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:337](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L337)
+[packages/cozy-client/src/CozyClient.js:338](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L338)
 
 ***
 
@@ -2078,4 +2078,4 @@ There are at the moment only 2 hooks available.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:858](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L858)
+[packages/cozy-client/src/CozyClient.js:859](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L859)

--- a/docs/api/cozy-pouch-link/classes/PouchLink.md
+++ b/docs/api/cozy-pouch-link/classes/PouchLink.md
@@ -32,7 +32,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:94](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L94)
+[CozyPouchLink.js:90](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L90)
 
 ## Properties
 
@@ -42,7 +42,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:169](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L169)
+[CozyPouchLink.js:165](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L165)
 
 ***
 
@@ -52,7 +52,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:112](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L112)
+[CozyPouchLink.js:108](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L108)
 
 ***
 
@@ -62,7 +62,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:113](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L113)
+[CozyPouchLink.js:109](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L109)
 
 ***
 
@@ -72,7 +72,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:114](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L114)
+[CozyPouchLink.js:110](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L110)
 
 ***
 
@@ -82,7 +82,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:118](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L118)
+[CozyPouchLink.js:114](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L114)
 
 ***
 
@@ -92,7 +92,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:106](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L106)
+[CozyPouchLink.js:102](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L102)
 
 ***
 
@@ -102,7 +102,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:134](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L134)
+[CozyPouchLink.js:130](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L130)
 
 ***
 
@@ -112,7 +112,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:119](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L119)
+[CozyPouchLink.js:115](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L115)
 
 ***
 
@@ -122,7 +122,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:242](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L242)
+[CozyPouchLink.js:238](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L238)
 
 ***
 
@@ -132,7 +132,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:122](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L122)
+[CozyPouchLink.js:118](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L118)
 
 ***
 
@@ -142,7 +142,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:115](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L115)
+[CozyPouchLink.js:111](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L111)
 
 ## Methods
 
@@ -162,7 +162,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:845](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L845)
+[CozyPouchLink.js:849](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L849)
 
 ***
 
@@ -182,7 +182,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:806](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L806)
+[CozyPouchLink.js:810](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L810)
 
 ***
 
@@ -208,7 +208,7 @@ Create the PouchDB index if not existing
 
 *Defined in*
 
-[CozyPouchLink.js:611](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L611)
+[CozyPouchLink.js:615](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L615)
 
 ***
 
@@ -229,7 +229,7 @@ Create the PouchDB index if not existing
 
 *Defined in*
 
-[CozyPouchLink.js:849](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L849)
+[CozyPouchLink.js:853](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L853)
 
 ***
 
@@ -249,7 +249,7 @@ Create the PouchDB index if not existing
 
 *Defined in*
 
-[CozyPouchLink.js:834](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L834)
+[CozyPouchLink.js:838](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L838)
 
 ***
 
@@ -272,13 +272,13 @@ Create the PouchDB index if not existing
 
 *Defined in*
 
-[CozyPouchLink.js:768](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L768)
+[CozyPouchLink.js:772](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L772)
 
 ***
 
 ### executeQuery
 
-▸ **executeQuery**(`__namedParameters`): `Promise`<{ `data`: `any` = res.cozyPouchData; `meta`: `undefined` ; `next`: `undefined` ; `skip`: `undefined` = offset } | { `data`: `any` ; `meta`: { `count`: `any` = docs.length } ; `next`: `boolean` ; `skip`: `any` = offset }>
+▸ **executeQuery**(`__namedParameters`): `Promise`<{ `data`: `any` = docs; `meta`: { `count`: `any` = docs.length } ; `next`: `boolean` ; `skip`: `any` = offset } | { `data`: `any` = res.cozyPouchData }>
 
 *Parameters*
 
@@ -288,11 +288,11 @@ Create the PouchDB index if not existing
 
 *Returns*
 
-`Promise`<{ `data`: `any` = res.cozyPouchData; `meta`: `undefined` ; `next`: `undefined` ; `skip`: `undefined` = offset } | { `data`: `any` ; `meta`: { `count`: `any` = docs.length } ; `next`: `boolean` ; `skip`: `any` = offset }>
+`Promise`<{ `data`: `any` = docs; `meta`: { `count`: `any` = docs.length } ; `next`: `boolean` ; `skip`: `any` = offset } | { `data`: `any` = res.cozyPouchData }>
 
 *Defined in*
 
-[CozyPouchLink.js:688](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L688)
+[CozyPouchLink.js:692](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L692)
 
 ***
 
@@ -316,7 +316,7 @@ Retrieve the PouchDB index if exist, undefined otherwise
 
 *Defined in*
 
-[CozyPouchLink.js:635](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L635)
+[CozyPouchLink.js:639](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L639)
 
 ***
 
@@ -342,7 +342,7 @@ The changes
 
 *Defined in*
 
-[CozyPouchLink.js:481](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L481)
+[CozyPouchLink.js:485](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L485)
 
 ***
 
@@ -367,7 +367,7 @@ The db info
 
 *Defined in*
 
-[CozyPouchLink.js:496](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L496)
+[CozyPouchLink.js:500](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L500)
 
 ***
 
@@ -387,7 +387,7 @@ The db info
 
 *Defined in*
 
-[CozyPouchLink.js:402](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L402)
+[CozyPouchLink.js:406](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L406)
 
 ***
 
@@ -407,7 +407,7 @@ The db info
 
 *Defined in*
 
-[CozyPouchLink.js:149](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L149)
+[CozyPouchLink.js:145](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L145)
 
 ***
 
@@ -427,7 +427,7 @@ The db info
 
 *Defined in*
 
-[CozyPouchLink.js:398](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L398)
+[CozyPouchLink.js:402](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L402)
 
 ***
 
@@ -447,7 +447,7 @@ The db info
 
 *Defined in*
 
-[CozyPouchLink.js:300](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L300)
+[CozyPouchLink.js:304](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L304)
 
 ***
 
@@ -467,7 +467,7 @@ The db info
 
 *Defined in*
 
-[CozyPouchLink.js:295](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L295)
+[CozyPouchLink.js:299](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L299)
 
 ***
 
@@ -493,7 +493,7 @@ Emits an event (pouchlink:sync:end) when the sync (all doctypes) is done
 
 *Defined in*
 
-[CozyPouchLink.js:281](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L281)
+[CozyPouchLink.js:277](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L277)
 
 ***
 
@@ -513,7 +513,7 @@ Emits an event (pouchlink:sync:end) when the sync (all doctypes) is done
 
 *Defined in*
 
-[CozyPouchLink.js:597](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L597)
+[CozyPouchLink.js:601](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L601)
 
 ***
 
@@ -543,7 +543,7 @@ Migrate the current adapter
 
 *Defined in*
 
-[CozyPouchLink.js:183](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L183)
+[CozyPouchLink.js:179](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L179)
 
 ***
 
@@ -568,7 +568,7 @@ the need to wait for the warmup
 
 *Defined in*
 
-[CozyPouchLink.js:583](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L583)
+[CozyPouchLink.js:587](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L587)
 
 ***
 
@@ -582,7 +582,7 @@ the need to wait for the warmup
 
 *Defined in*
 
-[CozyPouchLink.js:202](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L202)
+[CozyPouchLink.js:198](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L198)
 
 ***
 
@@ -602,7 +602,7 @@ the need to wait for the warmup
 
 *Defined in*
 
-[CozyPouchLink.js:378](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L378)
+[CozyPouchLink.js:382](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L382)
 
 ***
 
@@ -627,7 +627,7 @@ CozyLink.persistCozyData
 
 *Defined in*
 
-[CozyPouchLink.js:531](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L531)
+[CozyPouchLink.js:535](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L535)
 
 ***
 
@@ -647,7 +647,7 @@ CozyLink.persistCozyData
 
 *Defined in*
 
-[CozyPouchLink.js:168](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L168)
+[CozyPouchLink.js:164](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L164)
 
 ***
 
@@ -674,7 +674,7 @@ CozyLink.request
 
 *Defined in*
 
-[CozyPouchLink.js:421](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L421)
+[CozyPouchLink.js:425](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L425)
 
 ***
 
@@ -692,7 +692,7 @@ CozyLink.reset
 
 *Defined in*
 
-[CozyPouchLink.js:265](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L265)
+[CozyPouchLink.js:261](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L261)
 
 ***
 
@@ -712,7 +712,7 @@ CozyLink.reset
 
 *Defined in*
 
-[CozyPouchLink.js:504](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L504)
+[CozyPouchLink.js:508](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L508)
 
 ***
 
@@ -738,7 +738,7 @@ Emits pouchlink:sync:start event when the replication begins
 
 *Defined in*
 
-[CozyPouchLink.js:334](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L334)
+[CozyPouchLink.js:338](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L338)
 
 ***
 
@@ -763,7 +763,7 @@ Debounce delay can be configured through constructor's `syncDebounceDelayInMs` o
 
 *Defined in*
 
-[CozyPouchLink.js:351](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L351)
+[CozyPouchLink.js:355](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L355)
 
 ***
 
@@ -782,7 +782,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:370](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L370)
+[CozyPouchLink.js:374](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L374)
 
 ***
 
@@ -802,7 +802,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:406](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L406)
+[CozyPouchLink.js:410](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L410)
 
 ***
 
@@ -816,7 +816,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:879](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L879)
+[CozyPouchLink.js:883](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L883)
 
 ***
 
@@ -836,7 +836,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:811](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L811)
+[CozyPouchLink.js:815](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L815)
 
 ***
 
@@ -856,7 +856,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:816](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L816)
+[CozyPouchLink.js:820](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L820)
 
 ***
 
@@ -881,4 +881,4 @@ The adapter name
 
 *Defined in*
 
-[CozyPouchLink.js:144](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L144)
+[CozyPouchLink.js:140](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L140)

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -1126,6 +1126,73 @@ client.query(Q('io.cozy.bills'))`)
   }
 
   /**
+   * Save the document or array of documents into the persisted storage (if any)
+   *
+   * @private
+   * @param {CozyClientDocument | Array<CozyClientDocument>} data - Document or array of documents to be saved
+   * @returns {Promise<void>}
+   */
+  async persistVirtualDocuments(definition, data) {
+    const enforceList = ['io.cozy.files.shortcuts']
+
+    const enforce = enforceList.includes(definition.doctype)
+
+    if (definition.doctype === 'io.cozy.apps_registry') {
+      // io.cozy.apps_registry has a dedicated `maintenance` endpoint on cozy-stack that
+      // returns data different than the one stored in database
+      // As we want to have transparent queries, whether it uses the stack API or Pouch,
+      // we store the full response into a single doc, with a `maintenance` _id
+      // and a special `cozyPouchData` attribute, to highlight this special case
+      return await this.persistVirtualDocument(
+        {
+          _type: 'io.cozy.apps_registry',
+          _id: definition.id,
+          // @ts-ignore
+          cozyPouchData: data
+        },
+        enforce
+      )
+    }
+
+    if (!Array.isArray(data)) {
+      await this.persistVirtualDocument(data, enforce)
+    } else {
+      const documentsToPersist = data.filter(document => {
+        if (!document || document.cozyLocalOnly) {
+          return false
+        }
+
+        if ((!document.meta?.rev && !document._rev) || enforce) {
+          return true
+        }
+
+        return false
+      })
+      for (const document of documentsToPersist) {
+        await this.persistVirtualDocument(document, enforce)
+      }
+    }
+  }
+
+  /**
+   * Save the document or array of documents into the persisted storage (if any)
+   *
+   * @private
+   * @param {CozyClientDocument} document - Document to be saved
+   * @param {boolean} enforce - When true, save the document even if `meta.rev` or `_rev` exist
+   * @returns {Promise<void>}
+   */
+  async persistVirtualDocument(document, enforce) {
+    if (!document || document.cozyLocalOnly) {
+      return
+    }
+
+    if ((!document.meta?.rev && !document._rev) || enforce) {
+      await this.chain.persistCozyData(document)
+    }
+  }
+
+  /**
    * Fetch relationships for a response (can be several docs).
    * Fills the `relationships` attribute of each documents.
    *

--- a/packages/cozy-client/src/storage.js
+++ b/packages/cozy-client/src/storage.js
@@ -1,0 +1,89 @@
+import CozyClient from './CozyClient'
+import { QueryDefinition } from './queries/dsl'
+
+export const ENFORCE_LIST = ['io.cozy.files.shortcuts']
+
+/**
+ * @typedef {import("./types").CozyClientDocument} CozyClientDocument
+ */
+
+export const shouldEnforcePersist = definition => {
+  return ENFORCE_LIST.includes(definition.doctype)
+}
+
+/**
+ * Whether or not a document should be locally persisted
+ *
+ * @param {CozyClientDocument} document - The document to evaluate
+ * @returns {boolean} whether or not the doc should be persisted
+ */
+export const shouldDocumentBePersisted = (document, shouldEnforce = false) => {
+  if (!document || document.cozyLocalOnly) {
+    return false
+  }
+  if ((!document.meta?.rev && !document._rev) || shouldEnforce) {
+    return true
+  }
+  return false
+}
+
+/**
+ * Save the document or array of documents into the persisted storage (if any)
+ *
+ * @param {CozyClient} client - Cozy client instance
+ * @param {QueryDefinition} definition - The query definition
+ * @param {CozyClientDocument | Array<CozyClientDocument>} data - Document or array of documents to be saved
+ * @returns {Promise<void>}
+ */
+export const persistVirtualDocuments = async (client, definition, data) => {
+  const enforce = shouldEnforcePersist(definition)
+
+  if (definition.doctype === 'io.cozy.apps_registry') {
+    // io.cozy.apps_registry has a dedicated `maintenance` endpoint on cozy-stack that
+    // returns data different than the one stored in database
+    // As we want to have transparent queries, whether it uses the stack API or Pouch,
+    // we store the full response into a single doc, with a `maintenance` _id
+    // and a special `cozyPouchData` attribute, to highlight this special case
+    return await persistVirtualDocument(
+      client,
+      {
+        _type: 'io.cozy.apps_registry',
+        _id: definition.id,
+        // @ts-ignore
+        cozyPouchData: data
+      },
+      enforce
+    )
+  }
+
+  if (!Array.isArray(data)) {
+    await persistVirtualDocument(client, data, enforce)
+  } else {
+    const documentsToPersist = data.filter(document =>
+      shouldDocumentBePersisted(document, enforce)
+    )
+    for (const document of documentsToPersist) {
+      await persistVirtualDocument(client, document, enforce)
+    }
+  }
+}
+
+/**
+ * Save the document or array of documents into the persisted storage (if any)
+ *
+ * This relies on the fact that there are some "virtual" documents returned
+ * by the stack, in the sense that they are not CouchDB documents, but rather
+ * are computed on the fly by the server.
+ * To ensure we can use those documents locally, i.e. without the stack,
+ * we allow the possibility to persist them.
+ *
+ * @param {CozyClient} client - Cozy client instance
+ * @param {CozyClientDocument} document - Document to be saved
+ * @param {boolean} enforce - When true, save the document no matter its content
+ * @returns {Promise<void>}
+ */
+const persistVirtualDocument = async (client, document, enforce) => {
+  if (shouldDocumentBePersisted(document, enforce)) {
+    await client.chain.persistCozyData(document)
+  }
+}

--- a/packages/cozy-client/src/storage.spec.js
+++ b/packages/cozy-client/src/storage.spec.js
@@ -1,0 +1,31 @@
+import { shouldDocumentBePersisted } from './storage'
+
+const BASE_DOC = {
+  _id: '123',
+  name: 'saymy'
+}
+
+describe('shouldDocumentBePersisted', () => {
+  it('should not persist a doc with cozyLocalOnly flag', () => {
+    const doc = { ...BASE_DOC, cozyLocalOnly: true }
+    expect(shouldDocumentBePersisted(doc)).toBe(false)
+  })
+
+  it('should not persist a doc with rev', () => {
+    const doc1 = { ...BASE_DOC, _rev: '123' }
+    expect(shouldDocumentBePersisted(doc1)).toBe(false)
+
+    const doc2 = { ...BASE_DOC, meta: { rev: '123' } }
+    expect(shouldDocumentBePersisted(doc2)).toBe(false)
+  })
+
+  it('should persist if we enforce it', () => {
+    const doc = { ...BASE_DOC, _rev: '123' }
+    expect(shouldDocumentBePersisted(doc, true)).toBe(true)
+  })
+
+  it('should persist if there is not revision', () => {
+    const doc = { ...BASE_DOC }
+    expect(shouldDocumentBePersisted(doc)).toBe(true)
+  })
+})

--- a/packages/cozy-client/types/storage.d.ts
+++ b/packages/cozy-client/types/storage.d.ts
@@ -1,0 +1,48 @@
+export const ENFORCE_LIST: string[];
+export function shouldEnforcePersist(definition: any): boolean;
+export function shouldDocumentBePersisted(document: CozyClientDocument, shouldEnforce?: boolean): boolean;
+export function persistVirtualDocuments(client: CozyClient, definition: QueryDefinition, data: CozyClientDocument | Array<CozyClientDocument>): Promise<void>;
+export type CozyClientDocument = {
+    /**
+     * - Id of the document
+     */
+    _id?: string;
+    /**
+     * - Id of the document
+     */
+    id?: string;
+    /**
+     * - Type of the document
+     */
+    _type?: string;
+    /**
+     * - Current revision of the document
+     */
+    _rev?: string;
+    /**
+     * - When the document has been deleted
+     */
+    _deleted?: boolean;
+    /**
+     * - Relationships of the document
+     */
+    relationships?: import("./types").ReferencedByRelationship;
+    /**
+     * - referenced by of another document
+     */
+    referenced_by?: import("./types").Reference[];
+    /**
+     * - Cozy Metadata
+     */
+    cozyMetadata?: import("./types").CozyMetadata;
+    /**
+     * - Pouch Metadata
+     */
+    meta?: import("./types").CozyClientDocumentMeta;
+    /**
+     * - When true the document should NOT be replicated to the remote database
+     */
+    cozyLocalOnly?: boolean;
+};
+import CozyClient from "./CozyClient";
+import { QueryDefinition } from "./queries/dsl";

--- a/packages/cozy-pouch-link/src/jsonapi.spec.js
+++ b/packages/cozy-pouch-link/src/jsonapi.spec.js
@@ -31,6 +31,7 @@ const DELETED_DOC_FIXTURE = {
 const token = 'fake_token'
 const uri = 'https://claude.mycozy.cloud'
 const client = new CozyClient({ token, uri })
+client.capabilities = { flat_subdomains: true }
 
 describe('doc normalization', () => {
   it('keeps the highest between rev and _rev and removes the rev attribute', () => {
@@ -53,6 +54,36 @@ describe('doc normalization', () => {
       lastName: 'Fett',
       relationships: {
         referenced_by: undefined
+      }
+    })
+  })
+
+  it('should normalize apps links', () => {
+    const normalized = normalizeDoc(
+      {
+        _id: 1234,
+        _rev: '3-deadbeef',
+        rev: '4-cffee',
+        slug: 'contact',
+        version: '1.2.0'
+      },
+      'io.cozy.apps',
+      client
+    )
+    expect(normalized).toEqual({
+      _id: 1234,
+      id: 1234,
+      _rev: '4-cffee',
+      _type: 'io.cozy.apps',
+      slug: 'contact',
+      version: '1.2.0',
+      relationships: {
+        referenced_by: undefined
+      },
+      links: {
+        icon: '/apps/contact/icon/1.2.0',
+        related: 'https://claude-contact.mycozy.cloud/#/',
+        self: '/apps/contact'
       }
     })
   })
@@ -140,4 +171,404 @@ describe('jsonapi', () => {
       expect(lastNormalized.next).toBe(false)
     })
   })
+
+  describe('normalization', () => {
+    it('Should normalize single doc', () => {
+      const res = singleDocRes
+      const normalized = fromPouchResult({
+        res,
+        withRows: false,
+        doctype: 'io.cozy.settings',
+        client
+      })
+      expect(normalized).toEqual({
+        data: {
+          _id: 'io.cozy.settings.flags',
+          _rev: '1-078d414431314ea48ad6556cad579996',
+          _type: 'io.cozy.settings',
+          cozyLocalOnly: true,
+          id: 'io.cozy.settings.flags',
+          links: {
+            self: '/settings/flags'
+          },
+          relationships: {
+            referenced_by: undefined
+          },
+          'some.boolean.flag': true,
+          'some.number.flag': 30,
+          'some.object.flag': {
+            value1: 100,
+            value2: 100
+          },
+          'some.other.boolean.flag': true,
+          type: 'io.cozy.settings'
+        }
+      })
+    })
+  })
+  it('Should normalize docs array', () => {
+    const res = multipleDocRes
+    const normalized = fromPouchResult({
+      res,
+      withRows: true,
+      doctype: 'io.cozy.files',
+      client
+    })
+    expect(normalized).toEqual({
+      data: [
+        {
+          relationships: {
+            referenced_by: undefined
+          },
+          id: '018bdcec-00c8-7155-b352-c8a8f472f882',
+          type: 'file',
+          _type: 'io.cozy.files',
+          name: 'New note 2023-11-17T10-55-36Z.cozy-note',
+          dir_id: '3ab984a52b49806a2a29a14d31cc063f',
+          created_at: '2023-11-17T10:55:36.061274688Z',
+          updated_at: '2023-11-17T10:58:40.254562842Z',
+          size: '51',
+          md5sum: 'AYU8xZStzHKpiabOg2EHyg==',
+          mime: 'text/vnd.cozy.note+markdown',
+          class: 'text',
+          executable: false,
+          trashed: false,
+          encrypted: false,
+          metadata: {
+            content: {
+              content: [],
+              type: 'doc'
+            },
+            schema: {
+              marks: [],
+              nodes: [],
+              version: 4
+            },
+            title: '',
+            version: 57
+          },
+          cozyMetadata: {
+            doctypeVersion: '1',
+            metadataVersion: 1,
+            createdAt: '2023-11-17T10:55:36.061274688Z',
+            createdByApp: 'notes',
+            updatedAt: '2023-11-17T10:58:40.254562842Z',
+            createdOn: 'https://yannickchironcozywtf1.cozy.wtf/'
+          },
+          internal_vfs_id: 'HyepeHXMIHkKhrmq',
+          _id: '018bdcec-00c8-7155-b352-c8a8f472f882',
+          _rev: '2-c78707eb06cceaa5e95c1c4a4c4073bd'
+        },
+        {
+          relationships: {
+            referenced_by: [
+              {
+                id: '536bde9aef87dde16630d3c99d26453f',
+                type: 'io.cozy.photos.albums'
+              }
+            ]
+          },
+          id: '018c7cf1-1d00-73ac-9a7f-ee3190638183',
+          type: 'file',
+          _type: 'io.cozy.files',
+          name: 'IMG_0046.jpg',
+          dir_id: 'io.cozy.files.root-dir',
+          created_at: '2023-11-19T13:31:47+01:00',
+          updated_at: '2023-12-18T12:40:25.379Z',
+          size: '1732841',
+          md5sum: 'i19eI81lfj3dTwc7i8ihfA==',
+          mime: 'image/jpeg',
+          class: 'image',
+          executable: false,
+          trashed: false,
+          encrypted: false,
+          tags: ['library'],
+          metadata: {
+            datetime: '2023-11-19T13:31:47+01:00',
+            extractor_version: 2,
+            flash: 'On, Fired',
+            height: 3024,
+            orientation: 6,
+            width: 4032
+          },
+          referenced_by: [
+            {
+              id: '536bde9aef87dde16630d3c99d26453f',
+              type: 'io.cozy.photos.albums'
+            }
+          ],
+          cozyMetadata: {
+            doctypeVersion: '1',
+            metadataVersion: 1,
+            createdAt: '2023-12-18T12:40:25.556898681Z',
+            updatedAt: '2023-12-18T12:45:29.375968305Z',
+            updatedByApps: [
+              {
+                slug: 'photos',
+                date: '2023-12-18T12:45:29.375968305Z',
+                instance: 'https://yannickchironcozywtf1.cozy.wtf/'
+              }
+            ],
+            createdOn: 'https://yannickchironcozywtf1.cozy.wtf/',
+            uploadedAt: '2023-12-18T12:40:25.556898681Z',
+            uploadedOn: 'https://yannickchironcozywtf1.cozy.wtf/'
+          },
+          internal_vfs_id: 'SidToiYjmikHrFBP',
+          _id: '018c7cf1-1d00-73ac-9a7f-ee3190638183',
+          _rev: '2-02e800df012ea1cc740e5ad1554cefe6'
+        },
+        {
+          relationships: {
+            referenced_by: [
+              {
+                id: '536bde9aef87dde16630d3c99d26453f',
+                type: 'io.cozy.photos.albums'
+              }
+            ]
+          },
+          id: '018ca6a8-8292-7acb-bcaf-a95ccfd83662',
+          _type: 'io.cozy.files',
+          type: 'file',
+          name: 'IMG_0047.jpg',
+          dir_id: 'io.cozy.files.root-dir',
+          created_at: '2023-11-19T13:31:47+01:00',
+          updated_at: '2023-12-26T15:05:10.256Z',
+          size: '1732841',
+          md5sum: 'i19eI81lfj3dTwc7i8ihfA==',
+          mime: 'image/jpeg',
+          class: 'image',
+          executable: false,
+          trashed: false,
+          encrypted: false,
+          tags: ['library'],
+          metadata: {
+            datetime: '2023-11-19T13:31:47+01:00',
+            extractor_version: 2,
+            flash: 'On, Fired',
+            height: 3024,
+            orientation: 6,
+            width: 4032
+          },
+          referenced_by: [
+            {
+              id: '536bde9aef87dde16630d3c99d26453f',
+              type: 'io.cozy.photos.albums'
+            }
+          ],
+          cozyMetadata: {
+            doctypeVersion: '1',
+            metadataVersion: 1,
+            createdAt: '2023-12-26T15:05:10.51011657Z',
+            updatedAt: '2025-01-12T12:33:00.313230696Z',
+            updatedByApps: [
+              {
+                slug: 'photos',
+                date: '2023-12-26T15:11:03.400641304Z',
+                instance: 'https://yannickchironcozywtf1.cozy.wtf/'
+              },
+              {
+                slug: 'drive',
+                date: '2025-01-12T12:33:00.313230696Z',
+                instance: 'https://yannickchironcozywtf1.cozy.wtf/'
+              }
+            ],
+            createdOn: 'https://yannickchironcozywtf1.cozy.wtf/',
+            uploadedAt: '2023-12-26T15:05:10.51011657Z',
+            uploadedOn: 'https://yannickchironcozywtf1.cozy.wtf/'
+          },
+          internal_vfs_id: 'VSHXbbIKcufNgifx',
+          _id: '018ca6a8-8292-7acb-bcaf-a95ccfd83662',
+          _rev: '3-e18fb4f579ba93d569cabcbacc7bcd60'
+        }
+      ],
+      meta: { count: 3 },
+      skip: 0,
+      next: false
+    })
+  })
 })
+
+const singleDocRes = {
+  id: 'io.cozy.settings.flags',
+  type: 'io.cozy.settings',
+  links: {
+    self: '/settings/flags'
+  },
+  'some.boolean.flag': true,
+  'some.other.boolean.flag': true,
+  'some.object.flag': {
+    value1: 100,
+    value2: 100
+  },
+  'some.number.flag': 30,
+  cozyLocalOnly: true,
+  _id: 'io.cozy.settings.flags',
+  _rev: '1-078d414431314ea48ad6556cad579996'
+}
+
+const multipleDocRes = {
+  total_rows: 3,
+  offset: 0,
+  rows: [
+    {
+      id: '018bdcec-00c8-7155-b352-c8a8f472f882',
+      key: '018bdcec-00c8-7155-b352-c8a8f472f882',
+      value: {
+        rev: '2-c78707eb06cceaa5e95c1c4a4c4073bd'
+      },
+      doc: {
+        type: 'file',
+        name: 'New note 2023-11-17T10-55-36Z.cozy-note',
+        dir_id: '3ab984a52b49806a2a29a14d31cc063f',
+        created_at: '2023-11-17T10:55:36.061274688Z',
+        updated_at: '2023-11-17T10:58:40.254562842Z',
+        size: '51',
+        md5sum: 'AYU8xZStzHKpiabOg2EHyg==',
+        mime: 'text/vnd.cozy.note+markdown',
+        class: 'text',
+        executable: false,
+        trashed: false,
+        encrypted: false,
+        metadata: {
+          content: {
+            content: [],
+            type: 'doc'
+          },
+          schema: {
+            marks: [],
+            nodes: [],
+            version: 4
+          },
+          title: '',
+          version: 57
+        },
+        cozyMetadata: {
+          doctypeVersion: '1',
+          metadataVersion: 1,
+          createdAt: '2023-11-17T10:55:36.061274688Z',
+          createdByApp: 'notes',
+          updatedAt: '2023-11-17T10:58:40.254562842Z',
+          createdOn: 'https://yannickchironcozywtf1.cozy.wtf/'
+        },
+        internal_vfs_id: 'HyepeHXMIHkKhrmq',
+        _id: '018bdcec-00c8-7155-b352-c8a8f472f882',
+        _rev: '2-c78707eb06cceaa5e95c1c4a4c4073bd'
+      }
+    },
+    {
+      id: '018c7cf1-1d00-73ac-9a7f-ee3190638183',
+      key: '018c7cf1-1d00-73ac-9a7f-ee3190638183',
+      value: {
+        rev: '2-02e800df012ea1cc740e5ad1554cefe6'
+      },
+      doc: {
+        type: 'file',
+        name: 'IMG_0046.jpg',
+        dir_id: 'io.cozy.files.root-dir',
+        created_at: '2023-11-19T13:31:47+01:00',
+        updated_at: '2023-12-18T12:40:25.379Z',
+        size: '1732841',
+        md5sum: 'i19eI81lfj3dTwc7i8ihfA==',
+        mime: 'image/jpeg',
+        class: 'image',
+        executable: false,
+        trashed: false,
+        encrypted: false,
+        tags: ['library'],
+        metadata: {
+          datetime: '2023-11-19T13:31:47+01:00',
+          extractor_version: 2,
+          flash: 'On, Fired',
+          height: 3024,
+          orientation: 6,
+          width: 4032
+        },
+        referenced_by: [
+          {
+            id: '536bde9aef87dde16630d3c99d26453f',
+            type: 'io.cozy.photos.albums'
+          }
+        ],
+        cozyMetadata: {
+          doctypeVersion: '1',
+          metadataVersion: 1,
+          createdAt: '2023-12-18T12:40:25.556898681Z',
+          updatedAt: '2023-12-18T12:45:29.375968305Z',
+          updatedByApps: [
+            {
+              slug: 'photos',
+              date: '2023-12-18T12:45:29.375968305Z',
+              instance: 'https://yannickchironcozywtf1.cozy.wtf/'
+            }
+          ],
+          createdOn: 'https://yannickchironcozywtf1.cozy.wtf/',
+          uploadedAt: '2023-12-18T12:40:25.556898681Z',
+          uploadedOn: 'https://yannickchironcozywtf1.cozy.wtf/'
+        },
+        internal_vfs_id: 'SidToiYjmikHrFBP',
+        _id: '018c7cf1-1d00-73ac-9a7f-ee3190638183',
+        _rev: '2-02e800df012ea1cc740e5ad1554cefe6'
+      }
+    },
+    {
+      id: '018ca6a8-8292-7acb-bcaf-a95ccfd83662',
+      key: '018ca6a8-8292-7acb-bcaf-a95ccfd83662',
+      value: {
+        rev: '3-e18fb4f579ba93d569cabcbacc7bcd60'
+      },
+      doc: {
+        type: 'file',
+        name: 'IMG_0047.jpg',
+        dir_id: 'io.cozy.files.root-dir',
+        created_at: '2023-11-19T13:31:47+01:00',
+        updated_at: '2023-12-26T15:05:10.256Z',
+        size: '1732841',
+        md5sum: 'i19eI81lfj3dTwc7i8ihfA==',
+        mime: 'image/jpeg',
+        class: 'image',
+        executable: false,
+        trashed: false,
+        encrypted: false,
+        tags: ['library'],
+        metadata: {
+          datetime: '2023-11-19T13:31:47+01:00',
+          extractor_version: 2,
+          flash: 'On, Fired',
+          height: 3024,
+          orientation: 6,
+          width: 4032
+        },
+        referenced_by: [
+          {
+            id: '536bde9aef87dde16630d3c99d26453f',
+            type: 'io.cozy.photos.albums'
+          }
+        ],
+        cozyMetadata: {
+          doctypeVersion: '1',
+          metadataVersion: 1,
+          createdAt: '2023-12-26T15:05:10.51011657Z',
+          updatedAt: '2025-01-12T12:33:00.313230696Z',
+          updatedByApps: [
+            {
+              slug: 'photos',
+              date: '2023-12-26T15:11:03.400641304Z',
+              instance: 'https://yannickchironcozywtf1.cozy.wtf/'
+            },
+            {
+              slug: 'drive',
+              date: '2025-01-12T12:33:00.313230696Z',
+              instance: 'https://yannickchironcozywtf1.cozy.wtf/'
+            }
+          ],
+          createdOn: 'https://yannickchironcozywtf1.cozy.wtf/',
+          uploadedAt: '2023-12-26T15:05:10.51011657Z',
+          uploadedOn: 'https://yannickchironcozywtf1.cozy.wtf/'
+        },
+        internal_vfs_id: 'VSHXbbIKcufNgifx',
+        id: '018ca6a8-8292-7acb-bcaf-a95ccfd83662',
+        _rev: '3-e18fb4f579ba93d569cabcbacc7bcd60'
+      }
+    }
+  ]
+}

--- a/packages/cozy-pouch-link/src/jsonapi.spec.js
+++ b/packages/cozy-pouch-link/src/jsonapi.spec.js
@@ -34,46 +34,17 @@ const client = new CozyClient({ token, uri })
 client.capabilities = { flat_subdomains: true }
 
 describe('doc normalization', () => {
-  it('keeps the highest between rev and _rev and removes the rev attribute', () => {
-    const normalized = normalizeDoc(
-      {
-        _id: 1234,
-        _rev: '3-deadbeef',
-        rev: '4-cffee',
-        firstName: 'Bobba',
-        lastName: 'Fett'
-      },
-      'io.cozy.contacts'
-    )
-    expect(normalized).toEqual({
-      _id: 1234,
-      id: 1234,
-      _rev: '4-cffee',
-      _type: 'io.cozy.contacts',
-      firstName: 'Bobba',
-      lastName: 'Fett',
-      relationships: {
-        referenced_by: undefined
-      }
-    })
-  })
-
   it('should normalize apps links', () => {
-    const normalized = normalizeDoc(
-      {
-        _id: 1234,
-        _rev: '3-deadbeef',
-        rev: '4-cffee',
-        slug: 'contact',
-        version: '1.2.0'
-      },
-      'io.cozy.apps',
-      client
-    )
+    const normalized = normalizeDoc(client, 'io.cozy.apps', {
+      _id: 1234,
+      _rev: '3-deadbeef',
+      slug: 'contact',
+      version: '1.2.0'
+    })
     expect(normalized).toEqual({
       _id: 1234,
       id: 1234,
-      _rev: '4-cffee',
+      _rev: '3-deadbeef',
       _type: 'io.cozy.apps',
       slug: 'contact',
       version: '1.2.0',

--- a/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
+++ b/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
@@ -272,16 +272,13 @@ declare class PouchLink extends CozyLink {
         partialFilter: any;
     }): Promise<{
         data: any;
-        meta?: undefined;
-        skip?: undefined;
-        next?: undefined;
-    } | {
-        data: any;
         meta: {
             count: any;
         };
         skip: any;
         next: boolean;
+    } | {
+        data: any;
     }>;
     executeMutation(mutation: any, options: any, result: any, forward: any): Promise<any>;
     createDocument(mutation: any): Promise<any>;

--- a/packages/cozy-pouch-link/types/jsonapi.d.ts
+++ b/packages/cozy-pouch-link/types/jsonapi.d.ts
@@ -1,4 +1,5 @@
-export function normalizeDoc(doc: any, doctype: any, client: any): any;
+export function normalizeDocs(client: CozyClient, doctype: string, docs: Array<import('./CozyPouchLink').CozyClientDocument>): void;
+export function normalizeDoc(client: CozyClient, doctype: string, doc: any): void;
 export function fromPouchResult({ res, withRows, doctype, client }: {
     res: any;
     withRows: any;
@@ -6,14 +7,12 @@ export function fromPouchResult({ res, withRows, doctype, client }: {
     client: any;
 }): {
     data: any;
-    meta?: undefined;
-    skip?: undefined;
-    next?: undefined;
-} | {
-    data: any;
     meta: {
         count: any;
     };
     skip: any;
     next: boolean;
+} | {
+    data: any;
 };
+import CozyClient from "cozy-client";


### PR DESCRIPTION
This includes improvements to improve queries performances, after we noticed a high cozy-client overhead on large queries.
The details and performances improvements can be found in dedicated commits. 

For an overall performance insight, we measured a big query retrieving 25K documents, on a Redmi Note 10 mobile.
The query is the following: `await client.query(Q('io.cozy.files').limitBy(null))`

The results are : 

Before: 
- 2328ms to read pouch data 
**- Total: 5303ms**
- **43%** of total time is spent on database side

After:
- 2749ms to read pouch data
**- Total: 3156ms**
- **87%** of total time is spent on database side

Thus, before, 57% of the total query time was spent *outside* of the database. Now it is only 13% :rocket: 
