### PR TITLE
feat(permissions): Add shared drive link lookup by ids

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -1768,6 +1768,7 @@ Implements `DocumentCollection` API along with specific methods for `io.cozy.per
     * [new PermissionCollection(doctype, stackClient, [options])](#new_PermissionCollection_new)
     * [.create(permission)](#PermissionCollection+create)
     * [.add(document, permission, options)](#PermissionCollection+add) ⇒ <code>Promise</code>
+    * [.findLinksByIds(ids)](#PermissionCollection+findLinksByIds) ⇒ <code>Promise</code>
     * ~~[.findApps()](#PermissionCollection+findApps)~~
     * [.createSharingLink(document, options)](#PermissionCollection+createSharingLink)
     * [.fetchPermissionsByLink(permissions)](#PermissionCollection+fetchPermissionsByLink)
@@ -1830,6 +1831,29 @@ const permissions = await client.collection('io.cozy.permissions').add(
   { expiresAt: '2100-01-01T00:00:00Z', password: 'password' }
 )
 ```
+<a name="PermissionCollection+findLinksByIds"></a>
+
+### permissionCollection.findLinksByIds(ids) ⇒ <code>Promise</code>
+Find sharing links by document ids
+
+This is the shared-drive equivalent of `findLinksByDoctype` when you
+already know the document ids. It uses the same `this.prefix`, so the
+URL becomes `/sharings/drives/:driveId/permissions?ids=...` when the
+collection is built with `{ driveId }`.
+
+The returned permissions are normalized (have `_id` and `_type`).
+
+**Kind**: instance method of [<code>PermissionCollection</code>](#PermissionCollection)  
+**Returns**: <code>Promise</code> - The matching permissions  
+**Throws**:
+
+- <code>Error</code> If the collection is not configured with a `driveId`
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ids | <code>Array.&lt;string&gt;</code> | The list of document ids to look up |
+
 <a name="PermissionCollection+findApps"></a>
 
 ### ~~permissionCollection.findApps()~~

--- a/packages/cozy-stack-client/src/PermissionCollection.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.js
@@ -6,6 +6,11 @@ import logger from './logger'
 
 const normalizePermission = perm => normalizeDoc(perm, 'io.cozy.permissions')
 
+const normalizePermissionsResponse = resp => ({
+  ...resp,
+  data: resp.data.map(normalizePermission)
+})
+
 /**
  * Options that can be passed to PermissionCollection's constructor
  *
@@ -151,6 +156,44 @@ class PermissionCollection extends DocumentCollection {
       ...resp,
       data: resp.data.map(normalizePermission)
     }
+  }
+
+  /**
+   * Find sharing links by document ids
+   *
+   * This is the shared-drive equivalent of `findLinksByDoctype` when you
+   * already know the document ids. It uses the same `this.prefix`, so the
+   * URL becomes `/sharings/drives/:driveId/permissions?ids=...` when the
+   * collection is built with `{ driveId }`.
+   *
+   * The returned permissions are normalized (have `_id` and `_type`).
+   *
+   * @param {string[]} ids - The list of document ids to look up
+   * @throws {Error} If the collection is not configured with a `driveId`
+   * @returns {Promise} The matching permissions
+   */
+  async findLinksByIds(ids) {
+    if (!this.prefix) {
+      throw new Error('findLinksByIds is only supported for shared drives')
+    }
+
+    if (!Array.isArray(ids)) {
+      throw new TypeError('ids must be an array')
+    }
+
+    if (ids.length === 0) {
+      return normalizePermissionsResponse({ data: [] })
+    }
+
+    const searchParams = new URLSearchParams()
+    searchParams.append('ids', ids.join(','))
+
+    const resp = await this.stackClient.fetchJSON(
+      'GET',
+      `${this.prefix}/permissions?${searchParams}`
+    )
+
+    return normalizePermissionsResponse(resp)
   }
 
   /**

--- a/packages/cozy-stack-client/src/PermissionCollection.spec.js
+++ b/packages/cozy-stack-client/src/PermissionCollection.spec.js
@@ -318,6 +318,19 @@ describe('PermissionCollection', () => {
       )
     })
   })
+
+  describe('findLinksByIds', () => {
+    beforeEach(() => {
+      client.fetchJSON.mockReset()
+    })
+
+    it('throws when called without a shared drive prefix', async () => {
+      await expect(collection.findLinksByIds(['file_456'])).rejects.toEqual(
+        new Error('findLinksByIds is only supported for shared drives')
+      )
+      expect(client.fetchJSON).not.toHaveBeenCalled()
+    })
+  })
 })
 
 describe('revokeSharingLink', () => {
@@ -562,6 +575,60 @@ describe('PermissionCollection with driveId', () => {
         'GET',
         '/sharings/drives/abc123drive/permissions/self'
       )
+    })
+  })
+
+  describe('findLinksByIds', () => {
+    it('calls the API with the shared drive prefix and the file id', async () => {
+      client.fetchJSON.mockResolvedValue({
+        data: [
+          {
+            type: 'io.cozy.permissions',
+            id: 'perm_1',
+            attributes: {
+              type: 'share',
+              shortcodes: { code: 'abc123' },
+              permissions: {
+                files: {
+                  type: 'io.cozy.files',
+                  verbs: ['GET'],
+                  values: ['file_456']
+                }
+              }
+            }
+          }
+        ]
+      })
+      const resp = await collection.findLinksByIds(['file_456'])
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'GET',
+        '/sharings/drives/abc123drive/permissions?ids=file_456'
+      )
+      expect(resp.data).toHaveLength(1)
+      expect(resp.data[0].id).toBe('perm_1')
+      expect(resp.data[0]._id).toBe('perm_1')
+      expect(resp.data[0].attributes.shortcodes.code).toBe('abc123')
+    })
+
+    it('joins multiple ids with a comma in the query string', async () => {
+      client.fetchJSON.mockResolvedValue({ data: [] })
+      await collection.findLinksByIds(['file_456', 'file_789'])
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'GET',
+        '/sharings/drives/abc123drive/permissions?ids=file_456%2Cfile_789'
+      )
+    })
+
+    it('throws when ids is not an array', async () => {
+      await expect(collection.findLinksByIds('file_456')).rejects.toEqual(
+        new TypeError('ids must be an array')
+      )
+      expect(client.fetchJSON).not.toHaveBeenCalled()
+    })
+
+    it('returns an empty result without calling the API when ids is empty', async () => {
+      await expect(collection.findLinksByIds([])).resolves.toEqual({ data: [] })
+      expect(client.fetchJSON).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
This is needed to allow recipients of  shared drives to see the links they created on files or folders inside of shared drives

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a PermissionCollection method to retrieve sharing/permission links by document IDs for shared drives, returning normalized permission entries.

* **Tests**
  * Add coverage for shared-drive behavior: validates input, handles empty ID lists without network calls, enforces shared-drive configuration, and verifies request/response mapping.

* **Documentation**
  * Update API docs to describe the new method, its route behavior for shared drives, return format, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->