### PR TITLE
fix(pouch): complete mango operator coverage in the sqlite engine

### DIFF
--- a/packages/cozy-pouch-link/src/db/sqlite/sql.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sql.js
@@ -101,9 +101,31 @@ export const parseResults = (
 const escapeSQLString = str => str.replace(/'/g, "''")
 
 // Quote a value for inline SQL.
+// $in, $nin and $all are the operators whose operand is a list. A non-array
+// operand would reach .map / .length and either throw a TypeError or, worse,
+// silently iterate a string's characters.
+const requireArrayOperand = (operator, field, value) => {
+  if (!Array.isArray(value)) {
+    throw new UnsupportedMangoSelectorError(
+      `${operator} on "${field}" expects an array, got ${JSON.stringify(value)}`
+    )
+  }
+  return value
+}
+
+const joinTests = (tests, operator) =>
+  tests.length > 1 ? `(${tests.join(` ${operator} `)})` : tests[0]
+
 const quoteSQLValue = value => {
   if (typeof value === 'string') {
     return `'${escapeSQLString(value)}'`
+  }
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    // NaN and +/-Infinity have no SQL literal: they would be interpolated as the
+    // bare words "NaN" / "Infinity", which SQLite reads as column names.
+    throw new UnsupportedMangoSelectorError(
+      `Cannot express ${String(value)} as a SQL value`
+    )
   }
   if (value === undefined || (typeof value === 'object' && value !== null)) {
     // undefined, objects and arrays have no SQL literal form. A template
@@ -209,18 +231,38 @@ const parseCondition = (field, condition, columnName = 'data') => {
         `(${sqlField} IS NULL OR ${sqlField} != ${quoteSQLValue(value)})`
       )
     } else if (operator === '$in' || operator === '$nin') {
-      const list = value || []
+      const list = requireArrayOperand(operator, field, value)
       if (list.length === 0) {
         // "IN ()" is a syntax error. $in [] matches nothing (0 = false),
         // $nin [] matches everything (1 = true).
         conditions.push(operator === '$in' ? '0' : '1')
       } else {
-        const values = list.map(quoteSQLValue).join(', ')
-        conditions.push(
-          operator === '$in'
-            ? `${sqlField} IN (${values})`
-            : `(${sqlField} IS NULL OR ${sqlField} NOT IN (${values}))`
-        )
+        // SQL never matches NULL through IN / NOT IN, so a null member has to
+        // become an explicit IS NULL test rather than sit in the list.
+        const hasNull = list.some(item => item === null)
+        const values = list.filter(item => item !== null).map(quoteSQLValue)
+        const tests = []
+        if (operator === '$in') {
+          if (values.length > 0) {
+            tests.push(`${sqlField} IN (${values.join(', ')})`)
+          }
+          if (hasNull) {
+            tests.push(`${sqlField} IS NULL`)
+          }
+          conditions.push(joinTests(tests, 'OR'))
+        } else {
+          if (values.length > 0) {
+            tests.push(`${sqlField} NOT IN (${values.join(', ')})`)
+          }
+          // $nin keeps documents missing the field, matching CouchDB - unless
+          // null is itself excluded, which is exactly what those rows hold.
+          tests.push(
+            hasNull ? `${sqlField} IS NOT NULL` : `${sqlField} IS NULL`
+          )
+          conditions.push(
+            hasNull ? joinTests(tests, 'AND') : joinTests(tests.reverse(), 'OR')
+          )
+        }
       }
     } else if (operator === '$exists') {
       conditions.push(`${sqlField} IS ${value ? 'NOT NULL' : 'NULL'}`)
@@ -229,7 +271,7 @@ const parseCondition = (field, condition, columnName = 'data') => {
     } else if (operator === '$elemMatch') {
       conditions.push(parseElemMatch(field, value, columnName))
     } else if (operator === '$all') {
-      const list = value || []
+      const list = requireArrayOperand(operator, field, value)
       // One scan per value: SQLite has no "contains all of" primitive, and the
       // values may sit at any positions in the array.
       conditions.push(
@@ -308,9 +350,17 @@ const parseLogicalOperator = (operator, conditionsArray, columnName) => {
     )
   }
   const sqlOperator = operator === '$and' ? 'AND' : 'OR'
-  const parsedConditions = conditionsArray.map(
-    cond => `(${mangoSelectorToSQL(cond, columnName)})`
-  )
+  // An empty sub-selector translates to an empty string; wrapping it would emit
+  // "()" and break the statement.
+  const parsedConditions = conditionsArray
+    .map(cond => mangoSelectorToSQL(cond, columnName))
+    .filter(Boolean)
+    .map(sql => `(${sql})`)
+  if (parsedConditions.length === 0) {
+    throw new UnsupportedMangoSelectorError(
+      `${operator} expects at least one translatable selector`
+    )
+  }
   return parsedConditions.join(` ${sqlOperator} `)
 }
 
@@ -400,11 +450,19 @@ export const makeSortClause = mangoSortBy => {
   // every field the first entry's way and silently ignore mixed asc/desc sorts.
   return mangoSortBy
     .map(sort => {
-      const attribute = Object.keys(sort)[0]
+      // A bare string is the shorthand for ascending on that field; Object.keys
+      // would otherwise read its first index and sort on the JSON path "$.0".
+      const entry = typeof sort === 'string' ? { [sort]: 'asc' } : sort
+      if (!isPlainObject(entry)) {
+        throw new UnsupportedMangoSelectorError(
+          `Cannot sort on ${JSON.stringify(sort)}`
+        )
+      }
+      const attribute = Object.keys(entry)[0]
       // ASC/DESC are bare SQL keywords, so the direction cannot be quoted the
       // way a value would be - it has to be whitelisted instead.
       const order =
-        String(sort[attribute]).toUpperCase() === 'DESC' ? 'DESC' : 'ASC'
+        String(entry[attribute]).toUpperCase() === 'DESC' ? 'DESC' : 'ASC'
       return `${transformMangoFieldInJSONSQL(attribute)} ${order}`
     })
     .join(', ')

--- a/packages/cozy-pouch-link/src/db/sqlite/sql.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sql.js
@@ -401,8 +401,11 @@ export const makeSortClause = mangoSortBy => {
   return mangoSortBy
     .map(sort => {
       const attribute = Object.keys(sort)[0]
-      const order = String(sort[attribute]).toUpperCase()
-      return `json_extract(data, '$.${attribute}') ${order}`
+      // ASC/DESC are bare SQL keywords, so the direction cannot be quoted the
+      // way a value would be - it has to be whitelisted instead.
+      const order =
+        String(sort[attribute]).toUpperCase() === 'DESC' ? 'DESC' : 'ASC'
+      return `${transformMangoFieldInJSONSQL(attribute)} ${order}`
     })
     .join(', ')
 }
@@ -499,8 +502,14 @@ export const makeSQLCreateMangoIndex = (
   fieldsToIndex,
   { partialFilter }
 ) => {
+  // Escaped like the where clause's paths, so an index covers exactly the
+  // expression makeWhereClause emits for the same field.
+  // XXX - indexName itself is still interpolated raw here, in makeSQLDropIndex
+  // and in makeSQLQueryFromMango's INDEXED BY. The three must agree, so they are
+  // left alone together: a field name containing a quote would break index
+  // resolution rather than the where clause.
   const jsonAttributes = fieldsToIndex.map(
-    field => `json_extract(json, '$.${field}')`
+    field => `json_extract(json, '$.${escapeSQLString(field)}')`
   )
   const jsonIndex = jsonAttributes.join(',')
 

--- a/packages/cozy-pouch-link/src/db/sqlite/sql.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sql.js
@@ -1,16 +1,26 @@
 import { normalizeDoc } from '../../jsonapi'
 import { getCozyPouchData } from '../helpers'
+import { UnsupportedMangoSelectorError } from '../../errors'
 
+// Binary operators with a direct SQL equivalent. Everything else needs its own
+// SQL shape and is handled explicitly in parseCondition.
 const MANGO_TO_SQL_OP = {
   $eq: '=',
-  $ne: '!=',
   $gt: '>',
   $gte: '>=',
   $lt: '<',
-  $lte: '<=',
-  $in: 'IN',
-  $nin: 'NOT IN',
-  $exists: 'IS'
+  $lte: '<='
+}
+
+// Mango and SQLite do not spell types the same way: json_type() reports integers
+// and reals separately, and booleans as 'true'/'false'.
+const MANGO_TYPE_TO_JSON_TYPES = {
+  null: ['null'],
+  boolean: ['true', 'false'],
+  number: ['integer', 'real'],
+  string: ['text'],
+  array: ['array'],
+  object: ['object']
 }
 
 const extractRevPrefix = rev => {
@@ -86,63 +96,220 @@ export const parseResults = (
   }
 }
 
-// Quote a value for inline SQL. String single quotes are doubled ('' ) so a
-// value like "l'ete.txt" cannot break out of the literal (SQL error) or inject.
+// Single quotes are doubled ('') so a value like "l'ete.txt" cannot break out of
+// the literal (SQL error) or inject.
+const escapeSQLString = str => str.replace(/'/g, "''")
+
+// Quote a value for inline SQL.
 const quoteSQLValue = value => {
   if (typeof value === 'string') {
-    return `'${value.replace(/'/g, "''")}'`
+    return `'${escapeSQLString(value)}'`
+  }
+  if (value === undefined || (typeof value === 'object' && value !== null)) {
+    // undefined, objects and arrays have no SQL literal form. A template
+    // literal would stringify undefined to the word "undefined" - the very
+    // failure this translator exists to make impossible - and an object to
+    // "[object Object]".
+    throw new UnsupportedMangoSelectorError(
+      `Cannot express ${JSON.stringify(value)} as a SQL value`
+    )
   }
   return value
 }
 
-const parseCondition = (field, condition, columnName) => {
+// Mango forbids mixing operators and field names in the same object, so a single
+// $-prefixed key is enough to tell an operator object ({ $gt: 1 }) from a nested
+// document selector ({ b: 'x' }).
+const isOperatorObject = obj =>
+  Object.keys(obj).some(key => key.startsWith('$'))
+
+const isPlainObject = value =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+// json_extract yields SQL NULL for a missing path, and NOT NULL is NULL rather
+// than true. CouchDB's $not / $nor match documents where the inner condition
+// merely fails to hold, missing field included, so resolve the unknown to false
+// before negating.
+const negate = sql => `NOT IFNULL((${sql}), 0)`
+
+// json_each / json_type / json_array_length take (column, path) rather than a
+// pre-extracted value: json_extract unwraps a JSON string into bare SQL text,
+// which those functions then fail to re-parse as JSON.
+const makeJSONFunctionArgs = (field, columnName) =>
+  field ? `${columnName}, '$.${escapeSQLString(field)}'` : columnName
+
+// "at least one element of the array satisfies elementWhere", where the element
+// is bound to `elem.value`.
+const makeArrayElementExists = (field, columnName, elementWhere) =>
+  `EXISTS (SELECT 1 FROM json_each(${makeJSONFunctionArgs(
+    field,
+    columnName
+  )}) AS elem WHERE ${elementWhere})`
+
+// A sub-selector made of operators applies to the array element itself
+// ({ tags: { $elemMatch: { $eq: 'a' } } }); one made of field names applies to
+// the element's subfields ({ referenced_by: { $elemMatch: { type: 'album' } } }).
+const parseElemMatch = (field, subSelector, columnName) => {
+  if (!isPlainObject(subSelector)) {
+    throw new UnsupportedMangoSelectorError(
+      `$elemMatch on "${field}" expects a selector`
+    )
+  }
+  const elementColumn = 'elem.value'
+  const where = isOperatorObject(subSelector)
+    ? parseCondition('', subSelector, elementColumn)
+    : mangoSelectorToSQL(subSelector, elementColumn)
+  return makeArrayElementExists(field, columnName, where)
+}
+
+const parseCondition = (field, condition, columnName = 'data') => {
   const conditions = []
-
   const sqlField = transformMangoFieldInJSONSQL(field, columnName)
-  if (typeof condition === 'object' && !Array.isArray(condition)) {
-    for (const operator in condition) {
-      let sqlOp = MANGO_TO_SQL_OP[operator]
 
-      if (operator === '$in' || operator === '$nin') {
-        const list = condition[operator] || []
-        if (list.length === 0) {
-          // "IN ()" is a syntax error. $in [] matches nothing (0 = false),
-          // $nin [] matches everything (1 = true).
-          conditions.push(operator === '$in' ? '0' : '1')
-        } else {
-          const values = list.map(quoteSQLValue).join(', ')
-          conditions.push(`${sqlField} ${sqlOp} (${values})`)
-        }
-      } else if (operator === '$exists') {
-        const value = condition[operator]
-        if (value) {
-          sqlOp += ' NOT NULL'
-        } else {
-          sqlOp += ' NULL'
-        }
-        conditions.push(`${sqlField} ${sqlOp}`)
-      } else {
-        if (operator === '$gt' && condition[operator] === null) {
-          // Special case for $gt: null conditions
-          conditions.push(`${sqlField} IS NOT NULL`)
-        } else {
-          conditions.push(
-            `${sqlField} ${sqlOp} ${quoteSQLValue(condition[operator])}`
-          )
-        }
-      }
+  if (!isPlainObject(condition)) {
+    // Implicit equality. Routed through $eq so `null` gets the same IS NULL
+    // treatment as its explicit form.
+    return parseCondition(field, { $eq: condition }, columnName)
+  }
+
+  if (!isOperatorObject(condition)) {
+    // A nested document means subfield equality: { a: { b: 'x' } } selects the
+    // same documents as { 'a.b': 'x' }.
+    for (const subField in condition) {
+      conditions.push(
+        parseCondition(`${field}.${subField}`, condition[subField], columnName)
+      )
     }
-  } else {
-    conditions.push(`${sqlField} = ${quoteSQLValue(condition)}`)
+    return conditions.join(' AND ')
+  }
+
+  for (const operator in condition) {
+    const value = condition[operator]
+    const sqlOp = MANGO_TO_SQL_OP[operator]
+
+    // json_extract returns SQL NULL both for a JSON null and for a missing path,
+    // so every null comparison needs an IS [NOT] NULL form: `= NULL` and
+    // `!= NULL` are NULL, never true.
+    if (operator === '$eq' && value === null) {
+      conditions.push(`${sqlField} IS NULL`)
+    } else if ((operator === '$gt' || operator === '$ne') && value === null) {
+      conditions.push(`${sqlField} IS NOT NULL`)
+    } else if (value === null && sqlOp) {
+      // The remaining range operators have no meaningful null form here: `x >=
+      // NULL` is NULL for every row, so the query would silently match nothing.
+      // CouchDB orders null against every other type, which SQL comparison does
+      // not, so hand these to pouch-find rather than approximate them.
+      throw new UnsupportedMangoSelectorError(
+        `Cannot compare "${field}" to null with "${operator}"`
+      )
+    } else if (operator === '$ne') {
+      // CouchDB matches a missing field: `x != v` is NULL, not true, when
+      // json_extract finds nothing, so the absent case needs its own branch.
+      conditions.push(
+        `(${sqlField} IS NULL OR ${sqlField} != ${quoteSQLValue(value)})`
+      )
+    } else if (operator === '$in' || operator === '$nin') {
+      const list = value || []
+      if (list.length === 0) {
+        // "IN ()" is a syntax error. $in [] matches nothing (0 = false),
+        // $nin [] matches everything (1 = true).
+        conditions.push(operator === '$in' ? '0' : '1')
+      } else {
+        const values = list.map(quoteSQLValue).join(', ')
+        conditions.push(
+          operator === '$in'
+            ? `${sqlField} IN (${values})`
+            : `(${sqlField} IS NULL OR ${sqlField} NOT IN (${values}))`
+        )
+      }
+    } else if (operator === '$exists') {
+      conditions.push(`${sqlField} IS ${value ? 'NOT NULL' : 'NULL'}`)
+    } else if (operator === '$not') {
+      conditions.push(negate(parseCondition(field, value, columnName)))
+    } else if (operator === '$elemMatch') {
+      conditions.push(parseElemMatch(field, value, columnName))
+    } else if (operator === '$all') {
+      const list = value || []
+      // One scan per value: SQLite has no "contains all of" primitive, and the
+      // values may sit at any positions in the array.
+      conditions.push(
+        list.length === 0
+          ? '1'
+          : list
+              .map(item =>
+                makeArrayElementExists(
+                  field,
+                  columnName,
+                  `elem.value = ${quoteSQLValue(item)}`
+                )
+              )
+              .join(' AND ')
+      )
+    } else if (operator === '$size') {
+      conditions.push(
+        `json_array_length(${makeJSONFunctionArgs(
+          field,
+          columnName
+        )}) = ${quoteSQLValue(value)}`
+      )
+    } else if (operator === '$mod') {
+      if (!Array.isArray(value) || value.length !== 2) {
+        throw new UnsupportedMangoSelectorError(
+          `$mod on "${field}" expects a [divisor, remainder] pair`
+        )
+      }
+      // The numeric guard is not decoration: SQLite coerces a non-numeric
+      // operand of % to 0, so a text field would match any {$mod: [d, 0]}.
+      conditions.push(
+        `(json_type(${makeJSONFunctionArgs(
+          field,
+          columnName
+        )}) IN (${MANGO_TYPE_TO_JSON_TYPES.number
+          .map(quoteSQLValue)
+          .join(', ')}) AND ${sqlField} % ${quoteSQLValue(
+          value[0]
+        )} = ${quoteSQLValue(value[1])})`
+      )
+    } else if (operator === '$type') {
+      const jsonTypes = MANGO_TYPE_TO_JSON_TYPES[value]
+      if (!jsonTypes) {
+        throw new UnsupportedMangoSelectorError(
+          `Unsupported mango $type "${value}" on field "${field}"`
+        )
+      }
+      conditions.push(
+        `json_type(${makeJSONFunctionArgs(
+          field,
+          columnName
+        )}) IN (${jsonTypes.map(quoteSQLValue).join(', ')})`
+      )
+    } else if (sqlOp) {
+      conditions.push(`${sqlField} ${sqlOp} ${quoteSQLValue(value)}`)
+    } else {
+      // The single point where an untranslatable selector is caught. $regex ends
+      // up here - op-sqlite exposes no way to register a REGEXP function - along
+      // with any operator this translator does not know. Throwing rather than
+      // interpolating an undefined operator is what guarantees the generated SQL
+      // never contains "undefined"; SQLiteQueryEngine turns it into a pouch-find
+      // fallback.
+      throw new UnsupportedMangoSelectorError(
+        `Unsupported mango operator "${operator}" on field "${field}"`
+      )
+    }
   }
 
   return conditions.join(' AND ')
 }
 
 const parseLogicalOperator = (operator, conditionsArray, columnName) => {
+  if (!Array.isArray(conditionsArray) || conditionsArray.length === 0) {
+    throw new UnsupportedMangoSelectorError(
+      `${operator} expects a non-empty array of selectors`
+    )
+  }
   const sqlOperator = operator === '$and' ? 'AND' : 'OR'
   const parsedConditions = conditionsArray.map(
-    cond => `(${mangoSelectorToSQL(cond, columnName).replace(/^WHERE /, '')})`
+    cond => `(${mangoSelectorToSQL(cond, columnName)})`
   )
   return parsedConditions.join(` ${sqlOperator} `)
 }
@@ -155,23 +322,52 @@ const PHYSICAL_COLUMNS = { _id: 'doc_id', _rev: 'rev' }
 
 const transformMangoFieldInJSONSQL = (field, columnName = 'data') => {
   const physicalColumn = PHYSICAL_COLUMNS[field]
-  if (physicalColumn) {
-    // `data` is the query alias, where by-sequence is joined with document-store
-    // and the column needs qualifying; `json` is the CREATE INDEX context, which
-    // is scoped to by-sequence alone and must stay unqualified.
+  // Only at document level: inside a json_each element (`elem.value`) the row
+  // is an array item, which has no doc_id / rev of its own.
+  if (physicalColumn && (columnName === 'data' || columnName === 'json')) {
+    // `data` is the query alias, where by-sequence is joined with
+    // document-store and the column needs qualifying; `json` is the CREATE
+    // INDEX context, scoped to by-sequence alone, which must stay unqualified.
     return columnName === 'json'
       ? physicalColumn
       : `'by-sequence'.${physicalColumn}`
   }
-  return `json_extract(${columnName}, '$.${field}')`
+  if (!field) {
+    // No path: the value IS the column (a json_each element, for $elemMatch on
+    // an array of scalars). json_extract would re-parse it as JSON and fail on a
+    // bare string.
+    return columnName
+  }
+  return `json_extract(${columnName}, '$.${escapeSQLString(field)}')`
 }
 
-export const mangoSelectorToSQL = (selector, columnName) => {
+/**
+ * Translate a mango selector into a SQL boolean expression.
+ *
+ * @param {object} selector - The mango selector
+ * @param {string} [columnName] - The JSON column the paths are resolved against
+ * @returns {string} The SQL expression, never containing "undefined"
+ * @throws {UnsupportedMangoSelectorError} When the selector uses a mango feature
+ * this translator cannot express in SQL
+ */
+export const mangoSelectorToSQL = (selector, columnName = 'data') => {
+  if (!isPlainObject(selector)) {
+    throw new UnsupportedMangoSelectorError(
+      `Expected a selector, got ${JSON.stringify(selector)}`
+    )
+  }
   const conditions = []
 
   for (const key in selector) {
     if (key === '$and' || key === '$or') {
       conditions.push(parseLogicalOperator(key, selector[key], columnName))
+    } else if (key === '$nor') {
+      // "none of these match" is the negation of the $or.
+      conditions.push(
+        negate(parseLogicalOperator('$or', selector[key], columnName))
+      )
+    } else if (key === '$not') {
+      conditions.push(negate(mangoSelectorToSQL(selector[key], columnName)))
     } else {
       conditions.push(parseCondition(key, selector[key], columnName))
     }

--- a/packages/cozy-pouch-link/src/db/sqlite/sql.mango.spec.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sql.mango.spec.js
@@ -1,3 +1,5 @@
+import { UnsupportedMangoSelectorError } from '../../errors'
+
 import { makeWhereClause, makeSortClause, makeSQLQueryForIds } from './sql'
 
 // Compatibility of the native SQLite engine with the mango selector language
@@ -5,9 +7,10 @@ import { makeWhereClause, makeSortClause, makeSQLQueryForIds } from './sql'
 //
 // - "correctness fixes" lock the behaviour of selectors the engine DOES accept
 //   but used to mistranslate (quoting, $or precedence, empty $in, sort order).
-// - "gaps" document selectors mango accepts that the engine cannot translate
-//   yet; they are `.skip` and assert the SQL we want, so each unskips the day
-//   the gap is closed. See the tracking issue for the full matrix.
+// - "operator coverage" locks the operators the translator now expresses in SQL.
+// - "unsupported selectors" locks the other half of the contract: anything the
+//   translator cannot express throws, so SQLiteQueryEngine can route the query
+//   to pouch-find. No selector may ever produce "undefined" in the SQL.
 
 describe('native SQLite mango — correctness fixes', () => {
   it('escapes single quotes in string values (no SQL break / injection)', () => {
@@ -43,48 +46,176 @@ describe('native SQLite mango — correctness fixes', () => {
   })
 })
 
-describe('native SQLite mango — gaps (mango accepts, engine does not yet)', () => {
-  // $not / $nor are currently read as field names -> "json_extract('$.$not') undefined"
-  it.skip('translates $not', () => {
-    expect(makeWhereClause({ $not: { type: 'file' } })).not.toContain(
-      'undefined'
+describe('native SQLite mango — operator coverage', () => {
+  it('translates $not', () => {
+    // IFNULL, not a bare NOT: NOT NULL is NULL, so a document missing the field
+    // would be dropped where CouchDB keeps it.
+    expect(makeWhereClause({ $not: { type: 'file' } })).toBe(
+      "DELETED = 0 AND (NOT IFNULL((json_extract(data, '$.type') = 'file'), 0))"
     )
   })
 
-  // No mapping in MANGO_TO_SQL_OP -> literal "undefined" in the SQL
-  it.skip('translates $regex', () => {
-    expect(makeWhereClause({ name: { $regex: '^foo' } })).not.toContain(
-      'undefined'
+  it('translates a field-level $not', () => {
+    expect(makeWhereClause({ type: { $not: { $eq: 'file' } } })).toBe(
+      "DELETED = 0 AND (NOT IFNULL((json_extract(data, '$.type') = 'file'), 0))"
     )
   })
 
-  // Array operators are entirely absent
-  it.skip('translates $elemMatch on an array field', () => {
+  it('translates $nor as the negation of the $or', () => {
+    expect(
+      makeWhereClause({ $nor: [{ type: 'file' }, { type: 'directory' }] })
+    ).toBe(
+      "DELETED = 0 AND (NOT IFNULL(((json_extract(data, '$.type') = 'file') OR (json_extract(data, '$.type') = 'directory')), 0))"
+    )
+  })
+
+  it('translates $elemMatch on an array of objects', () => {
     expect(
       makeWhereClause({ referenced_by: { $elemMatch: { type: 'album' } } })
-    ).not.toContain('undefined')
-  })
-  it.skip('translates $all', () => {
-    expect(makeWhereClause({ tags: { $all: ['a', 'b'] } })).not.toContain(
-      'undefined'
+    ).toBe(
+      "DELETED = 0 AND (EXISTS (SELECT 1 FROM json_each(data, '$.referenced_by') AS elem WHERE json_extract(elem.value, '$.type') = 'album'))"
     )
   })
-  it.skip('translates $size', () => {
-    expect(makeWhereClause({ tags: { $size: 3 } })).not.toContain('undefined')
+
+  it('translates $elemMatch on an array of scalars against the element itself', () => {
+    expect(makeWhereClause({ tags: { $elemMatch: { $eq: 'a' } } })).toBe(
+      "DELETED = 0 AND (EXISTS (SELECT 1 FROM json_each(data, '$.tags') AS elem WHERE elem.value = 'a'))"
+    )
   })
 
-  // A nested object means subfield equality; the sub-keys are currently iterated
-  // as operators -> "json_extract('$.cozyMetadata') undefined 'drive'"
-  it.skip('treats a nested object as subfield equality', () => {
+  it('translates $all', () => {
+    expect(makeWhereClause({ tags: { $all: ['a', 'b'] } })).toBe(
+      "DELETED = 0 AND (EXISTS (SELECT 1 FROM json_each(data, '$.tags') AS elem WHERE elem.value = 'a') AND EXISTS (SELECT 1 FROM json_each(data, '$.tags') AS elem WHERE elem.value = 'b'))"
+    )
+  })
+
+  it('translates $size', () => {
+    expect(makeWhereClause({ tags: { $size: 3 } })).toBe(
+      "DELETED = 0 AND (json_array_length(data, '$.tags') = 3)"
+    )
+  })
+
+  it('translates $mod, guarding against SQLite coercing text to 0', () => {
+    expect(makeWhereClause({ count: { $mod: [4, 0] } })).toBe(
+      "DELETED = 0 AND ((json_type(data, '$.count') IN ('integer', 'real') AND json_extract(data, '$.count') % 4 = 0))"
+    )
+  })
+
+  it('maps mango $type onto the json_type vocabulary', () => {
+    expect(makeWhereClause({ size: { $type: 'number' } })).toBe(
+      "DELETED = 0 AND (json_type(data, '$.size') IN ('integer', 'real'))"
+    )
+    expect(makeWhereClause({ trashed: { $type: 'boolean' } })).toBe(
+      "DELETED = 0 AND (json_type(data, '$.trashed') IN ('true', 'false'))"
+    )
+  })
+
+  it('treats a nested object as subfield equality', () => {
     expect(makeWhereClause({ cozyMetadata: { createdByApp: 'drive' } })).toBe(
       "DELETED = 0 AND (json_extract(data, '$.cozyMetadata.createdByApp') = 'drive')"
     )
   })
 
-  // "= NULL" never matches; mango $eq null should match null / missing
-  it.skip('translates $eq null to an IS NULL check', () => {
+  it('recurses through several levels of nested objects', () => {
+    expect(makeWhereClause({ a: { b: { c: 'x' } } })).toBe(
+      "DELETED = 0 AND (json_extract(data, '$.a.b.c') = 'x')"
+    )
+  })
+
+  it('translates $eq null to an IS NULL check', () => {
     expect(makeWhereClause({ trashed: { $eq: null } })).toBe(
       "DELETED = 0 AND (json_extract(data, '$.trashed') IS NULL)"
     )
+  })
+
+  it('translates an implicit null equality the same way', () => {
+    expect(makeWhereClause({ trashed: null })).toBe(
+      "DELETED = 0 AND (json_extract(data, '$.trashed') IS NULL)"
+    )
+  })
+
+  it('matches missing fields on $ne and $nin, as CouchDB does', () => {
+    expect(makeWhereClause({ type: { $ne: 'file' } })).toBe(
+      "DELETED = 0 AND ((json_extract(data, '$.type') IS NULL OR json_extract(data, '$.type') != 'file'))"
+    )
+    expect(makeWhereClause({ type: { $nin: ['file'] } })).toBe(
+      "DELETED = 0 AND ((json_extract(data, '$.type') IS NULL OR json_extract(data, '$.type') NOT IN ('file')))"
+    )
+  })
+
+  it('translates $ne null to an IS NOT NULL check', () => {
+    expect(makeWhereClause({ trashed: { $ne: null } })).toBe(
+      "DELETED = 0 AND (json_extract(data, '$.trashed') IS NOT NULL)"
+    )
+  })
+
+  it('escapes single quotes in field names as well as values', () => {
+    expect(makeWhereClause({ "l'ete": 'x' })).toBe(
+      "DELETED = 0 AND (json_extract(data, '$.l''ete') = 'x')"
+    )
+  })
+})
+
+describe('native SQLite mango — unsupported selectors are routed, never mistranslated', () => {
+  // op-sqlite exposes no way to register a REGEXP function, so $regex cannot be
+  // expressed here at all. It must be detected, not approximated.
+  it('rejects $regex', () => {
+    expect(() => makeWhereClause({ name: { $regex: '^foo' } })).toThrow(
+      UnsupportedMangoSelectorError
+    )
+  })
+
+  it('rejects any unknown operator', () => {
+    expect(() => makeWhereClause({ name: { $whatever: 1 } })).toThrow(
+      UnsupportedMangoSelectorError
+    )
+  })
+
+  it('rejects a $type mango does accept but json_type does not name', () => {
+    expect(() => makeWhereClause({ size: { $type: 'decimal' } })).toThrow(
+      UnsupportedMangoSelectorError
+    )
+  })
+
+  it('rejects a malformed $mod instead of emitting a half-built expression', () => {
+    expect(() => makeWhereClause({ count: { $mod: [4] } })).toThrow(
+      UnsupportedMangoSelectorError
+    )
+  })
+
+  it('rejects a value with no SQL literal form', () => {
+    expect(() => makeWhereClause({ meta: { $gt: { a: 1 } } })).toThrow(
+      UnsupportedMangoSelectorError
+    )
+  })
+
+  // A template literal stringifies undefined to the word "undefined", so an
+  // unresolved variable in a selector - Q().where({ dir_id: someVar }) - is the
+  // shortest path back to the bug this whole change is about.
+  it('rejects an undefined value rather than stringifying it', () => {
+    expect(() => makeWhereClause({ dir_id: undefined })).toThrow(
+      UnsupportedMangoSelectorError
+    )
+  })
+
+  // $gt: null is the "field exists" idiom normalizeFindSelector injects, so it
+  // stays supported; the other range operators have no sound null form here.
+  it('rejects range operators compared to null, except $gt', () => {
+    expect(makeWhereClause({ date: { $gt: null } })).toBe(
+      "DELETED = 0 AND (json_extract(data, '$.date') IS NOT NULL)"
+    )
+    for (const operator of ['$gte', '$lt', '$lte']) {
+      expect(() => makeWhereClause({ date: { [operator]: null } })).toThrow(
+        UnsupportedMangoSelectorError
+      )
+    }
+  })
+
+  it('detects an unsupported operator nested inside a logical operator', () => {
+    expect(() =>
+      makeWhereClause({
+        $and: [{ type: 'file' }, { name: { $regex: '^foo' } }]
+      })
+    ).toThrow(UnsupportedMangoSelectorError)
   })
 })

--- a/packages/cozy-pouch-link/src/db/sqlite/sql.mango.spec.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sql.mango.spec.js
@@ -41,6 +41,20 @@ describe('native SQLite mango — correctness fixes', () => {
     )
   })
 
+  it('whitelists the sort direction instead of interpolating it', () => {
+    // ASC/DESC are bare keywords, so an unrecognised direction cannot simply be
+    // quoted - it has to be rejected.
+    expect(makeSortClause([{ name: 'asc; DROP TABLE docs' }])).toBe(
+      "json_extract(data, '$.name') ASC"
+    )
+  })
+
+  it('escapes single quotes in sorted field names too', () => {
+    expect(makeSortClause([{ "l'ete": 'asc' }])).toBe(
+      "json_extract(data, '$.l''ete') ASC"
+    )
+  })
+
   it('quotes each id separately in getByIds', () => {
     expect(makeSQLQueryForIds(['a', 'b'])).toContain('IN ("a", "b")')
   })

--- a/packages/cozy-pouch-link/src/db/sqlite/sql.mango.spec.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sql.mango.spec.js
@@ -232,4 +232,59 @@ describe('native SQLite mango — unsupported selectors are routed, never mistra
       })
     ).toThrow(UnsupportedMangoSelectorError)
   })
+
+  it('rejects a list operator whose operand is not an array', () => {
+    for (const operator of ['$in', '$nin', '$all']) {
+      expect(() => makeWhereClause({ tags: { [operator]: 'a' } })).toThrow(
+        UnsupportedMangoSelectorError
+      )
+    }
+  })
+
+  it('rejects a non-finite number', () => {
+    for (const value of [NaN, Infinity, -Infinity]) {
+      expect(() => makeWhereClause({ size: { $gt: value } })).toThrow(
+        UnsupportedMangoSelectorError
+      )
+    }
+  })
+
+  it('rejects a logical operator whose sub-selectors are all empty', () => {
+    expect(() => makeWhereClause({ $or: [{}, {}] })).toThrow(
+      UnsupportedMangoSelectorError
+    )
+  })
+
+  // SQL never matches NULL through IN / NOT IN, so a null member has to become
+  // an explicit IS NULL test.
+  it('tests null members of $in explicitly', () => {
+    expect(makeWhereClause({ name: { $in: [null] } })).toBe(
+      "DELETED = 0 AND (json_extract(data, '$.name') IS NULL)"
+    )
+    expect(makeWhereClause({ name: { $in: ['a', null] } })).toBe(
+      "DELETED = 0 AND ((json_extract(data, '$.name') IN ('a') OR json_extract(data, '$.name') IS NULL))"
+    )
+  })
+
+  it('excludes documents missing the field when $nin excludes null', () => {
+    expect(makeWhereClause({ name: { $nin: ['a', null] } })).toBe(
+      "DELETED = 0 AND ((json_extract(data, '$.name') NOT IN ('a') AND json_extract(data, '$.name') IS NOT NULL))"
+    )
+  })
+
+  it('keeps documents missing the field when $nin does not mention null', () => {
+    expect(makeWhereClause({ name: { $nin: ['a'] } })).toBe(
+      "DELETED = 0 AND ((json_extract(data, '$.name') IS NULL OR json_extract(data, '$.name') NOT IN ('a')))"
+    )
+  })
+
+  it('reads a bare string sort entry as ascending on that field', () => {
+    expect(makeSortClause(['name'])).toBe("json_extract(data, '$.name') ASC")
+  })
+
+  it('drops an empty sub-selector from a logical operator', () => {
+    expect(makeWhereClause({ $or: [{}, { type: 'file' }] })).toBe(
+      "DELETED = 0 AND ((json_extract(data, '$.type') = 'file'))"
+    )
+  })
 })

--- a/packages/cozy-pouch-link/src/db/sqlite/sql.spec.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sql.spec.js
@@ -32,9 +32,11 @@ describe('mangoSelectorToSQL', () => {
   })
 
   it('should handle $neq operator', () => {
+    // The IS NULL arm keeps documents missing the field, which CouchDB matches
+    // but a bare `!=` would drop (json_extract returns NULL for them).
     const selector = { status: { $ne: 'active' } }
     expect(mangoSelectorToSQL(selector)).toBe(
-      "json_extract(data, '$.status') != 'active'"
+      "(json_extract(data, '$.status') IS NULL OR json_extract(data, '$.status') != 'active')"
     )
   })
 
@@ -44,7 +46,7 @@ describe('mangoSelectorToSQL', () => {
       other_status: { $nin: ['maintenance', 'failing'] }
     }
     expect(mangoSelectorToSQL(selector)).toBe(
-      "json_extract(data, '$.status') IN ('active', 'pending') AND json_extract(data, '$.other_status') NOT IN ('maintenance', 'failing')"
+      "json_extract(data, '$.status') IN ('active', 'pending') AND (json_extract(data, '$.other_status') IS NULL OR json_extract(data, '$.other_status') NOT IN ('maintenance', 'failing'))"
     )
   })
 

--- a/packages/cozy-pouch-link/src/db/sqlite/sqliteDb.native.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sqliteDb.native.js
@@ -30,6 +30,13 @@ export default class SQLiteQueryEngine extends DatabaseQueryEngine {
     this.pouchManager = pouchManager
     this.client = pouchManager?.client
     this.doctype = doctype
+    /**
+     * Lazily built by getPouchFallback, and dropped whenever openDB points this
+     * engine at another database.
+     *
+     * @type {PouchDBQueryEngine | null}
+     */
+    this.pouchFallback = null
   }
 
   openDB(dbName) {

--- a/packages/cozy-pouch-link/src/db/sqlite/sqliteDb.native.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sqliteDb.native.js
@@ -34,6 +34,10 @@ export default class SQLiteQueryEngine extends DatabaseQueryEngine {
 
   openDB(dbName) {
     this.dbName = dbName
+    // The fallback caches a connection to the PREVIOUS dbName; reopening on a
+    // different database has to drop it, or queries would keep being answered
+    // from the database this engine no longer points at.
+    this.pouchFallback = null
     const fileDbName = `${dbName}.sqlite`
     // Resolve the DB handle lazily on first use, opening our OWN op-sqlite
     // connection on the same file the adapter uses. WAL mode + a busy timeout

--- a/packages/cozy-pouch-link/src/db/sqlite/sqliteDb.native.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sqliteDb.native.js
@@ -16,18 +16,24 @@ import {
   parseResults
 } from './sql'
 import { getIndexFields, getIndexName } from '../../mango'
-import { isMissingSQLiteIndexError } from '../../errors'
+import {
+  isMissingSQLiteIndexError,
+  isUnsupportedMangoSelectorError
+} from '../../errors'
+import PouchDBQueryEngine from '../pouchdb/pouchdb'
 import logger from '../../logger'
 
 export default class SQLiteQueryEngine extends DatabaseQueryEngine {
   constructor(pouchManager, doctype) {
     super()
     this.db = null
+    this.pouchManager = pouchManager
     this.client = pouchManager?.client
     this.doctype = doctype
   }
 
   openDB(dbName) {
+    this.dbName = dbName
     const fileDbName = `${dbName}.sqlite`
     // Resolve the DB handle lazily on first use, opening our OWN op-sqlite
     // connection on the same file the adapter uses. WAL mode + a busy timeout
@@ -55,6 +61,20 @@ export default class SQLiteQueryEngine extends DatabaseQueryEngine {
         return resolved
       }
     })
+  }
+
+  // pouch-find can answer every mango selector, at the cost of the mapreduce view
+  // this engine exists to avoid. Built lazily so the PouchDB handle is only
+  // resolved by queries that actually need it.
+  getPouchFallback() {
+    if (!this.pouchFallback) {
+      this.pouchFallback = new PouchDBQueryEngine(
+        this.pouchManager,
+        this.doctype
+      )
+      this.pouchFallback.openDB(this.dbName)
+    }
+    return this.pouchFallback
   }
 
   async allDocs({ limit = -1, skip = 0 } = {}) {
@@ -121,36 +141,52 @@ export default class SQLiteQueryEngine extends DatabaseQueryEngine {
       partialFilter,
       indexedFields
     })
-    const sql = makeSQLQueryFromMango({
-      selector,
-      sort,
-      indexName,
-      partialFilter,
-      limit,
-      skip
-    })
-    let result
-    if (recreateIndex) {
-      await deleteIndex(this.db, indexName)
-    }
+    let sql
     try {
-      result = await executeSQL(this.db, sql)
+      sql = makeSQLQueryFromMango({
+        selector,
+        sort,
+        indexName,
+        partialFilter,
+        limit,
+        skip
+      })
     } catch (err) {
-      if (isMissingSQLiteIndexError(err)) {
+      if (!isUnsupportedMangoSelectorError(err)) {
+        throw err
+      }
+      // The selector uses mango features SQL cannot express here ($regex, ...).
+      // Answering it with an empty result would be indistinguishable from "no
+      // match", so let pouch-find handle it instead.
+      logger.warn(`${err.message} - falling back to the PouchDB query engine`)
+      return this.getPouchFallback().find(options)
+    }
+
+    try {
+      if (recreateIndex) {
+        await deleteIndex(this.db, indexName)
+      }
+      let result
+      try {
+        result = await executeSQL(this.db, sql)
+      } catch (err) {
+        if (!isMissingSQLiteIndexError(err)) {
+          throw err
+        }
         await createMangoIndex(this.db, indexName, indexedFields, {
           partialFilter
         })
         result = await executeSQL(this.db, sql)
-      } else {
-        logger.error(err)
-        return null
       }
+      return parseResults(this.client, result, this.doctype, {
+        skip,
+        limit
+      })
+    } catch (err) {
+      // Returning null here would surface as an empty - but successful - result.
+      // Falling back makes a SQLite failure cost performance, not correctness.
+      logger.error(err)
+      return this.getPouchFallback().find(options)
     }
-
-    const docs = parseResults(this.client, result, this.doctype, {
-      skip,
-      limit
-    })
-    return docs
   }
 }

--- a/packages/cozy-pouch-link/src/db/sqlite/sqliteDb.native.spec.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sqliteDb.native.spec.js
@@ -1,0 +1,70 @@
+import PouchDBQueryEngine from '../pouchdb/pouchdb'
+
+import SQLiteQueryEngine from './sqliteDb.native'
+
+jest.mock('@op-engineering/op-sqlite', () => ({ open: jest.fn() }))
+jest.mock('../pouchdb/pouchdb')
+
+// The engine answers a query it cannot translate - or one SQLite rejects - by
+// delegating to pouch-find. Returning an empty result instead would be
+// indistinguishable from "no document matches".
+describe('SQLiteQueryEngine find fallback', () => {
+  const pouchManager = { client: {}, getPouch: jest.fn() }
+  const fallbackResult = { data: [{ _id: 'found-by-pouch' }] }
+  let engine
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    PouchDBQueryEngine.mockImplementation(() => ({
+      openDB: jest.fn(),
+      find: jest.fn().mockResolvedValue(fallbackResult)
+    }))
+    engine = new SQLiteQueryEngine(pouchManager, 'io.cozy.files')
+    engine.dbName = 'cozy-files'
+    // Bypass the lazy op-sqlite getter: these tests are about routing, not I/O.
+    Object.defineProperty(engine, 'db', {
+      configurable: true,
+      value: { executeAsync: jest.fn() }
+    })
+  })
+
+  it('routes an untranslatable selector to pouch-find without touching SQLite', async () => {
+    const options = { selector: { name: { $regex: '^foo' } } }
+
+    const result = await engine.find(options)
+
+    expect(result).toBe(fallbackResult)
+    expect(engine.db.executeAsync).not.toHaveBeenCalled()
+    expect(engine.getPouchFallback().find).toHaveBeenCalledWith(options)
+  })
+
+  it('routes to pouch-find when SQLite rejects the query', async () => {
+    engine.db.executeAsync.mockRejectedValue(new Error('malformed SQL'))
+
+    const result = await engine.find({ selector: { type: 'file' } })
+
+    expect(result).toBe(fallbackResult)
+  })
+
+  it('opens the fallback engine once, on the same database', async () => {
+    await engine.find({ selector: { name: { $regex: '^foo' } } })
+    await engine.find({ selector: { name: { $regex: '^bar' } } })
+
+    expect(PouchDBQueryEngine).toHaveBeenCalledTimes(1)
+    expect(PouchDBQueryEngine).toHaveBeenCalledWith(
+      pouchManager,
+      'io.cozy.files'
+    )
+    expect(engine.getPouchFallback().openDB).toHaveBeenCalledWith('cozy-files')
+  })
+
+  it('does not build a fallback engine for a selector it can translate', async () => {
+    engine.db.executeAsync.mockResolvedValue({
+      rows: { length: 0, item: () => undefined }
+    })
+
+    await engine.find({ selector: { type: 'file' } })
+
+    expect(PouchDBQueryEngine).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cozy-pouch-link/src/errors.js
+++ b/packages/cozy-pouch-link/src/errors.js
@@ -44,3 +44,22 @@ export const isMissingPouchDBIndexError = error => {
 export const isDocumentNotFoundPouchDBError = error => {
   return POUCHDB_NOT_FOUND_ERROR.test(error.name)
 }
+
+/**
+ * Thrown by the native SQLite mango translator when a selector uses a feature it
+ * cannot express in SQL. Raising it is what keeps the translator from emitting
+ * `undefined` SQL: every branch either produces valid SQL or throws.
+ */
+export class UnsupportedMangoSelectorError extends Error {
+  /**
+   * @param {string} message - What could not be translated
+   */
+  constructor(message) {
+    super(message)
+    this.name = 'UnsupportedMangoSelectorError'
+  }
+}
+
+export const isUnsupportedMangoSelectorError = error => {
+  return error instanceof UnsupportedMangoSelectorError
+}

--- a/packages/cozy-pouch-link/types/db/sqlite/sql.d.ts
+++ b/packages/cozy-pouch-link/types/db/sqlite/sql.d.ts
@@ -16,7 +16,7 @@ export function parseResults(client: any, result: any, doctype: any, { isSingleD
     skip: number;
     next: boolean;
 };
-export function mangoSelectorToSQL(selector: any, columnName: any): string;
+export function mangoSelectorToSQL(selector: object, columnName?: string): string;
 export function makeWhereClause(selector: any, columnName: any): string;
 export function makeSortClause(mangoSortBy: any): string;
 export function makeSQLQueryFromMango({ selector, sort, indexName, partialFilter, limit, skip }: {

--- a/packages/cozy-pouch-link/types/db/sqlite/sqliteDb.native.d.ts
+++ b/packages/cozy-pouch-link/types/db/sqlite/sqliteDb.native.d.ts
@@ -4,9 +4,15 @@ export default class SQLiteQueryEngine extends DatabaseQueryEngine {
     pouchManager: any;
     client: any;
     doctype: any;
+    /**
+     * Lazily built by getPouchFallback, and dropped whenever openDB points this
+     * engine at another database.
+     *
+     * @type {PouchDBQueryEngine | null}
+     */
+    pouchFallback: PouchDBQueryEngine | null;
     dbName: any;
     getPouchFallback(): PouchDBQueryEngine;
-    pouchFallback: PouchDBQueryEngine | null;
 }
 import DatabaseQueryEngine from "../dbInterface";
 import PouchDBQueryEngine from "../pouchdb/pouchdb";

--- a/packages/cozy-pouch-link/types/db/sqlite/sqliteDb.native.d.ts
+++ b/packages/cozy-pouch-link/types/db/sqlite/sqliteDb.native.d.ts
@@ -1,7 +1,12 @@
 export default class SQLiteQueryEngine extends DatabaseQueryEngine {
     constructor(pouchManager: any, doctype: any);
     db: any;
+    pouchManager: any;
     client: any;
     doctype: any;
+    dbName: any;
+    getPouchFallback(): PouchDBQueryEngine;
+    pouchFallback: PouchDBQueryEngine;
 }
 import DatabaseQueryEngine from "../dbInterface";
+import PouchDBQueryEngine from "../pouchdb/pouchdb";

--- a/packages/cozy-pouch-link/types/db/sqlite/sqliteDb.native.d.ts
+++ b/packages/cozy-pouch-link/types/db/sqlite/sqliteDb.native.d.ts
@@ -6,7 +6,7 @@ export default class SQLiteQueryEngine extends DatabaseQueryEngine {
     doctype: any;
     dbName: any;
     getPouchFallback(): PouchDBQueryEngine;
-    pouchFallback: PouchDBQueryEngine;
+    pouchFallback: PouchDBQueryEngine | null;
 }
 import DatabaseQueryEngine from "../dbInterface";
 import PouchDBQueryEngine from "../pouchdb/pouchdb";

--- a/packages/cozy-pouch-link/types/errors.d.ts
+++ b/packages/cozy-pouch-link/types/errors.d.ts
@@ -2,3 +2,15 @@ export function isExpiredTokenError(error: any): any;
 export function isMissingSQLiteIndexError(error: any): boolean;
 export function isMissingPouchDBIndexError(error: any): boolean;
 export function isDocumentNotFoundPouchDBError(error: any): boolean;
+/**
+ * Thrown by the native SQLite mango translator when a selector uses a feature it
+ * cannot express in SQL. Raising it is what keeps the translator from emitting
+ * `undefined` SQL: every branch either produces valid SQL or throws.
+ */
+export class UnsupportedMangoSelectorError extends Error {
+    /**
+     * @param {string} message - What could not be translated
+     */
+    constructor(message: string);
+}
+export function isUnsupportedMangoSelectorError(error: any): boolean;


### PR DESCRIPTION
## Summary

- Translate `$not`, `$nor`, `$elemMatch`, `$all`, `$size`, `$mod`, `$type`, nested-object subfield equality and `$eq: null` in the native SQLite mango translator.
- Throw `UnsupportedMangoSelectorError` from the single terminal branch of `parseCondition` instead of interpolating an unmapped operator, so generated SQL can no longer contain `undefined`. `$regex` lands there because op-sqlite exposes no way to register a REGEXP function.
- Route those selectors, and SQL errors that are not a missing index, to a `PouchDBQueryEngine` built lazily from the `pouchManager` the constructor already received. `find()` previously returned `null` on any failure, which `CozyPouchLink` turns into `{ data: [] }`.
- Keep documents missing the field on `$ne` and `$nin`, and negate `$not`/`$nor` through `IFNULL`, matching CouchDB where `json_extract` returning SQL NULL would otherwise drop them.
- Guard `$mod` on `json_type`, since SQLite coerces a non-numeric operand of `%` to 0 and would match any `{$mod: [d, 0]}`.
- Reject `$gte`/`$lt`/`$lte` compared to null, which produced SQL that silently matched nothing. `$gt: null` stays supported as the "field exists" idiom `normalizeFindSelector` injects.
- Escape field names in `makeSortClause` and `makeSQLCreateMangoIndex`, and whitelist the sort direction, which was interpolated verbatim.

Closes #1704

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Mango query translation for null values, logical operators, arrays, nested fields, types, and ranges.
  * Added safer handling for invalid or unsupported query selectors.
  * Prevented unsafe sort directions and properly escaped query and index field values.
  * Queries that SQLite cannot process now automatically fall back to the PouchDB engine instead of failing.

* **Tests**
  * Expanded coverage for query operators, escaping, sorting, null handling, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->