### PR TITLE
test(perf): add a normalizeDocs cold-cache benchmark

### DIFF
--- a/packages/cozy-client/benchmarks/README.md
+++ b/packages/cozy-client/benchmarks/README.md
@@ -19,6 +19,11 @@ The benchmarks exercise the real `packages/cozy-client/src/store/queries.js` red
 - **`store-queries:sift-compiled-exec-10k`** — a pure `sift` canary: run a pre-compiled
   selector over 10k documents. Catches a raw `sift` slowdown (e.g. a version bump).
   Informational.
+- **`pouch-normalize:files-cold-cache`** — `cozy-pouch-link`'s `normalizeDocs` over 200
+  directories + 10k `io.cozy.files` with a cold path cache (via the built
+  `packages/cozy-pouch-link/dist`). Guards the per-file parent-path resolution done on
+  every sync: without directory-path seeding each file falls through to a `getById` per
+  file. Gated on a regression threshold.
 
 ## Running locally
 

--- a/packages/cozy-client/benchmarks/normalize-docs.bench.js
+++ b/packages/cozy-client/benchmarks/normalize-docs.bench.js
@@ -1,0 +1,68 @@
+const path = require('path')
+
+const pouchDist = path.join(__dirname, '..', '..', 'cozy-pouch-link', 'dist')
+const jsonapi = require(path.join(pouchDist, 'jsonapi.js'))
+
+const { normalizeDocs, resetAllPaths } = jsonapi
+
+const DOCTYPE = 'io.cozy.files'
+const N_FILES = 10000
+const N_DIRS = 200
+
+// queryFileById (hit when a file's parent path is not cached) calls
+// client.fetchQueryAndGetFromState. Resolve it trivially so the benchmark
+// never touches the network and the fire-and-forget promise is harmless.
+const client = {
+  fetchQueryAndGetFromState: () => Promise.resolve({ data: undefined })
+}
+
+const buildTemplate = () => {
+  const dirs = []
+  for (let d = 0; d < N_DIRS; d++) {
+    dirs.push({
+      _id: `dir_${d}`,
+      _rev: `1-${d}`,
+      _type: DOCTYPE,
+      type: 'directory',
+      dir_id: 'io.cozy.files.root-dir',
+      name: `folder-${d}`,
+      path: `/folder-${d}`
+    })
+  }
+  const files = []
+  for (let i = 0; i < N_FILES; i++) {
+    files.push({
+      _id: `file_${i}`,
+      _rev: `1-${i}`,
+      _type: DOCTYPE,
+      type: 'file',
+      dir_id: `dir_${i % N_DIRS}`,
+      name: `document-${i}.txt`
+    })
+  }
+  // Directories land in the middle: replication order is not tree-ordered.
+  const half = Math.floor(N_FILES / 2)
+  return [...files.slice(0, half), ...dirs, ...files.slice(half)]
+}
+
+const template = buildTemplate()
+
+const freshBatch = () => template.map(doc => ({ ...doc }))
+
+const getSpecs = () => [
+  {
+    name: 'pouch-normalize:files-cold-cache',
+    description:
+      'normalizeDocs over 200 dirs + 10k io.cozy.files with a cold path ' +
+      'cache: guards the per-file parent-path resolution done on a first sync',
+    warmup: 1,
+    runs: 5,
+    regressionThresholdPct: 25,
+    run: () => {
+      resetAllPaths()
+      normalizeDocs(client, DOCTYPE, freshBatch())
+    }
+  }
+]
+
+module.exports = { getSpecs }

--- a/packages/cozy-client/benchmarks/run.js
+++ b/packages/cozy-client/benchmarks/run.js
@@ -2,7 +2,10 @@ const fs = require('fs')
 const path = require('path')
 
 const { runSuite } = require('./harness')
-const { getSpecs } = require('./store-queries.bench')
+const { getSpecs: getStoreQueriesSpecs } = require('./store-queries.bench')
+const { getSpecs: getNormalizeDocsSpecs } = require('./normalize-docs.bench')
+
+const getSpecs = () => [...getStoreQueriesSpecs(), ...getNormalizeDocsSpecs()]
 
 const parseOut = argv => {
   const flag = argv.find(arg => arg.startsWith('--out='))
@@ -29,7 +32,10 @@ const main = () => {
   fs.writeFileSync(outPath, JSON.stringify(output, null, 2))
 
   for (const bench of benchmarks) {
-    const ops = bench.opsPerSec >= 1 ? bench.opsPerSec.toFixed(1) : bench.opsPerSec.toFixed(3)
+    const ops =
+      bench.opsPerSec >= 1
+        ? bench.opsPerSec.toFixed(1)
+        : bench.opsPerSec.toFixed(3)
     console.log(
       `${bench.name}: ${bench.medianMs.toFixed(3)} ms (median), ${ops} ops/s`
     )


### PR DESCRIPTION
Builds on top of the perf-benchmarks harness (base branch `ci/perf-benchmarks`).

Adds a benchmark for **cozy-pouch-link's `normalizeDocs`** — the hot path that
runs over every synced `io.cozy.files` doc. `normalizeDocs → computeFileFullpath`
resolves each file's full path from its parent directory. When the parent path
isn't in the in-memory cache, each file falls through to a `getById` — one query
per file — which serializes into thousands of queries on a first sync.

## `pouch-normalize:files-cold-cache`
- 200 directories + 10k files, **cold path cache** each run.
- Reads the built `packages/cozy-pouch-link/dist` (like the store benches read
  cozy-client's `dist/`).
- Gated on a 25% regression threshold; wired into `run.js` / `compare.js`.

This gives the perf CI a signal on the normalization path, and will track the
improvement from linagora/cozy-client#1700 (seed directory paths in
normalizeDocs to skip the per-file getById) once it lands.

Local: `pouch-normalize:files-cold-cache: ~48 ms (median)` alongside the
existing store-queries benchmarks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Benchmarks**
  * Added a cold-cache performance benchmark for normalizing 10,000 file documents across 200 directories.
  * Integrated the new benchmark into the benchmark runner with regression gating.
  * Documented the new measurement in the benchmark guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->