### PR TITLE
fix(pouch): use fetchQueryAndGetFromState in queryFileById

### DIFF
--- a/packages/cozy-pouch-link/src/files.js
+++ b/packages/cozy-pouch-link/src/files.js
@@ -6,10 +6,11 @@ export const TYPE_DIRECTORY = 'directory'
 export const TYPE_FILE = 'file'
 
 export const queryFileById = async (client, id) => {
-  const queryOpts = {
+  const definition = Q('io.cozy.files').getById(id)
+  const options = {
     as: `io.cozy.files/${id}`,
     fetchPolicy: defaultFetchPolicy,
     singleDocData: true
   }
-  return client.query(Q('io.cozy.files').getById(id), queryOpts)
+  return client.fetchQueryAndGetFromState({ definition, options })
 }

--- a/packages/cozy-pouch-link/src/files.spec.js
+++ b/packages/cozy-pouch-link/src/files.spec.js
@@ -1,0 +1,25 @@
+import { Q } from 'cozy-client'
+
+import { queryFileById } from './files'
+
+describe('queryFileById', () => {
+  it('should call client.fetchQueryAndGetFromState with the expected definition and options', async () => {
+    const expectedResult = { data: { _id: 'parent', path: '/parent' } }
+    const client = {
+      fetchQueryAndGetFromState: jest.fn().mockResolvedValue(expectedResult)
+    }
+
+    const res = await queryFileById(client, 'parent')
+
+    expect(res).toBe(expectedResult)
+    expect(client.fetchQueryAndGetFromState).toHaveBeenCalledTimes(1)
+    expect(client.fetchQueryAndGetFromState).toHaveBeenCalledWith({
+      definition: expect.objectContaining(Q('io.cozy.files').getById('parent')),
+      options: {
+        as: 'io.cozy.files/parent',
+        fetchPolicy: expect.any(Function),
+        singleDocData: true
+      }
+    })
+  })
+})

--- a/packages/cozy-pouch-link/src/jsonapi.js
+++ b/packages/cozy-pouch-link/src/jsonapi.js
@@ -168,7 +168,10 @@ export const computeFileFullpath = async (client, file) => {
     logger.warn(`Missing dir_id for file ${file._id}`)
     return file
   }
-  const { data: parentDir } = await queryFileById(client, file.dir_id)
+  // queryFileById can resolve to undefined when offline (no parent dir
+  // found in the link chain), so we must guard before destructuring.
+  const result = await queryFileById(client, file.dir_id)
+  const parentDir = result?.data
 
   if (parentDir?.path) {
     const path = buildPathWithName(parentDir.path, file.name)

--- a/packages/cozy-pouch-link/src/jsonapi.spec.js
+++ b/packages/cozy-pouch-link/src/jsonapi.spec.js
@@ -719,4 +719,35 @@ describe('computeFileFullpath', () => {
     const res2 = await computeFileFullpath(client, updFile)
     expect(res2.path).toEqual('ROOT/MYDIR/file3.1')
   })
+
+  it('should return the file unchanged when queryFileById resolves to undefined', async () => {
+    // This happens offline when the link chain returns nothing for the
+    // parent dir lookup. Before the fix, destructuring `.data` from
+    // `undefined` crashed with "Cannot read property 'data' of undefined".
+    queryFileById.mockResolvedValue(undefined)
+    const file = {
+      _id: 'offline-file-1',
+      _type: 'io.cozy.files',
+      type: 'file',
+      dir_id: 'unknown-dir',
+      name: 'offline.txt'
+    }
+    const res = await computeFileFullpath(client, file)
+    expect(res).toBe(file)
+    expect(res.path).toBeUndefined()
+  })
+
+  it('should return the file unchanged when queryFileById resolves with null data', async () => {
+    queryFileById.mockResolvedValue({ data: null })
+    const file = {
+      _id: 'offline-file-2',
+      _type: 'io.cozy.files',
+      type: 'file',
+      dir_id: 'unknown-dir',
+      name: 'offline2.txt'
+    }
+    const res = await computeFileFullpath(client, file)
+    expect(res).toBe(file)
+    expect(res.path).toBeUndefined()
+  })
 })


### PR DESCRIPTION
## Bug

`computeFileFullpath` recursively walks up the `dir_id` chain calling
`queryFileById(client, parentId)` to get each parent's path. Inside,
`queryFileById` uses `client.query()` with a `fetchPolicy.olderThan(5min)`.

When another consumer has already populated the cozy-client store for
the same `as` (`io.cozy.files/${id}`) recently, the fetchPolicy returns
`false` and `client.query()` returns `undefined` — by design, per the
`client.query()` JSDoc:

> If the query is called under the fetch policy's delay, then the
> query is not executed and **nothing is returned**. If you need a
> result anyway, please use `fetchQueryAndGetFromState` instead.

The downstream consumer destructures `.data` on the `undefined` result
and crashes with:

```
TypeError: Cannot read property 'data' of undefined
    at packages/cozy-pouch-link/src/jsonapi.js:171
```

In our downstream consumer (twake-drive-mobile), this fired any time
the app's own `useQuery(fileByIdQuery(folderId))` had pre-populated the
store, then a folder listing arrived with files whose parent matched
that folder. Result: a flood of crashes on every folder navigation.

## Fix

- Switch `queryFileById` from `client.query()` to
  `client.fetchQueryAndGetFromState({ definition, options })`. That
  method always returns the store value, whether or not a fetch
  happened — which is exactly what the JSDoc tells consumers to use
  when they need a result even under the fetchPolicy delay.
- Keep a small defensive guard in `computeFileFullpath` so a falsy
  return (e.g. unknown id with no store entry yet) doesn't crash.

## Tests

- Two cases in `jsonapi.spec.js` mock `queryFileById` to resolve to
  `undefined` / `{ data: null }` and assert `computeFileFullpath`
  returns the file untouched. They pin the guard's behavior.
- A new case in `files.spec.js` asserts `queryFileById` now calls
  `client.fetchQueryAndGetFromState` (not `client.query`) with the
  right shape.

Full `cozy-pouch-link` jest suite: 186 tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of file operations during offline scenarios with better safeguards against missing data.

* **Tests**
  * Added comprehensive test coverage for offline synchronization edge cases and file query operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/cozy-client/pull/1681)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->