### PR TITLE
Add helpers to sort apps

### DIFF
--- a/docs/api/cozy-client/modules/models.applications.md
+++ b/docs/api/cozy-client/modules/models.applications.md
@@ -123,3 +123,29 @@ The io.cozy.app is installed or undefined if not
 *Defined in*
 
 [packages/cozy-client/src/models/applications.js:50](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/applications.js#L50)
+
+***
+
+### sortApplicationsList
+
+▸ **sortApplicationsList**(`apps`, `slugsOrder`): `any`\[]
+
+sortApplicationsList - Sort the apps based on the slugs in parameters. Apps listed in the slugsOrder array will be added first
+and will respect the order defined by slugsOrder and other apps will be added after.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `apps` | `any`\[] | io.cozy.apps array |
+| `slugsOrder` | `string`\[] | slugs array |
+
+*Returns*
+
+`any`\[]
+
+io.cozy.apps array
+
+*Defined in*
+
+[packages/cozy-client/src/models/applications.js:95](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/applications.js#L95)

--- a/packages/cozy-client/src/models/applications.js
+++ b/packages/cozy-client/src/models/applications.js
@@ -82,3 +82,38 @@ export const getAppDisplayName = (app, lang) => {
     ? `${translatedPrefix} ${translatedName}`
     : translatedName
 }
+
+/**
+ * sortApplicationsList - Sort the apps based on the slugs in parameters. Apps listed in the slugsOrder array will be added first
+ * and will respect the order defined by slugsOrder and other apps will be added after.
+ *
+ * @param {object[]} apps io.cozy.apps array
+ * @param {string[]} slugsOrder slugs array
+ *
+ * @returns {object[]} io.cozy.apps array
+ */
+export const sortApplicationsList = (apps, slugsOrder) => {
+  const sortedApps = []
+
+  // First we add apps that need to be added first with the custom order
+  slugsOrder.forEach(slugOrder => {
+    const app = apps.find(app => app.slug === slugOrder)
+
+    if (app) {
+      sortedApps.push(app)
+    }
+  })
+
+  // Then we add every other apps not already added
+  apps.forEach(app => {
+    const appAlreadyInSortedApps = sortedApps.find(
+      sortedApp => sortedApp.slug === app.slug
+    )
+
+    if (!appAlreadyInSortedApps) {
+      sortedApps.push(app)
+    }
+  })
+
+  return sortedApps
+}

--- a/packages/cozy-client/src/models/applications.js
+++ b/packages/cozy-client/src/models/applications.js
@@ -93,27 +93,13 @@ export const getAppDisplayName = (app, lang) => {
  * @returns {object[]} io.cozy.apps array
  */
 export const sortApplicationsList = (apps, slugsOrder) => {
-  const sortedApps = []
+  return [...apps].sort((a, b) => {
+    let indexA = slugsOrder.indexOf(a.slug)
+    if (indexA === -1) indexA = 1000
 
-  // First we add apps that need to be added first with the custom order
-  slugsOrder.forEach(slugOrder => {
-    const app = apps.find(app => app.slug === slugOrder)
+    let indexB = slugsOrder.indexOf(b.slug)
+    if (indexB === -1) indexB = 1000
 
-    if (app) {
-      sortedApps.push(app)
-    }
+    return indexA - indexB
   })
-
-  // Then we add every other apps not already added
-  apps.forEach(app => {
-    const appAlreadyInSortedApps = sortedApps.find(
-      sortedApp => sortedApp.slug === app.slug
-    )
-
-    if (!appAlreadyInSortedApps) {
-      sortedApps.push(app)
-    }
-  })
-
-  return sortedApps
 }

--- a/packages/cozy-client/src/models/applications.spec.js
+++ b/packages/cozy-client/src/models/applications.spec.js
@@ -1,5 +1,10 @@
 import { applications } from './'
-const { getAppDisplayName, getStoreURL, getStoreInstallationURL } = applications
+const {
+  getAppDisplayName,
+  getStoreURL,
+  getStoreInstallationURL,
+  sortApplicationsList
+} = applications
 
 describe('applications model', () => {
   describe('application name', () => {
@@ -127,6 +132,90 @@ describe('applications model', () => {
           'http://store.cozy.tools:8080/#/discover/contacts/install'
         )
       })
+    })
+  })
+
+  describe('sort applications list', () => {
+    it('should sort apps according to the given order', () => {
+      const availableApps = [
+        { slug: 'drive', name: 'Drive' },
+        { slug: 'chat', name: 'Chat' },
+        { slug: 'mail', name: 'Mail' },
+        { slug: 'contacts', name: 'Contacts' },
+        { slug: 'password', name: 'Password' }
+      ]
+      const order = ['chat', 'drive', 'mail', 'password', 'contacts']
+
+      const expected = [
+        { slug: 'chat', name: 'Chat' },
+        { slug: 'drive', name: 'Drive' },
+        { slug: 'mail', name: 'Mail' },
+        { slug: 'password', name: 'Password' },
+        { slug: 'contacts', name: 'Contacts' }
+      ]
+
+      const result = sortApplicationsList(availableApps, order)
+      expect(result).toEqual(expected)
+    })
+
+    it('should handle apps not in the order array', () => {
+      const availableApps = [
+        { slug: 'drive', name: 'Drive' },
+        { slug: 'chat', name: 'Chat' },
+        { slug: 'store', name: 'Store' },
+        { slug: 'mail', name: 'Mail' },
+        { slug: 'contacts', name: 'Contacts' },
+        { slug: 'password', name: 'Password' },
+        { slug: 'calendar', name: 'Calendar' }
+      ]
+      const order = ['chat', 'drive', 'mail', 'password', 'contacts']
+
+      const expected = [
+        { slug: 'chat', name: 'Chat' },
+        { slug: 'drive', name: 'Drive' },
+        { slug: 'mail', name: 'Mail' },
+        { slug: 'password', name: 'Password' },
+        { slug: 'contacts', name: 'Contacts' },
+        { slug: 'store', name: 'Store' },
+        { slug: 'calendar', name: 'Calendar' }
+      ]
+
+      const result = sortApplicationsList(availableApps, order)
+      expect(result).toEqual(expected)
+    })
+
+    it('should handle an empty apps array', () => {
+      const availableApps = []
+      const order = ['chat', 'drive', 'mail', 'password', 'notes', 'contacts']
+
+      const expected = []
+
+      const result = sortApplicationsList(availableApps, order)
+      expect(result).toEqual(expected)
+    })
+
+    it('should handle an empty order array', () => {
+      const availableApps = [
+        { slug: 'drive', name: 'Drive' },
+        { slug: 'chat', name: 'Chat' },
+        { slug: 'store', name: 'Store' },
+        { slug: 'mail', name: 'Mail' },
+        { slug: 'contacts', name: 'Contacts' },
+        { slug: 'password', name: 'Password' }
+      ]
+      const order = []
+
+      const expected = [
+        { slug: 'drive', name: 'Drive' },
+        { slug: 'chat', name: 'Chat' },
+        { slug: 'store', name: 'Store' },
+        { slug: 'mail', name: 'Mail' },
+        { slug: 'contacts', name: 'Contacts' },
+        { slug: 'password', name: 'Password' }
+      ]
+
+      const result = sortApplicationsList(availableApps, order)
+      expect(result).toEqual(expected)
     })
   })
 })

--- a/packages/cozy-client/types/models/applications.d.ts
+++ b/packages/cozy-client/types/models/applications.d.ts
@@ -3,3 +3,4 @@ export function getStoreInstallationURL(appData?: any[], app?: object): string;
 export function isInstalled(apps?: any[], wantedApp?: object): object;
 export function getUrl(app: object): string;
 export function getAppDisplayName(app: object, lang: string): string;
+export function sortApplicationsList(apps: object[], slugsOrder: string[]): object[];


### PR DESCRIPTION
To start, will be used on cozy-home and cozy-bar with flag `apps.sort` who can be set for example to `["chat", "drive", "mail", "passwords", "notes", "contacts"]`.

It will allow to display apps with this order, and other apps will come after.