### PR TITLE
feat: Store PouchDB databases locally

### DIFF
--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -74,11 +74,18 @@ class PouchManager {
       })
     )
 
-    Object.keys(this.pouches).forEach(dbName => {
+    const dbNames = Object.keys(this.pouches)
+    dbNames.forEach(dbName => {
       // Set query engine for all databases
       const doctype = getDoctypeFromDatabaseName(dbName)
       this.setQueryEngine(dbName, doctype)
     })
+
+    // Persist db names for old browsers not supporting indexeddb.databases()
+    // This is useful for cleanup.
+    // Note PouchDB adds itself the _pouch_ prefix
+    const pouchDbNames = dbNames.map(dbName => `_pouch_${dbName}`)
+    await this.storage.persistDatabasesNames(pouchDbNames)
 
     /** @type {Record<string, import('./types').SyncInfo>} - Stores synchronization info per doctype */
     this.syncedDoctypes = await this.storage.getPersistedSyncedDoctypes()

--- a/packages/cozy-pouch-link/src/localStorage.js
+++ b/packages/cozy-pouch-link/src/localStorage.js
@@ -3,7 +3,8 @@ export const LOCALSTORAGE_STORAGE_KEYS = {
   WARMUPEDQUERIES: 'cozy-client-pouch-link-warmupedqueries',
   LASTSEQUENCES: 'cozy-client-pouch-link-lastreplicationsequence',
   LASTREPLICATEDDOCID: 'cozy-client-pouch-link-lastreplicateddocid',
-  ADAPTERNAME: 'cozy-client-pouch-link-adaptername'
+  ADAPTERNAME: 'cozy-client-pouch-link-adaptername',
+  DB_NAMES: 'cozy-client-pouch-link-db-names'
 }
 
 export class PouchLocalStorage {
@@ -19,6 +20,19 @@ export class PouchLocalStorage {
    */
   async destroy() {
     this.storageEngine.destroy()
+  }
+
+  /**
+   * Persist the databases names
+   *
+   * @param {Array<string>} dbNames - The db names
+   * @returns {Promise<void>}
+   */
+  async persistDatabasesNames(dbNames) {
+    await this.storageEngine.setItem(
+      LOCALSTORAGE_STORAGE_KEYS.DB_NAMES,
+      JSON.stringify(dbNames)
+    )
   }
 
   /**

--- a/packages/cozy-pouch-link/types/localStorage.d.ts
+++ b/packages/cozy-pouch-link/types/localStorage.d.ts
@@ -4,6 +4,7 @@ export namespace LOCALSTORAGE_STORAGE_KEYS {
     const LASTSEQUENCES: string;
     const LASTREPLICATEDDOCID: string;
     const ADAPTERNAME: string;
+    const DB_NAMES: string;
 }
 export class PouchLocalStorage {
     constructor(storageEngine: any);
@@ -14,6 +15,13 @@ export class PouchLocalStorage {
      * @returns {Promise<void>}
      */
     destroy(): Promise<void>;
+    /**
+     * Persist the databases names
+     *
+     * @param {Array<string>} dbNames - The db names
+     * @returns {Promise<void>}
+     */
+    persistDatabasesNames(dbNames: Array<string>): Promise<void>;
     /**
      * Persist the last replicated doc id for a doctype
      *


### PR DESCRIPTION
This is useful at cleanup time for old browsers that do not support the `indexeddb.databases()` function.