### PR TITLE
fix(pouch-link): dedupe doctypes in addDoctype

### DIFF
--- a/docs/api/cozy-pouch-link/classes/PouchLink.md
+++ b/docs/api/cozy-pouch-link/classes/PouchLink.md
@@ -161,7 +161,8 @@ CozyLink.constructor
 ▸ **addDoctype**(`doctype`, `replicationOptions`, `options`): `Promise`<`void`>
 
 Adds a new doctype to the list of managed doctypes, sets its replication options,
-adds it to the pouches, and starts replication.
+adds it to the pouches, and starts replication. Does nothing when the doctype is
+already managed, so the list stays free of duplicates.
 
 *Parameters*
 
@@ -178,7 +179,7 @@ adds it to the pouches, and starts replication.
 
 *Defined in*
 
-[CozyPouchLink.js:823](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L823)
+[CozyPouchLink.js:824](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L824)
 
 ***
 
@@ -493,7 +494,7 @@ The authenticated replication URL
 
 *Defined in*
 
-[CozyPouchLink.js:848](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L848)
+[CozyPouchLink.js:856](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L856)
 
 ***
 
@@ -762,7 +763,7 @@ and removes it from the pouches.
 
 *Defined in*
 
-[CozyPouchLink.js:842](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L842)
+[CozyPouchLink.js:850](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L850)
 
 ***
 

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -813,7 +813,8 @@ class PouchLink extends CozyLink {
 
   /**
    * Adds a new doctype to the list of managed doctypes, sets its replication options,
-   * adds it to the pouches, and starts replication.
+   * adds it to the pouches, and starts replication. Does nothing when the doctype is
+   * already managed, so the list stays free of duplicates.
    *
    * @param {string} doctype - The name of the doctype to add.
    * @param {Object} replicationOptions - The replication options for the doctype.
@@ -821,12 +822,19 @@ class PouchLink extends CozyLink {
    * @param {boolean} [options.shouldStartReplication=true] - Whether the replication should be started.
    */
   async addDoctype(doctype, replicationOptions, options) {
+    if (this.doctypes.includes(doctype)) {
+      logger.debug(`PouchLink: doctype ${doctype} already managed, skipping`)
+      return
+    }
     this.doctypes.push(doctype)
     if (!this.doctypesReplicationOptions) {
       this.doctypesReplicationOptions = {}
     }
     this.doctypesReplicationOptions[doctype] = replicationOptions
-    this.pouches.doctypes.push(doctype)
+    // sync onto pouches.doctypes, a separate array only after removeDoctype
+    if (!this.pouches.doctypes.includes(doctype)) {
+      this.pouches.doctypes.push(doctype)
+    }
     await this.pouches.addDoctype(doctype, replicationOptions)
     if (options?.shouldStartReplication === true) {
       this.startReplicationWithDebounce()

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -574,6 +574,72 @@ describe('CozyPouchLink', () => {
     })
   })
 
+  describe('addDoctype', () => {
+    const OTHER_DOCTYPE = 'io.cozy.files'
+
+    it('should register a doctype only once, even though the link and pouch manager share the doctypes array', async () => {
+      await setup()
+      jest.spyOn(link.pouches, 'addDoctype').mockResolvedValue(undefined)
+      // The link and its pouch manager hold the same array, so a single
+      // registration must not land the doctype in it twice.
+      expect(link.doctypes).toBe(link.pouches.doctypes)
+
+      await link.addDoctype(OTHER_DOCTYPE, { strategy: 'fromRemote' })
+
+      expect(link.doctypes.filter(d => d === OTHER_DOCTYPE)).toHaveLength(1)
+      expect(
+        link.pouches.doctypes.filter(d => d === OTHER_DOCTYPE)
+      ).toHaveLength(1)
+      expect(link.pouches.addDoctype).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not re-register, restart replication, or overwrite options for a managed doctype', async () => {
+      await setup()
+      jest.spyOn(link.pouches, 'addDoctype').mockResolvedValue(undefined)
+      jest
+        .spyOn(link, 'startReplicationWithDebounce')
+        .mockImplementation(() => {})
+
+      await link.addDoctype(
+        OTHER_DOCTYPE,
+        { strategy: 'fromRemote' },
+        { shouldStartReplication: true }
+      )
+      await link.addDoctype(
+        OTHER_DOCTYPE,
+        { strategy: 'sync' },
+        { shouldStartReplication: true }
+      )
+
+      expect(link.doctypes.filter(d => d === OTHER_DOCTYPE)).toHaveLength(1)
+      expect(
+        link.pouches.doctypes.filter(d => d === OTHER_DOCTYPE)
+      ).toHaveLength(1)
+      expect(link.pouches.addDoctype).toHaveBeenCalledTimes(1)
+      expect(link.startReplicationWithDebounce).toHaveBeenCalledTimes(1)
+      // The no-op re-add keeps the original options instead of overwriting them.
+      expect(link.doctypesReplicationOptions[OTHER_DOCTYPE]).toEqual({
+        strategy: 'fromRemote'
+      })
+    })
+
+    it('should register again a doctype that was previously removed', async () => {
+      await setup()
+      const addSpy = jest.spyOn(link.pouches, 'addDoctype')
+
+      await link.addDoctype(OTHER_DOCTYPE, { strategy: 'fromRemote' })
+      await link.removeDoctype(OTHER_DOCTYPE)
+      await link.addDoctype(OTHER_DOCTYPE, { strategy: 'fromRemote' })
+
+      expect(link.doctypes.filter(d => d === OTHER_DOCTYPE)).toHaveLength(1)
+      expect(
+        link.pouches.doctypes.filter(d => d === OTHER_DOCTYPE)
+      ).toHaveLength(1)
+      // The pouch is recreated on the second registration.
+      expect(addSpy).toHaveBeenCalledTimes(2)
+    })
+  })
+
   describe('immediate sync', () => {
     it('should not throw if pouches not there', async () => {
       await setup()

--- a/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
+++ b/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
@@ -253,7 +253,8 @@ declare class PouchLink extends CozyLink {
     syncImmediately(): Promise<void>;
     /**
      * Adds a new doctype to the list of managed doctypes, sets its replication options,
-     * adds it to the pouches, and starts replication.
+     * adds it to the pouches, and starts replication. Does nothing when the doctype is
+     * already managed, so the list stays free of duplicates.
      *
      * @param {string} doctype - The name of the doctype to add.
      * @param {Object} replicationOptions - The replication options for the doctype.


### PR DESCRIPTION
## Context
PouchLink shares its doctypes array with the PouchManager it creates, yet addDoctype pushed into that array twice on every call and never checked whether the doctype was already registered. The same doctype could end up listed several times, so code that iterates the managed doctypes (recents queries each pouch in turn) hit the same pouch repeatedly and returned its documents more than once.

## Solution
Make addDoctype idempotent: return early when the doctype is already managed, and only push onto the pouch manager's list when it does not already contain it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate doctype registrations so the same item is no longer added multiple times.
  * Kept existing replication settings intact when a doctype is already managed.
  * Added clearer debug logging when an already-managed doctype is skipped.

* **Tests**
  * Added coverage for adding, re-adding, and removing doctypes to confirm duplicate handling works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->