### PR TITLE
fix: Downgrade react-native 0.65.x to 0.63.x

### DIFF
--- a/packages/cozy-client/package.json
+++ b/packages/cozy-client/package.json
@@ -68,7 +68,7 @@
     "cozy-intent": ">=2.23.0",
     "cozy-logger": ">1.7.0",
     "react": "^16.7.0",
-    "react-native": "^0.65.0",
+    "react-native": "~0.63.5",
     "react-native-google-play-integrity": "^1.1.0",
     "react-native-inappbrowser-reborn": "^3.5.1",
     "react-native-ios11-devicecheck": "^0.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6611,7 +6611,7 @@ __metadata:
     cozy-intent: ">=2.23.0"
     cozy-logger: ">1.7.0"
     react: ^16.7.0
-    react-native: ^0.65.0
+    react-native: ~0.63.5
     react-native-google-play-integrity: ^1.1.0
     react-native-inappbrowser-reborn: ^3.5.1
     react-native-ios11-devicecheck: ^0.0.3


### PR DESCRIPTION
react-native 0.65.x is compatible w/ react 17 only. Because our other libs required react 16, let's downgrade react-native so that every libs require react 16.