### PR TITLE
fix(cozy-client): Failed queries not respecting fetchPolicy

### DIFF
--- a/packages/cozy-client/src/policies.js
+++ b/packages/cozy-client/src/policies.js
@@ -17,10 +17,12 @@ const fetchPolicies = {
    * @returns {Function} Fetch policy to be used with `<Query />`
    */
   olderThan: delay => queryState => {
-    if (!queryState || !queryState.lastUpdate) {
+    const lastCheck = queryState.lastUpdate || queryState.lastErrorUpdate
+
+    if (!queryState || !lastCheck) {
       return true
     } else {
-      const elapsed = Date.now() - queryState.lastUpdate
+      const elapsed = Date.now() - lastCheck
       return elapsed > delay
     }
   },

--- a/packages/cozy-client/src/policies.js
+++ b/packages/cozy-client/src/policies.js
@@ -17,14 +17,18 @@ const fetchPolicies = {
    * @returns {Function} Fetch policy to be used with `<Query />`
    */
   olderThan: delay => queryState => {
-    const lastCheck = queryState.lastUpdate || queryState.lastErrorUpdate
-
-    if (!queryState || !lastCheck) {
+    if (!queryState) {
       return true
-    } else {
-      const elapsed = Date.now() - lastCheck
-      return elapsed > delay
     }
+    const lastFetch = Math.max(
+      queryState.lastUpdate || 0,
+      queryState.lastErrorUpdate || 0
+    )
+    if (!lastFetch) {
+      return true
+    }
+    const elapsed = Date.now() - lastFetch
+    return elapsed > delay
   },
 
   /**

--- a/packages/cozy-client/src/policies.spec.js
+++ b/packages/cozy-client/src/policies.spec.js
@@ -1,0 +1,65 @@
+import fetchPolicies from './policies'
+
+describe('fetchPolicies.olderThan', () => {
+  const NOW = 1600000000000
+  const delay = 30 * 1000
+  const policy = fetchPolicies.olderThan(delay)
+
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('refetches when there is no query state', () => {
+    expect(policy(undefined)).toBe(true)
+  })
+
+  it('refetches when the query has never been fetched nor errored', () => {
+    expect(policy({ lastUpdate: null, lastErrorUpdate: null })).toBe(true)
+  })
+
+  it('does not refetch a recent successful query', () => {
+    expect(policy({ lastUpdate: NOW - 1000, lastErrorUpdate: null })).toBe(
+      false
+    )
+  })
+
+  it('refetches a stale successful query', () => {
+    expect(policy({ lastUpdate: NOW - delay - 1, lastErrorUpdate: null })).toBe(
+      true
+    )
+  })
+
+  it('does not refetch right after a recent error (prevents infinite refetch loop on 500)', () => {
+    expect(policy({ lastUpdate: null, lastErrorUpdate: NOW - 1000 })).toBe(
+      false
+    )
+  })
+
+  it('refetches again once the error is older than the delay', () => {
+    expect(policy({ lastUpdate: null, lastErrorUpdate: NOW - delay - 1 })).toBe(
+      true
+    )
+  })
+
+  it('backs off on a recent error even when the last success is stale', () => {
+    expect(
+      policy({ lastUpdate: NOW - delay - 1, lastErrorUpdate: NOW - 1000 })
+    ).toBe(false)
+  })
+
+  it('stays fresh from a recent success even when the last error is stale', () => {
+    expect(
+      policy({ lastUpdate: NOW - 1000, lastErrorUpdate: NOW - delay - 1 })
+    ).toBe(false)
+  })
+})
+
+describe('fetchPolicies.noFetch', () => {
+  it('never fetches', () => {
+    expect(fetchPolicies.noFetch()).toBe(false)
+  })
+})


### PR DESCRIPTION
### issue

When a query fails, it does not update the store, which causes the OlderThan fetch policy to always return true, and this will cause an infinite loop when trying to fetch the same query.

```ts
olderThan: delay => queryState => {
  if (!queryState || !queryState.lastUpdate) {
    return true
  } else {
    const elapsed = Date.now() - queryState.lastUpdate
    return elapsed > delay
  }
},
```

this is used everywhere, especially in the useInstanceInfo hook,
```ts
const buildSettingsByIdQuery = id => ({
  definition: Q('io.cozy.settings').getById(id),
  options: {
    as: `io.cozy.settings/${id}`,
    fetchPolicy: CozyClient.fetchPolicies.olderThan(
      DEFAULT_CACHE_TIMEOUT_QUERIES
    ),
    singleDocData: true
  }
})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data refresh timing by considering both the latest successful update and error when determining whether information is stale.
  * Prevented unnecessary repeated fetch attempts after recent errors while still retrying once the configured delay has elapsed.

* **Tests**
  * Added coverage for missing, recent, stale, successful, and failed fetch states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->