### PR TITLE
fix(pouch): stop the sqlite engine racing its own connection setup

### DIFF
--- a/packages/cozy-pouch-link/src/db/sqlite/sqliteDb.native.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sqliteDb.native.js
@@ -76,13 +76,19 @@ export default class SQLiteQueryEngine extends DatabaseQueryEngine {
       get: () => {
         if (resolved) return resolved
         const handle = open({ name: fileDbName })
-        try {
-          handle.executeSync(`PRAGMA busy_timeout=${SETUP_BUSY_TIMEOUT_MS}`)
-          handle.executeSync('PRAGMA journal_mode=WAL')
-          handle.executeSync(`PRAGMA busy_timeout=${QUERY_BUSY_TIMEOUT_MS}`)
-        } catch (err) {
-          logger.error(err)
+        // Each pragma is independent and best-effort: journal_mode can lose the
+        // race for the write lock, and sharing one try/catch would then skip the
+        // query timeout and strand the connection on the setup one.
+        const applyPragma = sql => {
+          try {
+            handle.executeSync(sql)
+          } catch (err) {
+            logger.error(err)
+          }
         }
+        applyPragma(`PRAGMA busy_timeout=${SETUP_BUSY_TIMEOUT_MS}`)
+        applyPragma('PRAGMA journal_mode=WAL')
+        applyPragma(`PRAGMA busy_timeout=${QUERY_BUSY_TIMEOUT_MS}`)
         resolved = handle
         Promise.resolve()
           .then(() => executeSQL(handle, makeSQLCreateDocIDIndex()))

--- a/packages/cozy-pouch-link/src/db/sqlite/sqliteDb.native.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sqliteDb.native.js
@@ -23,6 +23,21 @@ import {
 import PouchDBQueryEngine from '../pouchdb/pouchdb'
 import logger from '../../logger'
 
+// busy_timeout is per-connection, not per-database, and applies to the
+// statements issued after it. Two values are needed because the statements it
+// covers here do not run on the same thread:
+//
+//   - journal_mode=WAL runs through executeSync, ON the JS thread, and needs the
+//     write lock to switch. Under a replication batch it would wait for the
+//     whole timeout, freezing the UI, hence the short value. Losing that race is
+//     harmless: the mode is persistent, so the next open retries it, and it is a
+//     no-op once the database is already in WAL.
+//   - queries run through executeAsync, OFF the JS thread, so waiting costs
+//     latency rather than responsiveness. A short value there would make them
+//     fail during a bulk insert and fall back to pouch-find for no reason.
+const SETUP_BUSY_TIMEOUT_MS = 250
+const QUERY_BUSY_TIMEOUT_MS = 5000
+
 export default class SQLiteQueryEngine extends DatabaseQueryEngine {
   constructor(pouchManager, doctype) {
     super()
@@ -60,15 +75,19 @@ export default class SQLiteQueryEngine extends DatabaseQueryEngine {
       },
       get: () => {
         if (resolved) return resolved
-        resolved = open({ name: fileDbName })
+        const handle = open({ name: fileDbName })
         try {
-          executeSQL(resolved, 'PRAGMA journal_mode=WAL')
-          executeSQL(resolved, 'PRAGMA busy_timeout=5000')
-          executeSQL(resolved, makeSQLCreateDocIDIndex())
-          executeSQL(resolved, makeSQLCreateDeletedIndex())
+          handle.executeSync(`PRAGMA busy_timeout=${SETUP_BUSY_TIMEOUT_MS}`)
+          handle.executeSync('PRAGMA journal_mode=WAL')
+          handle.executeSync(`PRAGMA busy_timeout=${QUERY_BUSY_TIMEOUT_MS}`)
         } catch (err) {
           logger.error(err)
         }
+        resolved = handle
+        Promise.resolve()
+          .then(() => executeSQL(handle, makeSQLCreateDocIDIndex()))
+          .then(() => executeSQL(handle, makeSQLCreateDeletedIndex()))
+          .catch(err => logger.error(err))
         return resolved
       }
     })

--- a/packages/cozy-pouch-link/src/db/sqlite/sqliteDb.native.spec.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sqliteDb.native.spec.js
@@ -133,4 +133,26 @@ describe('SQLiteQueryEngine openDB setup', () => {
 
     expect(engine.db).toBeDefined()
   })
+
+  it('still raises the query timeout when the journal-mode switch is refused', () => {
+    const executeSync = jest.fn(sql => {
+      if (sql.includes('journal_mode')) {
+        throw new Error('database is locked')
+      }
+    })
+    open.mockReturnValue({
+      executeSync,
+      executeAsync: jest.fn().mockResolvedValue({})
+    })
+    const engine = new SQLiteQueryEngine({ client: {} }, 'io.cozy.files')
+    engine.openDB('cozy-files')
+
+    void engine.db
+
+    const timeouts = executeSync.mock.calls
+      .map(([sql]) => sql)
+      .filter(sql => sql.includes('busy_timeout'))
+    expect(timeouts).toHaveLength(2)
+    expect(timeouts[timeouts.length - 1]).toContain('5000')
+  })
 })

--- a/packages/cozy-pouch-link/src/db/sqlite/sqliteDb.native.spec.js
+++ b/packages/cozy-pouch-link/src/db/sqlite/sqliteDb.native.spec.js
@@ -3,6 +3,8 @@ import PouchDBQueryEngine from '../pouchdb/pouchdb'
 import SQLiteQueryEngine from './sqliteDb.native'
 
 jest.mock('@op-engineering/op-sqlite', () => ({ open: jest.fn() }))
+
+import { open } from '@op-engineering/op-sqlite'
 jest.mock('../pouchdb/pouchdb')
 
 // The engine answers a query it cannot translate - or one SQLite rejects - by
@@ -66,5 +68,69 @@ describe('SQLiteQueryEngine find fallback', () => {
     await engine.find({ selector: { type: 'file' } })
 
     expect(PouchDBQueryEngine).not.toHaveBeenCalled()
+  })
+})
+
+describe('SQLiteQueryEngine openDB setup', () => {
+  const setup = ({ createIndexFails = false } = {}) => {
+    const executeSync = jest.fn()
+    const executeAsync = jest.fn(() =>
+      createIndexFails
+        ? Promise.reject(new Error('database is locked'))
+        : Promise.resolve({ rows: { length: 0, item: () => undefined } })
+    )
+    open.mockReturnValue({ executeSync, executeAsync })
+    const engine = new SQLiteQueryEngine({ client: {} }, 'io.cozy.files')
+    engine.openDB('cozy-files')
+    return { engine, executeSync, executeAsync }
+  }
+
+  it('applies the pragmas synchronously so a query cannot outrun them', () => {
+    const { engine, executeSync } = setup()
+
+    expect(engine.db).toBeDefined()
+    expect(executeSync).toHaveBeenCalled()
+  })
+
+  it('sets busy_timeout before switching the journal mode', () => {
+    const { engine, executeSync } = setup()
+    void engine.db
+
+    const statements = executeSync.mock.calls.map(([sql]) => sql)
+    const firstTimeout = statements.findIndex(sql =>
+      sql.includes('busy_timeout')
+    )
+    const journalMode = statements.findIndex(sql =>
+      sql.includes('journal_mode')
+    )
+
+    expect(firstTimeout).toBeGreaterThanOrEqual(0)
+    expect(journalMode).toBeGreaterThan(firstTimeout)
+  })
+
+  it('keeps a locked CREATE INDEX from becoming an unhandled rejection', async () => {
+    const { engine } = setup({ createIndexFails: true })
+    const unhandled = jest.fn()
+    process.on('unhandledRejection', unhandled)
+
+    void engine.db
+    await new Promise(resolve => setImmediate(resolve))
+    await new Promise(resolve => setImmediate(resolve))
+
+    process.off('unhandledRejection', unhandled)
+    expect(unhandled).not.toHaveBeenCalled()
+  })
+
+  it('still returns a usable handle when the pragmas throw', () => {
+    open.mockReturnValue({
+      executeSync: jest.fn(() => {
+        throw new Error('database is locked')
+      }),
+      executeAsync: jest.fn().mockResolvedValue({})
+    })
+    const engine = new SQLiteQueryEngine({ client: {} }, 'io.cozy.files')
+    engine.openDB('cozy-files')
+
+    expect(engine.db).toBeDefined()
   })
 })


### PR DESCRIPTION
## Summary

- `openDB` fired four unawaited `executeSQL` calls from a synchronous getter, so nothing sequenced them and the surrounding `try/catch` could not catch an async rejection. A `CREATE INDEX` losing the write lock to a replication batch escaped as `Uncaught (in promise) [op-sqlite] statement execution error: database is locked`, observed on an iOS device during a first sync.
- The pragmas now run synchronously, and the order matters: `busy_timeout` is connection-local and never blocks, and it is what lets the `journal_mode` switch wait for the writer instead of failing outright with `SQLITE_BUSY`. It was previously issued *second*, so the one statement that needs the write lock ran with no timeout at all.
- The two helper indexes only make queries faster, so they stay off the critical path rather than blocking the JS thread on that same write lock, and their rejection is observed.
- The setup timeout is kept short so a held write lock cannot stall the JS thread while opening; queries keep the longer one.
- Four tests cover the setup, which the lazy getter left untested. Three of them fail against the current code, including one asserting no unhandled rejection when `CREATE INDEX` is refused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite startup reliability under busy or locked database conditions.
  * Ensured database timeout settings are applied before journal mode changes.
  * Made database setup more robust by handling initialization errors safely.
  * Preserved usable access to the database even if setup steps fail.
* **Tests**
  * Added native SQLite test coverage for initialization sequencing, lock handling, and error recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->