### PR TITLE
fix: Normalize data for trash-related methods

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -761,11 +761,11 @@ files associated to a specific document
     * [.removeReferencedBy(document, documents)](#FileCollection+removeReferencedBy) ⇒ <code>Promise.&lt;{data, meta}&gt;</code>
     * [.addReferencesTo(document, documents)](#FileCollection+addReferencesTo)
     * [.removeReferencesTo(document, documents)](#FileCollection+removeReferencesTo)
-    * [.destroy(file, [options])](#FileCollection+destroy) ⇒ <code>Promise</code>
-    * [.emptyTrash()](#FileCollection+emptyTrash)
-    * [.restore(id)](#FileCollection+restore) ⇒ <code>Promise</code>
+    * [.destroy(file, [options])](#FileCollection+destroy) ⇒ <code>Promise.&lt;{data}&gt;</code>
+    * [.emptyTrash()](#FileCollection+emptyTrash) ⇒ <code>Promise.&lt;{data}&gt;</code>
+    * [.restore(id)](#FileCollection+restore) ⇒ <code>Promise.&lt;{data}&gt;</code>
     * [.copy(id, [name], [dirId], [options])](#FileCollection+copy) ⇒ <code>Promise.&lt;object&gt;</code>
-    * [.deleteFilePermanently(id, [options])](#FileCollection+deleteFilePermanently) ⇒ <code>Promise.&lt;object&gt;</code>
+    * [.deleteFilePermanently(id, [options])](#FileCollection+deleteFilePermanently) ⇒ <code>Promise.&lt;{data}&gt;</code>
     * [.upload(data, dirPath, [options])](#FileCollection+upload) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.create(attributes, [options])](#FileCollection+create)
     * [.updateFile(data, params, options)](#FileCollection+updateFile) ⇒ [<code>Promise.&lt;FileAttributes&gt;</code>](#FileAttributes)
@@ -930,12 +930,11 @@ Remove files references to a document — see https://docs.cozy.io/en/cozy-stack
 
 <a name="FileCollection+destroy"></a>
 
-### fileCollection.destroy(file, [options]) ⇒ <code>Promise</code>
+### fileCollection.destroy(file, [options]) ⇒ <code>Promise.&lt;{data}&gt;</code>
 Sends file to trash and removes references to it
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
-**Returns**: <code>Promise</code> - - Resolves when references have been removed
-and file has been sent to trash  
+**Returns**: <code>Promise.&lt;{data}&gt;</code> - The JSON API conformant response.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -944,17 +943,22 @@ and file has been sent to trash
 
 <a name="FileCollection+emptyTrash"></a>
 
-### fileCollection.emptyTrash()
+### fileCollection.emptyTrash() ⇒ <code>Promise.&lt;{data}&gt;</code>
 Empty the Trash
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
+**Returns**: <code>Promise.&lt;{data}&gt;</code> - The JSON API conformant response.  
+**Throws**:
+
+- <code>FetchError</code> 
+
 <a name="FileCollection+restore"></a>
 
-### fileCollection.restore(id) ⇒ <code>Promise</code>
+### fileCollection.restore(id) ⇒ <code>Promise.&lt;{data}&gt;</code>
 Restores a trashed file.
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
-**Returns**: <code>Promise</code> - - A promise that returns the restored file if resolved.  
+**Returns**: <code>Promise.&lt;{data}&gt;</code> - The JSON API conformant response.  
 **Throws**:
 
 - <code>FetchError</code> 
@@ -985,11 +989,11 @@ Copy a file.
 
 <a name="FileCollection+deleteFilePermanently"></a>
 
-### fileCollection.deleteFilePermanently(id, [options]) ⇒ <code>Promise.&lt;object&gt;</code>
+### fileCollection.deleteFilePermanently(id, [options]) ⇒ <code>Promise.&lt;{data}&gt;</code>
 async deleteFilePermanently - Definitely delete a file
 
 **Kind**: instance method of [<code>FileCollection</code>](#FileCollection)  
-**Returns**: <code>Promise.&lt;object&gt;</code> - The deleted file object  
+**Returns**: <code>Promise.&lt;{data}&gt;</code> - The JSON API conformant response.  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/packages/cozy-stack-client/src/FileCollection.js
+++ b/packages/cozy-stack-client/src/FileCollection.js
@@ -409,8 +409,7 @@ class FileCollection extends DocumentCollection {
    *
    * @param  {FileDocument} file - File that will be sent to trash
    * @param  {object} [options] - Optionnal request options
-   * @returns {Promise} - Resolves when references have been removed
-   * and file has been sent to trash
+   * @returns {Promise<{data}>} The JSON API conformant response.
    */
   async destroy(file, { ifMatch = '' } = {}) {
     const { _id, relationships, referenced_by } = file
@@ -438,21 +437,34 @@ class FileCollection extends DocumentCollection {
 
   /**
    * Empty the Trash
+   *
+   * @returns {Promise<{data}>} The JSON API conformant response.
+   * @throws {FetchError}
+   *
    */
-  emptyTrash() {
-    return this.stackClient.fetchJSON('DELETE', '/files/trash')
+  async emptyTrash() {
+    const resp = await this.stackClient.fetchJSON('DELETE', '/files/trash')
+    return {
+      data: normalizeFile(resp.data)
+    }
   }
 
   /**
    * Restores a trashed file.
    *
    * @param {string} id   - The file's id
-   * @returns {Promise}   - A promise that returns the restored file if resolved.
+   * @returns {Promise<{data}>} The JSON API conformant response.
    * @throws {FetchError}
    *
    */
-  restore(id) {
-    return this.stackClient.fetchJSON('POST', uri`/files/trash/${id}`)
+  async restore(id) {
+    const resp = await this.stackClient.fetchJSON(
+      'POST',
+      uri`/files/trash/${id}`
+    )
+    return {
+      data: normalizeFile(resp.data)
+    }
   }
 
   /**
@@ -491,7 +503,7 @@ class FileCollection extends DocumentCollection {
    *
    * @param  {string} id - The id of the file to delete
    * @param  {object} [options] - Optionnal request options
-   * @returns {Promise<object>} The deleted file object
+   * @returns {Promise<{data}>} The JSON API conformant response.
    */
   async deleteFilePermanently(id, { ifMatch = '' } = {}) {
     const resp = await this.stackClient.fetchJSON(
@@ -513,7 +525,9 @@ class FileCollection extends DocumentCollection {
       }
     )
 
-    return resp.data
+    return {
+      data: normalizeFile(resp.data)
+    }
   }
   /**
    * @param {File|Blob|Stream|string|ArrayBuffer} data file to be uploaded

--- a/packages/cozy-stack-client/src/FileCollection.spec.js
+++ b/packages/cozy-stack-client/src/FileCollection.spec.js
@@ -1283,7 +1283,9 @@ describe('FileCollection', () => {
       client.fetchJSON.mockReturnValue({
         data: {
           id: FILE_ID,
-          type: 'io.cozy.files',
+          meta: {
+            rev: 'abc'
+          },
           trashed: false
         }
       })
@@ -1295,7 +1297,12 @@ describe('FileCollection', () => {
       expect(result).toEqual({
         data: {
           id: FILE_ID,
-          type: 'io.cozy.files',
+          _id: FILE_ID,
+          _rev: 'abc',
+          meta: {
+            rev: 'abc'
+          },
+          _type: 'io.cozy.files',
           trashed: false
         }
       })
@@ -1463,7 +1470,9 @@ describe('FileCollection', () => {
       client.fetchJSON.mockReturnValue({
         data: {
           id: FILE_ID,
-          type: 'io.cozy.files'
+          meta: {
+            rev: 'abc'
+          }
         }
       })
       const result = await collection.deleteFilePermanently(FILE_ID)
@@ -1486,8 +1495,15 @@ describe('FileCollection', () => {
         }
       )
       expect(result).toEqual({
-        id: FILE_ID,
-        type: 'io.cozy.files'
+        data: {
+          id: FILE_ID,
+          _id: FILE_ID,
+          _type: 'io.cozy.files',
+          _rev: 'abc',
+          meta: {
+            rev: 'abc'
+          }
+        }
       })
     })
 


### PR DESCRIPTION
The `emptyTrash`, `restore` and `deleteFilePermanently` were not normalizing data.
Furthermore, `deleteFilePermanently` return was not including `data` object, making it non-standard.

BREAKING CHANGE: if you were relying on the `deleteFilePermanently` response, take care of handling the `data` attribute at the root of the response.