### PR TITLE
fix(pouch): pass clean doctypes to onSync (not prefixed pouch dbNames)

### DIFF
--- a/packages/cozy-pouch-link/src/PouchManager.spec.js
+++ b/packages/cozy-pouch-link/src/PouchManager.spec.js
@@ -235,7 +235,7 @@ describe('PouchManager', () => {
     manager.updateSyncInfo('io.cozy.todos')
     await manager.replicateOnce()
     expect(onSync).toHaveBeenCalledWith({
-      'cozy.tools__doctype__io.cozy.todos': [
+      'io.cozy.todos': [
         {
           _id: '1',
           name: 'Make replication work'

--- a/packages/cozy-pouch-link/src/replicateOnce.js
+++ b/packages/cozy-pouch-link/src/replicateOnce.js
@@ -87,7 +87,9 @@ export const replicateOnce = async pouchManager => {
   )
 
   // Waiting on each replication
-  const doctypes = Object.keys(pouchManager.pouches)
+  const doctypes = Object.keys(pouchManager.pouches).map(dbName =>
+    getDoctypeFromDatabaseName(dbName)
+  )
   const promises = Object.values(pouchManager.replications)
   try {
     const res = await allSettled(promises)

--- a/packages/cozy-pouch-link/src/replicateOnce.spec.js
+++ b/packages/cozy-pouch-link/src/replicateOnce.spec.js
@@ -1,0 +1,104 @@
+/* global jest */
+
+jest.mock('./remote', () => ({
+  fetchRemoteLastSequence: jest.fn().mockResolvedValue('0'),
+  isDatabaseNotFoundError: jest.fn().mockReturnValue(false),
+  isDatabaseUnradableError: jest.fn().mockReturnValue(false)
+}))
+
+jest.mock('./startReplication', () => ({
+  startReplication: jest.fn()
+}))
+
+import { replicateOnce } from './replicateOnce'
+import { startReplication } from './startReplication'
+
+describe('replicateOnce', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should call onSync with clean doctype keys, not prefixed pouch dbNames', async () => {
+    const dbName = 'instance__doctype__io.cozy.todos'
+    const docs = [{ _id: 'doc-1', name: 'a' }]
+
+    startReplication.mockResolvedValue(docs)
+
+    const pouchManager = {
+      pouches: { [dbName]: { id: 'fake-pouch' } },
+      replications: {},
+      doctypesReplicationOptions: {},
+      options: {
+        onSync: jest.fn()
+      },
+      storage: {
+        persistDoctypeLastSequence: jest.fn().mockResolvedValue(),
+        getDoctypeLastSequence: jest.fn().mockResolvedValue(''),
+        destroyDoctypeLastSequence: jest.fn().mockResolvedValue()
+      },
+      client: {},
+      isOnline: jest.fn().mockResolvedValue(true),
+      getReplicationURL: jest.fn().mockReturnValue('http://example/db'),
+      getSyncStatus: jest.fn().mockReturnValue('synced'),
+      updateSyncInfo: jest.fn().mockResolvedValue(),
+      checkToWarmupDoctype: jest.fn(),
+      handleReplicationError: jest.fn(),
+      cancelCurrentReplications: jest.fn()
+    }
+
+    await replicateOnce(pouchManager)
+
+    expect(pouchManager.options.onSync).toHaveBeenCalledTimes(1)
+    const payload = pouchManager.options.onSync.mock.calls[0][0]
+
+    // The bug: payload was keyed by the full prefixed dbName
+    // The fix: payload must be keyed by the clean doctype
+    expect(Object.keys(payload)).toEqual(['io.cozy.todos'])
+    expect(Object.keys(payload)).not.toContain(dbName)
+    expect(payload['io.cozy.todos']).toEqual(docs)
+  })
+
+  it('should preserve clean doctype keys for multiple pouches', async () => {
+    const dbNameA = 'instance__doctype__io.cozy.todos'
+    const dbNameB = 'instance__doctype__io.cozy.files'
+    const docsA = [{ _id: 'a1' }]
+    const docsB = [{ _id: 'b1' }]
+
+    startReplication.mockImplementation(pouch => {
+      if (pouch === 'pouchA') return Promise.resolve(docsA)
+      if (pouch === 'pouchB') return Promise.resolve(docsB)
+      return Promise.resolve([])
+    })
+
+    const pouchManager = {
+      pouches: { [dbNameA]: 'pouchA', [dbNameB]: 'pouchB' },
+      replications: {},
+      doctypesReplicationOptions: {},
+      options: { onSync: jest.fn() },
+      storage: {
+        persistDoctypeLastSequence: jest.fn().mockResolvedValue(),
+        getDoctypeLastSequence: jest.fn().mockResolvedValue(''),
+        destroyDoctypeLastSequence: jest.fn().mockResolvedValue()
+      },
+      client: {},
+      isOnline: jest.fn().mockResolvedValue(true),
+      getReplicationURL: jest.fn().mockReturnValue('http://example/db'),
+      getSyncStatus: jest.fn().mockReturnValue('synced'),
+      updateSyncInfo: jest.fn().mockResolvedValue(),
+      checkToWarmupDoctype: jest.fn(),
+      handleReplicationError: jest.fn(),
+      cancelCurrentReplications: jest.fn()
+    }
+
+    await replicateOnce(pouchManager)
+
+    expect(pouchManager.options.onSync).toHaveBeenCalledTimes(1)
+    const payload = pouchManager.options.onSync.mock.calls[0][0]
+    expect(Object.keys(payload).sort()).toEqual([
+      'io.cozy.files',
+      'io.cozy.todos'
+    ])
+    expect(payload['io.cozy.todos']).toEqual(docsA)
+    expect(payload['io.cozy.files']).toEqual(docsB)
+  })
+})


### PR DESCRIPTION
## Bug

`replicateOnce` zips per-doctype replication results with the keys of
`pouchManager.pouches`, which are the FULL prefixed Pouch dbNames
(e.g. `instance__doctype__io.cozy.todos`). The downstream consumer
(`handleOnSync` in `CozyPouchLink`) forwards that prefixed name as
the doctype to `normalizeDocs` + `client.setData`. The store's
`autoQueryUpdater` compares `query.definition.doctype` (clean, e.g.
`'io.cozy.todos'`) to the incoming `doc._type` (prefixed) -> mismatch
for every active query -> SKIP.

Symptom in a downstream consumer (twake-drive-mobile): periodic-sync
replication correctly pulls new revisions into local Pouch SQLite
(verified at the SQLite level), but the React UI never refreshes
because the store's auto-update path bails for every query. Only
pull-to-refresh works (it goes through the link chain which re-reads
from local Pouch directly).

Trace from the consumer with a temporary diagnostic log:

```
[handleOnSync] setData ["instance__doctype__io.cozy.files=1"]
[autoQueryUpdater] SKIP doctype mismatch io.cozy.files/...
  io.cozy.files vs data._type= instance__doctype__io.cozy.files
```

## Fix

In `replicateOnce.js`, map the dbNames through
`getDoctypeFromDatabaseName` before zipping. `doctypeUpdated` is
now keyed by the clean doctype, the downstream chain sees the
correct `doc._type`, `autoQueryUpdater` matches, queries auto-
update on every sync round.

## Tests

- New `replicateOnce.spec.js` regression test: assert `onSync` is
  called with clean doctype keys, not prefixed dbNames.
- Updated `PouchManager.spec.js` — the existing assertion
  `"should call on sync with doctype updates"` was encoding the
  bug (it asserted the prefixed key `'cozy.tools__doctype__io.cozy.todos'`).
  Switched to the clean `'io.cozy.todos'`. Without this fix the
  test passes but documents broken behavior.

Full `cozy-pouch-link` jest suite: 188 tests passing.

## Note

Discovered while working on the parent-lookup guard fix in #1681 —
originally bundled there but split out into its own PR for clean
review/merge.