### PR TITLE
fix(pouch): make the sqlite query engine able to return rows

### DIFF
--- a/packages/cozy-pouch-link/src/db/sqlite/sql.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sql.js
@@ -368,8 +368,38 @@ export const deleteIndex = async (db, indexName) => {
   await executeSQL(db, sql)
 }
 
+/**
+ * op-sqlite answers with positional rows (`rawRows`) and the column names beside
+ * them, while older releases exposed a WebSQL-style `rows` accessor. parseResults
+ * reads `rows.length` and `rows.item(i)`, so every shape is brought back to that
+ * contract: otherwise `rows` is undefined and each query dies reading `length`.
+ *
+ * @param {object} result - A raw op-sqlite result
+ * @returns {object} The same result, with a WebSQL-style `rows` accessor
+ */
+export const toWebSQLResult = result => {
+  if (!result) {
+    return result
+  }
+  const { rows } = result
+  if (rows && typeof rows.item === 'function') {
+    return result
+  }
+  const list = Array.isArray(rows)
+    ? rows
+    : (result.rawRows || []).map(row => {
+        const columnNames = result.columnNames || []
+        const record = {}
+        for (let i = 0; i < columnNames.length; i++) {
+          record[columnNames[i]] = row[i]
+        }
+        return record
+      })
+  return { ...result, rows: { length: list.length, item: i => list[i] } }
+}
+
 export const executeSQL = async (db, sql) => {
-  return db.executeAsync(sql).catch(err => {
+  return db.executeAsync(sql).then(toWebSQLResult).catch(err => {
     const message = (err && err.message) || String(err)
     // Before the adapter has created the by-sequence table, the earliest
     // queries hit a missing table. That is transient (the table appears once

--- a/packages/cozy-pouch-link/src/db/sqlite/sql.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sql.js
@@ -242,13 +242,16 @@ export const makeSQLQueryFromMango = ({
     `WHERE 'by-sequence'.seq = 'document-store'.winningseq AND ${whereClause}`
   ].join(' ')
 
-  if (skip > 0) {
-    sql += ` OFFSET ${skip}`
-  }
   if (sortClause) {
     sql += ` ORDER BY ${sortClause}`
   }
-  sql += ` LIMIT ${limit}`
+  // OFFSET is a modifier of LIMIT, not a clause of its own: SQL requires it last
+  // and rejects it without a LIMIT. `null` parses but fails at step time with a
+  // datatype mismatch, and the `limit = -1` default only catches `undefined`.
+  sql += ` LIMIT ${limit == null ? -1 : limit}`
+  if (skip > 0) {
+    sql += ` OFFSET ${skip}`
+  }
 
   sql += ';'
   return sql
@@ -285,7 +288,7 @@ export const makeSQLQueryAll = ({ limit = -1, skip = 0 } = {}) => {
     `SELECT 'by-sequence'.json AS data, 'by-sequence'.doc_id, 'by-sequence'.rev`,
     `FROM 'document-store', 'by-sequence'`,
     `WHERE 'by-sequence'.seq = 'document-store'.winningseq AND 'by-sequence'.deleted=0`,
-    `LIMIT ${limit}`
+    `LIMIT ${limit == null ? -1 : limit}`
   ].join(' ')
   if (skip > 0) {
     sql += ` OFFSET ${skip}`

--- a/packages/cozy-pouch-link/src/db/sqlite/sql.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sql.js
@@ -399,16 +399,19 @@ export const toWebSQLResult = result => {
 }
 
 export const executeSQL = async (db, sql) => {
-  return db.executeAsync(sql).then(toWebSQLResult).catch(err => {
-    const message = (err && err.message) || String(err)
-    // Before the adapter has created the by-sequence table, the earliest
-    // queries hit a missing table. That is transient (the table appears once
-    // replication first writes), so return empty instead of rejecting uncaught.
-    // Lock timeouts are NOT swallowed: WAL + busy_timeout handle contention, and
-    // a genuine lock error must surface rather than look like "no documents".
-    if (/no such table/i.test(message)) {
-      return { rows: { length: 0, item: () => undefined } }
-    }
-    throw err
-  })
+  return db
+    .executeAsync(sql)
+    .then(toWebSQLResult)
+    .catch(err => {
+      const message = (err && err.message) || String(err)
+      // Before the adapter has created the by-sequence table, the earliest
+      // queries hit a missing table. That is transient (the table appears once
+      // replication first writes), so return empty instead of rejecting uncaught.
+      // Lock timeouts are NOT swallowed: WAL + busy_timeout handle contention, and
+      // a genuine lock error must surface rather than look like "no documents".
+      if (/no such table/i.test(message)) {
+        return { rows: { length: 0, item: () => undefined } }
+      }
+      throw err
+    })
 }

--- a/packages/cozy-pouch-link/src/db/sqlite/sql.spec.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sql.spec.js
@@ -509,7 +509,10 @@ describe('_id and _rev selectors', () => {
       partialFilter: { _id: { $nin: ['io.cozy.files.trash-dir'] } }
     })
 
-    expect(sql).toContain(`doc_id NOT IN ('io.cozy.files.trash-dir')`),
+    expect(sql).toContain(`doc_id NOT IN ('io.cozy.files.trash-dir')`)
+  })
+})
+
 describe('toWebSQLResult', () => {
   it('should rebuild a rows accessor from rawRows and columnNames', () => {
     const result = toWebSQLResult({

--- a/packages/cozy-pouch-link/src/db/sqlite/sql.spec.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sql.spec.js
@@ -8,7 +8,8 @@ import {
   keepDocWitHighestRev,
   makeSQLQueryAll,
   parseResults,
-  makeSQLCreateMangoIndex
+  makeSQLCreateMangoIndex,
+  toWebSQLResult
 } from './sql'
 
 describe('mangoSelectorToSQL', () => {
@@ -508,6 +509,36 @@ describe('_id and _rev selectors', () => {
       partialFilter: { _id: { $nin: ['io.cozy.files.trash-dir'] } }
     })
 
-    expect(sql).toContain(`doc_id NOT IN ('io.cozy.files.trash-dir')`)
+    expect(sql).toContain(`doc_id NOT IN ('io.cozy.files.trash-dir')`),
+describe('toWebSQLResult', () => {
+  it('should rebuild a rows accessor from rawRows and columnNames', () => {
+    const result = toWebSQLResult({
+      rowsAffected: 0,
+      rawRows: [
+        ['{"a":1}', 'id1', '1-abc'],
+        ['{"a":2}', 'id2', '2-def']
+      ],
+      columnNames: ['data', 'doc_id', 'rev']
+    })
+
+    expect(result.rows.length).toBe(2)
+    expect(result.rows.item(0)).toEqual({
+      data: '{"a":1}',
+      doc_id: 'id1',
+      rev: '1-abc'
+    })
+    expect(result.rows.item(1).doc_id).toBe('id2')
+  })
+
+  it('should wrap a plain rows array', () => {
+    const result = toWebSQLResult({ rows: [{ doc_id: 'id1' }] })
+
+    expect(result.rows.length).toBe(1)
+    expect(result.rows.item(0).doc_id).toBe('id1')
+  })
+
+  it('should leave a WebSQL-style result untouched', () => {
+    const rows = { length: 0, item: () => undefined }
+    expect(toWebSQLResult({ rows }).rows).toBe(rows)
   })
 })

--- a/packages/cozy-pouch-link/src/db/sqlite/sql.spec.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sql.spec.js
@@ -196,14 +196,40 @@ describe('makeSQLQueryFromMango', () => {
       `SELECT 'by-sequence'.json AS data, 'by-sequence'.doc_id, 'by-sequence'.rev`,
       `FROM 'by-sequence' INDEXED BY by_name, 'document-store'`,
       `WHERE 'by-sequence'.seq = 'document-store'.winningseq AND DELETED = 0 AND (json_extract(data, '$.date') > '2025-01-01')`,
-      `OFFSET 100`,
-      `LIMIT 200;`
+      `LIMIT 200 OFFSET 100;`
     ].join(' ')
     expect(sql).toEqual(expectedSql)
+  })
+
+  it('should not emit an OFFSET without a LIMIT', () => {
+    const sql = makeSQLQueryFromMango({
+      selector: { name: { $gt: null } },
+      indexName: 'by_name',
+      skip: 10
+    })
+
+    expect(sql).toContain('LIMIT -1 OFFSET 10;')
+  })
+
+  it('should fall back to an unbounded LIMIT when limit is null', () => {
+    const sql = makeSQLQueryFromMango({
+      selector: { name: { $gt: null } },
+      indexName: 'by_name',
+      limit: null,
+      skip: 10
+    })
+
+    // `LIMIT null` parses but throws a datatype mismatch when stepped.
+    expect(sql).not.toContain('LIMIT null')
+    expect(sql).toContain('LIMIT -1 OFFSET 10;')
   })
 })
 
 describe('makeSQLQueryAll', () => {
+  it('should fall back to an unbounded LIMIT when limit is null', () => {
+    expect(makeSQLQueryAll({ limit: null })).toContain('LIMIT -1;')
+  })
+
   it('should return a correct sql query to get all docs', () => {
     const sql = makeSQLQueryAll()
     const expectedSql = [

--- a/packages/cozy-pouch-link/src/db/sqlite/sql.spec.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sql.spec.js
@@ -514,10 +514,7 @@ describe('toWebSQLResult', () => {
   it('should rebuild a rows accessor from rawRows and columnNames', () => {
     const result = toWebSQLResult({
       rowsAffected: 0,
-      rawRows: [
-        ['{"a":1}', 'id1', '1-abc'],
-        ['{"a":2}', 'id2', '2-def']
-      ],
+      rawRows: [['{"a":1}', 'id1', '1-abc'], ['{"a":2}', 'id2', '2-def']],
       columnNames: ['data', 'doc_id', 'rev']
     })
 

--- a/packages/cozy-pouch-link/types/db/sqlite/sql.d.ts
+++ b/packages/cozy-pouch-link/types/db/sqlite/sql.d.ts
@@ -43,4 +43,5 @@ export function createMangoIndex(db: any, indexName: any, fieldsToIndex: any, { 
     partialFilter: any;
 }): Promise<any>;
 export function deleteIndex(db: any, indexName: any): Promise<void>;
+export function toWebSQLResult(result: object): object;
 export function executeSQL(db: any, sql: any): Promise<any>;


### PR DESCRIPTION
## Summary

- `makeSQLQueryFromMango` emitted `OFFSET` before `ORDER BY`. SQL requires it after `LIMIT` and rejects it without one, so SQLite refused every paginated query with `near "OFFSET": syntax error`.
- The `limit = -1` default only catches `undefined`, so a caller passing `null` produced `LIMIT null`, which parses but throws a datatype mismatch when stepped. Both query builders now coerce it to `-1`.
- op-sqlite answers with `{ rowsAffected, rawRows, columnNames }`, values positional and column names alongside. `parseResults` reads `rows.length` and `rows.item(i)`, the WebSQL shape older releases exposed, so `rows` was undefined and every query threw `Cannot read property 'length' of undefined`. `executeSQL` now normalises to that contract, and accepts a plain `rows` array too.
- Measured on an iOS 18.3 simulator against a ~10 000 file replica with op-sqlite 15.0.7: before these two fixes `SQLiteQuery.find` failed on every call and silently dropped to the PouchDB fallback, so the native engine served 0 of 19 reads. After, it serves 60 of 60, and the folder-listing median goes from 236 ms to 109 ms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL query pagination so `ORDER BY`, `LIMIT`, and `OFFSET` are applied in the correct order.
  * Fixed unlimited queries by treating `null` limits as unbounded (`LIMIT -1`) while keeping `OFFSET` behavior consistent.
  * Standardized SQLite query results to match a WebSQL-style `rows` interface for more reliable access.
  * Preserved graceful behavior when querying non-existent tables by returning an empty `rows` result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->