### PR TITLE
feat(ContactModel): Add some helpers from Contacts app

### DIFF
--- a/docs/api/cozy-client/modules/models.contact.md
+++ b/docs/api/cozy-client/modules/models.contact.md
@@ -26,6 +26,28 @@
 
 ## Functions
 
+### cleanFormattedAddress
+
+▸ **cleanFormattedAddress**(`formattedAddress`): `string`
+
+Removed unwanted characters on contact's formatted address
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `formattedAddress` | `string` | The contact's formatted address |
+
+*Returns*
+
+`string`
+
+*Defined in*
+
+[packages/cozy-client/src/models/contact.js:257](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L257)
+
+***
+
 ### getDefaultSortIndexValue
 
 ▸ **getDefaultSortIndexValue**(`contact`): `string`
@@ -71,6 +93,31 @@ Returns a display name for the contact
 *Defined in*
 
 [packages/cozy-client/src/models/contact.js:176](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L176)
+
+***
+
+### getFormattedAddress
+
+▸ **getFormattedAddress**(`address`, `t`): `string`
+
+Returns the contact's formatted address
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `address` | `any` | A contact address |
+| `t` | `Function` | Translate function |
+
+*Returns*
+
+`string`
+
+*   The contact's formatted address
+
+*Defined in*
+
+[packages/cozy-client/src/models/contact.js:292](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L292)
 
 ***
 
@@ -395,3 +442,27 @@ Makes fullname from contact name
 *Defined in*
 
 [packages/cozy-client/src/models/contact.js:117](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L117)
+
+***
+
+### updateIndexFullNameAndDisplayName
+
+▸ **updateIndexFullNameAndDisplayName**(`contact`): `any`
+
+Update fullname, displayName and Index values of a contact
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `contact` | `any` | an io.cozy.contact document |
+
+*Returns*
+
+`any`
+
+an io.cozy.contact document
+
+*Defined in*
+
+[packages/cozy-client/src/models/contact.js:315](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/contact.js#L315)

--- a/packages/cozy-client/src/models/contact.js
+++ b/packages/cozy-client/src/models/contact.js
@@ -247,3 +247,78 @@ export const getIndexByFamilyNameGivenNameEmailCozyUrl = contact => {
  * @returns {boolean}
  */
 export const isContact = doc => doc._type === CONTACTS_DOCTYPE
+
+/**
+ * Removed unwanted characters on contact's formatted address
+ *
+ * @param {string} formattedAddress - The contact's formatted address
+ * @returns {string}
+ */
+export const cleanFormattedAddress = formattedAddress => {
+  // Replace all spaces by one space, to fix cases where there are multiple spaces
+  // Replace commas that have a space before
+  // And remove all spaces before & after the string
+  let formattedAddressClean = formattedAddress
+    .replace(/\s+/g, ' ')
+    .replace(/\s,/g, '')
+    .trim()
+
+  // Case where a comma is the last character
+  if (
+    formattedAddressClean.lastIndexOf(',') ===
+    formattedAddressClean.length - 1
+  ) {
+    formattedAddressClean = formattedAddressClean.slice(
+      0,
+      formattedAddressClean.length - 1
+    )
+  }
+
+  // Case where a comma is the first character
+  if (formattedAddressClean.indexOf(',') === 0) {
+    formattedAddressClean = formattedAddressClean.slice(1)
+  }
+
+  return formattedAddressClean
+}
+
+/**
+ * Returns the contact's formatted address
+ *
+ * @param {object} address - A contact address
+ * @param {function} t - Translate function
+ * @returns {string} - The contact's formatted address
+ */
+export const getFormattedAddress = (address, t) => {
+  if (address && address.formattedAddress) {
+    return address.formattedAddress
+  }
+
+  const unformattedAddress = {
+    number: address.number || '',
+    street: address.street || '',
+    code: address.postcode || '',
+    city: address.city || '',
+    region: address.region || '',
+    country: address.country || ''
+  }
+
+  return cleanFormattedAddress(t('formatted.address', unformattedAddress))
+}
+
+/**
+ * Update fullname, displayName and Index values of a contact
+ *
+ * @param {object} contact - an io.cozy.contact document
+ * @returns {object} an io.cozy.contact document
+ */
+export const updateIndexFullNameAndDisplayName = contact => {
+  return {
+    ...contact,
+    fullname: makeFullname(contact),
+    displayName: makeDisplayName(contact),
+    indexes: {
+      byFamilyNameGivenNameEmailCozyUrl: makeDefaultSortIndexValue(contact)
+    }
+  }
+}

--- a/packages/cozy-client/types/models/contact.d.ts
+++ b/packages/cozy-client/types/models/contact.d.ts
@@ -18,4 +18,7 @@ export function makeDefaultSortIndexValue(contact: import('../types').IOCozyCont
 export function getDefaultSortIndexValue(contact: import('../types').IOCozyContact): string;
 export function getIndexByFamilyNameGivenNameEmailCozyUrl(contact: import('../types').IOCozyContact): string;
 export function isContact(doc: object): boolean;
+export function cleanFormattedAddress(formattedAddress: string): string;
+export function getFormattedAddress(address: object, t: Function): string;
+export function updateIndexFullNameAndDisplayName(contact: object): object;
 export type FullnameAttributes = "namePrefix" | "givenName" | "additionalName" | "familyName" | "nameSuffix";


### PR DESCRIPTION
helpers comes from Contacts app as is, to mutualize them between apps (Contacts and Admin-panel for now). It comes from a hard work of refactoring and code extraction, so I didn't take the time to add some test of doc.