### PR TITLE
fix(store): resolve getById queries by _id index on setData

### DIFF
--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -442,16 +442,6 @@ export const makeSorterFromDefinition = definition => {
   }
 }
 
-// Within a single dispatch, `newData` is the same array reference for every
-// active query. A `getById`/`getByIds` query does not need to sift-scan the
-// whole `newData` array to know if its documents are in there: it only cares
-// about a handful of known ids. We therefore index `newData` by `_id` once per
-// dispatch and resolve those queries with an O(1) lookup, mirroring the O(1)
-// getById access already used by `executeQueryFromState`. Selector queries keep
-// the sift scan but memoize the partition per distinct definition, so several
-// queries sharing the same selector only scan `newData` once. On a full-sync
-// dispatch (thousands of getById queries against thousands of docs) this turns
-// an O(queries * docs) scan into O(queries + docs).
 let dedupNewData = null
 let dedupCache = null
 let dedupIdIndex = null
@@ -476,8 +466,7 @@ const getDedupIdIndex = newData => {
 }
 
 /**
- * Splits `newData` into the ids matching a query definition and the ids that
- * do not, memoized per dispatch (same `newData` reference) and per definition.
+ * Splits `newData` into the ids matching a query definition and the ids that do not
  *
  * @param  {QueryDefinition} definition - Definition of the query
  * @param  {Array<import("../types").CozyClientDocument>} newData - New documents

--- a/packages/cozy-client/src/store/queries.js
+++ b/packages/cozy-client/src/store/queries.js
@@ -442,6 +442,90 @@ export const makeSorterFromDefinition = definition => {
   }
 }
 
+// Within a single dispatch, `newData` is the same array reference for every
+// active query. A `getById`/`getByIds` query does not need to sift-scan the
+// whole `newData` array to know if its documents are in there: it only cares
+// about a handful of known ids. We therefore index `newData` by `_id` once per
+// dispatch and resolve those queries with an O(1) lookup, mirroring the O(1)
+// getById access already used by `executeQueryFromState`. Selector queries keep
+// the sift scan but memoize the partition per distinct definition, so several
+// queries sharing the same selector only scan `newData` once. On a full-sync
+// dispatch (thousands of getById queries against thousands of docs) this turns
+// an O(queries * docs) scan into O(queries + docs).
+let dedupNewData = null
+let dedupCache = null
+let dedupIdIndex = null
+
+const makeDefinitionKey = def =>
+  JSON.stringify([
+    def.doctype,
+    def.selector,
+    def.partialFilter,
+    def.id,
+    def.ids
+  ])
+
+const getDedupIdIndex = newData => {
+  if (dedupIdIndex) return dedupIdIndex
+  const idx = new Map()
+  for (const doc of newData) {
+    if (doc && doc._id != null) idx.set(doc._id, doc)
+  }
+  dedupIdIndex = idx
+  return idx
+}
+
+/**
+ * Splits `newData` into the ids matching a query definition and the ids that
+ * do not, memoized per dispatch (same `newData` reference) and per definition.
+ *
+ * @param  {QueryDefinition} definition - Definition of the query
+ * @param  {Array<import("../types").CozyClientDocument>} newData - New documents
+ * @returns {{ matchedIds: Array<string>, unmatchedIds: Array<string> }}
+ */
+export const computeMatchPartition = (definition, newData) => {
+  if (dedupNewData !== newData) {
+    dedupNewData = newData
+    dedupCache = {}
+    dedupIdIndex = null
+  }
+
+  const key = makeDefinitionKey(definition)
+  const cached = dedupCache[key]
+  if (cached) return cached
+
+  let partition
+  if (definition.id || definition.ids) {
+    const idx = getDedupIdIndex(newData)
+    const wanted = definition.id ? [definition.id] : definition.ids
+    const matchedIds = []
+    const unmatchedIds = []
+    for (const id of wanted) {
+      const doc = idx.get(id)
+      if (doc) {
+        if (!doc._deleted && doc._type === definition.doctype) {
+          matchedIds.push(properId(doc))
+        } else {
+          unmatchedIds.push(properId(doc))
+        }
+      }
+    }
+    partition = { matchedIds, unmatchedIds }
+  } else {
+    const belongsToQuery = makeFilterDocumentFn(definition)
+    const res = mapValues(groupBy(newData, belongsToQuery), docs =>
+      docs.map(properId)
+    )
+    partition = {
+      matchedIds: res.true === undefined ? [] : res.true,
+      unmatchedIds: res.false === undefined ? [] : res.false
+    }
+  }
+
+  dedupCache[key] = partition
+  return partition
+}
+
 /**
  * Updates query state when new data comes in
  *
@@ -451,11 +535,10 @@ export const makeSorterFromDefinition = definition => {
  * @returns {import("../types").QueryState} - Updated query state
  */
 export const updateData = (query, newData, documents) => {
-  const belongsToQuery = makeFilterDocumentFn(query.definition)
-  const res = mapValues(groupBy(newData, belongsToQuery), docs =>
-    docs.map(properId)
+  const { matchedIds, unmatchedIds } = computeMatchPartition(
+    query.definition,
+    newData
   )
-  const { true: matchedIds = [], false: unmatchedIds = [] } = res
   const originalIds = query.data
 
   const autoUpdate = query.options && query.options.autoUpdate

--- a/packages/cozy-client/src/store/queries.spec.js
+++ b/packages/cozy-client/src/store/queries.spec.js
@@ -9,6 +9,7 @@ import queries, {
   loadQuery,
   receiveQueryError,
   updateData,
+  computeMatchPartition,
   executeQueryFromState,
   mapIdsToDocuments
 } from './queries'
@@ -672,6 +673,64 @@ describe('updateData', () => {
     const updatedDataToCheck = updateData(queryState, newData, documents)
     expect(updatedDataToCheck.data.length).toEqual(1)
     expect(updatedDataToCheck.count).toEqual(1)
+  })
+})
+
+describe('computeMatchPartition', () => {
+  it('should resolve a getById query without scanning the whole newData', () => {
+    const newData = [TODO_1, TODO_2, TODO_3]
+    const definition = Q('io.cozy.todos').getById(TODO_2._id)
+    const { matchedIds, unmatchedIds } = computeMatchPartition(
+      definition,
+      newData
+    )
+    expect(matchedIds).toEqual([TODO_2._id])
+    expect(unmatchedIds).toEqual([])
+  })
+
+  it('should not match a getById query for a missing or wrong-doctype id', () => {
+    const newData = [TODO_1, { ...TODO_2, _type: 'io.cozy.other' }]
+    expect(
+      computeMatchPartition(Q('io.cozy.todos').getById('missing'), newData)
+    ).toEqual({ matchedIds: [], unmatchedIds: [] })
+    expect(
+      computeMatchPartition(Q('io.cozy.todos').getById(TODO_2._id), newData)
+    ).toEqual({ matchedIds: [], unmatchedIds: [TODO_2._id] })
+  })
+
+  it('should treat a deleted document as unmatched for a getById query', () => {
+    const newData = [{ ...TODO_1, _deleted: true }]
+    expect(
+      computeMatchPartition(Q('io.cozy.todos').getById(TODO_1._id), newData)
+    ).toEqual({ matchedIds: [], unmatchedIds: [TODO_1._id] })
+  })
+
+  it('should resolve a getByIds query', () => {
+    const newData = [TODO_1, TODO_2, TODO_3]
+    const definition = Q('io.cozy.todos').getByIds([TODO_1._id, 'missing'])
+    expect(computeMatchPartition(definition, newData)).toEqual({
+      matchedIds: [TODO_1._id],
+      unmatchedIds: []
+    })
+  })
+
+  it('should partition a selector query with the sift scan', () => {
+    const newData = [TODO_1, TODO_2, TODO_3]
+    const definition = Q('io.cozy.todos').where({ done: true })
+    const { matchedIds, unmatchedIds } = computeMatchPartition(
+      definition,
+      newData
+    )
+    expect(matchedIds).toEqual([TODO_3._id])
+    expect(unmatchedIds.sort()).toEqual([TODO_1._id, TODO_2._id].sort())
+  })
+
+  it('should memoize the partition per definition within the same newData', () => {
+    const newData = [TODO_1, TODO_2]
+    const definition = Q('io.cozy.todos').getById(TODO_1._id)
+    const first = computeMatchPartition(definition, newData)
+    const second = computeMatchPartition(definition, newData)
+    expect(second).toBe(first)
   })
 })
 

--- a/packages/cozy-client/types/store/queries.d.ts
+++ b/packages/cozy-client/types/store/queries.d.ts
@@ -8,6 +8,10 @@ export function convert$gtNullSelectors(selector: any): object;
 export function mergeSelectorAndPartialIndex(queryDefinition: object): object;
 export function executeQueryFromState(state: import('../types').CozyStore, queryDefinition: QueryDefinition): import("../types").QueryStateData;
 export function makeSorterFromDefinition(definition: QueryDefinition): (arg0: Array<import("../types").CozyClientDocument>) => Array<import("../types").CozyClientDocument>;
+export function computeMatchPartition(definition: QueryDefinition, newData: Array<import("../types").CozyClientDocument>): {
+    matchedIds: Array<string>;
+    unmatchedIds: Array<string>;
+};
 export function updateData(query: import("../types").QueryState, newData: Array<import("../types").CozyClientDocument>, documents: import("../types").DocumentsStateSlice): import("../types").QueryState;
 export default queries;
 export function initQuery(queryId: string, queryDefinition: QueryDefinition, options?: import("../types").QueryOptions): object;


### PR DESCRIPTION
## Summary

On a full sync, `client.setData(data)` dispatches `RECEIVE_QUERY_RESULT` with `queryId: null`, which re-evaluates every active query. `updateData` ran `groupBy(newData, makeFilterDocumentFn(query.definition))`, a sift scan over the whole `newData` array, once per query. With ~1500 getById queries active against ~9840 docs that is ~15M evaluations per dispatch and blocks the thread for ~38s.

getById/getByIds queries do not need to scan all of `newData`: this indexes `newData` by `_id` once per dispatch and resolves them with an O(1) lookup, mirroring the O(1) getById access already used by `executeQueryFromState`. Selector queries keep the sift scan but memoize the partition per definition within a dispatch. The `_deleted` / `_type === doctype` matching semantics and the autoUpdate add/remove/update behaviour are unchanged.

Measured on a real device: setData 38588ms to 247ms (~150x).

## Tests

- `yarn jest packages/cozy-client/src/store` gives 104 passing, snapshots unchanged.
- Added `computeMatchPartition` unit tests: getById hit / missing / wrong doctype / deleted, getByIds, selector, and per-dispatch memoization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved automatic query updates for faster data refreshes.
  * Optimized lookups for queries targeting specific records.
  * Improved handling of deleted, missing, or mismatched records during updates.

* **Bug Fixes**
  * Ensured query results correctly distinguish matching and non-matching records across supported query types.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->