### PR TITLE
feat: Support multiple create and delete

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -50,7 +50,9 @@ cozy-client
 | `ADD_REFERENCED_BY` | `string` |
 | `ADD_REFERENCES_TO` | `string` |
 | `CREATE_DOCUMENT` | `string` |
+| `CREATE_DOCUMENTS` | `string` |
 | `DELETE_DOCUMENT` | `string` |
+| `DELETE_DOCUMENTS` | `string` |
 | `REMOVE_REFERENCED_BY` | `string` |
 | `REMOVE_REFERENCES_TO` | `string` |
 | `UPDATE_DOCUMENT` | `string` |
@@ -59,7 +61,7 @@ cozy-client
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:510](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L510)
+[packages/cozy-client/src/queries/dsl.js:528](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L528)
 
 ***
 
@@ -74,7 +76,9 @@ cozy-client
 | `addReferencedBy` | (`document`: `any`, `referencedDocuments`: `any`) => { `document`: `any` ; `mutationType`: `string` = MutationTypes.ADD_REFERENCED_BY; `referencedDocuments`: `any`  } |
 | `addReferencesTo` | (`document`: `any`, `referencedDocuments`: `any`) => { `document`: `any` ; `mutationType`: `string` = MutationTypes.ADD_REFERENCES_TO; `referencedDocuments`: `any`  } |
 | `createDocument` | (`document`: `any`) => { `document`: `any` ; `mutationType`: `string` = MutationTypes.CREATE_DOCUMENT } |
+| `createDocuments` | (`documents`: `any`) => { `documents`: `any` ; `mutationType`: `string` = MutationTypes.CREATE_DOCUMENTS } |
 | `deleteDocument` | (`document`: `any`) => { `document`: `any` ; `mutationType`: `string` = MutationTypes.DELETE_DOCUMENT } |
+| `deleteDocuments` | (`documents`: `any`) => { `documents`: `any` ; `mutationType`: `string` = MutationTypes.DELETE_DOCUMENTS } |
 | `removeReferencedBy` | (`document`: `any`, `referencedDocuments`: `any`) => { `document`: `any` ; `mutationType`: `string` = MutationTypes.REMOVE_REFERENCED_BY; `referencedDocuments`: `any`  } |
 | `removeReferencesTo` | (`document`: `any`, `referencedDocuments`: `any`) => { `document`: `any` ; `mutationType`: `string` = MutationTypes.REMOVE_REFERENCES_TO; `referencedDocuments`: `any`  } |
 | `updateDocument` | (`document`: `any`) => { `document`: `any` ; `mutationType`: `string` = MutationTypes.UPDATE_DOCUMENT } |
@@ -83,7 +87,7 @@ cozy-client
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:498](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L498)
+[packages/cozy-client/src/queries/dsl.js:514](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L514)
 
 ***
 
@@ -565,7 +569,7 @@ Generated URL
 
 *Defined in*
 
-[packages/cozy-client/src/queries/dsl.js:474](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L474)
+[packages/cozy-client/src/queries/dsl.js:486](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/queries/dsl.js#L486)
 
 ***
 

--- a/docs/api/cozy-client/classes/CozyClient.md
+++ b/docs/api/cozy-client/classes/CozyClient.md
@@ -73,7 +73,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1889](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1889)
+[packages/cozy-client/src/CozyClient.js:1936](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1936)
 
 ***
 
@@ -83,7 +83,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1749](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1749)
+[packages/cozy-client/src/CozyClient.js:1796](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1796)
 
 ***
 
@@ -133,7 +133,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1885](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1885)
+[packages/cozy-client/src/CozyClient.js:1932](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1932)
 
 ***
 
@@ -220,7 +220,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1724](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1724)
+[packages/cozy-client/src/CozyClient.js:1771](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1771)
 
 ***
 
@@ -230,7 +230,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1654](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1654)
+[packages/cozy-client/src/CozyClient.js:1701](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1701)
 
 ***
 
@@ -260,7 +260,7 @@ Cozy-Client will automatically call `this.login()` if provided with a token and 
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1408](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1408)
+[packages/cozy-client/src/CozyClient.js:1455](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1455)
 
 ***
 
@@ -384,7 +384,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1570](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1570)
+[packages/cozy-client/src/CozyClient.js:1617](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1617)
 
 ***
 
@@ -402,7 +402,7 @@ This mechanism is described in https://github.com/cozy/cozy-client/blob/master/p
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1551](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1551)
+[packages/cozy-client/src/CozyClient.js:1598](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1598)
 
 ***
 
@@ -418,7 +418,7 @@ Returns whether the client has been revoked on the server
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1666](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1666)
+[packages/cozy-client/src/CozyClient.js:1713](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1713)
 
 ***
 
@@ -481,7 +481,32 @@ await client.create('io.cozy.todos', {
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:628](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L628)
+[packages/cozy-client/src/CozyClient.js:632](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L632)
+
+***
+
+### createAll
+
+▸ **createAll**(`docs`, `options?`): `Promise`<`any`>
+
+Create multiple documents in one batch.
+WARNING: this method is currently not supported by the stack, but
+works with PouchDB
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `docs` | `CozyClientDocument`\[] | Documents to create. Should not have \_id nor \_rev |
+| `options` | `any` | - |
+
+*Returns*
+
+`Promise`<`any`>
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:652](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L652)
 
 ***
 
@@ -502,13 +527,13 @@ If `oauth` options are passed, stackClient is an OAuthStackClient.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1704](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1704)
+[packages/cozy-client/src/CozyClient.js:1751](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1751)
 
 ***
 
 ### destroy
 
-▸ **destroy**(`document`, `mutationOptions?`): `Promise`<`CozyClientDocument`>
+▸ **destroy**(`document`, `options?`): `Promise`<`CozyClientDocument`>
 
 Destroys a document. {before,after}:destroy hooks will be fired.
 
@@ -517,7 +542,7 @@ Destroys a document. {before,after}:destroy hooks will be fired.
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `document` | `CozyClientDocument` | Document to be deleted |
-| `mutationOptions` | `Object` | - |
+| `options` | `any` | - |
 
 *Returns*
 
@@ -527,7 +552,32 @@ The document that has been deleted
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:884](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L884)
+[packages/cozy-client/src/CozyClient.js:914](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L914)
+
+***
+
+### destroyAll
+
+▸ **destroyAll**(`documents`, `options?`): `Promise`<`CozyClientDocument`\[]>
+
+Destroy multiple documents
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `documents` | `CozyClientDocument`\[] | Documents to be deleted |
+| `options` | `any` | - |
+
+*Returns*
+
+`Promise`<`CozyClientDocument`\[]>
+
+The deleted documents
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:928](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L928)
 
 ***
 
@@ -547,7 +597,7 @@ The document that has been deleted
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1775](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1775)
+[packages/cozy-client/src/CozyClient.js:1822](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1822)
 
 ***
 
@@ -595,7 +645,7 @@ a method from cozy-client
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:698](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L698)
+[packages/cozy-client/src/CozyClient.js:727](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L727)
 
 ***
 
@@ -619,7 +669,7 @@ Makes sure that the query exists in the store
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:905](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L905)
+[packages/cozy-client/src/CozyClient.js:951](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L951)
 
 ***
 
@@ -633,7 +683,7 @@ Makes sure that the query exists in the store
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1657](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1657)
+[packages/cozy-client/src/CozyClient.js:1704](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1704)
 
 ***
 
@@ -685,7 +735,7 @@ Query state
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1505](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1505)
+[packages/cozy-client/src/CozyClient.js:1552](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1552)
 
 ***
 
@@ -720,7 +770,7 @@ Query state
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1383](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1383)
+[packages/cozy-client/src/CozyClient.js:1430](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1430)
 
 ***
 
@@ -764,7 +814,7 @@ Creates an association that is linked to the store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1390](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1390)
+[packages/cozy-client/src/CozyClient.js:1437](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1437)
 
 ***
 
@@ -778,7 +828,7 @@ Creates an association that is linked to the store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1757](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1757)
+[packages/cozy-client/src/CozyClient.js:1804](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1804)
 
 ***
 
@@ -802,7 +852,7 @@ Array of documents or null if the collection does not exist.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1426](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1426)
+[packages/cozy-client/src/CozyClient.js:1473](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1473)
 
 ***
 
@@ -827,7 +877,7 @@ Document or null if the object does not exist.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1443](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1443)
+[packages/cozy-client/src/CozyClient.js:1490](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1490)
 
 ***
 
@@ -862,7 +912,7 @@ One or more mutation to execute
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:797](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L797)
+[packages/cozy-client/src/CozyClient.js:826](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L826)
 
 ***
 
@@ -882,7 +932,7 @@ One or more mutation to execute
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1310](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1310)
+[packages/cozy-client/src/CozyClient.js:1357](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1357)
 
 ***
 
@@ -898,7 +948,7 @@ getInstanceOptions - Returns current instance options, such as domain or app slu
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1784](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1784)
+[packages/cozy-client/src/CozyClient.js:1831](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1831)
 
 ***
 
@@ -925,7 +975,7 @@ Get a query from the internal store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1464](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1464)
+[packages/cozy-client/src/CozyClient.js:1511](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1511)
 
 ***
 
@@ -954,7 +1004,7 @@ the store up, which in turn will update the `<Query>`s and re-render the data.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1406](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1406)
+[packages/cozy-client/src/CozyClient.js:1453](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1453)
 
 ***
 
@@ -986,7 +1036,7 @@ extract the value corresponding to the given `key`
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1913](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1913)
+[packages/cozy-client/src/CozyClient.js:1960](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1960)
 
 ***
 
@@ -1000,7 +1050,7 @@ extract the value corresponding to the given `key`
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1764](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1764)
+[packages/cozy-client/src/CozyClient.js:1811](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1811)
 
 ***
 
@@ -1022,7 +1072,7 @@ Sets public attribute and emits event related to revocation
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1675](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1675)
+[packages/cozy-client/src/CozyClient.js:1722](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1722)
 
 ***
 
@@ -1044,7 +1094,7 @@ Emits event when token is refreshed
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1686](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1686)
+[packages/cozy-client/src/CozyClient.js:1733](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1733)
 
 ***
 
@@ -1070,7 +1120,7 @@ the relationship
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1353](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1353)
+[packages/cozy-client/src/CozyClient.js:1400](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1400)
 
 ***
 
@@ -1095,7 +1145,7 @@ Instead, the relationships will have null documents.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1330](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1330)
+[packages/cozy-client/src/CozyClient.js:1377](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1377)
 
 ***
 
@@ -1116,7 +1166,7 @@ Instead, the relationships will have null documents.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1364](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1364)
+[packages/cozy-client/src/CozyClient.js:1411](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1411)
 
 ***
 
@@ -1130,7 +1180,7 @@ Instead, the relationships will have null documents.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1527](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1527)
+[packages/cozy-client/src/CozyClient.js:1574](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1574)
 
 ***
 
@@ -1152,7 +1202,7 @@ loadInstanceOptionsFromDOM - Loads the dataset injected by the Stack in web page
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1795](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1795)
+[packages/cozy-client/src/CozyClient.js:1842](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1842)
 
 ***
 
@@ -1170,7 +1220,7 @@ This method is not iso with loadInstanceOptionsFromDOM for now.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1816](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1816)
+[packages/cozy-client/src/CozyClient.js:1863](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1863)
 
 ***
 
@@ -1251,7 +1301,7 @@ and working.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1376](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1376)
+[packages/cozy-client/src/CozyClient.js:1423](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1423)
 
 ***
 
@@ -1272,13 +1322,13 @@ and working.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1077](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1077)
+[packages/cozy-client/src/CozyClient.js:1123](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1123)
 
 ***
 
 ### mutate
 
-▸ **mutate**(`mutationDefinition`, `[options]?`): `Promise`<`any`>
+▸ **mutate**(`mutationDefinition`, `[params]?`): `Promise`<`any`>
 
 Mutate a document
 
@@ -1287,10 +1337,11 @@ Mutate a document
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `mutationDefinition` | `any` | Describe the mutation |
-| `[options]` | `Object` | Options |
-| `[options].as` | `string` | - |
-| `[options].update` | `Function` | - |
-| `[options].updateQueries` | `Function` | - |
+| `[params]` | `Object` | The mutation params |
+| `[params].as` | `string` | - |
+| `[params].options` | `any` | - |
+| `[params].update` | `Function` | - |
+| `[params].updateQueries` | `Function` | - |
 
 *Returns*
 
@@ -1298,7 +1349,7 @@ Mutate a document
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1095](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1095)
+[packages/cozy-client/src/CozyClient.js:1142](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1142)
 
 ***
 
@@ -1340,7 +1391,7 @@ Dehydrates and adds metadata before saving a document
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:768](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L768)
+[packages/cozy-client/src/CozyClient.js:797](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L797)
 
 ***
 
@@ -1371,7 +1422,7 @@ please use `fetchQueryAndGetFromState` instead
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:932](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L932)
+[packages/cozy-client/src/CozyClient.js:978](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L978)
 
 ***
 
@@ -1398,7 +1449,7 @@ All documents matching the query
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1037](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1037)
+[packages/cozy-client/src/CozyClient.js:1083](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1083)
 
 ***
 
@@ -1432,7 +1483,7 @@ All documents matching the query
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1771](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1771)
+[packages/cozy-client/src/CozyClient.js:1818](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1818)
 
 ***
 
@@ -1457,7 +1508,7 @@ Contains the fetched token and the client information.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1521](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1521)
+[packages/cozy-client/src/CozyClient.js:1568](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1568)
 
 ***
 
@@ -1578,7 +1629,7 @@ Contains the fetched token and the client information.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1616](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1616)
+[packages/cozy-client/src/CozyClient.js:1663](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1663)
 
 ***
 
@@ -1599,7 +1650,7 @@ Contains the fetched token and the client information.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1294](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1294)
+[packages/cozy-client/src/CozyClient.js:1341](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1341)
 
 ***
 
@@ -1625,22 +1676,22 @@ This method will reset the query state to its initial state and refetch it.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1942](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1942)
+[packages/cozy-client/src/CozyClient.js:1989](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1989)
 
 ***
 
 ### save
 
-▸ **save**(`doc`, `mutationOptions?`): `Promise`<`any`>
+▸ **save**(`doc`, `options?`): `Promise`<`any`>
 
-Create or update a document on the server
+Create or update a document
 
 *Parameters*
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `doc` | `any` | Document to save |
-| `mutationOptions` | `any` | Mutation options |
+| `options` | `any` | - |
 
 *Returns*
 
@@ -1648,7 +1699,7 @@ Create or update a document on the server
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:650](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L650)
+[packages/cozy-client/src/CozyClient.js:663](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L663)
 
 ***
 
@@ -1683,28 +1734,29 @@ save the new resulting settings into database
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1930](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1930)
+[packages/cozy-client/src/CozyClient.js:1977](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1977)
 
 ***
 
 ### saveAll
 
-▸ **saveAll**(`docs`, `mutationOptions?`): `Promise`<`void`>
+▸ **saveAll**(`docs`, `options?`): `Promise`<`void`>
 
-Saves multiple documents in one batch
+Create or update multiple documents in one batch
 
 *   Can only be called with documents from the same doctype
+*   Can either be creation (no \_id nor \_rev) or update, not both
 *   Does not support automatic creation of references
+
+WARNING: multiple creations is currently not supported by the stack, but
+works with PouchDB
 
 *Parameters*
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `docs` | `CozyClientDocument`\[] | Documents from the same doctype |
-| `mutationOptions` | `Object` | Mutation Options |
-| `mutationOptions.as` | `string` | - |
-| `mutationOptions.update` | `Function` | - |
-| `mutationOptions.updateQueries` | `Function` | - |
+| `options` | `any` | - |
 
 *Returns*
 
@@ -1712,7 +1764,7 @@ Saves multiple documents in one batch
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:671](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L671)
+[packages/cozy-client/src/CozyClient.js:696](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L696)
 
 ***
 
@@ -1732,7 +1784,7 @@ Saves multiple documents in one batch
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1870](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1870)
+[packages/cozy-client/src/CozyClient.js:1917](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1917)
 
 ***
 
@@ -1756,7 +1808,7 @@ set some data in the store.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1843](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1843)
+[packages/cozy-client/src/CozyClient.js:1890](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1890)
 
 ***
 
@@ -1780,7 +1832,7 @@ we manually call the links onLogin methods
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1884](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1884)
+[packages/cozy-client/src/CozyClient.js:1931](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1931)
 
 ***
 
@@ -1804,7 +1856,7 @@ At any time put an error function
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1856](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1856)
+[packages/cozy-client/src/CozyClient.js:1903](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1903)
 
 ***
 
@@ -1842,7 +1894,7 @@ use options.force = true.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1642](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1642)
+[packages/cozy-client/src/CozyClient.js:1689](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1689)
 
 ***
 
@@ -1866,7 +1918,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1537](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1537)
+[packages/cozy-client/src/CozyClient.js:1584](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1584)
 
 ***
 
@@ -1880,7 +1932,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1863](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1863)
+[packages/cozy-client/src/CozyClient.js:1910](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1910)
 
 ***
 
@@ -1901,29 +1953,56 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:869](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L869)
+[packages/cozy-client/src/CozyClient.js:898](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L898)
+
+***
+
+### updateAll
+
+▸ **updateAll**(`docs`, `options?`): `Promise`<`void`>
+
+Updates multiple documents in one batch. Should have \_id and \_rev
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `docs` | `CozyClientDocument`\[] | Documents from the same doctype |
+| `options` | `any` | - |
+
+*Returns*
+
+`Promise`<`void`>
+
+*Defined in*
+
+[packages/cozy-client/src/CozyClient.js:679](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L679)
 
 ***
 
 ### upload
 
-▸ **upload**(`file`, `dirPath`, `mutationOptions?`): `Promise`<`any`>
+▸ **upload**(`file`, `dirPath`, `options?`): `Promise`<`any`>
+
+Upload a file
 
 *Parameters*
 
-| Name | Type |
-| :------ | :------ |
-| `file` | `any` |
-| `dirPath` | `any` |
-| `mutationOptions` | `Object` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `file` | `any` | File to be uploaded |
+| `dirPath` | `string` | Path to upload the file to. ie : /Administative/XXX/ |
+| `options` | `any` | - |
 
 *Returns*
 
 `Promise`<`any`>
 
+Created io.cozy.files
+
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:894](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L894)
+[packages/cozy-client/src/CozyClient.js:940](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L940)
 
 ***
 
@@ -1943,7 +2022,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:639](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L639)
+[packages/cozy-client/src/CozyClient.js:604](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L604)
 
 ***
 
@@ -1963,7 +2042,7 @@ Contains the fetched token and the client information. These should be stored an
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:1070](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1070)
+[packages/cozy-client/src/CozyClient.js:1116](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L1116)
 
 ***
 
@@ -2099,4 +2178,4 @@ There are at the moment only 2 hooks available.
 
 *Defined in*
 
-[packages/cozy-client/src/CozyClient.js:863](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L863)
+[packages/cozy-client/src/CozyClient.js:892](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/CozyClient.js#L892)

--- a/docs/api/cozy-pouch-link/classes/PouchLink.md
+++ b/docs/api/cozy-pouch-link/classes/PouchLink.md
@@ -172,7 +172,27 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:723](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L723)
+[CozyPouchLink.js:741](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L741)
+
+***
+
+### bulkMutation
+
+▸ **bulkMutation**(`mutation`): `Promise`<`any`\[]>
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `mutation` | `any` |
+
+*Returns*
+
+`Promise`<`any`\[]>
+
+*Defined in*
+
+[CozyPouchLink.js:727](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L727)
 
 ***
 
@@ -192,7 +212,27 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:684](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L684)
+[CozyPouchLink.js:690](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L690)
+
+***
+
+### createDocuments
+
+▸ **createDocuments**(`mutation`): `Promise`<`any`\[]>
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `mutation` | `any` |
+
+*Returns*
+
+`Promise`<`any`\[]>
+
+*Defined in*
+
+[CozyPouchLink.js:695](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L695)
 
 ***
 
@@ -213,7 +253,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:727](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L727)
+[CozyPouchLink.js:745](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L745)
 
 ***
 
@@ -233,7 +273,27 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:712](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L712)
+[CozyPouchLink.js:708](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L708)
+
+***
+
+### deleteDocuments
+
+▸ **deleteDocuments**(`mutation`): `Promise`<`any`\[]>
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `mutation` | `any` |
+
+*Returns*
+
+`Promise`<`any`\[]>
+
+*Defined in*
+
+[CozyPouchLink.js:719](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L719)
 
 ***
 
@@ -782,7 +842,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:757](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L757)
+[CozyPouchLink.js:775](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L775)
 
 ***
 
@@ -802,7 +862,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:689](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L689)
+[CozyPouchLink.js:699](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L699)
 
 ***
 
@@ -822,7 +882,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:694](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L694)
+[CozyPouchLink.js:704](https://github.com/cozy/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L704)
 
 ***
 

--- a/packages/cozy-client/src/links/StackLink.js
+++ b/packages/cozy-client/src/links/StackLink.js
@@ -154,6 +154,8 @@ export default class StackLink extends CozyLink {
         return this.stackClient.collection(doc._type).update(doc)
       case MutationTypes.DELETE_DOCUMENT:
         return this.stackClient.collection(doc._type).destroy(doc)
+      case MutationTypes.DELETE_DOCUMENTS:
+        return this.stackClient.collection(doc._type).destroyAll(docs)
       case MutationTypes.ADD_REFERENCES_TO:
         return this.stackClient
           .collection(props.referencedDocuments[0]._type)

--- a/packages/cozy-client/src/queries/dsl.js
+++ b/packages/cozy-client/src/queries/dsl.js
@@ -412,9 +412,11 @@ export const isAGetByIdQuery = queryDefinition => {
 }
 // Mutations
 const CREATE_DOCUMENT = 'CREATE_DOCUMENT'
+const CREATE_DOCUMENTS = 'CREATE_DOCUMENTS'
 const UPDATE_DOCUMENT = 'UPDATE_DOCUMENT'
 const UPDATE_DOCUMENTS = 'UPDATE_DOCUMENTS'
 const DELETE_DOCUMENT = 'DELETE_DOCUMENT'
+const DELETE_DOCUMENTS = 'DELETE_DOCUMENTS'
 const ADD_REFERENCES_TO = 'ADD_REFERENCES_TO'
 const REMOVE_REFERENCES_TO = 'REMOVE_REFERENCES_TO'
 const ADD_REFERENCED_BY = 'ADD_REFERENCED_BY'
@@ -424,6 +426,11 @@ const UPLOAD_FILE = 'UPLOAD_FILE'
 export const createDocument = document => ({
   mutationType: MutationTypes.CREATE_DOCUMENT,
   document
+})
+
+export const createDocuments = documents => ({
+  mutationType: MutationTypes.CREATE_DOCUMENTS,
+  documents
 })
 
 export const updateDocument = document => ({
@@ -439,6 +446,11 @@ export const updateDocuments = documents => ({
 export const deleteDocument = document => ({
   mutationType: MutationTypes.DELETE_DOCUMENT,
   document
+})
+
+export const deleteDocuments = documents => ({
+  mutationType: MutationTypes.DELETE_DOCUMENTS,
+  documents
 })
 
 export const addReferencesTo = (document, referencedDocuments) => ({
@@ -477,12 +489,16 @@ export const getDoctypeFromOperation = operation => {
     switch (type) {
       case CREATE_DOCUMENT:
         return operation.document._type
+      case CREATE_DOCUMENTS:
+        return operation.documents[0]._type
       case UPDATE_DOCUMENT:
         return operation.document._type
       case UPDATE_DOCUMENTS:
         return operation.documents[0]._type
       case DELETE_DOCUMENT:
         return operation.document._type
+      case DELETE_DOCUMENTS:
+        return operation.documents[0]._type
       case ADD_REFERENCES_TO:
         throw new Error('Not implemented')
       case UPLOAD_FILE:
@@ -497,9 +513,11 @@ export const getDoctypeFromOperation = operation => {
 
 export const Mutations = {
   createDocument,
+  createDocuments,
   updateDocument,
   updateDocuments,
   deleteDocument,
+  deleteDocuments,
   addReferencesTo,
   removeReferencesTo,
   addReferencedBy,
@@ -509,9 +527,11 @@ export const Mutations = {
 
 export const MutationTypes = {
   CREATE_DOCUMENT,
+  CREATE_DOCUMENTS,
   UPDATE_DOCUMENT,
   UPDATE_DOCUMENTS,
   DELETE_DOCUMENT,
+  DELETE_DOCUMENTS,
   ADD_REFERENCES_TO,
   REMOVE_REFERENCES_TO,
   ADD_REFERENCED_BY,

--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -394,9 +394,9 @@ import { QueryDefinition } from './queries/dsl'
 
 /**
  * @typedef {object} MutationOptions
- * @property {string} [as]
- * @property {Function} [update]
- * @property {Function} [updateQueries]
+ * @property {string} as - Mutation id
+   @property  {Function} update - Function to update the document
+ * @property  {Function} updateQueries - Function to update queries
  */
 
 /**

--- a/packages/cozy-client/types/queries/dsl.d.ts
+++ b/packages/cozy-client/types/queries/dsl.d.ts
@@ -4,6 +4,10 @@ export function createDocument(document: any): {
     mutationType: string;
     document: any;
 };
+export function createDocuments(documents: any): {
+    mutationType: string;
+    documents: any;
+};
 export function updateDocument(document: any): {
     mutationType: string;
     document: any;
@@ -15,6 +19,10 @@ export function updateDocuments(documents: any): {
 export function deleteDocument(document: any): {
     mutationType: string;
     document: any;
+};
+export function deleteDocuments(documents: any): {
+    mutationType: string;
+    documents: any;
 };
 export function addReferencesTo(document: any, referencedDocuments: any): {
     mutationType: string;
@@ -44,9 +52,11 @@ export function uploadFile(file: any, dirPath: any): {
 export function getDoctypeFromOperation(operation: any): any;
 export namespace Mutations {
     export { createDocument };
+    export { createDocuments };
     export { updateDocument };
     export { updateDocuments };
     export { deleteDocument };
+    export { deleteDocuments };
     export { addReferencesTo };
     export { removeReferencesTo };
     export { addReferencedBy };
@@ -55,9 +65,11 @@ export namespace Mutations {
 }
 export namespace MutationTypes {
     export { CREATE_DOCUMENT };
+    export { CREATE_DOCUMENTS };
     export { UPDATE_DOCUMENT };
     export { UPDATE_DOCUMENTS };
     export { DELETE_DOCUMENT };
+    export { DELETE_DOCUMENTS };
     export { ADD_REFERENCES_TO };
     export { REMOVE_REFERENCES_TO };
     export { ADD_REFERENCED_BY };
@@ -297,9 +309,11 @@ export class QueryDefinition {
     };
 }
 declare const CREATE_DOCUMENT: "CREATE_DOCUMENT";
+declare const CREATE_DOCUMENTS: "CREATE_DOCUMENTS";
 declare const UPDATE_DOCUMENT: "UPDATE_DOCUMENT";
 declare const UPDATE_DOCUMENTS: "UPDATE_DOCUMENTS";
 declare const DELETE_DOCUMENT: "DELETE_DOCUMENT";
+declare const DELETE_DOCUMENTS: "DELETE_DOCUMENTS";
 declare const ADD_REFERENCES_TO: "ADD_REFERENCES_TO";
 declare const REMOVE_REFERENCES_TO: "REMOVE_REFERENCES_TO";
 declare const ADD_REFERENCED_BY: "ADD_REFERENCED_BY";

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -649,9 +649,18 @@ export type ReferenceMap = {
     [x: string]: Reference[];
 };
 export type MutationOptions = {
-    as?: string;
-    update?: Function;
-    updateQueries?: Function;
+    /**
+     * - Mutation id
+     */
+    as: string;
+    /**
+     * - Function to update the document
+     */
+    update: Function;
+    /**
+     * - Function to update queries
+     */
+    updateQueries: Function;
 };
 export type UpdatedByApp = {
     /**

--- a/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
+++ b/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
@@ -229,9 +229,12 @@ declare class PouchLink extends CozyLink {
     }): Promise<any>;
     executeMutation(mutation: any, options: any, result: any, forward: any): Promise<any>;
     createDocument(mutation: any): Promise<any>;
+    createDocuments(mutation: any): Promise<any[]>;
     updateDocument(mutation: any): Promise<any>;
     updateDocuments(mutation: any): Promise<any[]>;
     deleteDocument(mutation: any): Promise<any>;
+    deleteDocuments(mutation: any): Promise<any[]>;
+    bulkMutation(mutation: any): Promise<any[]>;
     addReferencesTo(mutation: any): Promise<void>;
     dbMethod(method: any, mutation: any): Promise<any>;
     syncImmediately(): Promise<void>;


### PR DESCRIPTION
We used to support mutliple updates but not create nor delete.  Thus, we now introduce the `createAll` and `destroyAll` API methods, to respectively bulk create and delete a batch of documents.  `updateAll`is also introduced, which is a simple wrapper for `saveAll`, just like `createAll`.

:warning: The `createAll` is currently not supported for stackClient links, but works for pouchLink. 

Adding the associated dsl mutations is also useful for apps that want to handle themselves store actions. For instance, Drive would be able to dispatch a single mutation action for multiple updates, typically after the deletion of a directory. This would improve performances, by avoiding to make a costful dispatch per document.