### PR TITLE
fix(pouch): seed directory paths in normalizeDocs to skip a getById per file

### DIFF
--- a/packages/cozy-pouch-link/src/jsonapi.js
+++ b/packages/cozy-pouch-link/src/jsonapi.js
@@ -32,6 +32,16 @@ export const resetAllPaths = () => {
  * @param {Array<import('./CozyPouchLink').CozyPouchDocument>} docs - The documents to normalize
  */
 export const normalizeDocs = (client, doctype, docs) => {
+  if (doctype === 'io.cozy.files') {
+    // Seed the path cache with every directory's path first, so each file
+    // resolves its parent path from memory instead of a per-file getById.
+    for (let j = 0; j < docs.length; j++) {
+      const dir = docs[j]
+      if (dir && dir.type === TYPE_DIRECTORY && dir.path) {
+        setFilePath(dir._id || dir.id, dir.path)
+      }
+    }
+  }
   for (let i = docs.length; i >= 0; i--) {
     const doc = docs[i]
     if (!doc) {

--- a/packages/cozy-pouch-link/src/jsonapi.spec.js
+++ b/packages/cozy-pouch-link/src/jsonapi.spec.js
@@ -4,6 +4,7 @@ import {
   computeFileFullpath,
   fromPouchResult,
   normalizeDoc,
+  normalizeDocs,
   resetAllPaths
 } from './jsonapi'
 import { queryFileById } from './files'
@@ -718,6 +719,15 @@ describe('computeFileFullpath', () => {
     const updFile = { ...filewithNoPath, name: 'file3.1', path: undefined }
     const res2 = await computeFileFullpath(client, updFile)
     expect(res2.path).toEqual('ROOT/MYDIR/file3.1')
+  })
+
+  it('normalizeDocs seeds directory paths so sibling files resolve without querying', async () => {
+    queryFileById.mockClear()
+    const dirDoc = { ...dir }
+    const fileDoc = { ...filewithNoPath }
+    normalizeDocs(client, 'io.cozy.files', [dirDoc, fileDoc])
+    expect(fileDoc.path).toEqual('ROOT/MYDIR/file3')
+    expect(queryFileById).not.toHaveBeenCalled()
   })
 
   it('should return the file unchanged when queryFileById resolves to undefined', async () => {

--- a/packages/cozy-pouch-link/src/jsonapi.spec.js
+++ b/packages/cozy-pouch-link/src/jsonapi.spec.js
@@ -722,6 +722,9 @@ describe('computeFileFullpath', () => {
   })
 
   it('normalizeDocs seeds directory paths so sibling files resolve without querying', async () => {
+    // Clear the module-level path cache so the result depends on the seeding
+    // block, not on a directory a previous test may have cached.
+    resetAllPaths()
     queryFileById.mockClear()
     const dirDoc = { ...dir }
     const fileDoc = { ...filewithNoPath }


### PR DESCRIPTION
## Problem

On sync, `normalizeDocs` normalizes every `io.cozy.files` doc and
`computeFileFullpath` resolves each **file**'s full path from its parent
directory's `path`. Files carry no `path` in Couch/Pouch (only directories
do), so the parent path is read from the in-memory `allPaths` cache — but
**directories return early without ever calling `setFilePath`**, so the cache
stays empty. Every file misses it and falls through to
`queryFileById(client, file.dir_id)` — **one query per file**.

On a first replication of thousands of files, and with clients where
`io.cozy.files` is served through the link chain (cozy-pouch-link forwards to
the stack until the local replica is warmed up), these serialize into
**thousands of network `getById` calls** and lock the JS thread for a very
long time (~100s on a ~9840-file drive on React Native).

## Fix

Before computing file paths, do one pass over the batch and seed the path
cache with every directory's own `path`. Each file then resolves its parent
path from memory (the `parentPath` branch of `computeFileFullpath`) and never
issues a query.

## Result (React Native, ~9840-file first sync)

| | before | after |
|---|---|---|
| parent-lookup network `getById` | thousands | **0** |
| max JS-thread stall | ~100s | **~2s** |

Measured on-device. Adds a test asserting a file resolves its path after
`normalizeDocs` without `queryFileById` being called; existing
`computeFileFullpath` tests unchanged and green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path resolution when processing directories and their files together.
  * File paths can now be resolved from available directory information without additional lookups, improving efficiency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->