### PR TITLE
fix: Use parentheses as default conflict filename suffix

### DIFF
--- a/docs/api/cozy-client/interfaces/models.file.FileUploadOptions.md
+++ b/docs/api/cozy-client/interfaces/models.file.FileUploadOptions.md
@@ -14,7 +14,7 @@ Conflict options
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:619](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L619)
+[packages/cozy-client/src/models/file.js:626](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L626)
 
 ***
 
@@ -26,7 +26,7 @@ Erase / rename
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:618](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L618)
+[packages/cozy-client/src/models/file.js:625](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L625)
 
 ***
 
@@ -38,7 +38,7 @@ The file Content-Type
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:617](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L617)
+[packages/cozy-client/src/models/file.js:624](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L624)
 
 ***
 
@@ -50,7 +50,7 @@ The dirId to upload the file to
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:615](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L615)
+[packages/cozy-client/src/models/file.js:622](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L622)
 
 ***
 
@@ -62,7 +62,7 @@ ID of the shared drive in which the file should be saved
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:620](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L620)
+[packages/cozy-client/src/models/file.js:627](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L627)
 
 ***
 
@@ -74,7 +74,7 @@ An object containing the metadata to attach
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:616](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L616)
+[packages/cozy-client/src/models/file.js:623](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L623)
 
 ***
 
@@ -86,4 +86,4 @@ The file name to upload
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:614](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L614)
+[packages/cozy-client/src/models/file.js:621](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L621)

--- a/docs/api/cozy-client/modules/models.file.md
+++ b/docs/api/cozy-client/modules/models.file.md
@@ -46,7 +46,7 @@ Copies a file to a specified destination.
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:737](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L737)
+[packages/cozy-client/src/models/file.js:744](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L744)
 
 ***
 
@@ -78,7 +78,7 @@ that will process the download
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:792](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L792)
+[packages/cozy-client/src/models/file.js:799](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L799)
 
 ***
 
@@ -126,7 +126,7 @@ file object with path attribute
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:718](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L718)
+[packages/cozy-client/src/models/file.js:725](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L725)
 
 ***
 
@@ -175,7 +175,7 @@ Generate a file name for a revision
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:604](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L604)
+[packages/cozy-client/src/models/file.js:611](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L611)
 
 ***
 
@@ -387,7 +387,7 @@ image src that can be used in an <img> tag
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:696](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L696)
+[packages/cozy-client/src/models/file.js:703](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L703)
 
 ***
 
@@ -431,7 +431,7 @@ Whether the file's metadata attribute exists
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:688](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L688)
+[packages/cozy-client/src/models/file.js:695](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L695)
 
 ***
 
@@ -579,7 +579,7 @@ Whether the folder is client-side encrypted
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:707](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L707)
+[packages/cozy-client/src/models/file.js:714](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L714)
 
 ***
 
@@ -644,7 +644,7 @@ Whether the file is supported by Only Office
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:680](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L680)
+[packages/cozy-client/src/models/file.js:687](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L687)
 
 ***
 
@@ -1000,4 +1000,4 @@ If there is a conflict, then we apply the conflict strategy : `erase` or `rename
 
 *Defined in*
 
-[packages/cozy-client/src/models/file.js:638](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L638)
+[packages/cozy-client/src/models/file.js:645](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/file.js#L645)

--- a/packages/cozy-client/src/models/file.js
+++ b/packages/cozy-client/src/models/file.js
@@ -575,14 +575,21 @@ export const generateNewFileNameOnConflict = (
   filenameWithoutExtension,
   conflictOptions
 ) => {
-  const delimiter = conflictOptions?.delimiter || '_'
+  const delimiter = conflictOptions?.delimiter
 
-  //Check if the string ends by _1
+  if (!delimiter) {
+    const matches = filenameWithoutExtension.match(/^(.*) \(([0-9]+)\)$/)
+    if (matches) {
+      return `${matches[1]} (${parseInt(matches[2], 10) + 1})`
+    }
+    return `${filenameWithoutExtension} (1)`
+  }
+
+  // Keep explicit delimiter support for callers that opted into the legacy format.
   const regex = new RegExp(`(${delimiter})([0-9]+)$`)
   const matches = filenameWithoutExtension.match(regex)
   if (matches) {
-    let versionNumber = parseInt(matches[2])
-    //increment versionNumber
+    let versionNumber = parseInt(matches[2], 10)
     versionNumber++
     const newFilenameWithoutExtension = filenameWithoutExtension.replace(
       new RegExp(`(${delimiter})([0-9]+)$`),

--- a/packages/cozy-client/src/models/file.spec.js
+++ b/packages/cozy-client/src/models/file.spec.js
@@ -592,19 +592,59 @@ describe('File Model', () => {
   })
 
   describe('generateNewFileNameOnConflict', () => {
-    it('should generate the right file name with _X', () => {
+    it('should generate the default file name with parenthesized copy counters', () => {
       const filename1 = fileModel.generateNewFileNameOnConflict('test')
-      expect(filename1).toEqual('test_1')
-      const filename2 = fileModel.generateNewFileNameOnConflict('test_1')
-      expect(filename2).toEqual('test_2')
+      expect(filename1).toEqual('test (1)')
+      const filename2 = fileModel.generateNewFileNameOnConflict('test (1)')
+      expect(filename2).toEqual('test (2)')
       const filename3 = fileModel.generateNewFileNameOnConflict('test_1_1_test')
+      expect(filename3).toEqual('test_1_1_test (1)')
+      const filename4 = fileModel.generateNewFileNameOnConflict(
+        'test_1_1_test (1)'
+      )
+      expect(filename4).toEqual('test_1_1_test (2)')
+      const filename5 = fileModel.generateNewFileNameOnConflict('test_')
+      expect(filename5).toEqual('test_ (1)')
+    })
+
+    it('should not increment numbers that are part of the file name', () => {
+      const filename1 = fileModel.generateNewFileNameOnConflict('IMG_4521')
+      expect(filename1).toEqual('IMG_4521 (1)')
+      const filename2 = fileModel.generateNewFileNameOnConflict('DSC_0001')
+      expect(filename2).toEqual('DSC_0001 (1)')
+      const filename3 = fileModel.generateNewFileNameOnConflict('report_2024')
+      expect(filename3).toEqual('report_2024 (1)')
+      const filename4 = fileModel.generateNewFileNameOnConflict(
+        'report (draft)'
+      )
+      expect(filename4).toEqual('report (draft) (1)')
+    })
+
+    it('should keep the legacy delimiter behavior when delimiter is passed', () => {
+      const conflictOptions = {
+        delimiter: '_'
+      }
+
+      const filename1 = fileModel.generateNewFileNameOnConflict(
+        'test',
+        conflictOptions
+      )
+      expect(filename1).toEqual('test_1')
+      const filename2 = fileModel.generateNewFileNameOnConflict(
+        'test_1',
+        conflictOptions
+      )
+      expect(filename2).toEqual('test_2')
+      const filename3 = fileModel.generateNewFileNameOnConflict(
+        'test_1_1_test',
+        conflictOptions
+      )
       expect(filename3).toEqual('test_1_1_test_1')
       const filename4 = fileModel.generateNewFileNameOnConflict(
-        'test_1_1_test_1'
+        'test_',
+        conflictOptions
       )
-      expect(filename4).toEqual('test_1_1_test_2')
-      const filename5 = fileModel.generateNewFileNameOnConflict('test_')
-      expect(filename5).toEqual('test__1')
+      expect(filename4).toEqual('test__1')
     })
 
     it('should generate the right file name with _cozyX', () => {
@@ -713,7 +753,33 @@ describe('File Model', () => {
       await fileModel.uploadFileWithConflictStrategy(cozyClient, '', opts)
       expect(createFileSpy).toHaveBeenCalledWith('', {
         ...opts,
-        name: 'filename_1'
+        name: 'filename (1)'
+      })
+    })
+
+    it('should keep real filename numbers when renaming a file with an extension', async () => {
+      const dirId = 'toto'
+      //first call we return an existing file => conflict
+      //second call, we reject as not found
+      statByPathSpy
+        .mockReturnValueOnce({
+          data: {
+            _id: 'file_id',
+            _type: 'io.cozy.files'
+          }
+        })
+        .mockRejectedValueOnce(new Error('Not Found'))
+
+      const opts = {
+        name: 'IMG_4521.jpg',
+        dirId,
+        conflictStrategy: 'rename',
+        contentType: 'image/jpeg'
+      }
+      await fileModel.uploadFileWithConflictStrategy(cozyClient, '', opts)
+      expect(createFileSpy).toHaveBeenCalledWith('', {
+        ...opts,
+        name: 'IMG_4521 (1).jpg'
       })
     })
 

--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -950,7 +950,7 @@ import { QueryDefinition } from './queries/dsl'
  * Represents available options of generateNewFileNameOnConflict method
  *
  * @typedef {object} ConflictOptions
- * @property {string} [delimiter] - Delimiter before the incremented number. Default to '_'
+ * @property {string} [delimiter] - Custom delimiter before the incremented number. Defaults to parenthesized copy counters.
  */
 
 /**

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -1702,7 +1702,7 @@ export type RedirectLinkData = {
  */
 export type ConflictOptions = {
     /**
-     * - Delimiter before the incremented number. Default to '_'
+     * - Custom delimiter before the incremented number. Defaults to parenthesized copy counters.
      */
     delimiter?: string;
 };


### PR DESCRIPTION
## Summary

 fix for #1686

 This changes the default conflict filename generation to use parenthesized copy counters instead of underscore counters.
 Explicit `conflictOptions.delimiter` behavior is preserved for compatibility.
  Examples:
  - `IMG_4521` -> `IMG_4521 (1)`
  - `DSC_0001` -> `DSC_0001 (1)`


  Explicit `conflictOptions.delimiter` behavior is preserved for compatibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file naming convention for naming conflicts—files now use parenthesized copy counters by default (e.g., "filename (1)" instead of underscore-based suffixes), providing a cleaner naming scheme for duplicates.
  * Custom delimiters remain supported when explicitly configured for backward compatibility.

* **Documentation**
  * Updated conflict handling configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->