### PR TITLE
fix(pouch): enforce partialFilter in the sqlite query engine

### DIFF
--- a/packages/cozy-pouch-link/src/db/sqlite/sql.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sql.js
@@ -95,10 +95,10 @@ const quoteSQLValue = value => {
   return value
 }
 
-const parseCondition = (field, condition) => {
+const parseCondition = (field, condition, columnName) => {
   const conditions = []
 
-  const sqlField = transformMangoFieldInJSONSQL(field)
+  const sqlField = transformMangoFieldInJSONSQL(field, columnName)
   if (typeof condition === 'object' && !Array.isArray(condition)) {
     for (const operator in condition) {
       let sqlOp = MANGO_TO_SQL_OP[operator]
@@ -139,10 +139,10 @@ const parseCondition = (field, condition) => {
   return conditions.join(' AND ')
 }
 
-const parseLogicalOperator = (operator, conditionsArray) => {
+const parseLogicalOperator = (operator, conditionsArray, columnName) => {
   const sqlOperator = operator === '$and' ? 'AND' : 'OR'
   const parsedConditions = conditionsArray.map(
-    cond => `(${mangoSelectorToSQL(cond).replace(/^WHERE /, '')})`
+    cond => `(${mangoSelectorToSQL(cond, columnName).replace(/^WHERE /, '')})`
   )
   return parsedConditions.join(` ${sqlOperator} `)
 }
@@ -151,26 +151,26 @@ const transformMangoFieldInJSONSQL = (field, columnName = 'data') => {
   return `json_extract(${columnName}, '$.${field}')`
 }
 
-export const mangoSelectorToSQL = selector => {
+export const mangoSelectorToSQL = (selector, columnName) => {
   const conditions = []
 
   for (const key in selector) {
     if (key === '$and' || key === '$or') {
-      conditions.push(parseLogicalOperator(key, selector[key]))
+      conditions.push(parseLogicalOperator(key, selector[key], columnName))
     } else {
-      conditions.push(parseCondition(key, selector[key]))
+      conditions.push(parseCondition(key, selector[key], columnName))
     }
   }
 
   return conditions.length > 0 ? `${conditions.join(' AND ')}` : ''
 }
 
-export const makeWhereClause = selector => {
+export const makeWhereClause = (selector, columnName) => {
   let baseWhere = 'DELETED = 0'
   if (!selector) {
     return baseWhere
   }
-  const mangoWhere = mangoSelectorToSQL(selector)
+  const mangoWhere = mangoSelectorToSQL(selector, columnName)
   if (!mangoWhere) {
     return baseWhere
   }
@@ -200,10 +200,21 @@ export const makeSQLQueryFromMango = ({
   selector,
   sort,
   indexName,
+  partialFilter,
   limit = -1,
   skip = 0
 }) => {
-  const whereClause = makeWhereClause(selector)
+  let whereClause = makeWhereClause(selector)
+  // Restate the partial filter in the query itself. Relying on the partial index
+  // alone is unsafe: CREATE INDEX IF NOT EXISTS never rewrites an index built
+  // under an older definition, so a stale unfiltered index would silently return
+  // the rows the filter is meant to hide.
+  if (partialFilter) {
+    const partialWhere = mangoSelectorToSQL(partialFilter)
+    if (partialWhere) {
+      whereClause += ` AND (${partialWhere})`
+    }
+  }
   const sortClause = makeSortClause(sort)
 
   // Scan by-sequence via the mango index, then join document-store on its
@@ -288,7 +299,10 @@ export const makeSQLCreateMangoIndex = (
     (${jsonIndex})
   `
   if (partialFilter) {
-    const whereClause = makeWhereClause(partialFilter)
+    // `data` only exists as a SELECT alias of 'by-sequence'.json; inside CREATE
+    // INDEX the column is `json`. Emitting the alias made every partial index
+    // fail with "no such column: data", so the filter was never enforced.
+    const whereClause = makeWhereClause(partialFilter, 'json')
     sql += ` WHERE ${whereClause}`
   }
   sql += ';'

--- a/packages/cozy-pouch-link/src/db/sqlite/sql.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sql.js
@@ -147,7 +147,22 @@ const parseLogicalOperator = (operator, conditionsArray, columnName) => {
   return parsedConditions.join(` ${sqlOperator} `)
 }
 
+// PouchDB keeps a document's id and rev in by-sequence COLUMNS and strips them
+// from the stored JSON, so json_extract(json, '$._id') is NULL on every row. A
+// selector on `_id` would therefore match nothing it is meant to match, and a
+// `$nin` on it would filter nothing at all.
+const PHYSICAL_COLUMNS = { _id: 'doc_id', _rev: 'rev' }
+
 const transformMangoFieldInJSONSQL = (field, columnName = 'data') => {
+  const physicalColumn = PHYSICAL_COLUMNS[field]
+  if (physicalColumn) {
+    // `data` is the query alias, where by-sequence is joined with document-store
+    // and the column needs qualifying; `json` is the CREATE INDEX context, which
+    // is scoped to by-sequence alone and must stay unqualified.
+    return columnName === 'json'
+      ? physicalColumn
+      : `'by-sequence'.${physicalColumn}`
+  }
   return `json_extract(${columnName}, '$.${field}')`
 }
 

--- a/packages/cozy-pouch-link/src/db/sqlite/sql.spec.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sql.spec.js
@@ -458,3 +458,30 @@ describe('partialFilter', () => {
     expect(sql).toContain(`json_extract(data, '$.trashed') = false`)
   })
 })
+
+describe('_id and _rev selectors', () => {
+  it('should resolve _id to the by-sequence column in a query', () => {
+    // PouchDB strips _id from the stored JSON, so json_extract would be NULL.
+    expect(mangoSelectorToSQL({ _id: 'abc' })).toEqual(
+      `'by-sequence'.doc_id = 'abc'`
+    )
+  })
+
+  it('should resolve _rev to the by-sequence column in a query', () => {
+    expect(mangoSelectorToSQL({ _rev: '1-abc' })).toEqual(
+      `'by-sequence'.rev = '1-abc'`
+    )
+  })
+
+  it('should leave the column unqualified in an index context', () => {
+    expect(mangoSelectorToSQL({ _id: 'abc' }, 'json')).toEqual(`doc_id = 'abc'`)
+  })
+
+  it('should keep filtering hidden ids out of a partial index', () => {
+    const sql = makeSQLCreateMangoIndex('by_name', ['name'], {
+      partialFilter: { _id: { $nin: ['io.cozy.files.trash-dir'] } }
+    })
+
+    expect(sql).toContain(`doc_id NOT IN ('io.cozy.files.trash-dir')`)
+  })
+})

--- a/packages/cozy-pouch-link/src/db/sqlite/sql.spec.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sql.spec.js
@@ -7,7 +7,8 @@ import {
   makeSQLQueryForIds,
   keepDocWitHighestRev,
   makeSQLQueryAll,
-  parseResults
+  parseResults,
+  makeSQLCreateMangoIndex
 } from './sql'
 
 describe('mangoSelectorToSQL', () => {
@@ -433,5 +434,27 @@ describe('parseResults', () => {
       _type: doctype,
       name: 'single_doc'
     })
+  })
+})
+
+describe('partialFilter', () => {
+  it('should build the index filter against the json column', () => {
+    const sql = makeSQLCreateMangoIndex('by_name', ['name'], {
+      partialFilter: { trashed: false }
+    })
+
+    // `data` is only a SELECT alias, CREATE INDEX would reject it.
+    expect(sql).toContain(`json_extract(json, '$.trashed') = false`)
+    expect(sql).not.toContain(`json_extract(data`)
+  })
+
+  it('should restate the partial filter in the query', () => {
+    const sql = makeSQLQueryFromMango({
+      selector: { dir_id: 'root' },
+      indexName: 'by_dir_id',
+      partialFilter: { trashed: false }
+    })
+
+    expect(sql).toContain(`json_extract(data, '$.trashed') = false`)
   })
 })

--- a/packages/cozy-pouch-link/src/db/sqlite/sqliteDb.native.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sqliteDb.native.js
@@ -125,6 +125,7 @@ export default class SQLiteQueryEngine extends DatabaseQueryEngine {
       selector,
       sort,
       indexName,
+      partialFilter,
       limit,
       skip
     })

--- a/packages/cozy-pouch-link/types/db/sqlite/sql.d.ts
+++ b/packages/cozy-pouch-link/types/db/sqlite/sql.d.ts
@@ -16,13 +16,14 @@ export function parseResults(client: any, result: any, doctype: any, { isSingleD
     skip: number;
     next: boolean;
 };
-export function mangoSelectorToSQL(selector: any): string;
-export function makeWhereClause(selector: any): string;
+export function mangoSelectorToSQL(selector: any, columnName: any): string;
+export function makeWhereClause(selector: any, columnName: any): string;
 export function makeSortClause(mangoSortBy: any): string;
-export function makeSQLQueryFromMango({ selector, sort, indexName, limit, skip }: {
+export function makeSQLQueryFromMango({ selector, sort, indexName, partialFilter, limit, skip }: {
     selector: any;
     sort: any;
     indexName: any;
+    partialFilter: any;
     limit?: number;
     skip?: number;
 }): string;


### PR DESCRIPTION
## Summary

- `makeSQLCreateMangoIndex` built its WHERE with `json_extract(data, ...)`, but `data` only exists as a SELECT alias of `'by-sequence'.json`. CREATE INDEX has no alias, so SQLite rejected every partial index with `no such column: data` and the filter was never applied. The index now targets the `json` column, through a column name threaded into the translator.
- The query restates the filter as well. `CREATE INDEX IF NOT EXISTS` never rewrites an index built under an older definition, so an existing unfiltered index would keep returning the rows the filter is meant to hide.
- PouchDB keeps a document id and rev in by-sequence columns and strips them from the stored JSON, so `json_extract(json, '$._id')` is NULL on every row: measured on a 10169 document replica, all of them. The translator mapped `_id` and `_rev` like any other attribute, so a selector on `_id` matched nothing it should have and a `$nin` on it filtered nothing. Both now resolve to `doc_id` and `rev`, qualified in the query and bare inside CREATE INDEX.
- Seen from the app: a folder listing whose query carries `partialIndex({ _id: { $nin: [trashDirId, sharedDrivesDirId] } })` returned the hidden root directories once the native engine started serving reads. With these fixes they are filtered again.