### PR TITLE
feat: Queue DataProxy requests when it is not ready

### DIFF
--- a/docs/api/cozy-client/classes/DataProxyLink.md
+++ b/docs/api/cozy-client/classes/DataProxyLink.md
@@ -27,9 +27,29 @@
 
 *Defined in*
 
-[packages/cozy-client/src/links/DataProxyLink.js:8](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L8)
+[packages/cozy-client/src/links/DataProxyLink.js:9](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L9)
 
 ## Properties
+
+### \_drainingRequests
+
+• **\_drainingRequests**: `boolean`
+
+*Defined in*
+
+[packages/cozy-client/src/links/DataProxyLink.js:13](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L13)
+
+***
+
+### \_queue
+
+• **\_queue**: `any`\[]
+
+*Defined in*
+
+[packages/cozy-client/src/links/DataProxyLink.js:12](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L12)
+
+***
 
 ### dataproxy
 
@@ -37,9 +57,64 @@
 
 *Defined in*
 
-[packages/cozy-client/src/links/DataProxyLink.js:10](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L10)
+[packages/cozy-client/src/links/DataProxyLink.js:11](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L11)
 
 ## Methods
+
+### \_flushQueue
+
+▸ **\_flushQueue**(): `Promise`<`void`>
+
+*Returns*
+
+`Promise`<`void`>
+
+*Defined in*
+
+[packages/cozy-client/src/links/DataProxyLink.js:66](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L66)
+
+***
+
+### \_onReceiveMessage
+
+▸ **\_onReceiveMessage**(`event`): `void`
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `any` |
+
+*Returns*
+
+`void`
+
+*Defined in*
+
+[packages/cozy-client/src/links/DataProxyLink.js:93](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L93)
+
+***
+
+### doRequest
+
+▸ **doRequest**(`operation`, `options`): `Promise`<`any`>
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `operation` | `any` |
+| `options` | `any` |
+
+*Returns*
+
+`Promise`<`any`>
+
+*Defined in*
+
+[packages/cozy-client/src/links/DataProxyLink.js:51](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L51)
+
+***
 
 ### persistCozyData
 
@@ -64,7 +139,7 @@ Persist the given data into the links storage
 
 *Defined in*
 
-[packages/cozy-client/src/links/DataProxyLink.js:42](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L42)
+[packages/cozy-client/src/links/DataProxyLink.js:61](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L61)
 
 ***
 
@@ -84,7 +159,7 @@ Persist the given data into the links storage
 
 *Defined in*
 
-[packages/cozy-client/src/links/DataProxyLink.js:13](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L13)
+[packages/cozy-client/src/links/DataProxyLink.js:20](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L20)
 
 ***
 
@@ -108,7 +183,7 @@ the dataproxy is ready and set
 
 *Defined in*
 
-[packages/cozy-client/src/links/DataProxyLink.js:24](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L24)
+[packages/cozy-client/src/links/DataProxyLink.js:31](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L31)
 
 ***
 
@@ -137,7 +212,7 @@ Request the given operation from the link
 
 *Defined in*
 
-[packages/cozy-client/src/links/DataProxyLink.js:32](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L32)
+[packages/cozy-client/src/links/DataProxyLink.js:40](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L40)
 
 ***
 
@@ -157,4 +232,4 @@ Reset the link data
 
 *Defined in*
 
-[packages/cozy-client/src/links/DataProxyLink.js:28](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L28)
+[packages/cozy-client/src/links/DataProxyLink.js:36](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L36)

--- a/packages/cozy-client/src/links/DataProxyLink.js
+++ b/packages/cozy-client/src/links/DataProxyLink.js
@@ -1,4 +1,5 @@
 import CozyLink from './CozyLink'
+import logger from 'cozy-logger'
 
 export default class DataProxyLink extends CozyLink {
   /**
@@ -8,6 +9,12 @@ export default class DataProxyLink extends CozyLink {
   constructor({ dataproxy } = {}) {
     super()
     this.dataproxy = dataproxy || null
+    this._queue = []
+    this._drainingRequests = false
+
+    if (window) {
+      window.addEventListener('message', this._onReceiveMessage)
+    }
   }
 
   registerClient(client) {
@@ -23,6 +30,7 @@ export default class DataProxyLink extends CozyLink {
    */
   registerDataProxy(dataproxy) {
     this.dataproxy = dataproxy
+    this._flushQueue()
   }
 
   async reset() {
@@ -30,17 +38,72 @@ export default class DataProxyLink extends CozyLink {
   }
 
   async request(operation, options, result, forward) {
-    if (this.dataproxy) {
-      // Send the request to the DataProxy, that will handle both web and mobile environments
-      const opts = options || {}
-      return this.dataproxy.requestLink(operation, opts)
-    } else {
-      return forward(operation, options)
+    if (this.dataproxy?.requestLink) {
+      return this.doRequest(operation, options)
     }
+    // Here we assume the DataProxy is not ready yet for querying, but we'll be eventually.
+    // So, we put the request in a queue that will be later flushed
+    return new Promise((resolve, reject) => {
+      this._queue.push({ operation, options, resolve, reject })
+    })
+  }
+
+  async doRequest(operation, options) {
+    const opts = options || {}
+    const startQuery = performance.now()
+    // Send the request to the DataProxy, that will handle both web and mobile environments
+    const resp = await this.dataproxy.requestLink(operation, opts)
+    const endQuery = performance.now()
+    logger.info(`Request query took ${endQuery - startQuery} ms`)
+    return resp
   }
 
   async persistCozyData(data, forward) {
     // Persist data should do nothing here as data is already persisted on DataProxy side
     return
+  }
+
+  async _flushQueue() {
+    if (!this.dataproxy?.requestLink || this._queue.length < 1) {
+      return
+    }
+    logger.info(`Execute ${this._queue.length} delayed requests`)
+
+    this._drainingRequests = true
+
+    try {
+      while (this._queue.length > 0) {
+        const { operation, options, resolve, reject } = this._queue.shift()
+        try {
+          const resp = await this.doRequest(operation, options)
+          resolve(resp)
+        } catch (err) {
+          reject(err)
+        }
+      }
+    } finally {
+      this._drainingRequests = false
+      // Run it again in case queue has filled again during the flush
+      if (this._queue.length > 0) {
+        this._flushQueue()
+      }
+    }
+  }
+
+  _onReceiveMessage = event => {
+    // See https://github.com/cozy/cozy-web-data-proxy/blob/1fc3deef767536aa264074c8a377f422b588409d/src/dataproxy/parent/ParentWindowProvider.tsx#L27
+    if (!event.origin.includes('dataproxy')) {
+      return
+    }
+    const eventData = event?.data
+    if (eventData && typeof eventData === 'object') {
+      if (
+        eventData.type === 'DATAPROXYMESSAGE' &&
+        eventData.payload === 'READY'
+      ) {
+        logger.info(`Received message: DataProxy is ready`)
+        this._flushQueue()
+      }
+    }
   }
 }

--- a/packages/cozy-client/src/links/DataProxyLink.spec.js
+++ b/packages/cozy-client/src/links/DataProxyLink.spec.js
@@ -1,0 +1,86 @@
+/** @jest-environment jsdom */
+import DataProxyLink from './DataProxyLink'
+
+describe('DataProxyLink queueing', () => {
+  it('should directly call dataproxy requestLink if available', async () => {
+    const requestLink = jest.fn().mockResolvedValue('OK')
+    const dataproxy = { requestLink }
+    const link = new DataProxyLink({ dataproxy })
+
+    const res = await link.request({ op: 'op1' }, {}, undefined, undefined)
+
+    expect(res).toBe('OK')
+    expect(requestLink).toHaveBeenCalledTimes(1)
+    expect(requestLink).toHaveBeenCalledWith({ op: 'op1' }, {})
+  })
+
+  it('should fill the event queue as long as dataproxy is not ready and run all of them once it registers', async () => {
+    const link = new DataProxyLink() // no dataproxy
+
+    const p1 = link.request({ op: 'op1' }, {}, undefined, undefined)
+    const p2 = link.request({ op: 'op2' }, {}, undefined, undefined)
+
+    expect(link._queue.length).toEqual(2)
+
+    const requestLink = jest
+      .fn()
+      .mockResolvedValueOnce('Res1')
+      .mockResolvedValueOnce('Res2')
+
+    link.registerDataProxy({ requestLink })
+
+    await expect(p1).resolves.toBe('Res1')
+    await expect(p2).resolves.toBe('Res2')
+
+    expect(requestLink.mock.calls.map(c => c[0].op)).toEqual(['op1', 'op2'])
+    expect(link._queue.length).toEqual(0)
+  })
+
+  it('should correctly deal with rejected promises ', async () => {
+    const link = new DataProxyLink()
+
+    const pOk1 = link.request({ op: 'op1' }, {})
+    const pFail = link.request({ op: 'op2' }, {})
+    const pOk2 = link.request({ op: 'op3' }, {})
+
+    const requestLink = jest
+      .fn()
+      .mockResolvedValueOnce('Res1')
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce('Res3')
+
+    link.registerDataProxy({ requestLink })
+
+    await expect(pOk1).resolves.toBe('Res1')
+    await expect(pFail).rejects.toThrow('boom')
+    await expect(pOk2).resolves.toBe('Res3')
+
+    expect(requestLink.mock.calls.map(c => c[0].op)).toEqual([
+      'op1',
+      'op2',
+      'op3'
+    ])
+  })
+
+  it('should flush events when ready message is received', async () => {
+    const link = new DataProxyLink()
+
+    const p1 = link.request({ op: 'op1' }, {})
+    const p2 = link.request({ op: 'op2' }, {})
+
+    const requestLink = jest
+      .fn()
+      .mockResolvedValueOnce('Res1')
+      .mockResolvedValueOnce('Res2')
+    link.dataproxy = { requestLink }
+
+    const ev = new MessageEvent('message', {
+      data: { type: 'DATAPROXYMESSAGE', payload: 'READY' },
+      origin: 'http://dataproxy.cozy.localhost:8080'
+    })
+    window.dispatchEvent(ev)
+
+    await expect(p1).resolves.toBe('Res1')
+    await expect(p2).resolves.toBe('Res2')
+  })
+})

--- a/packages/cozy-client/types/links/DataProxyLink.d.ts
+++ b/packages/cozy-client/types/links/DataProxyLink.d.ts
@@ -7,6 +7,8 @@ export default class DataProxyLink extends CozyLink {
         dataproxy: object;
     });
     dataproxy: any;
+    _queue: any[];
+    _drainingRequests: boolean;
     registerClient(client: any): void;
     /**
      * When the link is given to a cozy-client instance, the dataproxy might not be ready yet.
@@ -16,5 +18,8 @@ export default class DataProxyLink extends CozyLink {
      * @param {object} dataproxy - The dataproxy instance
      */
     registerDataProxy(dataproxy: object): void;
+    doRequest(operation: any, options: any): Promise<any>;
+    _flushQueue(): Promise<void>;
+    _onReceiveMessage: (event: any) => void;
 }
 import CozyLink from "./CozyLink";


### PR DESCRIPTION
The DataProxy needs some time to be initialized and answer requests. However, apps may ask for query execution before it is ready ; to prevent this, we had an init mechanism made in the `DataProxyProvider` to ensure the children are rendered only when the DataProxy is ready.

It works, but if something went wrong, nothing is displayed, which is confusing and hard to debug for the developer.

So, we change this by always rendering the children on the DataProxy side, and implement a queue on the `DataProxyLink` to bufferise requests, waiting for the dataproxy to be ready.

Once it is ready, all the requests in the queue are executed, in FIFO fashion.