### PR TITLE
fix: Ignore "Twake" prefix in getAppDisplayName

### DIFF
--- a/docs/api/cozy-client/modules/models.applications.md
+++ b/docs/api/cozy-client/modules/models.applications.md
@@ -148,4 +148,4 @@ io.cozy.apps array
 
 *Defined in*
 
-[packages/cozy-client/src/models/applications.js:95](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/applications.js#L95)
+[packages/cozy-client/src/models/applications.js:97](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/applications.js#L97)

--- a/packages/cozy-client/src/models/applications.js
+++ b/packages/cozy-client/src/models/applications.js
@@ -78,7 +78,9 @@ export const getAppDisplayName = (app, lang) => {
     basePrefix
   )
 
-  return translatedPrefix && translatedPrefix.toLowerCase() !== 'cozy'
+  return translatedPrefix &&
+    (translatedPrefix.toLowerCase() !== 'cozy' &&
+      translatedPrefix.toLowerCase() !== 'twake')
     ? `${translatedPrefix} ${translatedName}`
     : translatedName
 }

--- a/packages/cozy-client/src/models/applications.spec.js
+++ b/packages/cozy-client/src/models/applications.spec.js
@@ -23,6 +23,12 @@ describe('applications model', () => {
       expect(getAppDisplayName({ name_prefix: 'Cozy', name: 'Cozy' })).toBe(
         'Cozy'
       )
+      expect(getAppDisplayName({ name_prefix: 'Twake', name: 'Cloud' })).toBe(
+        'Cloud'
+      )
+      expect(getAppDisplayName({ name_prefix: 'Twake', name: 'Twake' })).toBe(
+        'Twake'
+      )
     })
 
     it('should support translations', () => {


### PR DESCRIPTION
We do not want to display "Twake Drive" but just "Drive" like previously with "Cozy Drive". I keep "Cozy" exception for the moment because we may have both in our codebase for a while.