### PR TITLE
feat: Add `shared_docs` parameter

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -1895,6 +1895,7 @@ Implements the `DocumentCollection` API along with specific methods for
 **Kind**: global class  
 
 * [SharingCollection](#SharingCollection)
+    * [.findByDoctype(doctype, [options])](#SharingCollection+findByDoctype) ⇒ <code>object</code>
     * [.get(id)](#SharingCollection+get) ⇒ [<code>Sharing</code>](#Sharing)
     * [.fetchSharedDrives()](#SharingCollection+fetchSharedDrives) ⇒ <code>Promise.&lt;{data: Array.&lt;Sharing&gt;}&gt;</code>
     * [.create(params)](#SharingCollection+create)
@@ -1904,6 +1905,20 @@ Implements the `DocumentCollection` API along with specific methods for
     * [.revokeGroup(sharing, groupIndex)](#SharingCollection+revokeGroup)
     * [.revokeSelf(sharing)](#SharingCollection+revokeSelf)
     * [.revokeAllRecipients(sharing)](#SharingCollection+revokeAllRecipients)
+
+<a name="SharingCollection+findByDoctype"></a>
+
+### sharingCollection.findByDoctype(doctype, [options]) ⇒ <code>object</code>
+Finds all sharings for a given doctype
+
+**Kind**: instance method of [<code>SharingCollection</code>](#SharingCollection)  
+**Returns**: <code>object</code> - The response  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| doctype | <code>string</code> | The doctype |
+| [options] | [<code>SharingRulesOptions</code>](#SharingRulesOptions) | The options |
+| [options.withSharedDocs] | <code>boolean</code> | If true, the response will include the shared documents |
 
 <a name="SharingCollection+get"></a>
 

--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -54,10 +54,18 @@ const normalizeSharing = normalizeDoctypeJsonApi(SHARING_DOCTYPE)
  * `io.cozy.sharings`.
  */
 class SharingCollection extends DocumentCollection {
-  async findByDoctype(doctype) {
+  /**
+   * Finds all sharings for a given doctype
+   *
+   * @param {string} doctype The doctype
+   * @param {SharingRulesOptions} [options] The options
+   * @param {boolean} [options.withSharedDocs] If true, the response will include the shared documents
+   * @returns {object} The response
+   */
+  async findByDoctype(doctype, { withSharedDocs = true } = {}) {
     const resp = await this.stackClient.fetchJSON(
       'GET',
-      uri`/sharings/doctype/${doctype}`
+      uri`/sharings/doctype/${doctype}?shared_docs=${withSharedDocs}`
     )
     return {
       ...resp,

--- a/packages/cozy-stack-client/src/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/SharingCollection.spec.js
@@ -53,7 +53,7 @@ describe('SharingCollection', () => {
       await collection.findByDoctype('io.cozy.files')
       expect(client.fetchJSON).toHaveBeenCalledWith(
         'GET',
-        '/sharings/doctype/io.cozy.files'
+        '/sharings/doctype/io.cozy.files?shared_docs=true'
       )
     })
   })


### PR DESCRIPTION
This param allows to skip the shared docs list for each
sharing, which can be slow and costful for large sharings.

Rely on https://github.com/cozy/cozy-stack/pull/4548