### PR TITLE
feat: Add doctypes model and fetch function

### DIFF
--- a/docs/api/cozy-client/modules/models.doctypes.md
+++ b/docs/api/cozy-client/modules/models.doctypes.md
@@ -1,0 +1,29 @@
+[cozy-client](../README.md) / [models](models.md) / doctypes
+
+# Namespace: doctypes
+
+[models](models.md).doctypes
+
+## Functions
+
+### listAllDoctypes
+
+▸ **listAllDoctypes**(`client`): `Promise`<`string`\[]>
+
+Fetches the list of all doctypes in the current instance.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`CozyClient`](../classes/CozyClient.md) | The CozyClient instance used to make the request. |
+
+*Returns*
+
+`Promise`<`string`\[]>
+
+*   A promise that resolves to an array of strings, each representing a doctype.
+
+*Defined in*
+
+[packages/cozy-client/src/models/doctypes/index.js:11](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/doctypes/index.js#L11)

--- a/docs/api/cozy-client/modules/models.md
+++ b/docs/api/cozy-client/modules/models.md
@@ -8,6 +8,7 @@
 *   [applications](models.applications.md)
 *   [contact](models.contact.md)
 *   [dacc](models.dacc.md)
+*   [doctypes](models.doctypes.md)
 *   [document](models.document.md)
 *   [file](models.file.md)
 *   [folder](models.folder.md)
@@ -31,7 +32,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/index.js:22](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/index.js#L22)
+[packages/cozy-client/src/models/index.js:23](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/index.js#L23)
 
 ***
 
@@ -41,4 +42,4 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/index.js:21](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/index.js#L21)
+[packages/cozy-client/src/models/index.js:22](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/index.js#L22)

--- a/packages/cozy-client/src/models/doctypes/index.js
+++ b/packages/cozy-client/src/models/doctypes/index.js
@@ -1,0 +1,17 @@
+import CozyClient from '../../CozyClient'
+
+const ALL_DOCTYPES_ENDPOINT = '/data/_all_doctypes'
+
+/**
+ * Fetches the list of all doctypes in the current instance.
+ *
+ * @param {CozyClient} client - The CozyClient instance used to make the request.
+ * @returns {Promise<Array<string>>} - A promise that resolves to an array of strings, each representing a doctype.
+ */
+export const listAllDoctypes = async client => {
+  const doctypesList = await client.stackClient.fetchJSON(
+    'GET',
+    ALL_DOCTYPES_ENDPOINT
+  )
+  return doctypesList
+}

--- a/packages/cozy-client/src/models/index.js
+++ b/packages/cozy-client/src/models/index.js
@@ -16,6 +16,7 @@ import * as dacc from './dacc'
 import * as paper from './paper'
 import * as user from './user'
 import * as geo from './geo'
+import * as doctypes from './doctypes'
 
 // For backward compatibility before 9.0.0
 const triggers = trigger
@@ -41,5 +42,6 @@ export {
   dacc,
   paper,
   user,
-  geo
+  geo,
+  doctypes
 }

--- a/packages/cozy-client/types/models/doctypes/index.d.ts
+++ b/packages/cozy-client/types/models/doctypes/index.d.ts
@@ -1,0 +1,2 @@
+export function listAllDoctypes(client: CozyClient): Promise<Array<string>>;
+import CozyClient from "../../CozyClient";

--- a/packages/cozy-client/types/models/index.d.ts
+++ b/packages/cozy-client/types/models/index.d.ts
@@ -18,4 +18,5 @@ import * as dacc from "./dacc";
 import * as paper from "./paper";
 import * as user from "./user";
 import * as geo from "./geo";
-export { trigger, instance, applications, file, folder, konnectorFolder, note, account, permission, utils, contact, document, timeseries, sharing, dacc, paper, user, geo };
+import * as doctypes from "./doctypes";
+export { trigger, instance, applications, file, folder, konnectorFolder, note, account, permission, utils, contact, document, timeseries, sharing, dacc, paper, user, geo, doctypes };


### PR DESCRIPTION
Introduced a new `doctypes` model with a function to fetch all doctypes
from the current Cozy instance.
