### PR TITLE
test: add store query benchmarks and PR-vs-master CI comparison

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -50,3 +50,77 @@ jobs:
           git remote set-url origin https://cozy-bot:$GH_TOKEN@github.com/cozy/cozy-client.git
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
           yarn lerna publish --yes -m "chore: Publish [skip ci]"
+
+  perf:
+    name: Performance benchmarks
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+      - name: Record PR ref
+        id: prref
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Install dependencies (PR)
+        run: yarn install --immutable
+      - name: Benchmark PR
+        run: yarn bench --out=pr.bench.json
+      - name: Checkout base branch
+        run: git checkout --force ${{ github.event.pull_request.base.sha }}
+      - name: Install dependencies (base)
+        run: yarn install --immutable
+      - name: Benchmark base (same runner)
+        run: yarn bench --out=base.bench.json || echo "No baseline on base branch (benchmarks are new)."
+      - name: Restore PR tree
+        run: git checkout --force ${{ steps.prref.outputs.sha }}
+      - name: Compare PR vs base
+        id: compare
+        run: |
+          set +e
+          node packages/cozy-client/benchmarks/compare.js base.bench.json pr.bench.json --md=perf-comment.md
+          echo "status=$?" >> "$GITHUB_OUTPUT"
+      - name: Post benchmark comment
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            const marker = '<!-- cozy-client-benchmarks -->'
+            const body = `${marker}\n${fs.readFileSync('perf-comment.md', 'utf8')}`
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            })
+            const existing = comments.find(c => c.body && c.body.includes(marker))
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body
+              })
+            }
+      - name: Fail on regression
+        if: steps.compare.outputs.status != '0'
+        run: |
+          echo "A guarded benchmark regressed beyond its threshold."
+          exit 1

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -81,7 +81,15 @@ jobs:
       - name: Install dependencies (base)
         run: yarn install --immutable
       - name: Benchmark base (same runner)
-        run: yarn bench --out=base.bench.json || echo "No baseline on base branch (benchmarks are new)."
+        # Only tolerate the "base branch has no benchmarks yet" bootstrap case;
+        # a real bench failure (bad build/install) must still fail the job
+        # rather than being masked into a missing baseline.
+        run: |
+          if [ -f packages/cozy-client/benchmarks/run.js ]; then
+            yarn bench --out=base.bench.json
+          else
+            echo "No baseline on base branch (benchmarks are new)."
+          fi
       - name: Restore PR tree
         run: git checkout --force ${{ steps.prref.outputs.sha }}
       - name: Compare PR vs base

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -63,6 +63,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Don't leave the workflow token in .git/config where the untrusted
+          # PR code we run below (yarn install / yarn bench) could read it. The
+          # comment step posts via github-script's ambient token, not git.
+          persist-credentials: false
       - name: Enable Corepack
         run: corepack enable
       - name: Use Node.js
@@ -77,7 +81,9 @@ jobs:
       - name: Benchmark PR
         run: yarn bench --out=pr.bench.json
       - name: Checkout base branch
-        run: git checkout --force ${{ github.event.pull_request.base.sha }}
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: git checkout --force "$BASE_SHA"
       - name: Install dependencies (base)
         run: yarn install --immutable
       - name: Benchmark base (same runner)
@@ -91,7 +97,9 @@ jobs:
             echo "No baseline on base branch (benchmarks are new)."
           fi
       - name: Restore PR tree
-        run: git checkout --force ${{ steps.prref.outputs.sha }}
+        env:
+          PR_SHA: ${{ steps.prref.outputs.sha }}
+        run: git checkout --force "$PR_SHA"
       - name: Compare PR vs base
         id: compare
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ yarn-error.log
 coverage
 .cache
 dist
+packages/*/benchmarks/results
+*.bench.json
+perf-comment.md
 .eslintcache
 .idea
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "scripts": {
     "lint": "eslint 'packages/*/src/**/*.{js,jsx}' 'packages/*/examples/**/*.{js,jsx}'",
     "test": "jest",
+    "bench": "yarn build && node packages/cozy-client/benchmarks/run.js",
     "watch": "lerna run watch --parallel --stream",
     "build": "lerna run build",
     "commitmsg": "commitlint -e $GIT_PARAMS",

--- a/packages/cozy-client/benchmarks/README.md
+++ b/packages/cozy-client/benchmarks/README.md
@@ -1,0 +1,68 @@
+# cozy-client benchmarks
+
+Micro-benchmarks for the hot paths of the redux store, plus a CI job that compares
+a pull request against its base branch on the same runner.
+
+## What is measured
+
+The benchmarks exercise the real `packages/cozy-client/src/store/queries.js` reducer
+(via the built `dist/`), not mocks.
+
+- **`store-queries:receiveQueryResult-getById-heavy`** — the `queries()` reducer
+  handling a `RECEIVE_QUERY_RESULT` that carries 10k `io.cozy.files` documents against
+  a store of 1000 `getById` queries and 200 selector queries. This is the key metric:
+  it guards the store update cost when a large `setData` lands. It is the only metric
+  with a regression gate.
+- **`store-queries:selector-eval-folder-listing`** — `updateData()` evaluating a
+  `{ dir_id, type, name: { $gt: null } }` folder-listing selector over 10k documents.
+  Exercises `sift` and the custom `$gtnull` operator. Informational.
+- **`store-queries:sift-compiled-exec-10k`** — a pure `sift` canary: run a pre-compiled
+  selector over 10k documents. Catches a raw `sift` slowdown (e.g. a version bump).
+  Informational.
+
+## Running locally
+
+The packages read from `dist/`, so a build is required first. `yarn bench` does both:
+
+```sh
+yarn bench                                  # build + run, writes benchmarks/results/latest.json
+yarn bench --out=/path/to/report.json       # choose the output file
+```
+
+Direct run without rebuilding (dist must already exist):
+
+```sh
+node packages/cozy-client/benchmarks/run.js --out=pr.json
+```
+
+Each report is JSON: `{ schemaVersion, generatedAt, node, platform, benchmarks: [...] }`,
+one entry per benchmark with `medianMs`, `minMs`, `meanMs` and `opsPerSec`.
+
+## Harness
+
+`harness.js` is a dependency-free `process.hrtime.bigint()` timer: it warms up each
+benchmark, runs it N times and reports the **median** (robust to outliers). Sizes and
+iteration counts live in `store-queries.bench.js`.
+
+## Comparing two reports
+
+`compare.js` compares a base report against a PR report and prints a Markdown table:
+
+```sh
+node packages/cozy-client/benchmarks/compare.js base.json pr.json --md=comment.md
+```
+
+- Delta is `(pr - base) / base` per benchmark; positive means the PR is **slower**.
+- The comparison is **same-runner, back-to-back** (PR and base measured on the same
+  machine in the same job), so absolute ms vary but the ratio is meaningful.
+- A benchmark carrying `regressionThresholdPct` is **guarded**: the script exits
+  non-zero when its delta exceeds the threshold (25% by default, override with
+  `--threshold=`). Other benchmarks are informational.
+- If the base report is missing (the base branch does not have the benchmarks yet),
+  `compare.js` prints the PR numbers as a baseline and exits 0.
+
+## CI
+
+The `perf` job in `.github/workflows/ci-cd.yml` runs on pull requests: it benches the
+PR, checks out the base branch and benches it on the same runner, then posts the table
+as a PR comment and fails on a guarded regression.

--- a/packages/cozy-client/benchmarks/compare.js
+++ b/packages/cozy-client/benchmarks/compare.js
@@ -1,0 +1,153 @@
+const fs = require('fs')
+const path = require('path')
+
+const DEFAULT_THRESHOLD_PCT = 25
+
+const parseArgs = argv => {
+  const positional = argv.filter(arg => !arg.startsWith('--'))
+  const mdFlag = argv.find(arg => arg.startsWith('--md='))
+  const thresholdFlag = argv.find(arg => arg.startsWith('--threshold='))
+  return {
+    basePath: positional[0],
+    prPath: positional[1],
+    mdPath: mdFlag ? path.resolve(mdFlag.slice('--md='.length)) : null,
+    threshold: thresholdFlag
+      ? Number(thresholdFlag.slice('--threshold='.length))
+      : DEFAULT_THRESHOLD_PCT
+  }
+}
+
+const readJson = filePath => {
+  if (!filePath || !fs.existsSync(filePath)) {
+    return null
+  }
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+  } catch (err) {
+    return null
+  }
+}
+
+const indexByName = report => {
+  const map = {}
+  if (report && Array.isArray(report.benchmarks)) {
+    for (const bench of report.benchmarks) {
+      map[bench.name] = bench
+    }
+  }
+  return map
+}
+
+const formatMs = value => (value == null ? 'n/a' : value.toFixed(3))
+
+const formatDelta = pct => {
+  if (pct == null) return 'n/a'
+  const sign = pct > 0 ? '+' : ''
+  return `${sign}${pct.toFixed(1)}%`
+}
+
+const computeDeltaPct = (baseBench, prBench) => {
+  if (!baseBench || baseBench.value === 0) return null
+  const raw = ((prBench.value - baseBench.value) / baseBench.value) * 100
+  return prBench.higherIsBetter ? -raw : raw
+}
+
+const buildBaselineReport = prReport => {
+  const lines = []
+  lines.push('### cozy-client benchmarks')
+  lines.push('')
+  lines.push(
+    'No baseline found on the base branch (benchmarks are new here). ' +
+      'Publishing PR numbers as the future baseline.'
+  )
+  lines.push('')
+  lines.push('| Benchmark | PR (ms, median) | ops/s |')
+  lines.push('| --- | ---: | ---: |')
+  for (const bench of prReport.benchmarks) {
+    lines.push(
+      `| ${bench.name} | ${formatMs(bench.medianMs)} | ${bench.opsPerSec.toFixed(1)} |`
+    )
+  }
+  return { markdown: lines.join('\n'), failed: false }
+}
+
+const buildComparison = (baseReport, prReport, threshold) => {
+  const baseMap = indexByName(baseReport)
+  const rows = []
+  let failed = false
+
+  for (const prBench of prReport.benchmarks) {
+    const baseBench = baseMap[prBench.name]
+    const deltaPct = computeDeltaPct(baseBench, prBench)
+    const guardThreshold =
+      prBench.regressionThresholdPct != null
+        ? prBench.regressionThresholdPct
+        : null
+
+    let status = 'informational'
+    if (deltaPct == null) {
+      status = 'no baseline'
+    } else if (guardThreshold != null && deltaPct > guardThreshold) {
+      status = `REGRESSION (> ${guardThreshold}%)`
+      failed = true
+    } else if (guardThreshold != null && deltaPct < -guardThreshold) {
+      status = 'improvement'
+    } else if (guardThreshold != null) {
+      status = 'ok'
+    }
+
+    rows.push({
+      name: prBench.name,
+      base: baseBench ? baseBench.medianMs : null,
+      pr: prBench.medianMs,
+      deltaPct,
+      status
+    })
+  }
+
+  const lines = []
+  lines.push('### cozy-client benchmarks')
+  lines.push('')
+  lines.push(
+    `Same-runner comparison (PR vs base), regression threshold ${threshold}% on guarded metrics.`
+  )
+  lines.push('')
+  lines.push('| Benchmark | master (ms) | PR (ms) | Δ% | Status |')
+  lines.push('| --- | ---: | ---: | ---: | --- |')
+  for (const row of rows) {
+    lines.push(
+      `| ${row.name} | ${formatMs(row.base)} | ${formatMs(row.pr)} | ${formatDelta(
+        row.deltaPct
+      )} | ${row.status} |`
+    )
+  }
+  lines.push('')
+  lines.push('Lower ms is better. Δ% > 0 means the PR is slower than master.')
+
+  return { markdown: lines.join('\n'), failed }
+}
+
+const main = () => {
+  const { basePath, prPath, mdPath, threshold } = parseArgs(process.argv.slice(2))
+
+  const prReport = readJson(prPath)
+  if (!prReport) {
+    console.error(`Cannot read PR benchmark report at ${prPath}`)
+    process.exit(2)
+  }
+
+  const baseReport = readJson(basePath)
+  const result = baseReport
+    ? buildComparison(baseReport, prReport, threshold)
+    : buildBaselineReport(prReport)
+
+  console.log(result.markdown)
+  if (mdPath) {
+    fs.mkdirSync(path.dirname(mdPath), { recursive: true })
+    fs.writeFileSync(mdPath, result.markdown)
+  }
+
+  process.exit(result.failed ? 1 : 0)
+}
+
+main()

--- a/packages/cozy-client/benchmarks/harness.js
+++ b/packages/cozy-client/benchmarks/harness.js
@@ -1,0 +1,51 @@
+const now = () => process.hrtime.bigint()
+
+const toMs = ns => Number(ns) / 1e6
+
+const median = values => {
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid]
+}
+
+const runBench = spec => {
+  const { name, description, warmup = 2, runs = 10, run } = spec
+
+  for (let i = 0; i < warmup; i++) {
+    run()
+  }
+
+  const samples = []
+  for (let i = 0; i < runs; i++) {
+    const start = now()
+    run()
+    samples.push(toMs(now() - start))
+  }
+
+  const medianMs = median(samples)
+  const minMs = Math.min(...samples)
+  const meanMs = samples.reduce((acc, value) => acc + value, 0) / samples.length
+
+  return {
+    name,
+    description,
+    unit: 'ms',
+    higherIsBetter: false,
+    value: medianMs,
+    medianMs,
+    minMs,
+    meanMs,
+    opsPerSec: 1000 / medianMs,
+    warmup,
+    runs,
+    ...(spec.regressionThresholdPct != null
+      ? { regressionThresholdPct: spec.regressionThresholdPct }
+      : {})
+  }
+}
+
+const runSuite = specs => specs.map(runBench)
+
+module.exports = { runBench, runSuite, median }

--- a/packages/cozy-client/benchmarks/run.js
+++ b/packages/cozy-client/benchmarks/run.js
@@ -1,0 +1,40 @@
+const fs = require('fs')
+const path = require('path')
+
+const { runSuite } = require('./harness')
+const { getSpecs } = require('./store-queries.bench')
+
+const parseOut = argv => {
+  const flag = argv.find(arg => arg.startsWith('--out='))
+  if (flag) {
+    return path.resolve(flag.slice('--out='.length))
+  }
+  return path.join(__dirname, 'results', 'latest.json')
+}
+
+const main = () => {
+  const outPath = parseOut(process.argv.slice(2))
+
+  const benchmarks = runSuite(getSpecs())
+
+  const output = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    node: process.version,
+    platform: `${process.platform}-${process.arch}`,
+    benchmarks
+  }
+
+  fs.mkdirSync(path.dirname(outPath), { recursive: true })
+  fs.writeFileSync(outPath, JSON.stringify(output, null, 2))
+
+  for (const bench of benchmarks) {
+    const ops = bench.opsPerSec >= 1 ? bench.opsPerSec.toFixed(1) : bench.opsPerSec.toFixed(3)
+    console.log(
+      `${bench.name}: ${bench.medianMs.toFixed(3)} ms (median), ${ops} ops/s`
+    )
+  }
+  console.log(`\nWrote ${outPath}`)
+}
+
+main()

--- a/packages/cozy-client/benchmarks/store-queries.bench.js
+++ b/packages/cozy-client/benchmarks/store-queries.bench.js
@@ -1,0 +1,143 @@
+const path = require('path')
+
+const distDir = path.join(__dirname, '..', 'dist')
+const queriesModule = require(path.join(distDir, 'store', 'queries.js'))
+const dsl = require(path.join(distDir, 'queries', 'dsl.js'))
+const {
+  defaultPerformanceApi
+} = require(path.join(distDir, 'performances', 'defaultPerformanceApi.js'))
+
+const siftPath = require.resolve('sift', { paths: [path.join(__dirname, '..')] })
+const siftModule = require(siftPath)
+const sift = siftModule.default || siftModule
+
+const queries = queriesModule.default
+const { receiveQueryResult, updateData } = queriesModule
+const { Q } = dsl
+
+const DOCTYPE = 'io.cozy.files'
+const N_DOCS = 10000
+const N_GET_BY_ID = 1000
+const N_SELECTOR = 200
+const N_DIRS = 50
+
+const makeFilesFixture = nDocs => {
+  const docs = []
+  const slice = {}
+  for (let i = 0; i < nDocs; i++) {
+    const _id = `file_${i}`
+    const doc = {
+      _id,
+      id: _id,
+      _type: DOCTYPE,
+      _rev: `1-${i}`,
+      type: 'file',
+      name: `document-${i}.txt`,
+      dir_id: `dir_${i % N_DIRS}`,
+      class: 'text',
+      size: 1024 + i,
+      updated_at: '2024-01-01T00:00:00Z'
+    }
+    docs.push(doc)
+    slice[_id] = doc
+  }
+  return { docs, documents: { [DOCTYPE]: slice } }
+}
+
+const makeQueryState = (id, definition, data) => ({
+  id,
+  definition,
+  fetchStatus: 'loaded',
+  isFetching: null,
+  lastFetch: 1,
+  lastUpdate: 1,
+  hasMore: false,
+  count: data.length,
+  fetchedPagesCount: 1,
+  data,
+  options: null
+})
+
+const makeGetByIdHeavyState = () => {
+  const state = {}
+  for (let i = 0; i < N_GET_BY_ID; i++) {
+    const docId = `file_${i}`
+    const definition = Q(DOCTYPE).getById(docId)
+    const queryId = `${DOCTYPE}/${docId}`
+    state[queryId] = makeQueryState(queryId, definition, [docId])
+  }
+  for (let i = 0; i < N_SELECTOR; i++) {
+    const definition = Q(DOCTYPE).where({
+      dir_id: `dir_${i % N_DIRS}`,
+      type: 'file',
+      name: { $gt: null }
+    })
+    const queryId = `selector_${i}`
+    state[queryId] = makeQueryState(queryId, definition, [])
+  }
+  return state
+}
+
+const getSpecs = () => {
+  const { docs, documents } = makeFilesFixture(N_DOCS)
+
+  const heavyState = makeGetByIdHeavyState()
+  const receiveAction = receiveQueryResult(null, { data: docs })
+
+  const selectorDefinition = Q(DOCTYPE).where({
+    dir_id: 'dir_7',
+    type: 'file',
+    name: { $gt: null }
+  })
+  const selectorQuery = makeQueryState('selector_bench', selectorDefinition, [])
+
+  const siftSelector = sift({
+    class: 'text',
+    dir_id: 'dir_7',
+    name: { $exists: true }
+  })
+
+  return [
+    {
+      name: 'store-queries:receiveQueryResult-getById-heavy',
+      description:
+        'queries() reducer applying a RECEIVE_QUERY_RESULT of 10k io.cozy.files ' +
+        'against 1000 getById queries + 200 selector queries',
+      warmup: 1,
+      runs: 5,
+      regressionThresholdPct: 25,
+      run: () => {
+        queries(defaultPerformanceApi, heavyState, receiveAction, documents, true)
+      }
+    },
+    {
+      name: 'store-queries:selector-eval-folder-listing',
+      description:
+        'updateData() evaluating a { dir_id, type, name: { $gt: null } } ' +
+        'folder-listing selector over 10k documents (sift + $gtnull)',
+      warmup: 3,
+      runs: 15,
+      run: () => {
+        updateData(selectorQuery, docs, documents)
+      }
+    },
+    {
+      name: 'store-queries:sift-compiled-exec-10k',
+      description:
+        'Pure sift canary: execute a pre-compiled selector over 10k documents',
+      warmup: 3,
+      runs: 15,
+      run: () => {
+        let matched = 0
+        for (let i = 0; i < docs.length; i++) {
+          if (siftSelector(docs[i])) {
+            matched++
+          }
+        }
+        return matched
+      }
+    }
+  ]
+}
+
+module.exports = { getSpecs }


### PR DESCRIPTION
## Summary

There are no perf tests in the repo today. This adds a dependency-free benchmark suite for the store query reducer and a CI job that compares the PR against master on the same runner (ratios, robust to runner noise).

Benchmarks run against the real built reducer:
- `receiveQueryResult-getById-heavy` is the guarded metric (a regression >25% fails the job): ~1000 getById + 200 selector queries over 10k docs, the hot path that #1697 takes from ~38s to ~247ms.
- `selector-eval-folder-listing` and a compiled-sift canary are informational (they catch a sift bump like the one rejected in #1698).

The `perf` job benchmarks the PR, checks out the base SHA and benchmarks it back-to-back on the same runner, then a committed compare script posts a single table comment and fails only on a guarded regression. The comparator is a small Node script (no third-party action, no secrets). The 'no baseline on master yet' case is handled: this PR just publishes its numbers as the baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated performance benchmarking for pull requests.
  - Performance results are compared with the base branch and shared directly in pull request comments.
  - Builds can now detect and flag significant performance regressions.

- **Documentation**
  - Added guidance for running benchmarks locally and interpreting comparison results.

- **Chores**
  - Added a convenient benchmark command for generating performance reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->