### PR TITLE
feat: Support name in createSharedDrive

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -2066,7 +2066,8 @@ Creates a new shared drive. See https://docs.cozy.io/en/cozy-stack/shared-drives
 | Param | Type | Description |
 | --- | --- | --- |
 | params | <code>object</code> | Sharing params |
-| params.document | [<code>Sharing</code>](#Sharing) | The document to share. Should have an _id |
+| [params.name] | <code>string</code> | Name for the new shared drive (mutually exclusive with document) |
+| [params.document] | [<code>Sharing</code>](#Sharing) | Existing folder to use as shared drive (mutually exclusive with name) |
 | params.description | <code>string</code> | Description of the sharing |
 | [params.recipients] | [<code>Array.&lt;Recipient&gt;</code>](#Recipient) | Recipients to add to the sharing |
 | [params.readOnlyRecipients] | [<code>Array.&lt;Recipient&gt;</code>](#Recipient) | Recipients to add with read only access |

--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -193,23 +193,32 @@ class SharingCollection extends DocumentCollection {
    * Creates a new shared drive. See https://docs.cozy.io/en/cozy-stack/shared-drives/
    *
    * @param {object} params Sharing params
-   * @param {Sharing} params.document The document to share. Should have an _id
+   * @param {string=} params.name Name for the new shared drive (mutually exclusive with document)
+   * @param {Sharing=} params.document Existing folder to use as shared drive (mutually exclusive with name)
    * @param {string} params.description Description of the sharing
    * @param {Array<Recipient>=} params.recipients Recipients to add to the sharing
    * @param {Array<Recipient>=} params.readOnlyRecipients Recipients to add with read only access
    */
   async createSharedDrive({
+    name,
     document,
     description,
     recipients = [],
     readOnlyRecipients = []
   }) {
+    const attributes = {
+      description
+    }
+
+    if (name) {
+      attributes.name = name
+    } else if (document) {
+      attributes.folder_id = document._id
+    }
+
     const resp = await this.stackClient.fetchJSON('POST', '/sharings/drives', {
       data: {
-        attributes: {
-          folder_id: document._id,
-          description
-        },
+        attributes,
         relationships: {
           ...(recipients.length > 0 && {
             recipients: { data: recipients.map(toRelationshipItem) }

--- a/packages/cozy-stack-client/src/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/SharingCollection.spec.js
@@ -461,6 +461,32 @@ describe('SharingCollection', () => {
       client.fetchJSON.mockResolvedValue({ data: [] })
     })
 
+    it('should call POST /sharings/drives with name and description', async () => {
+      await collection.createSharedDrive({
+        name: 'My shared drive',
+        recipients: [RECIPIENT],
+        description: 'shared drive'
+      })
+
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        '/sharings/drives',
+        {
+          data: {
+            attributes: {
+              name: 'My shared drive',
+              description: 'shared drive'
+            },
+            relationships: {
+              recipients: {
+                data: [{ id: 'contact_1', type: 'io.cozy.contacts' }]
+              }
+            }
+          }
+        }
+      )
+    })
+
     it('should call POST /sharings/drives with folder_id and description', async () => {
       await collection.createSharedDrive({
         document: FOLDER,


### PR DESCRIPTION
By passing name, cozy-stack will create folder and manage everything automatically.

See https://docs.cozy.io/en/cozy-stack/shared-drives/#creating-a-shared-drive