### PR TITLE
feat: support driveid-scoped reactive queries via forcelink

### DIFF
--- a/docs/api/cozy-client/README.md
+++ b/docs/api/cozy-client/README.md
@@ -839,6 +839,32 @@ if there are N queries, only 1 extra level of nesting is introduced.
 
 ***
 
+### resolveForceLink
+
+▸ **resolveForceLink**(`options`): `string`
+
+Resolves the effective forceLink target, mapping the deprecated forceStack option onto forceLink:'stack'.
+
+**`internal`**
+
+*Parameters*
+
+| Name | Type |
+| :------ | :------ |
+| `options` | `Object` |
+| `options.forceLink?` | `string` |
+| `options.forceStack?` | `boolean` |
+
+*Returns*
+
+`string`
+
+*Defined in*
+
+[packages/cozy-client/src/links/forceLink.js:18](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/forceLink.js#L18)
+
+***
+
 ### rootCozyUrl
 
 ▸ **rootCozyUrl**(`url`): `Promise`<`URL`>

--- a/docs/api/cozy-client/classes/CozyLink.md
+++ b/docs/api/cozy-client/classes/CozyLink.md
@@ -29,6 +29,22 @@
 
 [packages/cozy-client/src/links/CozyLink.js:2](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/CozyLink.js#L2)
 
+## Accessors
+
+### name
+
+• `get` **name**(): `string`
+
+Stable name used to target this link via the `forceLink` query option.
+
+*Returns*
+
+`string`
+
+*Defined in*
+
+[packages/cozy-client/src/links/CozyLink.js:50](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/CozyLink.js#L50)
+
 ## Methods
 
 ### persistCozyData

--- a/docs/api/cozy-client/classes/DataProxyLink.md
+++ b/docs/api/cozy-client/classes/DataProxyLink.md
@@ -27,7 +27,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/links/DataProxyLink.js:9](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L9)
+[packages/cozy-client/src/links/DataProxyLink.js:10](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L10)
 
 ## Properties
 
@@ -37,7 +37,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/links/DataProxyLink.js:13](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L13)
+[packages/cozy-client/src/links/DataProxyLink.js:14](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L14)
 
 ***
 
@@ -47,7 +47,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/links/DataProxyLink.js:12](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L12)
+[packages/cozy-client/src/links/DataProxyLink.js:13](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L13)
 
 ***
 
@@ -57,7 +57,25 @@
 
 *Defined in*
 
-[packages/cozy-client/src/links/DataProxyLink.js:11](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L11)
+[packages/cozy-client/src/links/DataProxyLink.js:12](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L12)
+
+## Accessors
+
+### name
+
+• `get` **name**(): `string`
+
+*Returns*
+
+`string`
+
+*Overrides*
+
+CozyLink.name
+
+*Defined in*
+
+[packages/cozy-client/src/links/DataProxyLink.js:21](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L21)
 
 ## Methods
 
@@ -71,7 +89,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/links/DataProxyLink.js:66](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L66)
+[packages/cozy-client/src/links/DataProxyLink.js:75](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L75)
 
 ***
 
@@ -91,7 +109,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/links/DataProxyLink.js:93](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L93)
+[packages/cozy-client/src/links/DataProxyLink.js:102](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L102)
 
 ***
 
@@ -112,7 +130,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/links/DataProxyLink.js:51](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L51)
+[packages/cozy-client/src/links/DataProxyLink.js:60](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L60)
 
 ***
 
@@ -139,7 +157,7 @@ Persist the given data into the links storage
 
 *Defined in*
 
-[packages/cozy-client/src/links/DataProxyLink.js:61](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L61)
+[packages/cozy-client/src/links/DataProxyLink.js:70](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L70)
 
 ***
 
@@ -159,7 +177,7 @@ Persist the given data into the links storage
 
 *Defined in*
 
-[packages/cozy-client/src/links/DataProxyLink.js:20](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L20)
+[packages/cozy-client/src/links/DataProxyLink.js:25](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L25)
 
 ***
 
@@ -183,7 +201,7 @@ the dataproxy is ready and set
 
 *Defined in*
 
-[packages/cozy-client/src/links/DataProxyLink.js:31](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L31)
+[packages/cozy-client/src/links/DataProxyLink.js:36](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L36)
 
 ***
 
@@ -212,7 +230,7 @@ Request the given operation from the link
 
 *Defined in*
 
-[packages/cozy-client/src/links/DataProxyLink.js:40](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L40)
+[packages/cozy-client/src/links/DataProxyLink.js:45](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L45)
 
 ***
 
@@ -232,4 +250,4 @@ Reset the link data
 
 *Defined in*
 
-[packages/cozy-client/src/links/DataProxyLink.js:36](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L36)
+[packages/cozy-client/src/links/DataProxyLink.js:41](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/DataProxyLink.js#L41)

--- a/docs/api/cozy-client/classes/StackLink.md
+++ b/docs/api/cozy-client/classes/StackLink.md
@@ -28,7 +28,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/links/StackLink.js:70](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L70)
+[packages/cozy-client/src/links/StackLink.js:71](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L71)
 
 ## Properties
 
@@ -38,7 +38,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/links/StackLink.js:78](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L78)
+[packages/cozy-client/src/links/StackLink.js:79](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L79)
 
 ***
 
@@ -48,7 +48,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/links/StackLink.js:81](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L81)
+[packages/cozy-client/src/links/StackLink.js:82](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L82)
 
 ***
 
@@ -58,7 +58,25 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/links/StackLink.js:77](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L77)
+[packages/cozy-client/src/links/StackLink.js:78](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L78)
+
+## Accessors
+
+### name
+
+• `get` **name**(): `string`
+
+*Returns*
+
+`string`
+
+*Overrides*
+
+CozyLink.name
+
+*Defined in*
+
+[packages/cozy-client/src/links/StackLink.js:85](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L85)
 
 ## Methods
 
@@ -81,7 +99,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/links/StackLink.js:154](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L154)
+[packages/cozy-client/src/links/StackLink.js:161](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L161)
 
 ***
 
@@ -101,7 +119,7 @@ Transfers queries and mutations to a remote stack
 
 *Defined in*
 
-[packages/cozy-client/src/links/StackLink.js:119](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L119)
+[packages/cozy-client/src/links/StackLink.js:126](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L126)
 
 ***
 
@@ -128,7 +146,7 @@ Persist the given data into the links storage
 
 *Defined in*
 
-[packages/cozy-client/src/links/StackLink.js:111](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L111)
+[packages/cozy-client/src/links/StackLink.js:118](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L118)
 
 ***
 
@@ -148,7 +166,7 @@ Persist the given data into the links storage
 
 *Defined in*
 
-[packages/cozy-client/src/links/StackLink.js:84](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L84)
+[packages/cozy-client/src/links/StackLink.js:89](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L89)
 
 ***
 
@@ -177,7 +195,7 @@ Request the given operation from the link
 
 *Defined in*
 
-[packages/cozy-client/src/links/StackLink.js:92](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L92)
+[packages/cozy-client/src/links/StackLink.js:97](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L97)
 
 ***
 
@@ -197,4 +215,4 @@ Reset the link data
 
 *Defined in*
 
-[packages/cozy-client/src/links/StackLink.js:88](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L88)
+[packages/cozy-client/src/links/StackLink.js:93](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/StackLink.js#L93)

--- a/docs/api/cozy-client/classes/WebFlagshipLink.md
+++ b/docs/api/cozy-client/classes/WebFlagshipLink.md
@@ -39,6 +39,26 @@
 
 [packages/cozy-client/src/links/WebFlagshipLink.js:10](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/WebFlagshipLink.js#L10)
 
+## Accessors
+
+### name
+
+• `get` **name**(): `string`
+
+Stable name used to target this link via the `forceLink` query option.
+
+*Returns*
+
+`string`
+
+*Inherited from*
+
+CozyLink.name
+
+*Defined in*
+
+[packages/cozy-client/src/links/CozyLink.js:50](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/links/CozyLink.js#L50)
+
 ## Methods
 
 ### persistCozyData

--- a/docs/api/cozy-pouch-link/classes/PouchLink.md
+++ b/docs/api/cozy-pouch-link/classes/PouchLink.md
@@ -197,7 +197,7 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:879](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L879)
+[CozyPouchLink.js:881](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L881)
 
 ***
 
@@ -217,7 +217,7 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:827](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L827)
+[CozyPouchLink.js:829](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L829)
 
 ***
 
@@ -237,7 +237,7 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:813](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L813)
+[CozyPouchLink.js:815](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L815)
 
 ***
 
@@ -257,7 +257,7 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:776](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L776)
+[CozyPouchLink.js:778](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L778)
 
 ***
 
@@ -277,7 +277,7 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:781](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L781)
+[CozyPouchLink.js:783](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L783)
 
 ***
 
@@ -298,7 +298,7 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:831](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L831)
+[CozyPouchLink.js:833](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L833)
 
 ***
 
@@ -318,7 +318,7 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:794](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L794)
+[CozyPouchLink.js:796](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L796)
 
 ***
 
@@ -338,7 +338,7 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:805](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L805)
+[CozyPouchLink.js:807](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L807)
 
 ***
 
@@ -361,7 +361,7 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:732](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L732)
+[CozyPouchLink.js:734](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L734)
 
 ***
 
@@ -382,7 +382,7 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:677](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L677)
+[CozyPouchLink.js:679](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L679)
 
 ***
 
@@ -537,7 +537,7 @@ The authenticated replication URL
 
 *Defined in*
 
-[CozyPouchLink.js:911](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L911)
+[CozyPouchLink.js:913](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L913)
 
 ***
 
@@ -643,7 +643,7 @@ Emits an event (pouchlink:sync:end) when the sync (all doctypes) is done
 
 *Defined in*
 
-[CozyPouchLink.js:669](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L669)
+[CozyPouchLink.js:671](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L671)
 
 ***
 
@@ -698,7 +698,7 @@ the need to wait for the warmup
 
 *Defined in*
 
-[CozyPouchLink.js:655](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L655)
+[CozyPouchLink.js:657](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L657)
 
 ***
 
@@ -806,7 +806,7 @@ and removes it from the pouches.
 
 *Defined in*
 
-[CozyPouchLink.js:905](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L905)
+[CozyPouchLink.js:907](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L907)
 
 ***
 
@@ -956,7 +956,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:861](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L861)
+[CozyPouchLink.js:863](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L863)
 
 ***
 
@@ -976,7 +976,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:785](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L785)
+[CozyPouchLink.js:787](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L787)
 
 ***
 
@@ -996,7 +996,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:790](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L790)
+[CozyPouchLink.js:792](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L792)
 
 ***
 

--- a/docs/api/cozy-pouch-link/classes/PouchLink.md
+++ b/docs/api/cozy-pouch-link/classes/PouchLink.md
@@ -32,7 +32,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:100](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L100)
+[CozyPouchLink.js:101](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L101)
 
 ## Properties
 
@@ -42,7 +42,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:184](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L184)
+[CozyPouchLink.js:191](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L191)
 
 ***
 
@@ -52,7 +52,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:118](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L118)
+[CozyPouchLink.js:119](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L119)
 
 ***
 
@@ -62,7 +62,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:119](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L119)
+[CozyPouchLink.js:120](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L120)
 
 ***
 
@@ -72,7 +72,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:120](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L120)
+[CozyPouchLink.js:121](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L121)
 
 ***
 
@@ -82,7 +82,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:124](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L124)
+[CozyPouchLink.js:127](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L127)
 
 ***
 
@@ -92,7 +92,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:112](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L112)
+[CozyPouchLink.js:113](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L113)
 
 ***
 
@@ -102,7 +102,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:141](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L141)
+[CozyPouchLink.js:144](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L144)
 
 ***
 
@@ -112,7 +112,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:125](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L125)
+[CozyPouchLink.js:128](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L128)
 
 ***
 
@@ -122,7 +122,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:259](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L259)
+[CozyPouchLink.js:266](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L266)
 
 ***
 
@@ -132,7 +132,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:257](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L257)
+[CozyPouchLink.js:264](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L264)
 
 ***
 
@@ -142,7 +142,7 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:128](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L128)
+[CozyPouchLink.js:131](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L131)
 
 ***
 
@@ -152,7 +152,25 @@ CozyLink.constructor
 
 *Defined in*
 
-[CozyPouchLink.js:121](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L121)
+[CozyPouchLink.js:124](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L124)
+
+## Accessors
+
+### name
+
+• `get` **name**(): `string`
+
+*Returns*
+
+`string`
+
+*Overrides*
+
+CozyLink.name
+
+*Defined in*
+
+[CozyPouchLink.js:147](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L147)
 
 ## Methods
 
@@ -179,7 +197,7 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:824](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L824)
+[CozyPouchLink.js:879](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L879)
 
 ***
 
@@ -199,7 +217,7 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:772](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L772)
+[CozyPouchLink.js:827](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L827)
 
 ***
 
@@ -219,7 +237,7 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:758](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L758)
+[CozyPouchLink.js:813](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L813)
 
 ***
 
@@ -239,7 +257,7 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:721](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L721)
+[CozyPouchLink.js:776](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L776)
 
 ***
 
@@ -259,7 +277,7 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:726](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L726)
+[CozyPouchLink.js:781](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L781)
 
 ***
 
@@ -280,7 +298,7 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:776](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L776)
+[CozyPouchLink.js:831](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L831)
 
 ***
 
@@ -300,7 +318,7 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:739](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L739)
+[CozyPouchLink.js:794](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L794)
 
 ***
 
@@ -320,7 +338,7 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:750](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L750)
+[CozyPouchLink.js:805](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L805)
 
 ***
 
@@ -343,19 +361,20 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:677](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L677)
+[CozyPouchLink.js:732](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L732)
 
 ***
 
 ### executeQuery
 
-▸ **executeQuery**(`__namedParameters`): `Promise`<`any`>
+▸ **executeQuery**(`operation`, `options`): `Promise`<`any`>
 
 *Parameters*
 
-| Name | Type |
-| :------ | :------ |
-| `__namedParameters` | `Object` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `operation` | `any` | The query operation |
+| `options` | `any` | - |
 
 *Returns*
 
@@ -363,7 +382,7 @@ already managed, so the list stays free of duplicates.
 
 *Defined in*
 
-[CozyPouchLink.js:625](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L625)
+[CozyPouchLink.js:677](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L677)
 
 ***
 
@@ -389,7 +408,30 @@ The changes
 
 *Defined in*
 
-[CozyPouchLink.js:530](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L530)
+[CozyPouchLink.js:578](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L578)
+
+***
+
+### getDbDoctype
+
+▸ **getDbDoctype**(`logicalDoctype`, `options`): `any`
+
+Returns the registered physical doctype for a given logical doctype and query options.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `logicalDoctype` | `any` | The logical doctype |
+| `options` | `any` | - |
+
+*Returns*
+
+`any`
+
+*Defined in*
+
+[CozyPouchLink.js:450](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L450)
 
 ***
 
@@ -414,7 +456,7 @@ The db info
 
 *Defined in*
 
-[CozyPouchLink.js:545](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L545)
+[CozyPouchLink.js:593](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L593)
 
 ***
 
@@ -434,19 +476,20 @@ The db info
 
 *Defined in*
 
-[CozyPouchLink.js:443](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L443)
+[CozyPouchLink.js:487](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L487)
 
 ***
 
 ### getQueryEngineFromDoctype
 
-▸ **getQueryEngineFromDoctype**(`doctype`): `any`
+▸ **getQueryEngineFromDoctype**(`doctype`, `options`): `any`
 
 *Parameters*
 
-| Name | Type |
-| :------ | :------ |
-| `doctype` | `any` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `doctype` | `any` | The doctype |
+| `options` | `any` | - |
 
 *Returns*
 
@@ -454,7 +497,7 @@ The db info
 
 *Defined in*
 
-[CozyPouchLink.js:435](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L435)
+[CozyPouchLink.js:463](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L463)
 
 ***
 
@@ -480,7 +523,7 @@ The authenticated replication URL
 
 *Defined in*
 
-[CozyPouchLink.js:164](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L164)
+[CozyPouchLink.js:171](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L171)
 
 ***
 
@@ -494,7 +537,7 @@ The authenticated replication URL
 
 *Defined in*
 
-[CozyPouchLink.js:856](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L856)
+[CozyPouchLink.js:911](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L911)
 
 ***
 
@@ -514,7 +557,7 @@ The authenticated replication URL
 
 *Defined in*
 
-[CozyPouchLink.js:431](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L431)
+[CozyPouchLink.js:440](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L440)
 
 ***
 
@@ -534,7 +577,7 @@ The authenticated replication URL
 
 *Defined in*
 
-[CozyPouchLink.js:327](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L327)
+[CozyPouchLink.js:336](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L336)
 
 ***
 
@@ -554,7 +597,7 @@ The authenticated replication URL
 
 *Defined in*
 
-[CozyPouchLink.js:322](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L322)
+[CozyPouchLink.js:331](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L331)
 
 ***
 
@@ -580,7 +623,7 @@ Emits an event (pouchlink:sync:end) when the sync (all doctypes) is done
 
 *Defined in*
 
-[CozyPouchLink.js:300](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L300)
+[CozyPouchLink.js:309](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L309)
 
 ***
 
@@ -600,7 +643,7 @@ Emits an event (pouchlink:sync:end) when the sync (all doctypes) is done
 
 *Defined in*
 
-[CozyPouchLink.js:621](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L621)
+[CozyPouchLink.js:669](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L669)
 
 ***
 
@@ -630,7 +673,7 @@ Migrate the current adapter
 
 *Defined in*
 
-[CozyPouchLink.js:198](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L198)
+[CozyPouchLink.js:205](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L205)
 
 ***
 
@@ -655,7 +698,7 @@ the need to wait for the warmup
 
 *Defined in*
 
-[CozyPouchLink.js:607](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L607)
+[CozyPouchLink.js:655](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L655)
 
 ***
 
@@ -669,7 +712,7 @@ the need to wait for the warmup
 
 *Defined in*
 
-[CozyPouchLink.js:217](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L217)
+[CozyPouchLink.js:224](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L224)
 
 ***
 
@@ -689,7 +732,7 @@ the need to wait for the warmup
 
 *Defined in*
 
-[CozyPouchLink.js:405](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L405)
+[CozyPouchLink.js:414](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L414)
 
 ***
 
@@ -720,7 +763,7 @@ CozyLink.persistCozyData
 
 *Defined in*
 
-[CozyPouchLink.js:560](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L560)
+[CozyPouchLink.js:608](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L608)
 
 ***
 
@@ -740,7 +783,7 @@ CozyLink.persistCozyData
 
 *Defined in*
 
-[CozyPouchLink.js:183](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L183)
+[CozyPouchLink.js:190](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L190)
 
 ***
 
@@ -763,7 +806,7 @@ and removes it from the pouches.
 
 *Defined in*
 
-[CozyPouchLink.js:850](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L850)
+[CozyPouchLink.js:905](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L905)
 
 ***
 
@@ -790,7 +833,7 @@ CozyLink.request
 
 *Defined in*
 
-[CozyPouchLink.js:470](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L470)
+[CozyPouchLink.js:517](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L517)
 
 ***
 
@@ -808,7 +851,7 @@ CozyLink.reset
 
 *Defined in*
 
-[CozyPouchLink.js:284](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L284)
+[CozyPouchLink.js:292](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L292)
 
 ***
 
@@ -834,7 +877,7 @@ Emits pouchlink:sync:start event when the replication begins
 
 *Defined in*
 
-[CozyPouchLink.js:361](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L361)
+[CozyPouchLink.js:370](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L370)
 
 ***
 
@@ -859,7 +902,7 @@ Debounce delay can be configured through constructor's `syncDebounceDelayInMs` o
 
 *Defined in*
 
-[CozyPouchLink.js:378](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L378)
+[CozyPouchLink.js:387](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L387)
 
 ***
 
@@ -878,19 +921,20 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:397](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L397)
+[CozyPouchLink.js:406](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L406)
 
 ***
 
 ### supportsOperation
 
-▸ **supportsOperation**(`operation`): `boolean`
+▸ **supportsOperation**(`operation`, `options`): `boolean`
 
 *Parameters*
 
 | Name | Type |
 | :------ | :------ |
 | `operation` | `any` |
+| `options` | `any` |
 
 *Returns*
 
@@ -898,7 +942,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:451](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L451)
+[CozyPouchLink.js:495](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L495)
 
 ***
 
@@ -912,7 +956,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:806](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L806)
+[CozyPouchLink.js:861](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L861)
 
 ***
 
@@ -932,7 +976,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:730](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L730)
+[CozyPouchLink.js:785](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L785)
 
 ***
 
@@ -952,7 +996,7 @@ Emits pouchlink:sync:stop event
 
 *Defined in*
 
-[CozyPouchLink.js:735](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L735)
+[CozyPouchLink.js:790](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L790)
 
 ***
 
@@ -977,4 +1021,4 @@ The adapter name
 
 *Defined in*
 
-[CozyPouchLink.js:151](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L151)
+[CozyPouchLink.js:158](https://github.com/linagora/cozy-client/blob/master/packages/cozy-pouch-link/src/CozyPouchLink.js#L158)

--- a/packages/cozy-client/src/index.js
+++ b/packages/cozy-client/src/index.js
@@ -3,6 +3,7 @@ export { default as CozyLink } from './links/CozyLink'
 export { default as StackLink } from './links/StackLink'
 export { default as WebFlagshipLink } from './links/WebFlagshipLink'
 export { default as DataProxyLink } from './links/DataProxyLink'
+export { resolveForceLink } from './links/forceLink'
 export { default as compose } from 'lodash/flow'
 export {
   QueryDefinition,

--- a/packages/cozy-client/src/index.node.js
+++ b/packages/cozy-client/src/index.node.js
@@ -48,3 +48,4 @@ export { default as fetchPolicies } from './policies'
 
 export { webPerformanceApi } from './performances/webPerformanceApi'
 export { defaultPerformanceApi } from './performances/defaultPerformanceApi'
+export { resolveForceLink } from './links/forceLink'

--- a/packages/cozy-client/src/links/CozyLink.js
+++ b/packages/cozy-client/src/links/CozyLink.js
@@ -41,6 +41,15 @@ export default class CozyLink {
   async reset() {
     throw new Error('reset is not implemented')
   }
+
+  /**
+   * Stable name used to target this link via the `forceLink` query option.
+   *
+   * @returns {string|undefined}
+   */
+  get name() {
+    return undefined
+  }
 }
 
 const toLink = handler =>

--- a/packages/cozy-client/src/links/CozyLink.spec.js
+++ b/packages/cozy-client/src/links/CozyLink.spec.js
@@ -16,6 +16,11 @@ describe('CozyLink', () => {
     expect(link.request('dummyOperation')).toBe('foobarbaz')
   })
 
+  it('has name === undefined by default', () => {
+    const link = new CozyLink()
+    expect(link.name).toBe(undefined)
+  })
+
   describe('default last link', () => {
     it('should throw an error when called without result', () => {
       const link = chain([

--- a/packages/cozy-client/src/links/DataProxyLink.js
+++ b/packages/cozy-client/src/links/DataProxyLink.js
@@ -1,5 +1,6 @@
 import CozyLink from './CozyLink'
 import logger from 'cozy-logger'
+import { resolveForceLink } from './forceLink'
 
 export default class DataProxyLink extends CozyLink {
   /**
@@ -15,6 +16,10 @@ export default class DataProxyLink extends CozyLink {
     if (window) {
       window.addEventListener('message', this._onReceiveMessage)
     }
+  }
+
+  get name() {
+    return 'dataproxy'
   }
 
   registerClient(client) {
@@ -38,6 +43,10 @@ export default class DataProxyLink extends CozyLink {
   }
 
   async request(operation, options, result, forward) {
+    const forceLink = resolveForceLink(options)
+    if (forceLink && forceLink !== this.name) {
+      return forward(operation, options)
+    }
     if (this.dataproxy?.requestLink) {
       return this.doRequest(operation, options)
     }

--- a/packages/cozy-client/src/links/DataProxyLink.spec.js
+++ b/packages/cozy-client/src/links/DataProxyLink.spec.js
@@ -1,6 +1,54 @@
 /** @jest-environment jsdom */
 import DataProxyLink from './DataProxyLink'
 
+describe('DataProxyLink name', () => {
+  it('should expose a stable name', () => {
+    expect(new DataProxyLink().name).toBe('dataproxy')
+  })
+})
+
+describe('DataProxyLink forceLink', () => {
+  it('forwards a forceStack:true query (routes away from dataproxy)', async () => {
+    const link = new DataProxyLink()
+    const forwardFn = jest.fn().mockResolvedValue(null)
+    await link.request(
+      { doctype: 'io.cozy.files' },
+      { forceStack: true },
+      null,
+      forwardFn
+    )
+    expect(forwardFn).toHaveBeenCalled()
+  })
+
+  it('handles when forceLink targets it', async () => {
+    const link = new DataProxyLink()
+    link.registerDataProxy({
+      requestLink: jest.fn().mockResolvedValue({ data: [{ _id: '1' }] })
+    })
+    const forward = jest.fn()
+    const res = await link.request(
+      { doctype: 'io.cozy.files' },
+      { forceLink: 'dataproxy' },
+      undefined,
+      forward
+    )
+    expect(forward).not.toHaveBeenCalled()
+    expect(res).toEqual({ data: [{ _id: '1' }] })
+  })
+  it('forwards when forceLink targets another link', async () => {
+    const link = new DataProxyLink()
+    const forward = jest.fn().mockResolvedValue('forwarded')
+    expect(
+      await link.request(
+        { doctype: 'io.cozy.files' },
+        { forceLink: 'stack' },
+        undefined,
+        forward
+      )
+    ).toBe('forwarded')
+  })
+})
+
 describe('DataProxyLink queueing', () => {
   it('should directly call dataproxy requestLink if available', async () => {
     const requestLink = jest.fn().mockResolvedValue('OK')

--- a/packages/cozy-client/src/links/StackLink.js
+++ b/packages/cozy-client/src/links/StackLink.js
@@ -7,6 +7,7 @@ import { BulkEditError } from '../errors'
 import logger from '../logger'
 import { isReactNativeOfflineError } from '../utils'
 import { defaultPerformanceApi } from '../performances/defaultPerformanceApi'
+import { resolveForceLink } from './forceLink'
 
 /**
  *
@@ -81,6 +82,10 @@ export default class StackLink extends CozyLink {
     this.performanceApi = performanceApi || defaultPerformanceApi
   }
 
+  get name() {
+    return 'stack'
+  }
+
   registerClient(client) {
     this.stackClient = client.stackClient || client.client
   }
@@ -90,18 +95,20 @@ export default class StackLink extends CozyLink {
   }
 
   async request(operation, options, result, forward) {
-    //console.log('[CozySackLink] ', operation)
-    if (!options?.forceStack && this.isOnline && !(await this.isOnline())) {
+    const forceLink = resolveForceLink(options)
+    if (forceLink && forceLink !== this.name) {
       return forward(operation, options)
     }
-
+    if (forceLink !== 'stack' && this.isOnline && !(await this.isOnline())) {
+      return forward(operation, options)
+    }
     try {
       if (operation.mutationType) {
         return await this.executeMutation(operation, options, result, forward)
       }
       return await this.executeQuery(operation)
     } catch (err) {
-      if (!options?.forceStack && isReactNativeOfflineError(err)) {
+      if (forceLink !== 'stack' && isReactNativeOfflineError(err)) {
         return forward(operation, options)
       }
       throw err

--- a/packages/cozy-client/src/links/StackLink.spec.js
+++ b/packages/cozy-client/src/links/StackLink.spec.js
@@ -2,14 +2,71 @@ import { Q } from '../queries/dsl'
 import CozyClient from '../CozyClient'
 import StackLink, { transformBulkDocsResponse } from './StackLink'
 import { SCHEMA } from '../__tests__/fixtures'
+import logger from '../logger'
+// eslint-disable-next-line no-underscore-dangle
+import { _resetForceStackWarning } from './forceLink'
 
 describe('StackLink', () => {
+  describe('name', () => {
+    it('should expose a stable name', () => {
+      expect(new StackLink().name).toBe('stack')
+    })
+  })
+
   let stackClient, link, client
 
   beforeEach(() => {
     link = new StackLink()
     client = new CozyClient({ links: [link], schema: SCHEMA })
     stackClient = client.getStackClient()
+  })
+
+  describe('forceLink', () => {
+    let warnSpy
+
+    beforeEach(() => {
+      _resetForceStackWarning()
+      warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      warnSpy.mockRestore()
+    })
+
+    it('forwards when forceLink targets another link', async () => {
+      const link = new StackLink()
+      const forward = jest.fn().mockResolvedValue('forwarded')
+      expect(
+        await link.request(
+          { doctype: 'io.cozy.files' },
+          { forceLink: 'dataproxy' },
+          undefined,
+          forward
+        )
+      ).toBe('forwarded')
+    })
+
+    it('handles a forceStack:true query (legacy: does not forward, emits deprecation warning)', async () => {
+      const link = new StackLink()
+      link.executeQuery = jest.fn().mockResolvedValue({ data: [] })
+      link.isOnline = jest.fn().mockResolvedValue(false) // offline — should NOT bail because forceStack
+      const forwardFn = jest.fn()
+      const op = { doctype: 'io.cozy.files' }
+      await link.request(op, { forceStack: true }, null, forwardFn)
+      expect(forwardFn).not.toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('forceStack is deprecated')
+      )
+    })
+
+    it('forwards a plain query when offline', async () => {
+      const link = new StackLink()
+      link.isOnline = jest.fn().mockResolvedValue(false)
+      const forwardFn = jest.fn().mockResolvedValue(null)
+      const op = { doctype: 'io.cozy.files' }
+      await link.request(op, {}, null, forwardFn)
+      expect(forwardFn).toHaveBeenCalled()
+    })
   })
 
   describe('query execution', () => {

--- a/packages/cozy-client/src/links/forceLink.js
+++ b/packages/cozy-client/src/links/forceLink.js
@@ -1,0 +1,31 @@
+import logger from '../logger'
+
+let hasWarnedForceStack = false
+
+// eslint-disable-next-line no-underscore-dangle
+export const _resetForceStackWarning = () => {
+  hasWarnedForceStack = false
+}
+
+/* eslint-disable jsdoc/check-tag-names */
+/**
+ * Resolves the effective forceLink target, mapping the deprecated forceStack option onto forceLink:'stack'.
+ *
+ * @internal
+ * @param {{ forceLink?: string, forceStack?: boolean }} [options] - Query options
+ * @returns {string|undefined}
+ */
+export const resolveForceLink = options => {
+  if (options?.forceLink) return options.forceLink
+  if (options?.forceStack) {
+    if (!hasWarnedForceStack) {
+      logger.warn(
+        "options.forceStack is deprecated, use forceLink: 'stack' instead"
+      )
+      hasWarnedForceStack = true
+    }
+    return 'stack'
+  }
+  return undefined
+}
+/* eslint-enable jsdoc/check-tag-names */

--- a/packages/cozy-client/src/types.js
+++ b/packages/cozy-client/src/types.js
@@ -308,7 +308,8 @@ import { QueryDefinition } from './queries/dsl'
  * a single doc instead of an array for single doc queries. Defaults to false for backward
  * compatibility but will be set to true in the future.
  * @property {boolean} [executeFromStore=false] - If set to true, the query will be run directly on the current store's state
- * @property {boolean} [forceStack] - If set to true, the query will be executed through StackLink only even if there are other links available
+ * @property {boolean} [forceStack] - Deprecated: use forceLink:'stack'. Executes the query through StackLink only.
+ * @property {string} [forceLink] - Route this query exclusively to the link whose name matches (e.g. 'dataproxy').
  */
 
 /**

--- a/packages/cozy-client/types/index.d.ts
+++ b/packages/cozy-client/types/index.d.ts
@@ -3,6 +3,7 @@ export { default as CozyLink } from "./links/CozyLink";
 export { default as StackLink } from "./links/StackLink";
 export { default as WebFlagshipLink } from "./links/WebFlagshipLink";
 export { default as DataProxyLink } from "./links/DataProxyLink";
+export { resolveForceLink } from "./links/forceLink";
 export { default as compose } from "lodash/flow";
 export { default as Registry } from "./registry";
 export { default as RealTimeQueries } from "./RealTimeQueries";

--- a/packages/cozy-client/types/index.node.d.ts
+++ b/packages/cozy-client/types/index.node.d.ts
@@ -12,6 +12,7 @@ export { BulkEditError } from "./errors";
 export { default as fetchPolicies } from "./policies";
 export { webPerformanceApi } from "./performances/webPerformanceApi";
 export { defaultPerformanceApi } from "./performances/defaultPerformanceApi";
+export { resolveForceLink } from "./links/forceLink";
 import * as manifest from "./models/manifest";
 import * as models from "./models";
 export { manifest, models };

--- a/packages/cozy-client/types/links/CozyLink.d.ts
+++ b/packages/cozy-client/types/links/CozyLink.d.ts
@@ -24,5 +24,11 @@ export default class CozyLink {
      * @returns {Promise<any>}
      */
     reset(): Promise<any>;
+    /**
+     * Stable name used to target this link via the `forceLink` query option.
+     *
+     * @returns {string|undefined}
+     */
+    get name(): string;
 }
 export function chain(links: any): any;

--- a/packages/cozy-client/types/links/forceLink.d.ts
+++ b/packages/cozy-client/types/links/forceLink.d.ts
@@ -1,0 +1,5 @@
+export function _resetForceStackWarning(): void;
+export function resolveForceLink(options?: {
+    forceLink?: string;
+    forceStack?: boolean;
+}): string | undefined;

--- a/packages/cozy-client/types/types.d.ts
+++ b/packages/cozy-client/types/types.d.ts
@@ -567,9 +567,13 @@ export type QueryOptions = {
      */
     executeFromStore?: boolean;
     /**
-     * - If set to true, the query will be executed through StackLink only even if there are other links available
+     * - Deprecated: use forceLink:'stack'. Executes the query through StackLink only.
      */
     forceStack?: boolean;
+    /**
+     * - Route this query exclusively to the link whose name matches (e.g. 'dataproxy').
+     */
+    forceLink?: string;
 };
 export type Query = {
     definition: QueryDefinition;

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -3,7 +3,8 @@ import {
   CozyLink,
   getDoctypeFromOperation,
   BulkEditError,
-  defaultPerformanceApi
+  defaultPerformanceApi,
+  resolveForceLink
 } from 'cozy-client'
 import PouchDB from 'pouchdb-browser'
 import PouchDBFind from 'pouchdb-find'
@@ -118,6 +119,8 @@ class PouchLink extends CozyLink {
     this.doctypes = doctypes
     this.doctypesReplicationOptions = doctypesReplicationOptions
     this.indexes = {}
+    /** @private Cache of per-drive logical-typed query engines, keyed by `dbDoctype::logicalDoctype`. */
+    this._driveQueryEngines = new Map()
     this.storage = new PouchLocalStorage(
       options.platform?.storage || platformWeb.storage
     )
@@ -139,6 +142,10 @@ class PouchLink extends CozyLink {
 
     /** @type {import('cozy-client/src/performances/types').PerformanceAPI} */
     this.performanceApi = performanceApi || defaultPerformanceApi
+  }
+
+  get name() {
+    return 'pouch'
   }
 
   /**
@@ -270,6 +277,7 @@ class PouchLink extends CozyLink {
       queryEngine: this.queryEngine,
       client: this.client
     })
+    this._driveQueryEngines = new Map()
     await this.pouches.init()
 
     if (this.client && this.initialSync) {
@@ -288,6 +296,7 @@ class PouchLink extends CozyLink {
 
     this.pouches = null
     this.client = null
+    this._driveQueryEngines = new Map()
   }
 
   /**
@@ -432,12 +441,47 @@ class PouchLink extends CozyLink {
     return this.pouches.getSyncInfo(doctype)
   }
 
-  getQueryEngineFromDoctype(doctype) {
+  /**
+   * Returns the registered physical doctype for a given logical doctype and query options.
+   *
+   * @param {any} logicalDoctype - The logical doctype
+   * @param {object} [options] - Optional query options
+   */
+  getDbDoctype(logicalDoctype, options) {
+    const driveId = options?.driveId
+    if (!driveId) return logicalDoctype
+    const match = Object.keys(this.doctypesReplicationOptions || {}).find(
+      d => this.doctypesReplicationOptions[d]?.driveId === driveId
+    )
+    return match || logicalDoctype
+  }
+
+  /**
+   * @param {any} doctype - The doctype
+   * @param {object} [options] - Optional query options
+   */
+  getQueryEngineFromDoctype(doctype, options) {
+    const logicalDoctype = doctype
+    const dbDoctype = this.getDbDoctype(doctype, options)
     const dbName = getDatabaseName(
       getPrefix(this.client.stackClient.uri),
-      doctype
+      dbDoctype
     )
-    return this.pouches.getQueryEngine(dbName, doctype)
+    if (logicalDoctype !== dbDoctype) {
+      // Separate cache keyed by dbDoctype::logicalDoctype so a drive DB is never stamped with the wrong _type.
+      const cacheKey = `${dbDoctype}::${logicalDoctype}`
+      let engine = this._driveQueryEngines.get(cacheKey)
+      if (!engine) {
+        const QueryEngine =
+          /** @type {typeof PouchDBQueryEngine} */ (this.queryEngine ||
+          PouchDBQueryEngine)
+        engine = new QueryEngine(this.pouches, logicalDoctype)
+        engine.openDB(dbName)
+        this._driveQueryEngines.set(cacheKey, engine)
+      }
+      return engine
+    }
+    return this.pouches.getQueryEngine(dbName, logicalDoctype)
   }
 
   getPouch(doctype) {
@@ -448,11 +492,14 @@ class PouchLink extends CozyLink {
     return this.pouches.getPouch(dbName)
   }
 
-  supportsOperation(operation) {
+  supportsOperation(operation, options) {
     if (this.options.readOnly && operation.mutationType) {
       return false
     }
-    const impactedDoctype = getDoctypeFromOperation(operation)
+    const impactedDoctype = this.getDbDoctype(
+      getDoctypeFromOperation(operation),
+      options
+    )
 
     // If the Pouch is configured only to replicate from the remote,
     // we don't want to apply the mutation on it, but to forward
@@ -468,43 +515,44 @@ class PouchLink extends CozyLink {
   }
 
   async request(operation, options, result = null, forward = doNothing) {
-    if (options?.forceStack) {
+    if (resolveForceLink(options) === 'stack') {
       return forward(operation, options)
     }
 
     const doctype = getDoctypeFromOperation(operation)
+    const dbDoctype = this.getDbDoctype(doctype, options)
 
     if (!this.pouches) {
       if (process.env.NODE_ENV !== 'production') {
         logger.info(
-          `Tried to access local ${doctype} but Cozy Pouch is not initialized yet. Forwarding the operation to next link`
+          `Tried to access local ${dbDoctype} but Cozy Pouch is not initialized yet. Forwarding the operation to next link`
         )
       }
 
       return forward(operation, options)
     }
 
-    if (this.pouches.getSyncStatus(doctype) === 'not_synced') {
+    if (this.pouches.getSyncStatus(dbDoctype) === 'not_synced') {
       // The doctype is not locally synced and thus cannot be requested: forward to next link
       if (process.env.NODE_ENV !== 'production') {
         logger.info(
-          `Tried to access local ${doctype} but Cozy Pouch is not synced yet. Forwarding the operation to next link`
+          `Tried to access local ${dbDoctype} but Cozy Pouch is not synced yet. Forwarding the operation to next link`
         )
       }
       return forward(operation, options)
     }
 
-    if (await this.needsToWaitWarmup(doctype)) {
+    if (await this.needsToWaitWarmup(dbDoctype)) {
       if (process.env.NODE_ENV !== 'production') {
         logger.info(
-          `Tried to access local ${doctype} but not warmuped yet. Forwarding the operation to next link`
+          `Tried to access local ${dbDoctype} but not warmuped yet. Forwarding the operation to next link`
         )
       }
       return forward(operation, options)
     }
 
     // Forwards if opeartion on doctype not supported
-    if (!this.supportsOperation(operation)) {
+    if (!this.supportsOperation(operation, options)) {
       if (process.env.NODE_ENV !== 'production') {
         logger.info(
           `The doctype '${doctype}' is not supported. Forwarding the operation to next link`
@@ -515,7 +563,7 @@ class PouchLink extends CozyLink {
     if (operation.mutationType) {
       return this.executeMutation(operation, options, result, forward)
     } else {
-      return this.executeQuery(operation)
+      return this.executeQuery(operation, options)
     }
   }
 
@@ -622,20 +670,27 @@ class PouchLink extends CozyLink {
     return Boolean(this.indexes[name])
   }
 
-  async executeQuery({
-    doctype,
-    selector,
-    sort,
-    fields,
-    limit,
-    id,
-    ids,
-    skip,
-    indexedFields,
-    partialFilter,
-    sharingId
-  }) {
-    const engine = this.getQueryEngineFromDoctype(doctype)
+  /**
+   * @param {object} operation - The query operation
+   * @param {object} [options] - Optional query options
+   */
+  async executeQuery(
+    {
+      doctype,
+      selector,
+      sort,
+      fields,
+      limit,
+      id,
+      ids,
+      skip,
+      indexedFields,
+      partialFilter,
+      sharingId
+    },
+    options
+  ) {
+    const engine = this.getQueryEngineFromDoctype(doctype, options)
 
     let res
     if (id) {

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -624,8 +624,10 @@ class PouchLink extends CozyLink {
       const pouch = this.getPouch(doc._type)
       const resp = await getExistingDocument(engine, sanitizedDoc._id)
       if (!resp?.data || Object.keys(resp?.data).length < 1) {
-        // Doc does not exist in db, save it
-        return pouch.put(sanitizedDoc)
+        // Doc does not exist in db, save it. Must be awaited so a concurrent
+        // insert (409 conflict) is caught below instead of rejecting the
+        // in-flight read query.
+        return await pouch.put(sanitizedDoc)
       }
       const oldDoc = sanitizeJsonApi(resp.data)
       if (areDocsEqual(oldDoc, sanitizedDoc)) {

--- a/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.spec.js
@@ -78,6 +78,38 @@ describe('CozyPouchLink', () => {
     expect(url).toBe('http://user:token@cozy.tools:8080/data/io.cozy.todos')
   })
 
+  it('has name === "pouch"', async () => {
+    await setup()
+    expect(link.name).toBe('pouch')
+  })
+
+  it('handles a forceLink:"dataproxy" query (regression: Plan A drive capability)', async () => {
+    await setup()
+    link.pouches.getSyncStatus = jest.fn().mockReturnValue('synced')
+    const forwardFn = jest.fn()
+    await link.request(
+      Q(TODO_DOCTYPE),
+      { forceLink: 'dataproxy' },
+      null,
+      forwardFn
+    )
+    expect(forwardFn).not.toHaveBeenCalled()
+  })
+
+  it('forwards a forceLink:"stack" query', async () => {
+    await setup()
+    const forwardFn = jest.fn()
+    await link.request(Q(TODO_DOCTYPE), { forceLink: 'stack' }, null, forwardFn)
+    expect(forwardFn).toHaveBeenCalled()
+  })
+
+  it('forwards a legacy forceStack:true query', async () => {
+    await setup()
+    const forwardFn = jest.fn()
+    await link.request(Q(TODO_DOCTYPE), { forceStack: true }, null, forwardFn)
+    expect(forwardFn).toHaveBeenCalled()
+  })
+
   describe('request handling', () => {
     const query1 = () => ({
       definition: () => Q(TODO_DOCTYPE).limitBy(100),
@@ -680,6 +712,180 @@ describe('CozyPouchLink', () => {
       link.registerClient(client)
 
       expect(link.onLogin()).rejects.toThrow()
+    })
+  })
+
+  describe('driveId support', () => {
+    it('maps a driveId option to its registered drive doctype', () => {
+      const driveLink = new CozyPouchLink({
+        doctypes: ['io.cozy.files', 'io.cozy.files.shareddrives-abc'],
+        doctypesReplicationOptions: {
+          'io.cozy.files.shareddrives-abc': { driveId: 'abc' }
+        }
+      })
+      expect(driveLink.getDbDoctype('io.cozy.files', { driveId: 'abc' })).toBe(
+        'io.cozy.files.shareddrives-abc'
+      )
+      expect(driveLink.getDbDoctype('io.cozy.files', {})).toBe('io.cozy.files')
+      expect(driveLink.getDbDoctype('io.cozy.files', { driveId: 'nope' })).toBe(
+        'io.cozy.files'
+      )
+    })
+
+    it('reads the drive database but types docs as io.cozy.files', async () => {
+      const FILES_DOCTYPE = 'io.cozy.files'
+      const DRIVE_DOCTYPE = 'io.cozy.files.shareddrives-abc'
+
+      const driveLink = new CozyPouchLink({
+        doctypes: [FILES_DOCTYPE, DRIVE_DOCTYPE],
+        doctypesReplicationOptions: {
+          [DRIVE_DOCTYPE]: { driveId: 'abc' }
+        }
+      })
+      const driveClient = new CozyClient({
+        ...mockClient,
+        links: [driveLink],
+        warningForCustomHandlers: false,
+        schema: {}
+      })
+      driveClient.emit = jest.fn()
+      await driveLink.onLogin()
+      driveClient.setData = jest.fn()
+
+      await driveLink.getPouch(FILES_DOCTYPE).put({ _id: 'own1' })
+      await driveLink.getPouch(DRIVE_DOCTYPE).put({ _id: 'drive1' })
+
+      driveLink.pouches.getSyncStatus = jest.fn().mockReturnValue('synced')
+
+      const res = await driveLink.request(Q(FILES_DOCTYPE).getById('drive1'), {
+        driveId: 'abc'
+      })
+      expect(res.data._id).toBe('drive1')
+      expect(res.data._type).toBe(FILES_DOCTYPE)
+
+      await driveLink.reset()
+    })
+
+    it('reads the drive database through the find path and types docs as io.cozy.files', async () => {
+      const FILES_DOCTYPE = 'io.cozy.files'
+      const DRIVE_DOCTYPE = 'io.cozy.files.shareddrives-abc'
+
+      const driveLink = new CozyPouchLink({
+        doctypes: [FILES_DOCTYPE, DRIVE_DOCTYPE],
+        doctypesReplicationOptions: {
+          [DRIVE_DOCTYPE]: { driveId: 'abc' }
+        }
+      })
+      const driveClient = new CozyClient({
+        ...mockClient,
+        links: [driveLink],
+        warningForCustomHandlers: false,
+        schema: {}
+      })
+      driveClient.emit = jest.fn()
+      await driveLink.onLogin()
+      driveClient.setData = jest.fn()
+
+      await driveLink
+        .getPouch(FILES_DOCTYPE)
+        .put({ _id: 'own1', updated_at: '2024-01-01' })
+      await driveLink
+        .getPouch(DRIVE_DOCTYPE)
+        .put({ _id: 'drive1', updated_at: '2024-06-01' })
+
+      driveLink.pouches.getSyncStatus = jest.fn().mockReturnValue('synced')
+
+      const res = await driveLink.request(
+        Q(FILES_DOCTYPE)
+          .where({ updated_at: { $gt: null } })
+          .indexFields(['updated_at']),
+        { driveId: 'abc' }
+      )
+
+      expect(res.data.some(d => d._id === 'drive1')).toBe(true)
+      expect(res.data.some(d => d._id === 'own1')).toBe(false)
+      expect(res.data.every(d => d._type === FILES_DOCTYPE)).toBe(true)
+
+      await driveLink.reset()
+    })
+
+    it('supportsOperation is true for io.cozy.files with driveId when drive doctype is managed', async () => {
+      const FILES_DOCTYPE = 'io.cozy.files'
+      const DRIVE_DOCTYPE = 'io.cozy.files.shareddrives-abc'
+
+      const driveLink = new CozyPouchLink({
+        doctypes: [FILES_DOCTYPE, DRIVE_DOCTYPE],
+        doctypesReplicationOptions: {
+          [DRIVE_DOCTYPE]: { driveId: 'abc' }
+        }
+      })
+      const driveClient = new CozyClient({
+        ...mockClient,
+        links: [driveLink],
+        warningForCustomHandlers: false,
+        schema: {}
+      })
+      driveClient.emit = jest.fn()
+      await driveLink.onLogin()
+
+      expect(driveLink.supportsOperation({ doctype: FILES_DOCTYPE })).toBe(true)
+
+      await driveLink.reset()
+    })
+
+    it('request uses drive doctype sync state, not io.cozy.files sync state', async () => {
+      const FILES_DOCTYPE = 'io.cozy.files'
+      const DRIVE_DOCTYPE = 'io.cozy.files.shareddrives-abc'
+
+      const driveLink = new CozyPouchLink({
+        doctypes: [FILES_DOCTYPE, DRIVE_DOCTYPE],
+        doctypesReplicationOptions: {
+          [DRIVE_DOCTYPE]: { driveId: 'abc' }
+        }
+      })
+      const driveClient = new CozyClient({
+        ...mockClient,
+        links: [driveLink],
+        warningForCustomHandlers: false,
+        schema: {}
+      })
+      driveClient.emit = jest.fn()
+      await driveLink.onLogin()
+
+      await driveLink.getPouch(DRIVE_DOCTYPE).put({ _id: 'drive1' })
+
+      // Drive doctype synced, io.cozy.files not synced: drive query must be handled locally
+      driveLink.pouches.getSyncStatus = jest.fn(doctype => {
+        if (doctype === DRIVE_DOCTYPE) return 'synced'
+        return 'not_synced'
+      })
+
+      const forwardSpy = jest.fn()
+      const res = await driveLink.request(
+        Q(FILES_DOCTYPE).getById('drive1'),
+        { driveId: 'abc' },
+        null,
+        forwardSpy
+      )
+      expect(forwardSpy).not.toHaveBeenCalled()
+      expect(res.data._id).toBe('drive1')
+
+      // Inverse: drive doctype not synced, io.cozy.files synced: drive query must be forwarded
+      driveLink.pouches.getSyncStatus = jest.fn(doctype => {
+        if (doctype === DRIVE_DOCTYPE) return 'not_synced'
+        return 'synced'
+      })
+
+      const forwardSpy2 = jest.fn().mockResolvedValue({ data: null })
+      await driveLink.request(
+        Q(FILES_DOCTYPE).getById('drive1'),
+        { driveId: 'abc' },
+        null,
+        forwardSpy2
+      )
+      expect(forwardSpy2).toHaveBeenCalled()
+
+      await driveLink.reset()
     })
   })
 

--- a/packages/cozy-pouch-link/src/files.js
+++ b/packages/cozy-pouch-link/src/files.js
@@ -5,12 +5,20 @@ const defaultFetchPolicy = fetchPolicies.olderThan(5 * 60 * 1000) // 5 min
 export const TYPE_DIRECTORY = 'directory'
 export const TYPE_FILE = 'file'
 
-export const queryFileById = async (client, id) => {
+/**
+ * @param {object} client - The cozy client
+ * @param {string} id - The file id
+ * @param {string} [driveId] - Optional shared-drive id to read the file from the drive scope
+ */
+export const queryFileById = async (client, id, driveId) => {
   const definition = Q('io.cozy.files').getById(id)
   const options = {
-    as: `io.cozy.files/${id}`,
+    as: driveId
+      ? `io.cozy.files/drive/${driveId}/${id}`
+      : `io.cozy.files/${id}`,
     fetchPolicy: defaultFetchPolicy,
-    singleDocData: true
+    singleDocData: true,
+    ...(driveId ? { driveId } : {})
   }
   return client.fetchQueryAndGetFromState({ definition, options })
 }

--- a/packages/cozy-pouch-link/src/files.spec.js
+++ b/packages/cozy-pouch-link/src/files.spec.js
@@ -22,4 +22,36 @@ describe('queryFileById', () => {
       }
     })
   })
+
+  it('with a driveId, builds a drive-scoped query with driveId and per-drive cache key, no forceLink', async () => {
+    const expectedResult = { data: { _id: 'dir-123', path: '/Drive/Folder' } }
+    const client = {
+      fetchQueryAndGetFromState: jest.fn().mockResolvedValue(expectedResult)
+    }
+
+    const res = await queryFileById(client, 'dir-123', 'drive-abc')
+
+    expect(res).toBe(expectedResult)
+    expect(client.fetchQueryAndGetFromState).toHaveBeenCalledTimes(1)
+    const calledOptions =
+      client.fetchQueryAndGetFromState.mock.calls[0][0].options
+    expect(calledOptions.as).toBe('io.cozy.files/drive/drive-abc/dir-123')
+    expect(calledOptions.driveId).toBe('drive-abc')
+    expect(calledOptions).not.toHaveProperty('forceLink')
+    expect(calledOptions.singleDocData).toBe(true)
+  })
+
+  it('without a driveId, options are byte-for-byte identical to the legacy call', async () => {
+    const client = {
+      fetchQueryAndGetFromState: jest.fn().mockResolvedValue({ data: null })
+    }
+
+    await queryFileById(client, 'some-id', undefined)
+
+    const calledOptions =
+      client.fetchQueryAndGetFromState.mock.calls[0][0].options
+    expect(calledOptions).not.toHaveProperty('driveId')
+    expect(calledOptions).not.toHaveProperty('forceLink')
+    expect(calledOptions.as).toBe('io.cozy.files/some-id')
+  })
 })

--- a/packages/cozy-pouch-link/src/jsonapi.js
+++ b/packages/cozy-pouch-link/src/jsonapi.js
@@ -170,7 +170,7 @@ export const computeFileFullpath = async (client, file) => {
   }
   // queryFileById can resolve to undefined when offline (no parent dir
   // found in the link chain), so we must guard before destructuring.
-  const result = await queryFileById(client, file.dir_id)
+  const result = await queryFileById(client, file.dir_id, file.driveId)
   const parentDir = result?.data
 
   if (parentDir?.path) {

--- a/packages/cozy-pouch-link/src/jsonapi.spec.js
+++ b/packages/cozy-pouch-link/src/jsonapi.spec.js
@@ -750,4 +750,47 @@ describe('computeFileFullpath', () => {
     expect(res).toBe(file)
     expect(res.path).toBeUndefined()
   })
+
+  it('passes file.driveId to queryFileById when the file carries a driveId', async () => {
+    const driveParentDir = {
+      _id: 'drive-dir-1',
+      _type: 'io.cozy.files',
+      type: 'directory',
+      path: '/Drive/Folder'
+    }
+    queryFileById.mockResolvedValue({ data: driveParentDir })
+    const driveFile = {
+      _id: 'drive-file-1',
+      _type: 'io.cozy.files',
+      type: 'file',
+      dir_id: 'drive-dir-1',
+      name: 'report.pdf',
+      driveId: 'drive-abc'
+    }
+
+    const res = await computeFileFullpath(client, driveFile)
+
+    expect(queryFileById).toHaveBeenCalledWith(
+      client,
+      'drive-dir-1',
+      'drive-abc'
+    )
+    expect(res.path).toBe('/Drive/Folder/report.pdf')
+  })
+
+  it('passes undefined driveId to queryFileById for own (non-drive) files', async () => {
+    queryFileById.mockResolvedValue({ data: dir })
+    const ownFile = {
+      _id: 'own-file-1',
+      _type: 'io.cozy.files',
+      type: 'file',
+      dir_id: '123',
+      name: 'own.txt'
+      // no driveId field
+    }
+
+    await computeFileFullpath(client, ownFile)
+
+    expect(queryFileById).toHaveBeenCalledWith(client, '123', undefined)
+  })
 })

--- a/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
+++ b/packages/cozy-pouch-link/types/CozyPouchLink.d.ts
@@ -89,6 +89,8 @@ declare class PouchLink extends CozyLink {
     doctypes: string[];
     doctypesReplicationOptions: Record<string, any>;
     indexes: {};
+    /** @private Cache of per-drive logical-typed query engines, keyed by `dbDoctype::logicalDoctype`. */
+    private _driveQueryEngines;
     storage: PouchLocalStorage;
     initialSync: boolean;
     periodicSync: boolean;
@@ -197,9 +199,20 @@ declare class PouchLink extends CozyLink {
     public stopReplication(): void;
     onSyncError(error: any): Promise<void>;
     getSyncInfo(doctype: any): import("./types").SyncInfo;
-    getQueryEngineFromDoctype(doctype: any): any;
+    /**
+     * Returns the registered physical doctype for a given logical doctype and query options.
+     *
+     * @param {any} logicalDoctype - The logical doctype
+     * @param {object} [options] - Optional query options
+     */
+    getDbDoctype(logicalDoctype: any, options?: object): any;
+    /**
+     * @param {any} doctype - The doctype
+     * @param {object} [options] - Optional query options
+     */
+    getQueryEngineFromDoctype(doctype: any, options?: object): any;
     getPouch(doctype: any): any;
-    supportsOperation(operation: any): boolean;
+    supportsOperation(operation: any, options: any): boolean;
     /**
      * Get PouchDB changes
      * See https://pouchdb.com/api.html#changes
@@ -227,19 +240,11 @@ declare class PouchLink extends CozyLink {
      */
     needsToWaitWarmup(doctype: string): Promise<boolean>;
     hasIndex(name: any): boolean;
-    executeQuery({ doctype, selector, sort, fields, limit, id, ids, skip, indexedFields, partialFilter, sharingId }: {
-        doctype: any;
-        selector: any;
-        sort: any;
-        fields: any;
-        limit: any;
-        id: any;
-        ids: any;
-        skip: any;
-        indexedFields: any;
-        partialFilter: any;
-        sharingId: any;
-    }): Promise<any>;
+    /**
+     * @param {object} operation - The query operation
+     * @param {object} [options] - Optional query options
+     */
+    executeQuery({ doctype, selector, sort, fields, limit, id, ids, skip, indexedFields, partialFilter, sharingId }: object, options?: object): Promise<any>;
     executeMutation(mutation: any, options: any, result: any, forward: any): Promise<any>;
     createDocument(mutation: any): Promise<any>;
     createDocuments(mutation: any): Promise<any[]>;

--- a/packages/cozy-pouch-link/types/files.d.ts
+++ b/packages/cozy-pouch-link/types/files.d.ts
@@ -1,3 +1,3 @@
 export const TYPE_DIRECTORY: "directory";
 export const TYPE_FILE: "file";
-export function queryFileById(client: any, id: any): Promise<any>;
+export function queryFileById(client: object, id: string, driveId?: string): Promise<any>;


### PR DESCRIPTION
## Summary

- Add a `forceLink` query option that routes a query to the link whose `name` matches; `StackLink` and `DataProxyLink` now expose a stable `name` (`stack`, `dataproxy`).
- A query without `forceLink` is unchanged: each link forwards immediately when the option targets another link.
- Resolve a query's `driveId` option to its registered `io.cozy.files.shareddrives-<id>` doctype in cozy-pouch-link, read that drive's database, and keep the returned documents typed `io.cozy.files` so they stay in the same reactive store slice.
- Cache the per-drive query engines and clear them on reset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `forceLink` option to route operations to a specific link via stable `name` identifiers.
  * Drive-aware query execution and drive-scoped file lookups using optional `driveId`.

* **Bug Fixes**
  * Legacy `forceStack` now maps to `forceLink: 'stack'`, with a one-time deprecation warning and consistent routing (including offline behavior).

* **Documentation**
  * Updated API docs and TypeScript typings for `resolveForceLink`, `forceLink`, and `name` accessors, plus updated `PouchLink` query method signatures.

* **Tests**
  * Added/expanded unit tests for force routing and drive-focused behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->