### PR TITLE
feat: Update upload file to be abled in shared drive :sparkles:

### DIFF
--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -574,7 +574,7 @@ export const uploadFileWithConflictStrategy = async (client, file, options) => {
 
   const filesCollection = client.collection(DOCTYPE_FILES, { driveId })
   try {
-    const path = await getFullpath(client, dirId, name)
+    const path = await getFullpath(client, dirId, name, driveId)
     const existingFile = await filesCollection.statByPath(path)
     const { id: fileId } = existingFile.data
     if (conflictStrategy === 'erase') {


### PR DESCRIPTION
### Change:

Update the function `uploadFileWithConflictStrategy` to be able to create OnlyOffice file in shared drive, and replace the same function in `cozy-doctypes`.

### Relate to:

[cozy/cozy-drive#3493](https://github.com/cozy/cozy-drive/pull/3493)