### PR TITLE
feat(cozy-stack-client): Add SharingCollection read-only methods

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -1986,6 +1986,8 @@ Implements the `DocumentCollection` API along with specific methods for
     * [.getDiscoveryLink(sharingId, sharecode, [options])](#SharingCollection+getDiscoveryLink) ⇒ <code>string</code>
     * [.addRecipients(options)](#SharingCollection+addRecipients)
     * [.revokeRecipient(sharing, recipientIndex)](#SharingCollection+revokeRecipient)
+    * [.setReadOnly(sharing, recipientIndex)](#SharingCollection+setReadOnly)
+    * [.setReadWrite(sharing, recipientIndex)](#SharingCollection+setReadWrite)
     * [.revokeGroup(sharing, groupIndex)](#SharingCollection+revokeGroup)
     * [.revokeSelf(sharing)](#SharingCollection+revokeSelf)
     * [.revokeAllRecipients(sharing)](#SharingCollection+revokeAllRecipients)
@@ -2104,6 +2106,30 @@ Add an array of contacts to the Sharing
 
 ### sharingCollection.revokeRecipient(sharing, recipientIndex)
 Revoke only one recipient of the sharing.
+
+**Kind**: instance method of [<code>SharingCollection</code>](#SharingCollection)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| sharing | [<code>Sharing</code>](#Sharing) | Sharing Object |
+| recipientIndex | <code>number</code> | Index of this recipient in the members array of the sharing |
+
+<a name="SharingCollection+setReadOnly"></a>
+
+### sharingCollection.setReadOnly(sharing, recipientIndex)
+Downgrade a sharing member to read-only.
+
+**Kind**: instance method of [<code>SharingCollection</code>](#SharingCollection)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| sharing | [<code>Sharing</code>](#Sharing) | Sharing Object |
+| recipientIndex | <code>number</code> | Index of this recipient in the members array of the sharing |
+
+<a name="SharingCollection+setReadWrite"></a>
+
+### sharingCollection.setReadWrite(sharing, recipientIndex)
+Upgrade a read-only sharing member to read-write.
 
 **Kind**: instance method of [<code>SharingCollection</code>](#SharingCollection)  
 

--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -299,6 +299,32 @@ class SharingCollection extends DocumentCollection {
   }
 
   /**
+   * Downgrade a sharing member to read-only.
+   *
+   * @param {Sharing} sharing Sharing Object
+   * @param {number} recipientIndex Index of this recipient in the members array of the sharing
+   */
+  setReadOnly(sharing, recipientIndex) {
+    return this.stackClient.fetchJSON(
+      'POST',
+      uri`/sharings/${sharing._id}/recipients/${recipientIndex}/readonly`
+    )
+  }
+
+  /**
+   * Upgrade a read-only sharing member to read-write.
+   *
+   * @param {Sharing} sharing Sharing Object
+   * @param {number} recipientIndex Index of this recipient in the members array of the sharing
+   */
+  setReadWrite(sharing, recipientIndex) {
+    return this.stackClient.fetchJSON(
+      'DELETE',
+      uri`/sharings/${sharing._id}/recipients/${recipientIndex}/readonly`
+    )
+  }
+
+  /**
    * Revoke only one group of the sharing.
    *
    * @param {Sharing} sharing Sharing Object

--- a/packages/cozy-stack-client/src/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/SharingCollection.spec.js
@@ -591,6 +591,36 @@ describe('SharingCollection', () => {
     })
   })
 
+  describe('setReadOnly', () => {
+    beforeEach(() => {
+      client.fetch.mockReset()
+      client.fetchJSON.mockResolvedValue({ data: [] })
+    })
+
+    it('should call the right route', async () => {
+      await collection.setReadOnly(SHARING, 1)
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        `/sharings/${SHARING._id}/recipients/1/readonly`
+      )
+    })
+  })
+
+  describe('setReadWrite', () => {
+    beforeEach(() => {
+      client.fetch.mockReset()
+      client.fetchJSON.mockResolvedValue({ data: [] })
+    })
+
+    it('should call the right route', async () => {
+      await collection.setReadWrite(SHARING, 1)
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'DELETE',
+        `/sharings/${SHARING._id}/recipients/1/readonly`
+      )
+    })
+  })
+
   describe('addRecipients', () => {
     beforeEach(() => {
       client.fetch.mockReset()


### PR DESCRIPTION
Wrap the POST and DELETE /sharings/:id/recipients/:index/readonly endpoints exposed by the stack to toggle a sharing member's read_only flag.

This will allow users to update update recipient's rights without revoking and recreating recipients

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `setReadOnly()` method to manage sharing recipient permissions.
  * Added `setReadWrite()` method to manage sharing recipient permissions.

* **Documentation**
  * Updated API documentation with new sharing permission management methods and their parameters.

* **Tests**
  * Added test coverage for new sharing permission methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->