### PR TITLE
fix: Allow to pass a returnUrl when fetching public note URL

### DIFF
--- a/docs/api/cozy-client/interfaces/models.note.FetchURLOptions.md
+++ b/docs/api/cozy-client/interfaces/models.note.FetchURLOptions.md
@@ -1,0 +1,41 @@
+[cozy-client](../README.md) / [models](../modules/models.md) / [note](../modules/models.note.md) / FetchURLOptions
+
+# Interface: FetchURLOptions<>
+
+[models](../modules/models.md).[note](../modules/models.note.md).FetchURLOptions
+
+## Properties
+
+### driveId
+
+• **driveId**: `string`
+
+Shared drive ID used to fetch the URL
+
+*Defined in*
+
+[packages/cozy-client/src/models/note.js:7](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L7)
+
+***
+
+### pathname
+
+• **pathname**: `string`
+
+Pathname to use in the URL
+
+*Defined in*
+
+[packages/cozy-client/src/models/note.js:6](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L6)
+
+***
+
+### returnUrl
+
+• **returnUrl**: `string`
+
+Return URL to add in query string
+
+*Defined in*
+
+[packages/cozy-client/src/models/note.js:8](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L8)

--- a/docs/api/cozy-client/modules/models.note.md
+++ b/docs/api/cozy-client/modules/models.note.md
@@ -4,11 +4,15 @@
 
 [models](models.md).note
 
+## Interfaces
+
+*   [FetchURLOptions](../interfaces/models.note.FetchURLOptions.md)
+
 ## Functions
 
 ### fetchURL
 
-▸ **fetchURL**(`client`, `file`, `options?`): `Promise`<`string`>
+▸ **fetchURL**(`client`, `file`, `[options]?`): `Promise`<`string`>
 
 Fetch and build an URL to open a note.
 
@@ -18,10 +22,7 @@ Fetch and build an URL to open a note.
 | :------ | :------ | :------ |
 | `client` | `any` | CozyClient instance |
 | `file` | `any` | io.cozy.file object |
-| `options` | `Object` | Options |
-| `options.driveId` | `string` | - |
-| `options.pathname` | `string` | - |
-| `options.returnUrl` | `string` | - |
+| `[options]` | [`FetchURLOptions`](../interfaces/models.note.FetchURLOptions.md) | Options |
 
 *Returns*
 
@@ -31,7 +32,7 @@ url
 
 *Defined in*
 
-[packages/cozy-client/src/models/note.js:35](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L35)
+[packages/cozy-client/src/models/note.js:39](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L39)
 
 ***
 
@@ -53,7 +54,7 @@ url
 
 *Defined in*
 
-[packages/cozy-client/src/models/note.js:9](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L9)
+[packages/cozy-client/src/models/note.js:16](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L16)
 
 ***
 
@@ -74,4 +75,4 @@ url
 
 *Defined in*
 
-[packages/cozy-client/src/models/note.js:18](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L18)
+[packages/cozy-client/src/models/note.js:25](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L25)

--- a/docs/api/cozy-client/modules/models.note.md
+++ b/docs/api/cozy-client/modules/models.note.md
@@ -21,6 +21,7 @@ Fetch and build an URL to open a note.
 | `options` | `Object` | Options |
 | `options.driveId` | `string` | - |
 | `options.pathname` | `string` | - |
+| `options.returnUrl` | `string` | - |
 
 *Returns*
 
@@ -30,7 +31,7 @@ url
 
 *Defined in*
 
-[packages/cozy-client/src/models/note.js:34](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L34)
+[packages/cozy-client/src/models/note.js:35](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/note.js#L35)
 
 ***
 

--- a/packages/cozy-client/src/models/note.js
+++ b/packages/cozy-client/src/models/note.js
@@ -29,6 +29,7 @@ export const generateUrlForNote = (notesAppUrl, file) => {
  * @param {object} options Options
  * @param {string} [options.pathname] Pathname to use in the URL
  * @param {string} [options.driveId] Shared drive ID used to fetched the URL
+ * @param {string} [options.returnUrl] Return URL to add in query string
  * @returns {Promise<string>} url
  */
 export const fetchURL = async (client, file, options = {}) => {
@@ -41,7 +42,15 @@ export const fetchURL = async (client, file, options = {}) => {
   if (sharecode) {
     const searchParams = [['id', note_id]]
     searchParams.push(['sharecode', sharecode])
-    if (public_name) searchParams.push(['username', public_name])
+
+    if (public_name) {
+      searchParams.push(['username', public_name])
+    }
+
+    if (options.returnUrl) {
+      searchParams.push(['returnUrl', options.returnUrl])
+    }
+
     return generateWebLink({
       cozyUrl: `${protocol}://${instance}`,
       searchParams,

--- a/packages/cozy-client/src/models/note.js
+++ b/packages/cozy-client/src/models/note.js
@@ -2,6 +2,13 @@ import { generateWebLink } from '../helpers'
 import logger from '../logger'
 
 /**
+ * @typedef {Object} FetchURLOptions
+ * @property {string} [pathname] - Pathname to use in the URL
+ * @property {string} [driveId] - Shared drive ID used to fetch the URL
+ * @property {string} [returnUrl] - Return URL to add in query string
+ */
+
+/**
  *
  * @param {string} notesAppUrl URL to the Notes App (https://notes.foo.mycozy.cloud)
  * @param {object} file io.cozy.files object
@@ -26,18 +33,19 @@ export const generateUrlForNote = (notesAppUrl, file) => {
  *
  * @param {object} client CozyClient instance
  * @param {object} file io.cozy.file object
- * @param {object} options Options
- * @param {string} [options.pathname] Pathname to use in the URL
- * @param {string} [options.driveId] Shared drive ID used to fetched the URL
- * @param {string} [options.returnUrl] Return URL to add in query string
+ * @param {FetchURLOptions} [options] Options
  * @returns {Promise<string>} url
  */
-export const fetchURL = async (client, file, options = {}) => {
+export const fetchURL = async (
+  client,
+  file,
+  { pathname, driveId, returnUrl } = {}
+) => {
   const {
     data: { note_id, subdomain, protocol, instance, sharecode, public_name }
   } = await client
     .getStackClient()
-    .collection('io.cozy.notes', { driveId: options.driveId })
+    .collection('io.cozy.notes', { driveId })
     .fetchURL({ _id: file.id })
   if (sharecode) {
     const searchParams = [['id', note_id]]
@@ -47,21 +55,21 @@ export const fetchURL = async (client, file, options = {}) => {
       searchParams.push(['username', public_name])
     }
 
-    if (options.returnUrl) {
-      searchParams.push(['returnUrl', options.returnUrl])
+    if (returnUrl) {
+      searchParams.push(['returnUrl', returnUrl])
     }
 
     return generateWebLink({
       cozyUrl: `${protocol}://${instance}`,
       searchParams,
-      pathname: options.pathname ?? '/public/',
+      pathname: pathname ?? '/public/',
       slug: 'notes',
       subDomainType: subdomain
     })
   } else {
     return generateWebLink({
       cozyUrl: `${protocol}://${instance}`,
-      pathname: options.pathname ?? '',
+      pathname: pathname ?? '',
       slug: 'notes',
       subDomainType: subdomain,
       hash: `/n/${note_id}`

--- a/packages/cozy-client/types/models/note.d.ts
+++ b/packages/cozy-client/types/models/note.d.ts
@@ -3,4 +3,5 @@ export function generateUrlForNote(notesAppUrl: any, file: any): string;
 export function fetchURL(client: object, file: object, options?: {
     pathname: string;
     driveId: string;
+    returnUrl: string;
 }): Promise<string>;

--- a/packages/cozy-client/types/models/note.d.ts
+++ b/packages/cozy-client/types/models/note.d.ts
@@ -1,7 +1,17 @@
 export function generatePrivateUrl(notesAppUrl: string, file: object, options?: {}): string;
 export function generateUrlForNote(notesAppUrl: any, file: any): string;
-export function fetchURL(client: object, file: object, options?: {
-    pathname: string;
-    driveId: string;
-    returnUrl: string;
-}): Promise<string>;
+export function fetchURL(client: object, file: object, { pathname, driveId, returnUrl }?: FetchURLOptions): Promise<string>;
+export type FetchURLOptions = {
+    /**
+     * - Pathname to use in the URL
+     */
+    pathname?: string;
+    /**
+     * - Shared drive ID used to fetch the URL
+     */
+    driveId?: string;
+    /**
+     * - Return URL to add in query string
+     */
+    returnUrl?: string;
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional return URL support for shared/public links so receivers can be redirected back after viewing; URL generation now includes this parameter when provided.

* **Documentation**
  * Updated API docs to describe the new return URL option and clarify the URL-generation parameters for consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->