### PR TITLE
fix: Skip setStore in CozyProvider when client already holds same store

### DIFF
--- a/packages/cozy-client/src/Provider.jsx
+++ b/packages/cozy-client/src/Provider.jsx
@@ -23,7 +23,7 @@ export default class CozyProvider extends Component {
     if (!props.client) {
       throw new Error('CozyProvider was not passed a client instance.')
     }
-    if (props.store) {
+    if (props.store && props.client.store !== props.store) {
       props.client.setStore(props.store)
     }
   }


### PR DESCRIPTION
This prevents a crash in React 18 StrictMode, where components are intentionally mounted twice causing CozyProvider's constructor to call client.setStore() a second time with the same store reference, which previously threw unconditionally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed redundant store reassignments in the provider to improve performance and application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->