### PR TITLE
Fix file paths handling for Pouch

### DIFF
--- a/packages/cozy-pouch-link/src/jsonapi.js
+++ b/packages/cozy-pouch-link/src/jsonapi.js
@@ -166,12 +166,12 @@ export const computeFileFullpath = async (client, file) => {
     logger.warn(`Missing dir_id for file ${file._id}`)
     return file
   }
-  const parentDir = await queryFileById(client, file.dir_id)
+  const { data: parentDir } = await queryFileById(client, file.dir_id)
 
   if (parentDir?.path) {
-    const path = buildPathWithName(parentDir?.path, file.name)
+    const path = buildPathWithName(parentDir.path, file.name)
     file.path = path
-    // Add the paths in memory
+    // Add the computed paths in memory
     setFilePath(file.dir_id, parentDir.path)
     setFilePath(file._id, path)
   }

--- a/packages/cozy-pouch-link/src/jsonapi.js
+++ b/packages/cozy-pouch-link/src/jsonapi.js
@@ -132,7 +132,6 @@ export const computeFileFullpath = async (client, file) => {
     // No need to compute directory path: it is always here
     return file
   }
-
   if (file.path) {
     // If a file path exists, check it is complete, i.e. it includes the name.
     // The stack typically does not include the name in the path, which is useful to search on it
@@ -146,17 +145,20 @@ export const computeFileFullpath = async (client, file) => {
     return file
   }
   const filePath = getFilePath(file._id)
-  if (filePath) {
-    // File path exists in memory
-    file.path = filePath
+  const parentPath = getFilePath(file.dir_id)
+  if (parentPath && filePath) {
+    // Check if file path is up to date
+    const builtPath = buildPathWithName(parentPath, file.name)
+    if (filePath !== builtPath) {
+      setFilePath(file._id, builtPath)
+    }
+    file.path = builtPath
     return file
   }
-
-  const parentPath = getFilePath(file.dir_id)
   if (parentPath) {
-    // Parent path exists in memory
+    // Parent path exists in memory: use it to compute file path and save in memory
     const path = buildPathWithName(parentPath, file.name)
-    setFilePath(file._id, path) // Add the path in memory
+    setFilePath(file._id, path)
     file.path = path
     return file
   }


### PR DESCRIPTION
File paths are not stored in PouchDB. Therefore, we keep a Map of paths in-memory, for fast retrieval.
This PR adds 2 fixes: 
- The Map was not properly initialized, because we failed to correctly retrieve the parent path from database
- Updates on file paths were not properly handled

Note the paths were still properly displayed to the user at search time, because the paths handling was originally done on search side: https://github.com/cozy/cozy-libs/blob/master/packages/cozy-dataproxy-lib/src/search/helpers/filePaths.ts

But this is better to mutualize the logic here, so both search and pouch queries can benefit from it. So we'll eventually remove the paths handling on dataproxy search. 